### PR TITLE
Added jackson databinder to in memory db.

### DIFF
--- a/elide-dbmanager/elide-dbmanager-inmemorydb/pom.xml
+++ b/elide-dbmanager/elide-dbmanager-inmemorydb/pom.xml
@@ -36,6 +36,17 @@
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
         </dependency>
+        <!-- Jackson data-binder -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.6.3</version>
+        </dependency>
         <!-- Test deps -->
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
Database managers should include the appropriate data binders for jackson. In the case of in-memory DB, nothing special is required. However, for other DB managers such as hibernate, there are special data binders.