### PR TITLE
Use Criteria.DISTINCT_ROOT_ENTITY and disable join by default

### DIFF
--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -238,6 +238,7 @@ public class HibernateTransaction implements RequestScopedTransaction {
             joinCriteria(sessionCriteria, loadClass);
         }
 
+        sessionCriteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
         if (!isScrollEnabled || isJoinQuery()) {
             return sessionCriteria.list();
         }
@@ -245,28 +246,11 @@ public class HibernateTransaction implements RequestScopedTransaction {
     }
 
     /**
-     * Should this transaction use JOINs. By default will be enabled if Sparse fields are available.
+     * Should this transaction use JOINs. Override to force joins.
      *
      * @return true to use join logic
      */
     public boolean isJoinQuery() {
-        if (requestScope != null) {
-            if (requestScope.getQueryParams().isPresent()) {
-                List<String> join = requestScope.getQueryParams().get().get("join");
-                if (join != null) {
-                    return Boolean.valueOf(join.get(0));
-                }
-            }
-
-            if (!requestScope.getSparseFields().isEmpty()) {
-                return true;
-            }
-
-            if (requestScope.getQueryParams().isPresent()
-                    && requestScope.getQueryParams().get().get("include") != null) {
-                return true;
-            }
-        }
         return false;
     }
 
@@ -372,7 +356,7 @@ public class HibernateTransaction implements RequestScopedTransaction {
                     }
                 }
 
-                return query.list();
+                return query.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY).list();
             }
         }
 

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
@@ -95,7 +94,7 @@ public class DataStoreIT extends AbstractIntegrationTestInitializer {
             assertFalse(tx.isJoinQuery());
 
             params.add("join", "true");
-            assertTrue(tx.isJoinQuery());
+            assertFalse(tx.isJoinQuery());
 
             params.remove("join");
             params.add("join", "false");
@@ -103,7 +102,7 @@ public class DataStoreIT extends AbstractIntegrationTestInitializer {
 
             params.remove("join");
             params.add("include", "foo,bar");
-            assertTrue(tx.isJoinQuery());
+            assertFalse(tx.isJoinQuery());
 
             params.add("join", "false");
             assertFalse(tx.isJoinQuery());


### PR DESCRIPTION
Disabled any JOIN by default due to cross-product expansion of many queries.