### PR TITLE
Test thread safety of Slf4jLogger

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/audit/Logger.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/Logger.java
@@ -7,23 +7,22 @@ package com.yahoo.elide.audit;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
  * Base Audit Logger
  * <p>
- * This class uses synchronized list to be thread safe.
+ * This class uses ThreadLocal list to be thread safe.
  */
 public abstract class Logger {
-    protected final List<LogMessage> messages;
+    protected final ThreadLocal<List<LogMessage>> messages;
 
     public Logger() {
-        messages = Collections.synchronizedList(new ArrayList<>());
+        messages = ThreadLocal.withInitial(() -> { return new ArrayList<>(); });
     }
 
     public void log(LogMessage message) {
-        messages.add(message);
+        messages.get().add(message);
     }
 
     public abstract void commit() throws IOException;

--- a/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
@@ -17,11 +17,21 @@ public class Slf4jLogger extends Logger {
 
     @Override
     public void commit() throws IOException {
-        synchronized (messages) {
-            for (LogMessage message : messages) {
+        RuntimeException cause = null;
+        for (LogMessage message : messages.get()) {
+            try {
                 log.info("{} {} {}", System.currentTimeMillis(), message.getOperationCode(), message.getMessage());
+            } catch (RuntimeException e) {
+                if (cause != null) {
+                    cause.addSuppressed(e);
+                } else {
+                    cause = e;
+                }
             }
-            messages.clear();
+        }
+        messages.get().clear();
+        if (cause != null) {
+            throw cause;
         }
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
@@ -17,21 +17,12 @@ public class Slf4jLogger extends Logger {
 
     @Override
     public void commit() throws IOException {
-        RuntimeException cause = null;
-        for (LogMessage message : messages.get()) {
-            try {
+        try {
+            for (LogMessage message : messages.get()) {
                 log.info("{} {} {}", System.currentTimeMillis(), message.getOperationCode(), message.getMessage());
-            } catch (RuntimeException e) {
-                if (cause != null) {
-                    cause.addSuppressed(e);
-                } else {
-                    cause = e;
-                }
             }
-        }
-        messages.get().clear();
-        if (cause != null) {
-            throw cause;
+        } finally {
+            messages.get().clear();
         }
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
@@ -7,15 +7,17 @@ package com.yahoo.elide.audit;
 
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
-
 import com.yahoo.elide.core.RequestScope;
-import com.google.common.collect.Sets;
 
+import com.google.common.collect.Sets;
 import example.Child;
 import example.Parent;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Random;
 
 public class LogMessageTest {
     private transient PersistentResource<Child> childRecord;
@@ -69,5 +71,36 @@ public class LogMessageTest {
     public void invalidTemplate() {
         final String[] expressions = { "${child.id}" };
         new LogMessage("{}", childRecord, expressions, 1).getMessage();
+    }
+
+    public static class TestLoggerException extends RuntimeException {
+    }
+
+    private Logger testLogger = new Slf4jLogger();
+
+    @Test(threadPoolSize = 10, invocationCount = 10)
+    public void threadSafeLogger() throws IOException, InterruptedException {
+        TestLoggerException testException = new TestLoggerException();
+        LogMessage failMessage = new LogMessage("test", 0) {
+            @Override
+            public String getMessage() {
+                throw testException;
+            }
+        };
+        try {
+            testLogger.log(failMessage);
+            Thread.sleep(Math.floorMod(new Random().nextInt(), 100));
+            testLogger.commit();
+            Assert.fail("Exception expected");
+        } catch (TestLoggerException e) {
+            Assert.assertSame(e, testException);
+        }
+
+        // should not cause another exception
+        try {
+            testLogger.commit();
+        } catch (TestLoggerException e) {
+            Assert.fail("Exception not cleared from previous logger commit");
+        }
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/audit/TestLogger.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/TestLogger.java
@@ -15,6 +15,6 @@ public class TestLogger extends Logger {
     }
 
     public List<LogMessage> getMessages() {
-        return new ArrayList<>(this.messages);
+        return new ArrayList<>(this.messages.get());
     }
 }


### PR DESCRIPTION
Changed abstract Logger global message collection to ThreadLocal.  
Added tests to validate thread safety.