### PR TITLE
Use travis-ci to publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
   before_install:
     - sudo apt-get install libaio1
   script: mvn verify
-  before_deploy: "cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/ > travis/release.json"
+  before_deploy: cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/ > travis/release.json
   deploy:
     provider: bintray
     file: "travis/release.json"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,29 @@
-language: java
-jdk:
-- oraclejdk8
-before_install:
-- sudo apt-get install libaio1
-script: mvn verify
-after_success:
-- test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && mvn deploy
-  --settings travis/settings.xml
-cache:
-  directories:
-  - "~/.m2"
-branches:
-  only:
-  - master
-  - "/^elide-parent-pom-[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/"
-env:
-  global:
-  - secure: VV+uJlBgXRCUSj3+khXnKvbrB0bxtay3yovKAchTT83Y6+iXUAgp3b7EA1QjT0l3Hz88Y+EAVuiZqwzFRidbZwbgApaxYMJKWjHTmr+VsXXJp29J1tyGtXR1K+DUG0HO/jiRCxMVythB68BnNMIXfprpmsLFpXhKMPf41fzMaAtqSYrPdJkNvEzBDhu5hIPG9apyEcpIZNhtfwnk18DntyGFC3OVAKzEma51s0tS6NeXiZNzTvc9j0d4Fr8vyWGclAp1XKMjWzpvfRyB2EFto076V+8tJ5E3czJjJs12SDwOvEdzYeCpGk3VWboiz9DuZn41IdTLYy89OmcIooZQHViMwiatcqqHREEbuuUWZLYMEh1bUHZHRWQf2AnUScDfJB1QUKVR8mbkSr5DXto4FIsHpqofoBloDveaXkWC735DqOPwbIwe2owGZfkQv19vPpVvF3e2LyFn1vf8blR3wFBItKKZyvBTbrIVM/YxuTDfswDVlhEgHTeet0TQSy4yEoMxGTHsfk8Ykc2B0JDheWH5zhhZBdozmV5TFbM50PXjLqfqWVDD+WqzGVer1Sokfv6MMERoWKvb/LEyKO4Eq3aHgXyy2GoRQHfUh9qOOvBnNpHbtacL+NzfggLZ1Ut97QIbEoWb3VPx6lbNKxiiC4DbwR7nnc92zNJM5YU6Dog=
-  - secure: SSqm3fI2slK6qcmfeRiWvQJ8kNd5VQD6wSkFM5NMCo7Uvo3peNNwCDiTpWMN6nNuM4LSJJhgGwDLZeIlRF4i74xgWpDznjZ4AoqgG1QeIjg/4Xdy+szz0+BiTdUhQnRsaKHfUoky4wm+Jrix1rYgz/eED6uiOHmgLWywD4+BEBHN37N5N6/vT7ELkxi/jzXWOunMA12Y6F+LFcw4A87qM94iFws94C0BEqfWRqaXYPZoQ7v5Yw7TilJuPGiL6pcdWyh5ObfAhIbHhhxmIvaMFWV7HGoB1rC2T/E/GQynKU/l1uQHTf/rNK70uUTCKz3usl28AnVsnyhjg7+Ivk22Z0pSnZtLw1TJT5prPdX+Cas8NEElk6zSS/h3lMmQuGZk8T6FmsqkDx3tkFiJqgxvbgGLZBMgYdm87OCzrM55ZTlxBOYErQQgFrevJ2oJV98Pb4DNCPx5uu/CVCbR+d1kZ6b91rabzjl+a3yiz10vnaO00dyW1gR1P0KHZiRactdds2jLsxBhr3MFDymZD7W+WhuI4RtP2/bsQQ1dnLIvWm+JYmDvr09/7k1uX7WCm9AkMb0u1gW19WYQT1Qct3hFfvKIbgv3gTNJz2+Alu3mqeIpSkmtdtGjVMij3/0OBdYBNC+BfaR4IQVnIbvyu0HmjtJgRji2TO/U7rCUKjOrm6c=
+---
+  language: java
+  jdk:
+    - oraclejdk8
+
+  # steps
+  before_install:
+    - sudo apt-get install libaio1
+  script: mvn verify
+  before_deploy: "cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/ > travis/release.json"
+  deploy:
+    provider: bintray
+    file: "travis/release.json"
+    user: "denis's user"
+    key: "denis's key"
+    dry-run: true #remove after we know this works
+
+  # settings
+  sudo: false # use the new infrastructure
+  cache:
+    directories:
+      - "~/.m2"
+  branches:
+    only:
+      - master
+  env:
+    global:
+      - secure: VV+uJlBgXRCUSj3+khXnKvbrB0bxtay3yovKAchTT83Y6+iXUAgp3b7EA1QjT0l3Hz88Y+EAVuiZqwzFRidbZwbgApaxYMJKWjHTmr+VsXXJp29J1tyGtXR1K+DUG0HO/jiRCxMVythB68BnNMIXfprpmsLFpXhKMPf41fzMaAtqSYrPdJkNvEzBDhu5hIPG9apyEcpIZNhtfwnk18DntyGFC3OVAKzEma51s0tS6NeXiZNzTvc9j0d4Fr8vyWGclAp1XKMjWzpvfRyB2EFto076V+8tJ5E3czJjJs12SDwOvEdzYeCpGk3VWboiz9DuZn41IdTLYy89OmcIooZQHViMwiatcqqHREEbuuUWZLYMEh1bUHZHRWQf2AnUScDfJB1QUKVR8mbkSr5DXto4FIsHpqofoBloDveaXkWC735DqOPwbIwe2owGZfkQv19vPpVvF3e2LyFn1vf8blR3wFBItKKZyvBTbrIVM/YxuTDfswDVlhEgHTeet0TQSy4yEoMxGTHsfk8Ykc2B0JDheWH5zhhZBdozmV5TFbM50PXjLqfqWVDD+WqzGVer1Sokfv6MMERoWKvb/LEyKO4Eq3aHgXyy2GoRQHfUh9qOOvBnNpHbtacL+NzfggLZ1Ut97QIbEoWb3VPx6lbNKxiiC4DbwR7nnc92zNJM5YU6Dog=
+      - secure: SSqm3fI2slK6qcmfeRiWvQJ8kNd5VQD6wSkFM5NMCo7Uvo3peNNwCDiTpWMN6nNuM4LSJJhgGwDLZeIlRF4i74xgWpDznjZ4AoqgG1QeIjg/4Xdy+szz0+BiTdUhQnRsaKHfUoky4wm+Jrix1rYgz/eED6uiOHmgLWywD4+BEBHN37N5N6/vT7ELkxi/jzXWOunMA12Y6F+LFcw4A87qM94iFws94C0BEqfWRqaXYPZoQ7v5Yw7TilJuPGiL6pcdWyh5ObfAhIbHhhxmIvaMFWV7HGoB1rC2T/E/GQynKU/l1uQHTf/rNK70uUTCKz3usl28AnVsnyhjg7+Ivk22Z0pSnZtLw1TJT5prPdX+Cas8NEElk6zSS/h3lMmQuGZk8T6FmsqkDx3tkFiJqgxvbgGLZBMgYdm87OCzrM55ZTlxBOYErQQgFrevJ2oJV98Pb4DNCPx5uu/CVCbR+d1kZ6b91rabzjl+a3yiz10vnaO00dyW1gR1P0KHZiRactdds2jLsxBhr3MFDymZD7W+WhuI4RtP2/bsQQ1dnLIvWm+JYmDvr09/7k1uX7WCm9AkMb0u1gW19WYQT1Qct3hFfvKIbgv3gTNJz2+Alu3mqeIpSkmtdtGjVMij3/0OBdYBNC+BfaR4IQVnIbvyu0HmjtJgRji2TO/U7rCUKjOrm6c=

--- a/travis/bintray_template.json
+++ b/travis/bintray_template.json
@@ -1,0 +1,36 @@
+{
+  "package": {
+    "name": "elide",
+    "repo": "maven",
+    "subject": "yahoo"
+  },
+  "version": {
+    "name": "${TRAVIS_TAG}",
+    "desc": "This is a version",
+    "released": "2015-01-04",
+    "vcs_tag": "${TRAVIS_TAG}"
+  },
+  "files":
+  [
+    {
+      "includePattern": "pom.xml",
+      "uploadPattern": "elide-parent-pom/${TRAVIS_TAG}/elide-parent-pom-${TRAVIS_TAG}.pom"
+    },
+    {
+      "includePattern": "elide-core\/pom.xml",
+      "uploadPattern": "elide-core/${TRAVIS_TAG}/elide-core-${TRAVIS_TAG}.pom"
+    },
+    {
+      "includePattern": "elide-core\/target\/(elide-core-${TRAVIS_TAG}\.jar)",
+      "uploadPattern": "elide-core/${TRAVIS_TAG}/$1"},
+    {
+      "includePattern": "elide-dbmanager\/(elide-dbmanager-[^\/]*)/pom.xml",
+      "uploadPattern": "$1/${TRAVIS_TAG}/$1.pom"
+    },
+    {
+      "includePattern": "elide-dbmanager\/(elide-dbmanager-[^\/]*)\/target\/(elide-dbmanager.*\.jar)",
+      "uploadPattern": "$1/${TRAVIS_TAG}/$2"
+    }
+  ],
+  "publish": true
+}

--- a/travis/settings.xml
+++ b/travis/settings.xml
@@ -1,9 +1,0 @@
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <servers>
-    <server>
-      <id>bintray-elide-repo</id>
-      <username>${env.BINTRAY_USER}</username>
-      <password>${env.BINTRAY_API_KEY}</password>
-    </server>
-  </servers>
-</settings>


### PR DESCRIPTION
Once we use DPL to publish to bintree we can add an `after_publish`
step to have bintree sync the new version to Maven Central.
[Bintree API](https://bintray.com/docs/api/#_sync_version_artifacts_to_maven_central)

* [ ] verify that this pushes to bintree correctly
* [ ] add script to tell bintree to publish to Maven Central