### PR TITLE
Allow any HTTP status code to be thrown from within custom business l…

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ForbiddenAccessException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ForbiddenAccessException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -16,11 +16,6 @@ public class ForbiddenAccessException extends HttpStatusException {
     private static final long serialVersionUID = 1L;
 
     public ForbiddenAccessException(String verboseMessage) {
-        super(null, verboseMessage);
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_FORBIDDEN;
+        super(HttpStatus.SC_FORBIDDEN, null, verboseMessage);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -19,27 +19,32 @@ import java.util.Map;
  * Creates fast exceptions without stack traces since filter checks can throw many of these.
  */
 @Slf4j
-public abstract class HttpStatusException extends RuntimeException {
+public class HttpStatusException extends RuntimeException {
     private static final long serialVersionUID = 1L;
     protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    protected final int status;
 
-    public abstract int getStatus();
+    public int getStatus() {
+        return status;
+    }
+
     private final String verboseMessage;
 
-    public HttpStatusException() {
-        this(null);
+    public HttpStatusException(int status) {
+        this(status, null);
     }
 
-    public HttpStatusException(String message) {
-        this(message, null);
+    public HttpStatusException(int status, String message) {
+        this(status, message, null);
     }
 
-    public HttpStatusException(String message, String verboseMessage) {
-        this(message, verboseMessage, null);
+    public HttpStatusException(int status, String message, String verboseMessage) {
+        this(status, message, verboseMessage, null);
     }
 
-    public HttpStatusException(String message, String verboseMessage, Throwable cause) {
+    public HttpStatusException(int status, String message, String verboseMessage, Throwable cause) {
         super(message, cause, true, log.isTraceEnabled());
+        this.status = status;
         this.verboseMessage = verboseMessage;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InternalServerErrorException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InternalServerErrorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -16,14 +16,9 @@ public class InternalServerErrorException extends HttpStatusException {
     private static final long serialVersionUID = 1L;
 
     public InternalServerErrorException(String message) {
-        super(message);
+        super(HttpStatus.SC_INTERNAL_SERVER_ERROR, message);
     }
     public InternalServerErrorException(Exception e) {
-        super(e.toString(), null, e);
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_INTERNAL_SERVER_ERROR;
+        super(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.toString(), null, e);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidAttributeException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidAttributeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -13,15 +13,10 @@ import com.yahoo.elide.core.HttpStatus;
  */
 public class InvalidAttributeException extends HttpStatusException {
     public InvalidAttributeException(String attributeName, String type) {
-        super("Unknown attribute '" + attributeName + "' in " + "'" + type + "'");
+        super(HttpStatus.SC_NOT_FOUND, "Unknown attribute '" + attributeName + "' in " + "'" + type + "'");
     }
 
     public InvalidAttributeException(String message, Throwable cause) {
-        super(message, null, cause);
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_NOT_FOUND;
+        super(HttpStatus.SC_NOT_FOUND, message, null, cause);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidCollectionException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidCollectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -17,11 +17,6 @@ public class InvalidCollectionException extends HttpStatusException {
     }
 
     public InvalidCollectionException(String format, String collection) {
-        super(String.format(format,  collection));
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_NOT_FOUND;
+        super(HttpStatus.SC_NOT_FOUND, String.format(format,  collection));
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidEntityBodyException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidEntityBodyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -15,11 +15,6 @@ public class InvalidEntityBodyException extends HttpStatusException {
     private static final long serialVersionUID = 1L;
 
     public InvalidEntityBodyException(String body) {
-        super("Bad Request Body'" + body + "'");
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_BAD_REQUEST;
+        super(HttpStatus.SC_BAD_REQUEST, "Bad Request Body'" + body + "'");
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidObjectIdentifierException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidObjectIdentifierException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -15,11 +15,6 @@ public class InvalidObjectIdentifierException extends HttpStatusException {
     private static final long serialVersionUID = 1L;
 
     public InvalidObjectIdentifierException(String id, String objectOrFieldName) {
-        super("Unknown identifier '" + id + "' for " + objectOrFieldName);
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_NOT_FOUND;
+        super(HttpStatus.SC_NOT_FOUND, "Unknown identifier '" + id + "' for " + objectOrFieldName);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidOperationException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidOperationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -14,11 +14,6 @@ public class InvalidOperationException extends HttpStatusException {
     private static final long serialVersionUID = 1L;
 
     public InvalidOperationException(String body) {
-        super("Invalid operation: '" + body + "'");
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_BAD_REQUEST;
+        super(HttpStatus.SC_BAD_REQUEST, "Invalid operation: '" + body + "'");
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidPredicateException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidPredicateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -12,15 +12,10 @@ import com.yahoo.elide.core.HttpStatus;
  */
 public class InvalidPredicateException extends HttpStatusException {
     public InvalidPredicateException(String message) {
-        super(message);
+        super(HttpStatus.SC_BAD_REQUEST, message);
     }
 
     public InvalidPredicateException(String message, Throwable cause) {
-        super(message, null, cause);
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_BAD_REQUEST;
+        super(HttpStatus.SC_BAD_REQUEST, message, null, cause);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidURLException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidURLException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -15,11 +15,6 @@ public class InvalidURLException extends HttpStatusException {
     private static final long serialVersionUID = 1L;
 
     public InvalidURLException(Exception e) {
-        super(e.getMessage());
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_NOT_FOUND;
+        super(HttpStatus.SC_NOT_FOUND, e.getMessage());
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidValueException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -14,19 +14,14 @@ import com.yahoo.elide.core.HttpStatus;
 public class InvalidValueException extends HttpStatusException {
 
     public InvalidValueException(Object value) {
-        super("Invalid value: " + value.toString());
+        super(HttpStatus.SC_BAD_REQUEST, "Invalid value: " + value.toString());
     }
 
     public InvalidValueException(Object value, String verboseMessage) {
-        super("Invalid value: " + value.toString(), verboseMessage);
+        super(HttpStatus.SC_BAD_REQUEST, "Invalid value: " + value.toString(), verboseMessage);
     }
 
     public InvalidValueException(String message, Throwable cause) {
-        super(message, null, cause);
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_BAD_REQUEST;
+        super(HttpStatus.SC_BAD_REQUEST, message, null, cause);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/JsonPatchExtensionException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/JsonPatchExtensionException.java
@@ -15,19 +15,16 @@ public class JsonPatchExtensionException extends HttpStatusException {
     private final Pair<Integer, JsonNode> response;
 
     public JsonPatchExtensionException(int status, final JsonNode errorNode) {
+        super(status);
         response = Pair.of(status, errorNode);
     }
 
     public JsonPatchExtensionException(final Pair<Integer, JsonNode> response) {
+        super(response.getLeft());
         this.response = response;
     }
 
     public Pair<Integer, JsonNode> getResponse() {
         return response;
-    }
-
-    @Override
-    public int getStatus() {
-        return response.getLeft();
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/TransactionException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/TransactionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2016, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -16,11 +16,6 @@ public class TransactionException extends HttpStatusException {
     private static final long serialVersionUID = 1L;
 
     public TransactionException(Throwable e) {
-        super(formatExceptionCause(e), null, e);
-    }
-
-    @Override
-    public int getStatus() {
-        return HttpStatus.SC_LOCKED;
+        super(HttpStatus.SC_LOCKED, formatExceptionCause(e), null, e);
     }
 }


### PR DESCRIPTION
…ogic

This PR allows custom logic inside a DataStoreTransaction or a trigger to control the error returned by Elide by simply using HttpStatusException (rather than having to explicitly override it).