### PR TITLE
PomCleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /.settings
 .classpath
 .checkstyle
-/node_modules
 /test-output
 .idea/
 *.iml

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <version.hk2>2.4.0-b25</version.hk2>
         <version.logback>1.1.3</version.logback>
-        <version.restassured>2.4.1</version.restassured>
     </properties>
 
     <dependencies>
@@ -76,22 +75,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${version.logback}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>${version.logback}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>de.odysseus.juel</groupId>
@@ -105,6 +88,18 @@
         </dependency>
 
         <!-- Test -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${version.logback}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${version.logback}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/elide-integration-tests/pom.xml
+++ b/elide-integration-tests/pom.xml
@@ -17,7 +17,6 @@
     </parent>
 
     <properties>
-        <version.hk2>2.4.0-b25</version.hk2>
         <version.logback>1.1.3</version.logback>
         <version.restassured>2.4.1</version.restassured>
         <version.elide>${project.parent.version}</version.elide>
@@ -26,7 +25,7 @@
     </properties>
 
     <dependencies>
-        <!-- Elide deps for integration testing -->
+        <!-- Elide dependencies for integration testing -->
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
@@ -38,7 +37,7 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Additional deps -->
+        <!-- Additional dependencies -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -52,12 +51,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-hibernate3</artifactId>
-            <version>2.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,12 @@
     <name>Elide Parent Pom</name>
     <description>Parent pom for Elide project</description>
 
-    <!-- Children -->
     <modules>
         <module>elide-dbmanager</module>
         <module>elide-core</module>
         <module>elide-integration-tests</module>
     </modules>
 
-    <!-- Common settings -->
     <issueManagement>
         <system>GitHub Issues</system>
         <url>https://github.com/yahoo/elide/issues</url>
@@ -55,11 +53,15 @@
         <max.jdk.version>1.10</max.jdk.version>
         <source.jdk.version>${min.jdk.version}</source.jdk.version>
         <target.jdk.version>${min.jdk.version}</target.jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- dependency versions -->
         <version.slf4j>1.7.12</version.slf4j>
         <version.jetty>9.2.10.v20150310</version.jetty>
         <version.jersey>2.19</version.jersey>
+
+        <!-- plugin versions -->
         <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
         <checkstyle.version>6.1.1</checkstyle.version>
         <surefire.plugin.version>2.18.1</surefire.plugin.version>
@@ -91,6 +93,23 @@
                 <artifactId>guava</artifactId>
                 <version>16.0.1</version>
             </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.3.2</version>
+            </dependency>
+
+            <!-- Test dependencies -->
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>
@@ -127,25 +146,9 @@
                 <version>2.0.13-beta</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-collections4</artifactId>
-                <version>4.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.3.2</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
-    <!-- Build settings -->
     <build>
         <pluginManagement>
             <plugins>
@@ -154,7 +157,6 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.plugin.version}</version>
                 </plugin>
-                <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
- Fix build warnings
  - Project encoding
  - Duplicate dependencies (commons-collections4, jackson-datatype-hibernate3)
- Removed unused properties
- Grouped dependency scopes
- Cleaned up extraneous comments