### PR TITLE
Corrected annotation lookup in ExpressionBuilder

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -73,8 +73,8 @@ public class EntityPermissions implements CheckInstantiator {
                 });
     }
 
-    private void bindClassPermissions(Class<?> cls, Class annotationClass) {
-        Annotation annotation = cls.getAnnotation(annotationClass);
+    private void bindClassPermissions(Class<?> cls, Class<? extends Annotation> annotationClass) {
+        Annotation annotation = EntityDictionary.getFirstAnnotation(cls, Arrays.asList(annotationClass));
         if (annotation != null) {
             ParseTree permissions = getPermissionExpressionTree(annotationClass, annotation);
             classPermissions.put(annotationClass, permissions);

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AndExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AndExpression.java
@@ -51,4 +51,9 @@ public class AndExpression implements Expression {
 
         return DEFERRED_RESULT;
     }
+
+    @Override
+    public String toString() {
+        return "(" + left + ") AND (" + right + ")";
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/Expression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/Expression.java
@@ -27,11 +27,21 @@ public interface Expression {
             public ExpressionResult evaluate() {
                 return ExpressionResult.PASS_RESULT;
             }
+
+            @Override
+            public String toString() {
+                return "SUCCESS";
+            }
         };
         public static final Expression FAILURE = new Expression() {
             @Override
             public ExpressionResult evaluate() {
                 return new ExpressionResult(ExpressionResult.Status.FAIL);
+            }
+
+            @Override
+            public String toString() {
+                return "FAILURE";
             }
         };
     }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
@@ -52,4 +52,9 @@ public class OrExpression implements Expression {
 
         return DEFERRED_RESULT;
     }
+
+    @Override
+    public String toString() {
+        return "(" + left + ") OR (" + right + ")";
+    }
 }

--- a/elide-core/src/test/java/nocreate/NoCreateEntity.java
+++ b/elide-core/src/test/java/nocreate/NoCreateEntity.java
@@ -3,19 +3,18 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package example;
+package nocreate;
 
-import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.security.checks.prefab.Role;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-@CreatePermission(all = { Role.NONE.class })
+/**
+ * Must inherit @CreatePermission from package.  Do not add here.
+ */
 @Include(rootLevel = true, type = "nocreate") // optional here because class has this name
-// Hibernate
 @Entity
 @Table(name = "nocreate")
 public class NoCreateEntity {

--- a/elide-core/src/test/java/nocreate/package-info.java
+++ b/elide-core/src/test/java/nocreate/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+@CreatePermission(all = { Role.NONE.class })
+package nocreate;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.security.checks.prefab.Role;


### PR DESCRIPTION
The ExpressionBuilder was asking only the class for annotations instead of using EntityDictionary lookup.