### PR TITLE
Allow removal of objects from relationships without general update permission

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -1236,17 +1236,19 @@ public class PersistentResourceTest extends PersistentResource {
         Left left = new Left();
         left.setId(1);
         Right right = new Right();
+        right.setId(2);
 
-        left.noInverseDelete = Sets.newHashSet(right);
-        right.noDelete = Sets.newHashSet(left);
+        left.fieldLevelDelete = Sets.newHashSet(right);
+        right.allowDeleteAtFieldLevel = Sets.newHashSet(left);
 
         //Bad User triggers the delete permission failure
         User badUser = new User(-1);
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
         RequestScope badScope = new RequestScope(null, tx, badUser, dictionary, null, MOCK_LOGGER);
         PersistentResource<Left> leftResource = new PersistentResource<>(left, null, badScope);
-        Assert.assertTrue(leftResource.clearRelation("noInverseDelete"));
-        Assert.assertEquals(leftResource.getObject().noInverseDelete.size(), 0);
+
+        Assert.assertTrue(leftResource.clearRelation("fieldLevelDelete"));
+        Assert.assertEquals(leftResource.getObject().fieldLevelDelete.size(), 0);
     }
 
 

--- a/elide-core/src/test/java/example/Left.java
+++ b/elide-core/src/test/java/example/Left.java
@@ -98,7 +98,7 @@ public class Left {
     @ManyToMany(
         cascade = { CascadeType.PERSIST, CascadeType.MERGE },
         targetEntity = Right.class,
-        mappedBy = "noDelete"
+        mappedBy = "allowDeleteAtFieldLevel"
     )
-    public Set<Right> noInverseDelete;
+    public Set<Right> fieldLevelDelete;
 }

--- a/elide-core/src/test/java/example/Right.java
+++ b/elide-core/src/test/java/example/Right.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 @Include(rootLevel = true, type = "right") // optional here because class has this name
 @SharePermission(any = {Role.ALL.class})
+@UpdatePermission(any = {Role.NONE.class})
 @Entity
 @Table(name = "xright")     // right is SQL keyword
 public class Right {
@@ -36,6 +37,9 @@ public class Right {
     @OneToOne(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Left.class
+    )
+    @UpdatePermission(
+            any = { Role.ALL.class }
     )
     public Left getOne2one() {
         return one2one;
@@ -89,5 +93,8 @@ public class Right {
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Left.class
     )
-    public Set<Left> noDelete;
+    @UpdatePermission(
+            any = {Role.ALL.class}
+    )
+    public Set<Left> allowDeleteAtFieldLevel;
 }

--- a/elide-integration-tests/src/test/java/example/Left.java
+++ b/elide-integration-tests/src/test/java/example/Left.java
@@ -101,7 +101,7 @@ public class Left {
     @ManyToMany(
         cascade = { CascadeType.PERSIST, CascadeType.MERGE },
         targetEntity = Right.class,
-        mappedBy = "noDelete"
+        mappedBy = "allowDeleteAtFieldLevel"
     )
     public Set<Right> noInverseDelete;
 }


### PR DESCRIPTION


We now do a field level check when we are removing objects from inverse relationships,
rather than requiring the user to have the ability to modify the related object wholesale.