### PR TITLE
Reintroduce the requestScope.logAuthFailure

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -37,7 +37,6 @@ import com.yahoo.elide.security.User;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 import lombok.NonNull;
 import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.text.WordUtils;
 
@@ -49,7 +48,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -70,7 +68,6 @@ import java.util.stream.Collectors;
  * @param <T> type of resource
  */
 @ToString
-@Slf4j
 public class PersistentResource<T> implements com.yahoo.elide.security.PersistentResource<T> {
     private final String type;
     protected T obj;
@@ -579,9 +576,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                 if (persistentResource.isShareable()) {
                     checkPermission(SharePermission.class, persistentResource);
                 } else if (!lineage.getRecord(persistentResource.getType()).contains(persistentResource)) {
-                    requestScope.logAuthFailure(Arrays.asList(),
-                            persistentResource.getType(),
-                            persistentResource.getId());
+                    requestScope.logAuthFailure(persistentResource.getType(), persistentResource.getId());
                     throw new ForbiddenAccessException("Resource Not Shareable");
                 }
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -13,13 +13,11 @@ import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.security.PermissionExecutor;
 import com.yahoo.elide.security.SecurityMode;
 import com.yahoo.elide.security.User;
-import com.yahoo.elide.security.checks.Check;
 import lombok.Getter;
 
 import javax.ws.rs.core.MultivaluedMap;
 
-import lombok.extern.slf4j.Slf4j;
-
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,7 +32,6 @@ import java.util.function.Supplier;
 /**
  * Request scope object for relaying request-related data to various subsystems.
  */
-@Slf4j
 public class RequestScope implements com.yahoo.elide.security.RequestScope {
     @Getter private final JsonApiDocument jsonApiDocument;
     @Getter private final DataStoreTransaction transaction;
@@ -216,11 +213,13 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         commitTriggers.add(() -> resource.runTriggers(OnCommit.class, fieldName));
     }
 
-    public void logAuthFailure(List<Class<? extends Check>> checks, String type, String id) {
-        failedAuthorizations.add(() -> {
-            return String.format("ForbiddenAccess %s %s#%s", checks, type, id);
-        });
+    public void logAuthFailure(String type, String id) {
+        failedAuthorizations.add(() -> String.format("ForbiddenAccess %s#%s", type, id));
     }
+
+    public void logAuthFailure(Class<? extends Annotation> annotationClass, String failureMessage) {
+        failedAuthorizations.add(() -> String.format("ForbiddenAccess %s:%s", annotationClass, failureMessage));
+    };
 
     public String getAuthFailureReason() {
         Set<String> uniqueReasons = new HashSet<>();


### PR DESCRIPTION
auth failure logging was lost in 2.0 conversion