### PR TITLE
restoring persistent resource hash code

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1027,10 +1027,13 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
     @Override
     public int hashCode() {
-        if (getType() == null) {
-            return -1;
-        }
-        return getType().hashCode();
+        final int prime = 31;
+        int result = 1;
+        String id = dictionary.getId(getObject());
+        result = prime * result + (uuid.isPresent() ? uuid.hashCode() : 0);
+        result = prime * result + (id == null ? 0 : id.hashCode());
+        result = prime * result + (type == null ? 0 : type.hashCode());
+        return result;
     }
 
     @Override


### PR DESCRIPTION
For a query involving one level of include, server was getting pegged at 100% cpu, with the hotspot being inside `java.util.HashMap`. Changing `hashCode` function to [its original implementation](https://github.com/yahoo/elide/commit/37881cfddb62ae934bd3939a6532e3bf80e9f965#diff-01adfd7c58c229be01f3e188e23974e3R902) reduced query time from 14 seconds to 3 seconds.