### PR TITLE
Avoid read on create

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -399,7 +399,7 @@ public class Elide {
             if (JsonApiPatch.isPatchExtension(contentType) && JsonApiPatch.isPatchExtension(accept)) {
                 // build Outer RequestScope to be used for each action
                 PatchRequestScope patchRequestScope = new PatchRequestScope(
-                        transaction, user, dictionary, mapper, auditLogger);
+                        transaction, user, dictionary, mapper, auditLogger, permissionExecutor);
                 requestScope = patchRequestScope;
                 isVerbose = requestScope.getPermissionExecutor().isVerbose();
                 responder = JsonApiPatch.processJsonPatch(dataStore, path, jsonApiDocument, patchRequestScope);

--- a/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
@@ -11,7 +11,11 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
+import com.yahoo.elide.security.PermissionExecutor;
+import com.yahoo.elide.security.SecurityMode;
 import com.yahoo.elide.security.User;
+
+import java.util.function.Function;
 
 /**
  * Special request scope for Patch Extension.
@@ -32,8 +36,10 @@ public class PatchRequestScope extends RequestScope {
             User user,
             EntityDictionary dictionary,
             JsonApiMapper mapper,
-            AuditLogger auditLogger) {
-        super(transaction, user, dictionary, mapper, auditLogger);
+            AuditLogger auditLogger,
+            Function<RequestScope, PermissionExecutor> permissionExecutorGenerator) {
+        super(null, transaction, user, dictionary, mapper, auditLogger, SecurityMode.SECURITY_ACTIVE,
+                permissionExecutorGenerator);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/VerbosePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/VerbosePermissionExecutor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.security.executors;
+
+import com.yahoo.elide.core.RequestScope;
+
+/**
+ * Permission executor that returns verbose debug to the client.
+ */
+public class VerbosePermissionExecutor extends ActivePermissionExecutor {
+
+    /**
+     * Constructor.
+     *
+     * @param requestScope Request scope.
+     */
+    public VerbosePermissionExecutor(RequestScope requestScope) {
+        super(requestScope);
+    }
+
+    @Override
+    public boolean isVerbose() {
+        return true;
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
@@ -36,4 +36,9 @@ public class AnyFieldExpression implements Expression {
 
         return (entityExpression == null) ? PASS_RESULT : entityExpression.evaluate();
     }
+
+    @Override
+    public String toString() {
+        return "ANY (" + entityExpression + " : " + fieldExpression + ")";
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/ImmediateCheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/ImmediateCheckExpression.java
@@ -118,4 +118,9 @@ public class ImmediateCheckExpression implements Expression {
 
         return new ExpressionResult(FAIL, failure);
     }
+
+    @Override
+    public String toString() {
+        return "(" + check.checkIdentifier() + ")";
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/NotExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/NotExpression.java
@@ -43,4 +43,9 @@ public class NotExpression implements Expression {
 
         return DEFERRED_RESULT;
     }
+
+    @Override
+    public String toString() {
+        return "NOT (" + logical + ")";
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
@@ -55,6 +55,9 @@ public class OrExpression implements Expression {
 
     @Override
     public String toString() {
+        if (right == null) {
+            return String.valueOf(left);
+        }
         return "(" + left + ") OR (" + right + ")";
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/SpecificFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/SpecificFieldExpression.java
@@ -34,4 +34,10 @@ public class SpecificFieldExpression implements Expression {
 
         return fieldExpression.get().evaluate();
     }
+
+
+    @Override
+    public String toString() {
+        return "FIELD (" + entityExpression + " : " + fieldExpression + ")";
+    }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -1592,7 +1592,7 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/")
             .then()
-            .statusCode(HttpStatus.SC_OK)
+            .statusCode(HttpStatus.SC_FORBIDDEN)
             .body(equalTo(expected));
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -1582,6 +1582,20 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
                 .statusCode(HttpStatus.SC_FORBIDDEN);
     }
 
+    @Test
+    public void testPatchDeferredOnCreate() {
+        String request = jsonParser.getJson("/ResourceIT/testPatchDeferredOnCreate.req.json");
+        String expected = jsonParser.getJson("/ResourceIT/testPatchDeferredOnCreate.json");
+        given()
+            .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+            .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+            .body(request)
+            .patch("/")
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .body(equalTo(expected));
+    }
+
     // TODO: Test that user checks still apply at commit time
 
     @Test

--- a/elide-integration-tests/src/test/java/example/CreateButNoRead.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */

--- a/elide-integration-tests/src/test/java/example/CreateButNoRead.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoRead.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.security.ChangeSpec;
+import com.yahoo.elide.security.RequestScope;
+import com.yahoo.elide.security.checks.OperationCheck;
+import com.yahoo.elide.security.checks.prefab.Role;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+
+/**
+ * A model intended to be ONLY created and read, but never updated
+ */
+@Include(rootLevel = true)
+@Entity
+@CreatePermission(any = {Role.ALL.class})
+public class CreateButNoRead extends BaseId {
+    private Set<CreateButNoReadChild> otherObjects;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @ReadPermission(any = {NOREAD.class})
+    public Set<CreateButNoReadChild> getOtherObjects() {
+        return otherObjects;
+    }
+
+    public void setOtherObjects(Set<CreateButNoReadChild> otherObjects) {
+        this.otherObjects = otherObjects;
+    }
+
+    public static class NOREAD extends OperationCheck<CreateButNoRead> {
+        @Override
+        public boolean ok(CreateButNoRead object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            return false;
+        }
+    }
+}

--- a/elide-integration-tests/src/test/java/example/CreateButNoReadChild.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoReadChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */

--- a/elide-integration-tests/src/test/java/example/CreateButNoReadChild.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoReadChild.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.security.checks.prefab.Role;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+/**
+ * A model intended to be ONLY created and read, but never updated
+ */
+@Include(rootLevel = true)
+@Entity
+@CreatePermission(any = {Role.ALL.class})
+public class CreateButNoReadChild extends BaseId {
+    private CreateButNoRead otherObject;
+
+    @ManyToOne()
+    @ReadPermission(any = {Role.ALL.class})
+    public CreateButNoRead getOtherObject() {
+        return otherObject;
+    }
+
+    public void setOtherObject(CreateButNoRead otherObject) {
+        this.otherObject = otherObject;
+    }
+}

--- a/elide-integration-tests/src/test/resources/ResourceIT/testPatchDeferredOnCreate.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/testPatchDeferredOnCreate.json
@@ -1,32 +1,5 @@
-[
-    {
-        "data":{
-            "type":"createButNoRead",
-            "id":"1",
-            "relationships":{
-                "otherObjects":{
-                    "data":[
-                        {
-                            "type":"createButNoReadChild",
-                            "id":"1"
-                        }
-                    ]
-                }
-            }
-        }
-    },
-    {
-        "data":{
-            "type":"createButNoReadChild",
-            "id":"1",
-            "relationships":{
-                "otherObject":{
-                    "data":{
-                        "type":"createButNoRead",
-                        "id":"1"
-                    }
-                }
-            }
-        }
-    }
-]
+{
+  "errors": [
+    "ForbiddenAccessException"
+  ]
+}

--- a/elide-integration-tests/src/test/resources/ResourceIT/testPatchDeferredOnCreate.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/testPatchDeferredOnCreate.json
@@ -1,0 +1,32 @@
+[
+    {
+        "data":{
+            "type":"createButNoRead",
+            "id":"1",
+            "relationships":{
+                "otherObjects":{
+                    "data":[
+                        {
+                            "type":"createButNoReadChild",
+                            "id":"1"
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "data":{
+            "type":"createButNoReadChild",
+            "id":"1",
+            "relationships":{
+                "otherObject":{
+                    "data":{
+                        "type":"createButNoRead",
+                        "id":"1"
+                    }
+                }
+            }
+        }
+    }
+]

--- a/elide-integration-tests/src/test/resources/ResourceIT/testPatchDeferredOnCreate.req.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/testPatchDeferredOnCreate.req.json
@@ -1,0 +1,26 @@
+[
+    {
+        "op":"add",
+        "path":"createButNoRead",
+        "value":{
+            "type":"createButNoRead",
+            "id":"gh202bcd3-8103-4166-a5b0-abccaa07322d"
+        }
+    },
+    {
+        "op":"add",
+        "path":"/createButNoRead/gh202bcd3-8103-4166-a5b0-abccaa07322d/otherObjects",
+        "value":{
+            "type":"createButNoReadChild",
+            "id":"r7712424-b52a-44c2-b0fd-e654a38bbf8a",
+            "relationships":{
+                "otherObject":{
+                    "data":{
+                        "type":"createButNoRead",
+                        "id":"gh202bcd3-8103-4166-a5b0-abccaa07322d"
+                    }
+                }
+            }
+        }
+    }
+]


### PR DESCRIPTION
@DeathByTape Added a test to reproduce the post-processing read collection on create problem.