### PR TITLE
Relationship filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ##What Is Elide?
 
-Elide is a Java library that let's you stand up a [JSON API](http://jsonapi.org) web service with minimal effort starting from a JPA annotated data model. 
+Elide is a Java library that lets you stand up a [JSON API](http://jsonapi.org) web service with minimal effort starting from a JPA annotated data model. 
 Elide is designed to quickly build and deploy **production quality** web services that expose databases as services.  Beyond the basics, elide provides:
   1. **Access** to JPA entities via JSON API CRUD operations.  Entities can be explicitly included or excluded via annotations.
   2. **Patch Extension** Elide supports the [JSON API Patch extension](http://jsonapi.org/extensions/jsonpatch/) allowing multiple create, edit, and delete operations in a single request.

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -650,5 +651,22 @@ public class EntityDictionary {
     public AccessibleObject getAccessibleObject(Class<?> targetClass, String fieldName) {
         ConcurrentHashMap<String, AccessibleObject> map = entityBinding(targetClass).accessibleObject;
         return map.get(fieldName);
+    }
+
+    /**
+     * Retrieve fields from an object containing a particular type.
+     *
+     * @param targetClass Class to search for fields
+     * @param targetType Type of fields to find
+     * @return Set containing field names
+     */
+    public Set<String> getFieldsOfType(Class<?> targetClass, Class<?> targetType) {
+        HashSet<String> fields = new HashSet<>();
+        for (String field : getAllFields(targetClass)) {
+            if (getParameterizedType(targetClass, field).equals(targetType)) {
+                fields.add(field);
+            }
+        }
+        return fields;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
@@ -45,27 +45,18 @@ public class Predicate {
             if (matcher.find()) {
                 final String[] keyParts = matcher.group(1).split("\\.");
 
-                if (keyParts.length != 2) {
+                if (keyParts.length < 2) {
                     throw new InvalidPredicateException("Invalid filter format: " + queryParameter.getKey());
                 }
 
-                final String type = keyParts[0];
-                final String field = keyParts[1];
 
                 final Operator operator = (matcher.group(3) == null) ? Operator.IN
                         : Operator.fromString(matcher.group(3));
 
-                final Class<?> entityClass = dictionary.getBinding(type);
-                if (entityClass == null) {
-                    throw new InvalidPredicateException("Unknown entity in filter: " + type);
-                }
-
-                final Class<?> fieldType = ("id".equals(field.toLowerCase(Locale.ENGLISH)))
-                                           ? dictionary.getIdType(entityClass)
-                                           : dictionary.getParameterizedType(entityClass, field);
-                if (fieldType == null) {
-                    throw new InvalidPredicateException("Unknown field in filter: " + field);
-                }
+                final Class<?>[] types = getTypes(keyParts, dictionary);
+                final String type = getType(types);
+                final String field = getField(keyParts);
+                final Class<?> fieldType = getFieldType(types);
 
                 final List<Object> values = new ArrayList<>();
                 for (String valueParams : queryParameter.getValue()) {
@@ -82,5 +73,79 @@ public class Predicate {
         });
 
         return predicates;
+    }
+
+    /**
+     * Retrieve the type of the object to be filtered.
+     *
+     * @param types Array of types
+     * @return Type of object to be filtered. Empty string if nothing found.
+     */
+    private static String getType(final Class<?>[] types) {
+        if (types == null || types.length <= 1) {
+            return "";
+        }
+        return types[types.length - 2].getSimpleName().toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Retrieve the type of the field being accessed.
+     *
+     * @param types Array of types
+     * @return Type of the field
+     */
+    private static Class<?> getFieldType(final Class<?>[] types) {
+        if (types == null || types.length <= 1) {
+            throw new InvalidPredicateException("Unknown type for field");
+        }
+        return types[types.length - 1];
+    }
+
+    /**
+     * Get the classes of each field contained within the key part.
+     *
+     * NOTE: This method checks that the specified traversal path to a particular type
+     *       is valid. In the case of an invalid field, it will throw an "InvalidPredicateException."
+     *
+     * @param keyParts Key components
+     * @param dictionary Entity dictionary
+     * @return An array containing types for each of the key parts (in order). Empty array if none found.
+     */
+    private static Class<?>[] getTypes(final String[] keyParts, final EntityDictionary dictionary) {
+        if (keyParts == null || keyParts.length <= 0) {
+            return new Class[0];
+        }
+        Class<?>[] types = new Class[keyParts.length];
+        String type = keyParts[0];
+        types[0] = dictionary.getBinding(type);
+        for (int i = 1 ; i < keyParts.length ; ++i) {
+            final String field = keyParts[i];
+            final Class<?> entityClass = types[i - 1];
+            if (entityClass == null) {
+                throw new InvalidPredicateException("Unknown entity in filter: " + type);
+            }
+
+            final Class<?> fieldType = ("id".equals(field.toLowerCase(Locale.ENGLISH)))
+                    ? dictionary.getIdType(entityClass)
+                    : dictionary.getParameterizedType(entityClass, field);
+            if (fieldType == null) {
+                throw new InvalidPredicateException("Unknown field in filter: " + field);
+            }
+            types[i] = fieldType;
+        }
+        return types;
+    }
+
+    /**
+     * Retrieve the string name for the final field being accessed in a list of keyParts.
+     *
+     * @param keyParts Key components
+     * @return Final field being accessed or empty string if no key parts
+     */
+    private static String getField(final String[] keyParts) {
+        if (keyParts != null && keyParts.length > 0) {
+            return keyParts[keyParts.length - 1];
+        }
+        return "";
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -87,14 +88,7 @@ public class Predicate {
         if (types == null || types.length <= 1) {
             return "";
         }
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0 ; i < types.length - 1 ; ++i) {
-            sb.append(types[i]);
-            if (i != types.length - 2) {
-                sb.append(".");
-            }
-        }
-        return sb.toString();
+        return String.join(".", Arrays.copyOf(types, types.length - 1));
     }
 
     /**
@@ -127,13 +121,12 @@ public class Predicate {
         Class<?>[] types = new Class[keyParts.length];
         String type = keyParts[0];
         types[0] = dictionary.getBinding(type);
+        if (types[0] == null) {
+            throw new InvalidPredicateException("Unknown entity in filter: " + type);
+        }
         for (int i = 1 ; i < keyParts.length ; ++i) {
             final String field = keyParts[i];
             final Class<?> entityClass = types[i - 1];
-            if (entityClass == null) {
-                throw new InvalidPredicateException("Unknown entity in filter: " + type);
-            }
-
             final Class<?> fieldType = ("id".equals(field.toLowerCase(Locale.ENGLISH)))
                     ? dictionary.getIdType(entityClass)
                     : dictionary.getParameterizedType(entityClass, field);

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
@@ -54,7 +54,7 @@ public class Predicate {
                         : Operator.fromString(matcher.group(3));
 
                 final Class<?>[] types = getTypes(keyParts, dictionary);
-                final String type = getType(types);
+                final String type = getType(keyParts);
                 final String field = getField(keyParts);
                 final Class<?> fieldType = getFieldType(types);
 
@@ -78,14 +78,23 @@ public class Predicate {
     /**
      * Retrieve the type of the object to be filtered.
      *
+     * NOTE: Types are now fully qualified by (ROOT_TYPE.FIELD1.FIELD2..FIELD(N-1)).ACCESSED_FIELD
+     *
      * @param types Array of types
      * @return Type of object to be filtered. Empty string if nothing found.
      */
-    private static String getType(final Class<?>[] types) {
+    private static String getType(final String[] types) {
         if (types == null || types.length <= 1) {
             return "";
         }
-        return types[types.length - 2].getSimpleName().toLowerCase(Locale.ENGLISH);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0 ; i < types.length - 1 ; ++i) {
+            sb.append(types[i]);
+            if (i != types.length - 2) {
+                sb.append(".");
+            }
+        }
+        return sb.toString();
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/filter/CriteriaExplorer.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/filter/CriteriaExplorer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.hibernate3.filter;
+
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.filter.Predicate;
+
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.criterion.Criterion;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Explorer intended to construct criteria from filtering for constraining object loading.
+ */
+public class CriteriaExplorer {
+    private final Criterion rootCriterion;
+    private final CriterionFilterOperation filterOperation;
+    private final RequestScope requestScope;
+    private final EntityDictionary dictionary;
+    private final Class<?> loadClass;
+
+    /**
+     * Constructor.
+     *
+     * @param loadClass Root class being loaded
+     * @param requestScope Request scope
+     * @param existing Pre-existing criterion related to loadClass
+     */
+    public CriteriaExplorer(Class<?> loadClass, RequestScope requestScope, Criterion existing) {
+        this.filterOperation = new CriterionFilterOperation();
+        this.requestScope = requestScope;
+        this.dictionary = requestScope.getDictionary();
+        this.rootCriterion = buildRootCriterion(loadClass, existing);
+        this.loadClass = loadClass;
+    }
+
+    /**
+     * Build a set of criteria from sessionCriteria.
+     *
+     * NOTE: It is assumed that sessionCriteria is a criteria corresponding to the "loadClass"
+     *       that this was instantiated with.
+     *
+     * @param sessionCriteria Session criteria to update
+     * @param session Session to create criteria on
+     */
+    public void buildCriteria(final Criteria sessionCriteria, final Session session) {
+        if (rootCriterion != null) {
+            sessionCriteria.add(rootCriterion);
+        }
+
+        for (Map.Entry<String, Set<Predicate>> entry : requestScope.getPredicates().entrySet()) {
+            String criteriaPath = entry.getKey();
+            Set<Predicate> predicates = entry.getValue();
+
+            String[] objects = criteriaPath.split("\\.");
+
+            Criteria criteria;
+            Class filterClass = dictionary.getBinding(objects[0]);
+            if (loadClass.equals(filterClass)) {
+                criteria = sessionCriteria;
+            } else {
+                criteria = session.createCriteria(filterClass);
+            }
+
+            for (int i = 1 ; i < objects.length ; ++i) {
+                criteria = criteria.createCriteria(objects[i]);
+            }
+            criteria.add(filterOperation.applyAll(predicates));
+        }
+    }
+
+    /**
+     * Build root criteria object.
+     *
+     * @param loadClass Root class being loaded
+     * @param existing Pre-existing criterion related to loadClass
+     * @return Criterion for root class
+     */
+    private Criterion buildRootCriterion(final Class<?> loadClass, final Criterion existing) {
+        String type = dictionary.getBinding(loadClass);
+        return CriterionFilterOperation.andWithNull(existing,
+                filterOperation.applyAll(requestScope.getPredicatesOfType(type)));
+    }
+}

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/filter/CriterionFilterOperation.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/filter/CriterionFilterOperation.java
@@ -14,7 +14,7 @@ import org.hibernate.criterion.Restrictions;
 import java.util.Set;
 
 /**
- * FilterOperation that creates Hibernate Criterions from Predicates.
+ * FilterOperation that creates Hibernate Criteria from Predicates.
  */
 public class CriterionFilterOperation implements FilterOperation<Criterion> {
     @Override

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/filter/CriteriaExplorer.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/filter/CriteriaExplorer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.hibernate5.filter;
+
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.filter.Predicate;
+
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.criterion.Criterion;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Explorer intended to construct criteria from filtering for constraining object loading.
+ */
+public class CriteriaExplorer {
+    private final Criterion rootCriterion;
+    private final CriterionFilterOperation filterOperation;
+    private final RequestScope requestScope;
+    private final EntityDictionary dictionary;
+    private final Class<?> loadClass;
+
+    /**
+     * Constructor.
+     *
+     * @param loadClass Root class being loaded
+     * @param requestScope Request scope
+     * @param existing Pre-existing criterion related to loadClass
+     */
+    public CriteriaExplorer(Class<?> loadClass, RequestScope requestScope, Criterion existing) {
+        this.filterOperation = new CriterionFilterOperation();
+        this.requestScope = requestScope;
+        this.dictionary = requestScope.getDictionary();
+        this.rootCriterion = buildRootCriterion(loadClass, existing);
+        this.loadClass = loadClass;
+    }
+
+    /**
+     * Build a set of criteria from sessionCriteria.
+     *
+     * NOTE: It is assumed that sessionCriteria is a criteria corresponding to the "loadClass"
+     *       that this was instantiated with.
+     *
+     * @param sessionCriteria Session criteria to update
+     * @param session Session to create criteria on
+     */
+    public void buildCriteria(final Criteria sessionCriteria, final Session session) {
+        if (rootCriterion != null) {
+            sessionCriteria.add(rootCriterion);
+        }
+
+        for (Map.Entry<String, Set<Predicate>> entry : requestScope.getPredicates().entrySet()) {
+            String criteriaPath = entry.getKey();
+            Set<Predicate> predicates = entry.getValue();
+
+            String[] objects = criteriaPath.split("\\.");
+
+            Criteria criteria;
+            Class filterClass = dictionary.getBinding(objects[0]);
+            if (loadClass.equals(filterClass)) {
+                criteria = sessionCriteria;
+            } else {
+                criteria = session.createCriteria(filterClass);
+            }
+
+            for (int i = 1 ; i < objects.length ; ++i) {
+                criteria = criteria.createCriteria(objects[i]);
+            }
+            criteria.add(filterOperation.applyAll(predicates));
+        }
+    }
+
+    /**
+     * Build root criteria object.
+     *
+     * @param loadClass Root class being loaded
+     * @param existing Pre-existing criterion related to loadClass
+     * @return Criterion for root class
+     */
+    private Criterion buildRootCriterion(final Class<?> loadClass, final Criterion existing) {
+        String type = dictionary.getBinding(loadClass);
+        return CriterionFilterOperation.andWithNull(existing,
+                filterOperation.applyAll(requestScope.getPredicatesOfType(type)));
+    }
+}

--- a/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/FilterIT.groovy
+++ b/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/FilterIT.groovy
@@ -891,7 +891,7 @@ class FilterIT extends AbstractIntegrationTestInitializer {
 
     @Test
     public void testGetBadRelationshipNameWithNestedFieldFilter() {
-        def result = mapper.readTree(RestAssured.get("book?filter[book.author12.name]=Null%20Ned").asString());
+        def result = mapper.readTree(RestAssured.get("book?filter[book.author12.name]=Null Ned").asString());
         Assert.assertEquals(result.get("errors").get(0).asText(), "InvalidPredicateException: Unknown field in filter: author12");
     }
 

--- a/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/FilterIT.groovy
+++ b/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/FilterIT.groovy
@@ -924,6 +924,24 @@ class FilterIT extends AbstractIntegrationTestInitializer {
         }
     }
 
+    @Test
+    public void testGetBadRelationshipRoot() {
+        def result = mapper.readTree(RestAssured.get("author?filter[idontexist.books.title][in]=Viva la Roma!,Mamma mia I wantz some pizza!").asString());
+        Assert.assertEquals(result.get("errors").get(0).asText(), "InvalidPredicateException: Unknown entity in filter: idontexist");
+    }
+
+    @Test
+    public void testGetBadRelationshipIntermediate() {
+        def result = mapper.readTree(RestAssured.get("author?filter[author.idontexist.title][in]=Viva la Roma!,Mamma mia I wantz some pizza!").asString());
+        Assert.assertEquals(result.get("errors").get(0).asText(), "InvalidPredicateException: Unknown field in filter: idontexist");
+    }
+
+    @Test
+    public void testGetBadRelationshipLeaf() {
+        def result = mapper.readTree(RestAssured.get("author?filter[author.books.idontexist][in]=Viva la Roma!,Mamma mia I wantz some pizza!").asString());
+        Assert.assertEquals(result.get("errors").get(0).asText(), "InvalidPredicateException: Unknown field in filter: idontexist");
+    }
+
     @AfterTest
     public void cleanUp() {
         for (int id : authorIds) {

--- a/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/FilterIT.groovy
+++ b/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/FilterIT.groovy
@@ -867,6 +867,21 @@ class FilterIT extends AbstractIntegrationTestInitializer {
         }
     }
 
+    @Test
+    public void testGetBadRelationshipNameWithNestedFieldFilter() {
+        def result = mapper.readTree(RestAssured.get("book?filter[book.author12.name]=Null%20Ned").asString());
+        Assert.assertEquals(result.get("errors").get(0), "\"InvalidPredicateException: Unknown field in filter: author12\"");
+    }
+
+    @Test
+    public void testGetBooksByAuthors() {
+        def result = mapper.readTree(RestAssured.get("book?filter[book.authors.name]=Null%20Ned").asString());
+        for (JsonNode book : result.get("data")) {
+            String authorName = book.get("attributes").get("authors").get(0).asText();
+            Assert.assertEquals(authorName, "Null Ned");
+        }
+    }
+
     @AfterTest
     public void cleanUp() {
         for (int id : authorIds) {

--- a/elide-integration-tests/src/test/java/example/Book.java
+++ b/elide-integration-tests/src/test/java/example/Book.java
@@ -37,6 +37,7 @@ public class Book {
     private String language;
     private long publishDate = 0;
     private Collection<Author> authors = new ArrayList<>();
+    private Collection<Chapter> chapters = new ArrayList<>();
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     public long getId() {
@@ -77,6 +78,15 @@ public class Book {
 
     public long getPublishDate() {
         return this.publishDate;
+    }
+
+    @ManyToMany
+    public Collection<Chapter> getChapters() {
+        return chapters;
+    }
+
+    public void setChapters(Collection<Chapter> chapters) {
+        this.chapters = chapters;
     }
 
     @ManyToMany

--- a/elide-integration-tests/src/test/java/example/Chapter.java
+++ b/elide-integration-tests/src/test/java/example/Chapter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.SharePermission;
+import com.yahoo.elide.security.checks.prefab.Role;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Include(rootLevel = true, type = "chapter")
+@SharePermission(all = {Role.ALL.class})
+public class Chapter {
+    private Long id;
+    @Getter @Setter private String title;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
This allows filtering. To filter collections, traverse a path relative to the parent. For instance,

`/parent?include=[children]&filter[parent.children.id]=4`

will give all parents that have child id 4.

`/parent?include[children]&filter[child.id]=4`

will provide all parents and include a child with id 4.

This allows us to continue to honor existing behavior while providing greater flexibility in filtering at the collection level.