### PR TITLE
Avoid accessing lazy relationship collection if entity is denied.

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -108,10 +108,12 @@ public class PersistentResourceTest extends PersistentResource {
 
         Map<String, Relationship> relationships = funResource.getRelationships();
 
-        Assert.assertEquals(relationships.size(), 3, "All relationships should be returned.");
+        Assert.assertEquals(relationships.size(), 5, "All relationships should be returned.");
         Assert.assertTrue(relationships.containsKey("relation1"), "relation1 should be present");
         Assert.assertTrue(relationships.containsKey("relation2"), "relation2 should be present");
         Assert.assertTrue(relationships.containsKey("relation3"), "relation3 should be present");
+        Assert.assertTrue(relationships.containsKey("relation4"), "relation4 should be present");
+        Assert.assertTrue(relationships.containsKey("relation5"), "relation5 should be present");
 
         PersistentResource<FunWithPermissions> funResourceWithBadScope = new PersistentResource<>(fun, null, "3", badUserScope);
         relationships = funResourceWithBadScope.getRelationships();
@@ -666,6 +668,26 @@ public class PersistentResourceTest extends PersistentResource {
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
 
         funResource.getRelation("relation2", "-1000");
+    }
+
+    @Test
+    public void testGetRelationsNoEntityAccess() {
+        FunWithPermissions fun = new FunWithPermissions();
+
+        PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
+
+        Set set = funResource.getRelation("relation4");
+        Assert.assertEquals(0,  set.size());
+    }
+
+    @Test
+    public void testGetRelationsNoEntityAccess2() {
+        FunWithPermissions fun = new FunWithPermissions();
+
+        PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
+
+        Set set = funResource.getRelation("relation5");
+        Assert.assertEquals(0,  set.size());
     }
 
     @Test

--- a/elide-core/src/test/java/example/FunWithPermissions.java
+++ b/elide-core/src/test/java/example/FunWithPermissions.java
@@ -13,6 +13,10 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.security.Role;
 
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Set;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -22,7 +26,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import java.util.Set;
 
 @CreatePermission(any = { Role.ALL.class })
 @ReadPermission(all = { Role.ALL.class })
@@ -65,6 +68,48 @@ public class FunWithPermissions {
 
     public void setRelation3(Child relation3) {
         this.relation3 = relation3;
+    }
+
+
+    private Set<NoReadEntity> relation4;
+
+    @ReadPermission(any = { NegativeIntegerUserCheck.class })
+    @OneToMany(
+            targetEntity = NoReadEntity.class,
+            cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    public Set<NoReadEntity> getRelation4() {
+        // Permission should block access to this collection
+        return new AbstractSet<NoReadEntity>() {
+            @Override
+            public Iterator<NoReadEntity> iterator() {
+                // do not allow iteration
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int size() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    public void setRelation4(Set<NoReadEntity> relation4) {
+        this.relation4 = relation4;
+    }
+
+    private NoReadEntity relation5;
+
+    @ReadPermission(any = { NegativeIntegerUserCheck.class })
+    @OneToOne(
+            targetEntity = NoReadEntity.class,
+            cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    public NoReadEntity getRelation5() {
+        // Permission should block access to this collection
+        throw new UnsupportedOperationException();
+    }
+
+    public void setRelation5(NoReadEntity relation5) {
+        this.relation5 = relation5;
     }
 
     @Id


### PR DESCRIPTION
Move `isDeny` filter check ahead of the `getValue` to avoid unneccessiarily  hydrating a lazy collection