### PR TITLE
HTTP 204 must not return a body.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -566,7 +566,7 @@ public class Elide {
         try {
             JsonNode responseNode = response.getRight();
             Integer responseCode = response.getLeft();
-            String body = mapper.writeJsonApiDocument(responseNode);
+            String body = responseNode == null ? null : mapper.writeJsonApiDocument(responseNode);
             return new ElideResponse(responseCode, body);
         } catch (JsonProcessingException e) {
             return new ElideResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.toString());

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordTerminalState.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.parsers.state;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
@@ -63,7 +62,6 @@ public class RecordTerminalState extends BaseState {
 
     @Override
     public Supplier<Pair<Integer, JsonNode>> handlePatch(StateContext state) {
-        final JsonNode empty = JsonNodeFactory.instance.nullNode();
         JsonApiDocument jsonApiDocument = state.getJsonApiDocument();
 
         Data<Resource> data = jsonApiDocument.getData();
@@ -82,7 +80,7 @@ public class RecordTerminalState extends BaseState {
         }
 
         patch(resource, state.getRequestScope());
-        return () -> Pair.of(HttpStatus.SC_NO_CONTENT, empty);
+        return () -> Pair.of(HttpStatus.SC_NO_CONTENT, null);
     }
 
     @Override

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -224,7 +224,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/parent/2")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
 
         String actual = given()
             .contentType(JSONAPI_CONTENT_TYPE)
@@ -281,7 +282,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/parent/4")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
 
         String actual = given()
             .contentType(JSONAPI_CONTENT_TYPE)
@@ -325,7 +327,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/parent/4")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
 
         String actual = given()
             .contentType(JSONAPI_CONTENT_TYPE)
@@ -348,7 +351,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/parent/4")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
     }
 
     @Test(priority = 7)
@@ -362,7 +366,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/parent/4")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
 
         String actual = given()
             .contentType(JSONAPI_CONTENT_TYPE)
@@ -554,7 +559,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/parent/4/relationships/children")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
 
         String actual = given()
             .contentType(JSONAPI_CONTENT_TYPE)
@@ -595,7 +601,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/parent/4/relationships/children")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
     }
 
     @Test(priority = 11)
@@ -768,7 +775,9 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request1)
             .patch("/fun/1")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
+
         final String expected1 = jsonParser.getJson("/ResourceIT/testAddAndRemoveOneToOneRelationship.json");
         final String actual1 = given().when().get("/fun/1").then().statusCode(HttpStatus.SC_OK).extract().body().asString();
         assertEqualDocuments(actual1, expected1);
@@ -781,7 +790,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request2)
             .patch("/fun/1")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
         final String expected2 = jsonParser.getJson("/ResourceIT/testAddAndRemoveOneToOneRelationship.2.json");
         final String actual2 = given().when().get("/fun/1").then().statusCode(HttpStatus.SC_OK).extract().body().asString();
         assertEqualDocuments(actual2, expected2);
@@ -1005,7 +1015,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .post("/parent/5/children/6/relationships/parents")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
         String response = given()
             .contentType(JSONAPI_CONTENT_TYPE)
             .accept(JSONAPI_CONTENT_TYPE)
@@ -1027,7 +1038,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .delete("/parent/5/children/6/relationships/parents")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-length", (String) null);
         given()
             .contentType(JSONAPI_CONTENT_TYPE)
             .accept(JSONAPI_CONTENT_TYPE)
@@ -1539,7 +1551,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .body(request)
             .patch("/user/1")
             .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+            .statusCode(HttpStatus.SC_NO_CONTENT)
+            .header("content-lenth", (String) null);
 
         given().when().get("/user/1").then().statusCode(HttpStatus.SC_OK)
             .body(equalTo(expected));


### PR DESCRIPTION
Elide Patch was returning a body of `null` for HTTP 204 responses.