### PR TITLE
Fix test dir for hibernate3

### DIFF
--- a/elide-dbmanager/elide-dbmanager-hibernate3/src/test/java/com/yahoo/elide/dbmanagers/hibernate3/HibernateManagerTest.java
+++ b/elide-dbmanager/elide-dbmanager-hibernate3/src/test/java/com/yahoo/elide/dbmanagers/hibernate3/HibernateManagerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
 package com.yahoo.elide.dbmanagers.hibernate3;
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
- Fixed the test directory location for Hibernate 3 database manager (move src/main/test to src/test)
- Add license & newline