### PR TITLE
More hooks in the Dropwizard Bundle

### DIFF
--- a/elide-contrib/dropwizard-elide/src/main/java/com/yahoo/elide/contrib/dropwizard/elide/ElideConfiguration.java
+++ b/elide-contrib/dropwizard-elide/src/main/java/com/yahoo/elide/contrib/dropwizard/elide/ElideConfiguration.java
@@ -7,11 +7,16 @@
 package com.yahoo.elide.contrib.dropwizard.elide;
 
 import com.yahoo.elide.audit.AuditLogger;
-import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.resources.JsonApiEndpoint;
+import com.yahoo.elide.security.PermissionExecutor;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
+
+import java.util.function.Function;
 
 /**
  * Elide Configuration
@@ -29,7 +34,7 @@ public interface ElideConfiguration<T extends Configuration> {
      * @return auditLogger to be used in Elide
      */
     default AuditLogger getAuditLogger(T configuration, Environment environment) {
-        return new Slf4jLogger();
+        return null;
     }
 
     /**
@@ -55,4 +60,37 @@ public interface ElideConfiguration<T extends Configuration> {
      * @return dataStore to be used in Elide
      */
     DataStore getDataStore(T configuration, Environment environment);
+
+    /**
+     * Get the EntityDictionary for Elide
+     *
+     * Override this method to plug in your own EntityDictionary
+     *
+     * @param configuration Dropwizard Configuration
+     * @param environment Dropwizard Environment
+     * @return entityDictionary to be used in Elide
+     */
+    default EntityDictionary getEntityDictionary(T configuration, Environment environment) {
+        return null;
+    }
+
+    /**
+     *
+     * @param configuration Dropwizard Configuration
+     * @param environment Dropwizard Environment
+     * @return jsonApiMapper to be used in Elide
+     */
+    default JsonApiMapper getJsonApiMapper(T configuration, Environment environment) {
+        return null;
+    }
+
+    /**
+     *
+     * @param configuration Dropwizard Configuration
+     * @param environment Dropwizard Environment
+     * @return permissionExecutor function to be used in Elide
+     */
+    default Function<RequestScope, PermissionExecutor> getPermissionExecutor(T configuration, Environment environment) {
+        return null;
+    }
 }

--- a/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/ElideBundleTest.java
+++ b/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/ElideBundleTest.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.contrib.dropwizard.elide;
 
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.common.collect.ImmutableList;
-import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.datastores.hibernate5.HibernateStore;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
@@ -71,7 +70,7 @@ public class ElideBundleTest {
 
     @Test
     public void defaultAuditLoggerIsSlf4jLogger() throws Exception {
-        Assert.assertTrue(bundle.getAuditLogger(configuration, environment) instanceof Slf4jLogger);
+        Assert.assertNull(bundle.getAuditLogger(configuration, environment));
     }
 
     @Test

--- a/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/ElideBundleTest.java
+++ b/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/ElideBundleTest.java
@@ -69,11 +69,6 @@ public class ElideBundleTest {
     }
 
     @Test
-    public void defaultAuditLoggerIsSlf4jLogger() throws Exception {
-        Assert.assertNull(bundle.getAuditLogger(configuration, environment));
-    }
-
-    @Test
     public void hasADataStore() throws Exception {
         Assert.assertTrue(bundle.getDataStore(configuration, environment) instanceof HibernateStore);
     }


### PR DESCRIPTION
Extend the dropwizard-bundle with more hooks to override `EntityDictionary`, `JsonApiMapper` and `PermissionExecutor`