### PR TITLE
test for add unshared child with parent relationship

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -549,7 +549,7 @@ public class PersistentResource<T> {
             if (!newResources.contains(persistentResource)) {
                 if (persistentResource.isShareable()) {
                     checkPermission(SharePermission.class, persistentResource);
-                } else {
+                } else if (!lineage.getRecord(persistentResource.getType()).contains(persistentResource)) {
                     throw new ForbiddenAccessException();
                 }
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/ResourceLineage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/ResourceLineage.java
@@ -9,6 +9,7 @@ import org.apache.commons.collections4.map.LinkedMap;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -58,7 +59,8 @@ public class ResourceLineage {
      * @return the record
      */
     public List<PersistentResource> getRecord(String name) {
-        return resourceMap.get(name);
+        List<PersistentResource> list = resourceMap.get(name);
+        return list == null ? Collections.emptyList() : list;
     }
 
     /**

--- a/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/ShareableIT.groovy
+++ b/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/ShareableIT.groovy
@@ -416,4 +416,30 @@ class ShareableIT extends AHibernateTest {
         // Container should have 2 shareables
         Assert.assertEquals(patchJson[0]["data"]["relationships"]["shareables"]["data"].size(), 2)
     }
+
+
+    @Test(priority = 3)
+    public void addUnsharedRelationship() {
+        given()
+                .contentType("application/vnd.api+json")
+                .accept("application/vnd.api+json")
+                .body("""
+                    {
+                        "data":{
+                            "type":"right",
+                            "relationships":{
+                                "one2one":{
+                                    "data":{
+                                        "type":"left",
+                                        "id":"1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                """)
+                .post("/left/1/one2many")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+    }
 }


### PR DESCRIPTION
Fixes the problem when adding a child containing a relationship to the parent without a SharePermission.