### PR TITLE
ComputedRelationship Annotation

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/ComputedRelationship.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/ComputedRelationship.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method or field as a computed relationship that should be exposed via Elide regardless of whether or
+ * not it is marked as Transient.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface ComputedRelationship {
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -6,27 +6,23 @@
 package com.yahoo.elide.core;
 
 import com.yahoo.elide.annotation.ComputedAttribute;
+import com.yahoo.elide.annotation.ComputedRelationship;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.OnCommit;
 import com.yahoo.elide.annotation.OnCreate;
 import com.yahoo.elide.annotation.OnDelete;
 import com.yahoo.elide.annotation.OnUpdate;
 import com.yahoo.elide.core.exceptions.DuplicateMappingException;
-import lombok.Getter;
-import lombok.Setter;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.text.WordUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import javax.persistence.Column;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Transient;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
@@ -40,6 +36,14 @@ import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Transient;
 
 /**
  * Entity Dictionary maps JSON API Entity beans to/from Entity type names.
@@ -120,7 +124,8 @@ class EntityBinding {
             if (fieldOrMethod.isAnnotationPresent(Id.class)) {
                 bindEntityId(cls, type, fieldOrMethod);
             } else if (fieldOrMethod.isAnnotationPresent(Transient.class)
-                    && !fieldOrMethod.isAnnotationPresent(ComputedAttribute.class)) {
+                    && !fieldOrMethod.isAnnotationPresent(ComputedAttribute.class)
+                    && !fieldOrMethod.isAnnotationPresent(ComputedRelationship.class)) {
                 continue; // Transient. Don't serialize
             } else if (!fieldOrMethod.isAnnotationPresent(Exclude.class)) {
                 if (fieldOrMethod instanceof Field && Modifier.isTransient(((Field) fieldOrMethod).getModifiers())) {
@@ -196,7 +201,8 @@ class EntityBinding {
         boolean manyToOne = fieldOrMethod.isAnnotationPresent(ManyToOne.class);
         boolean oneToMany = fieldOrMethod.isAnnotationPresent(OneToMany.class);
         boolean oneToOne = fieldOrMethod.isAnnotationPresent(OneToOne.class);
-        boolean isRelation = manyToMany || manyToOne || oneToMany || oneToOne;
+        boolean computedRelationship = fieldOrMethod.isAnnotationPresent(ComputedRelationship.class);
+        boolean isRelation = manyToMany || manyToOne || oneToMany || oneToOne || computedRelationship;
 
         String fieldName = getFieldName(fieldOrMethod);
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -5,10 +5,8 @@
  */
 package com.yahoo.elide.core;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Maps;
 import com.yahoo.elide.annotation.ComputedAttribute;
+import com.yahoo.elide.annotation.ComputedRelationship;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.SharePermission;
@@ -18,12 +16,16 @@ import com.yahoo.elide.security.checks.prefab.Collections.AppendOnly;
 import com.yahoo.elide.security.checks.prefab.Collections.RemoveOnly;
 import com.yahoo.elide.security.checks.prefab.Common;
 import com.yahoo.elide.security.checks.prefab.Role;
-import lombok.extern.slf4j.Slf4j;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Maps;
+
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.commons.lang3.text.WordUtils;
 
-import javax.persistence.Entity;
-import javax.persistence.Transient;
+import lombok.extern.slf4j.Slf4j;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
@@ -42,6 +44,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.persistence.Entity;
+import javax.persistence.Transient;
 
 /**
  * Entity Dictionary maps JSON API Entity beans to/from Entity type names.
@@ -112,7 +117,9 @@ public class EntityDictionary {
         Method m = entityClass.getMethod(name, paramClass);
         int modifiers = m.getModifiers();
         if (Modifier.isAbstract(modifiers)
-                || (m.isAnnotationPresent(Transient.class) && !m.isAnnotationPresent(ComputedAttribute.class))) {
+                || m.isAnnotationPresent(Transient.class)
+                && !m.isAnnotationPresent(ComputedAttribute.class)
+                && !m.isAnnotationPresent(ComputedRelationship.class)) {
             throw new NoSuchMethodException(name);
         }
         return m;


### PR DESCRIPTION
Have a `@ComputedRelationship` annotation that resembles the `@ComputedAttribute` except that the results of annotated field/method will show up in `relationships` section instead of `attributes` in JSON response. 