### PR TITLE
Fixed security hole in shareable permission check

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -540,7 +540,11 @@ public class PersistentResource<T> {
 
         for (PersistentResource persistentResource : resourceIdentifiers) {
             if (!newResources.contains(persistentResource)) {
-                checkPermission(SharePermission.class, persistentResource);
+                if (persistentResource.isShareable()) {
+                    checkPermission(SharePermission.class, persistentResource);
+                } else {
+                    throw new ForbiddenAccessException();
+                }
             }
         }
     }


### PR DESCRIPTION
Found a somewhat obvious bug in how I implemented the SharePermission check.  This is now fixed.