### PR TITLE
Revert DPL provider till bintray fixes headless user permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,29 @@
   cache:
     directories:
       - "~/.m2"
+  env:
+    global:
+      - secure: VV+uJlBgXRCUSj3+khXnKvbrB0bxtay3yovKAchTT83Y6+iXUAgp3b7EA1QjT0l3Hz88Y+EAVuiZqwzFRidbZwbgApaxYMJKWjHTmr+VsXXJp29J1tyGtXR1K+DUG0HO/jiRCxMVythB68BnNMIXfprpmsLFpXhKMPf41fzMaAtqSYrPdJkNvEzBDhu5hIPG9apyEcpIZNhtfwnk18DntyGFC3OVAKzEma51s0tS6NeXiZNzTvc9j0d4Fr8vyWGclAp1XKMjWzpvfRyB2EFto076V+8tJ5E3czJjJs12SDwOvEdzYeCpGk3VWboiz9DuZn41IdTLYy89OmcIooZQHViMwiatcqqHREEbuuUWZLYMEh1bUHZHRWQf2AnUScDfJB1QUKVR8mbkSr5DXto4FIsHpqofoBloDveaXkWC735DqOPwbIwe2owGZfkQv19vPpVvF3e2LyFn1vf8blR3wFBItKKZyvBTbrIVM/YxuTDfswDVlhEgHTeet0TQSy4yEoMxGTHsfk8Ykc2B0JDheWH5zhhZBdozmV5TFbM50PXjLqfqWVDD+WqzGVer1Sokfv6MMERoWKvb/LEyKO4Eq3aHgXyy2GoRQHfUh9qOOvBnNpHbtacL+NzfggLZ1Ut97QIbEoWb3VPx6lbNKxiiC4DbwR7nnc92zNJM5YU6Dog=
+      - secure: SSqm3fI2slK6qcmfeRiWvQJ8kNd5VQD6wSkFM5NMCo7Uvo3peNNwCDiTpWMN6nNuM4LSJJhgGwDLZeIlRF4i74xgWpDznjZ4AoqgG1QeIjg/4Xdy+szz0+BiTdUhQnRsaKHfUoky4wm+Jrix1rYgz/eED6uiOHmgLWywD4+BEBHN37N5N6/vT7ELkxi/jzXWOunMA12Y6F+LFcw4A87qM94iFws94C0BEqfWRqaXYPZoQ7v5Yw7TilJuPGiL6pcdWyh5ObfAhIbHhhxmIvaMFWV7HGoB1rC2T/E/GQynKU/l1uQHTf/rNK70uUTCKz3usl28AnVsnyhjg7+Ivk22Z0pSnZtLw1TJT5prPdX+Cas8NEElk6zSS/h3lMmQuGZk8T6FmsqkDx3tkFiJqgxvbgGLZBMgYdm87OCzrM55ZTlxBOYErQQgFrevJ2oJV98Pb4DNCPx5uu/CVCbR+d1kZ6b91rabzjl+a3yiz10vnaO00dyW1gR1P0KHZiRactdds2jLsxBhr3MFDymZD7W+WhuI4RtP2/bsQQ1dnLIvWm+JYmDvr09/7k1uX7WCm9AkMb0u1gW19WYQT1Qct3hFfvKIbgv3gTNJz2+Alu3mqeIpSkmtdtGjVMij3/0OBdYBNC+BfaR4IQVnIbvyu0HmjtJgRji2TO/U7rCUKjOrm6c=
+  branches:
+    only:
+      - master
+      - "/^elide-parent-pom-[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/"
 
   # build steps
   before_install:
     - sudo apt-get install libaio1
   script: mvn verify
-  before_deploy: cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/g > travis/release.json
-  deploy:
-    on:
-      tags: true
-    provider: bintray
-    file: travis/release.json
-    user:
-      secure: TvyOrjLtOBgaBt986RSuRhyUYwBEPS3d3ug3Y7Bd0rRIw32jL8yH3GcSz+pf2wSb80CIm5xTRuyin3NEYAKGo2X4y2PQx6FkXrxxa4T/RR8u5OyAm4JqRjfB3ZCkSU5agvUCRPXSoch6r1FYZ/NL/tian3kw/ajKDutXurpyXAPCfXmRiQIqGUwzty+znIlmLvpwtsJMcOpSy/gqNJNqHSoLHSXTNETTFoeLvbogLhfl0em88LuApWC4sZIQTMtHPssugNYagxFpjUg16PCLdX5f7HolG8TLf7JjO/W7tXOwXHOl8sePVEtzZogJGWKtA8C9ob02uyPerGyK+lPyFPwf/2OhX4eVcq7W9WCTqnU3gR/ihkRe6ssqhOceWu3uSm9iZ5k9LUFgDId3VaDI3Tq1DI6TFTrco1F2qGSChB0avCITDGKhfeI/oiHD4a4T9AVKx7uyw7pTlkpRFvZMzKXHlq5FWml6pz4vY9+d26O23KTfKqbUhaLvHqN8O77ExjsPDpozIJtyZP8dA0od2xemZSy03GXhLpd9hu5P8t8q+c01EGNgTK93PCMcxjQddIGuYC8H87ElfinJ9XlnmTP9QVRky40NZiTSWZf1bXHZoFMV4t7zzJqw6LqENp8jeYzewM0hnW9TDTXmZMcXgg1bouyRnMBO9aN9SJvO69g=
-    key:
-      secure: ea9647jI7moJIjttA9YSCwKI0oXt53NiRBeN4+mngNT34u/8oCMpks2zXoc6RecYHfnX44gz9QO9F6c2PMn0alkGzZHZk46VhNx/kV0jXksIBs1WQK8gAR0hqkOpRgETUi+E9Gv/oZuA+ZSIr42YZ9X+DD2VwFE5S357GQhXeyZ+Z+OT2cr9bRxqMBjC7mbNUZuoCJMORuqQqbFIOkEIc0cHK8WZ9s8ZkMHlekr6cYdpL3WqPCjxs6j6fn7YfvGLgkspiM5WpNunQLbM9sLQt8O4lMNNPcPYJzMM4/cuXQxZ+JOARs5M7YJTjFkcHEufGYiqc6Ha5zpnqCo+d2QAc9atX+lMqr4TO7KuQjL+k6qqtzYRDg1QDZvz+lapEb5n6DPDNG92D8OQZMq4rYiRYqm9wOLQZ6TB3by9ClZJQZZT1+gsayCR8IHnp7LzaLFzQVOXCpht2pMx1Rk9z6lIvy3D2sCl7B8jIik9YoLr/86U4mg6kp/B9+3jtIC3S4Bxznm5v2ZMbzQlngm6z/26w86pJ8UYhK/nAh1TDYPZEWmyU0iScXAI8ocrhdPXKsd/grdEXnb+Ka7ct9EldINztDkoOpMcXvf2ZA1WdCevMtmelkaiW9nNenN94537JP+24RYNNdhZUg80X1B+Q8Mo1+QKcmhIhw+6BMqY4WVrghQ=
-
-  after_deploy: echo "Pending"
+  after_success:
+    - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && mvn deploy --settings travis/settings.xml
+#  before_deploy: cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/g > travis/release.json
+#  deploy:
+#    on:
+#      tags: true
+#    provider: bintray
+#    file: travis/release.json
+#    user:
+#      secure: TvyOrjLtOBgaBt986RSuRhyUYwBEPS3d3ug3Y7Bd0rRIw32jL8yH3GcSz+pf2wSb80CIm5xTRuyin3NEYAKGo2X4y2PQx6FkXrxxa4T/RR8u5OyAm4JqRjfB3ZCkSU5agvUCRPXSoch6r1FYZ/NL/tian3kw/ajKDutXurpyXAPCfXmRiQIqGUwzty+znIlmLvpwtsJMcOpSy/gqNJNqHSoLHSXTNETTFoeLvbogLhfl0em88LuApWC4sZIQTMtHPssugNYagxFpjUg16PCLdX5f7HolG8TLf7JjO/W7tXOwXHOl8sePVEtzZogJGWKtA8C9ob02uyPerGyK+lPyFPwf/2OhX4eVcq7W9WCTqnU3gR/ihkRe6ssqhOceWu3uSm9iZ5k9LUFgDId3VaDI3Tq1DI6TFTrco1F2qGSChB0avCITDGKhfeI/oiHD4a4T9AVKx7uyw7pTlkpRFvZMzKXHlq5FWml6pz4vY9+d26O23KTfKqbUhaLvHqN8O77ExjsPDpozIJtyZP8dA0od2xemZSy03GXhLpd9hu5P8t8q+c01EGNgTK93PCMcxjQddIGuYC8H87ElfinJ9XlnmTP9QVRky40NZiTSWZf1bXHZoFMV4t7zzJqw6LqENp8jeYzewM0hnW9TDTXmZMcXgg1bouyRnMBO9aN9SJvO69g=
+#    key:
+#      secure: ea9647jI7moJIjttA9YSCwKI0oXt53NiRBeN4+mngNT34u/8oCMpks2zXoc6RecYHfnX44gz9QO9F6c2PMn0alkGzZHZk46VhNx/kV0jXksIBs1WQK8gAR0hqkOpRgETUi+E9Gv/oZuA+ZSIr42YZ9X+DD2VwFE5S357GQhXeyZ+Z+OT2cr9bRxqMBjC7mbNUZuoCJMORuqQqbFIOkEIc0cHK8WZ9s8ZkMHlekr6cYdpL3WqPCjxs6j6fn7YfvGLgkspiM5WpNunQLbM9sLQt8O4lMNNPcPYJzMM4/cuXQxZ+JOARs5M7YJTjFkcHEufGYiqc6Ha5zpnqCo+d2QAc9atX+lMqr4TO7KuQjL+k6qqtzYRDg1QDZvz+lapEb5n6DPDNG92D8OQZMq4rYiRYqm9wOLQZ6TB3by9ClZJQZZT1+gsayCR8IHnp7LzaLFzQVOXCpht2pMx1Rk9z6lIvy3D2sCl7B8jIik9YoLr/86U4mg6kp/B9+3jtIC3S4Bxznm5v2ZMbzQlngm6z/26w86pJ8UYhK/nAh1TDYPZEWmyU0iScXAI8ocrhdPXKsd/grdEXnb+Ka7ct9EldINztDkoOpMcXvf2ZA1WdCevMtmelkaiW9nNenN94537JP+24RYNNdhZUg80X1B+Q8Mo1+QKcmhIhw+6BMqY4WVrghQ=
+#  after_deploy: echo "Pending"

--- a/travis/settings.xml
+++ b/travis/settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>bintray-elide-repo</id>
+      <username>${env.BINTRAY_USER}</username>
+      <password>${env.BINTRAY_API_KEY}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
This reverts the changes to use DPL to deploy to bintray. Cutting a release still requires running `mvn -B release:prepare` locally to kick off the build process.