### PR TITLE
Cache result of check.forName for improved performance

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/CheckInstantiator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/CheckInstantiator.java
@@ -23,15 +23,6 @@ public interface CheckInstantiator {
      */
     default Check getCheck(EntityDictionary dictionary, String checkName) {
         Class<? extends Check> checkCls = dictionary.getCheck(checkName);
-
-        if (checkCls == null) {
-            try {
-                checkCls = (Class<? extends Check>) Class.forName(checkName);
-            } catch (ClassNotFoundException | ClassCastException e) {
-                throw new IllegalArgumentException("Could not instantiate specified check '" + checkName + "'.", e);
-            }
-        }
-
         return instantiateCheck(checkCls);
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -183,7 +183,19 @@ public class EntityDictionary {
      * @return the {@link Check} mapped to the identifier or {@code null} if the given identifer is unmapped
      */
     public Class<? extends Check> getCheck(String checkIdentifier) {
-        return checkNames.get(checkIdentifier);
+        Class<? extends Check> checkCls = checkNames.get(checkIdentifier);
+
+        if (checkCls == null) {
+            try {
+                checkCls = (Class<? extends Check>) Class.forName(checkIdentifier);
+                checkNames.putIfAbsent(checkIdentifier, checkCls);
+            } catch (ClassNotFoundException | ClassCastException e) {
+                throw new IllegalArgumentException(
+                        "Could not instantiate specified check '" + checkIdentifier + "'.", e);
+            }
+        }
+
+        return checkCls;
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -172,8 +173,7 @@ public class EntityPermissions implements CheckInstantiator {
         return classPermissions.get(annotationClass);
     }
 
-    private static final Map<Class<? extends Annotation>, ParseTree> EMPTY_MAP = new ConcurrentHashMap<>();
     public ParseTree getFieldChecksForPermission(String field, Class<? extends Annotation> annotationClass) {
-        return fieldPermissions.getOrDefault(field, EMPTY_MAP).get(annotationClass);
+        return fieldPermissions.getOrDefault(field, Collections.emptyMap()).get(annotationClass);
     }
 }


### PR DESCRIPTION
Received 10x speed increase for a test query.  
Remaining overhead is in `com.yahoo.elide.security.executors.ActivePermissionExecutor.checkPermission`