### PR TITLE
Faster Serializer/Deserializer for JSON API

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -63,11 +63,7 @@ public class Elide {
      * @param dictionary the dictionary
      */
     public Elide(Logger auditLogger, DataStore dataStore, EntityDictionary dictionary) {
-        this.auditLogger = auditLogger;
-        this.dataStore = dataStore;
-        this.dictionary = dictionary;
-        dataStore.populateEntityDictionary(dictionary);
-        this.mapper = new JsonApiMapper(dictionary);
+        this(auditLogger, dataStore, dictionary, new JsonApiMapper(dictionary));
     }
 
     /**
@@ -78,6 +74,22 @@ public class Elide {
      */
     public Elide(Logger auditLogger, DataStore dataStore) {
         this(auditLogger, dataStore, new EntityDictionary());
+    }
+
+    /**
+     * Instantiates a new Elide.
+     *
+     * @param auditLogger the audit logger
+     * @param dataStore the dataStore
+     * @param dictionary the dictionary
+     * @param mapper Serializer/Deserializer for JSON API
+     */
+    public Elide(Logger auditLogger, DataStore dataStore, EntityDictionary dictionary, JsonApiMapper mapper) {
+        this.auditLogger = auditLogger;
+        this.dataStore = dataStore;
+        this.dictionary = dictionary;
+        dataStore.populateEntityDictionary(dictionary);
+        this.mapper = mapper;
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Relationship.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Relationship.java
@@ -73,6 +73,9 @@ public class Relationship {
         if (resources != null) {
             for (Resource resource : resources) {
                 try {
+                    if (data.isToOne() && resource == null) {
+                        continue;
+                    }
                     res.add(resource.toPersistentResource(requestScope));
                 } catch (ForbiddenAccessException e) {
                     //skip resource

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/DataDeserializer.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/DataDeserializer.java
@@ -32,12 +32,12 @@ public class DataDeserializer extends JsonDeserializer<Data<Resource>> {
         if (node.isArray()) {
             List<Resource> resources = new ArrayList<>();
             for (JsonNode n : node) {
-                Resource r = mapper.readValue(n.toString(), Resource.class);
+                Resource r = mapper.convertValue(n, Resource.class);
                 resources.add(r);
             }
             return new Data<>(resources);
         }
-        Resource resource = mapper.readValue(node.toString(), Resource.class);
+        Resource resource = mapper.convertValue(node, Resource.class);
         return new Data<>(resource);
     }
 }


### PR DESCRIPTION
Allow caller to provide the JSON API Mapper.
Use convertValue instead of deserialize-reserialize of the JsonNode.
