### PR TITLE
coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 ---
   language: java
+  sudo: false
   jdk:
     - oraclejdk8
+  addons:
+    apt:
+      packages:
+      - libaio-dev
   cache:
     directories:
       - "~/.m2"
@@ -9,17 +14,13 @@
     global:
       - secure: VV+uJlBgXRCUSj3+khXnKvbrB0bxtay3yovKAchTT83Y6+iXUAgp3b7EA1QjT0l3Hz88Y+EAVuiZqwzFRidbZwbgApaxYMJKWjHTmr+VsXXJp29J1tyGtXR1K+DUG0HO/jiRCxMVythB68BnNMIXfprpmsLFpXhKMPf41fzMaAtqSYrPdJkNvEzBDhu5hIPG9apyEcpIZNhtfwnk18DntyGFC3OVAKzEma51s0tS6NeXiZNzTvc9j0d4Fr8vyWGclAp1XKMjWzpvfRyB2EFto076V+8tJ5E3czJjJs12SDwOvEdzYeCpGk3VWboiz9DuZn41IdTLYy89OmcIooZQHViMwiatcqqHREEbuuUWZLYMEh1bUHZHRWQf2AnUScDfJB1QUKVR8mbkSr5DXto4FIsHpqofoBloDveaXkWC735DqOPwbIwe2owGZfkQv19vPpVvF3e2LyFn1vf8blR3wFBItKKZyvBTbrIVM/YxuTDfswDVlhEgHTeet0TQSy4yEoMxGTHsfk8Ykc2B0JDheWH5zhhZBdozmV5TFbM50PXjLqfqWVDD+WqzGVer1Sokfv6MMERoWKvb/LEyKO4Eq3aHgXyy2GoRQHfUh9qOOvBnNpHbtacL+NzfggLZ1Ut97QIbEoWb3VPx6lbNKxiiC4DbwR7nnc92zNJM5YU6Dog=
       - secure: SSqm3fI2slK6qcmfeRiWvQJ8kNd5VQD6wSkFM5NMCo7Uvo3peNNwCDiTpWMN6nNuM4LSJJhgGwDLZeIlRF4i74xgWpDznjZ4AoqgG1QeIjg/4Xdy+szz0+BiTdUhQnRsaKHfUoky4wm+Jrix1rYgz/eED6uiOHmgLWywD4+BEBHN37N5N6/vT7ELkxi/jzXWOunMA12Y6F+LFcw4A87qM94iFws94C0BEqfWRqaXYPZoQ7v5Yw7TilJuPGiL6pcdWyh5ObfAhIbHhhxmIvaMFWV7HGoB1rC2T/E/GQynKU/l1uQHTf/rNK70uUTCKz3usl28AnVsnyhjg7+Ivk22Z0pSnZtLw1TJT5prPdX+Cas8NEElk6zSS/h3lMmQuGZk8T6FmsqkDx3tkFiJqgxvbgGLZBMgYdm87OCzrM55ZTlxBOYErQQgFrevJ2oJV98Pb4DNCPx5uu/CVCbR+d1kZ6b91rabzjl+a3yiz10vnaO00dyW1gR1P0KHZiRactdds2jLsxBhr3MFDymZD7W+WhuI4RtP2/bsQQ1dnLIvWm+JYmDvr09/7k1uX7WCm9AkMb0u1gW19WYQT1Qct3hFfvKIbgv3gTNJz2+Alu3mqeIpSkmtdtGjVMij3/0OBdYBNC+BfaR4IQVnIbvyu0HmjtJgRji2TO/U7rCUKjOrm6c=
-      - MAVEN_OPTS="-XX:MaxPermSize=2g -Xmx4g"
-      - JAVA_OPTS="-XX:MaxPermSize=2g -Xmx4g"
   branches:
     only:
       - master
       - "/^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+/"
   # build steps
-  before_install:
-    - sudo apt-get install libaio1
   install: true
-  script: mvn -q clean verify cobertura:cobertura coveralls:report
+  script: mvn clean verify jacoco:report coveralls:report
   after_success:
     - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && mvn deploy --settings travis/settings.xml
 #  before_deploy: cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/g > travis/release.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@
   before_install:
     - sudo apt-get install libaio1
   install: true
-  script: mvn clean verify
+  script: mvn -q clean verify cobertura:cobertura coveralls:report
   after_success:
     - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && mvn deploy --settings travis/settings.xml
 #  before_deploy: cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/g > travis/release.json

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,34 @@
                     <tagNameFormat>@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.0.0</version>
+                <configuration>
+                    <repoToken>${env.coveralls_repo_token}</repoToken>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <reportSets>
+                    <reportSet>
+                        <id>cobertura</id>
+                        <reports>
+                            <report>cobertura</report>
+                        </reports>
+                        <configuration>
+                            <aggregate>true</aggregate>
+                        </configuration>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,19 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.5.201505241946</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.0.0</version>
@@ -342,24 +355,4 @@
             </plugin>
         </plugins>
     </build>
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <reportSets>
-                    <reportSet>
-                        <id>cobertura</id>
-                        <reports>
-                            <report>cobertura</report>
-                        </reports>
-                        <configuration>
-                            <aggregate>true</aggregate>
-                        </configuration>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>


### PR DESCRIPTION
- Use new travis docker containers and fix builds
- Use addons spec to install libaio1 (from libaio-dev)
- Jacoco coverage (not using cobertura because of limited Java 8 support).
- Reports to coveralls: https://coveralls.io/github/yahoo/elide