### PR TITLE
Revert total deprecating of filterCollection

### DIFF
--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.hibernate5;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.FilterScope;
-import com.yahoo.elide.core.RelationshipType;
 import com.yahoo.elide.core.exceptions.TransactionException;
 import com.yahoo.elide.core.filter.HQLFilterOperation;
 import com.yahoo.elide.core.filter.Predicate;
@@ -16,6 +15,7 @@ import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 import com.yahoo.elide.datastores.hibernate5.filter.CriteriaExplorer;
 import com.yahoo.elide.security.User;
+
 import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
@@ -264,73 +264,5 @@ public class HibernateTransaction implements DataStoreTransaction {
     @Override
     public User accessUser(Object opaqueUser) {
         return new User(opaqueUser);
-    }
-
-    @Override
-    public <T> Object getRelation(
-            Object entity,
-            RelationshipType relationshipType,
-            String relationName,
-            Class<T> relationClass,
-            EntityDictionary dictionary,
-            Set<Predicate> filters
-    ) {
-        Object val = com.yahoo.elide.core.PersistentResource.getValue(entity, relationName, dictionary);
-
-        if ((val instanceof Collection) && (val instanceof AbstractPersistentCollection) && !filters.isEmpty()) {
-            Collection filteredVal = (Collection) val;
-            String filterString = new HQLFilterOperation().applyAll(filters);
-
-            if (filterString.length() != 0) {
-                Query query = session.createFilter(filteredVal, filterString);
-
-                for (Predicate predicate : filters) {
-                    if (predicate.getOperator().isParameterized()) {
-                        query = query.setParameterList(predicate.getField(), predicate.getValues());
-                    }
-                }
-
-                filteredVal = query.list();
-            }
-            return filteredVal;
-        }
-
-        return val;
-    }
-
-    @Override
-    public <T> Object getRelationWithSortingAndPagination(
-            Object entity,
-            RelationshipType relationshipType,
-            String relationName,
-            Class<T> relationClass,
-            EntityDictionary dictionary,
-            Set<Predicate> filters,
-            Sorting sorting,
-            Pagination pagination
-    ) {
-        Object val = com.yahoo.elide.core.PersistentResource.getValue(entity, relationName, dictionary);
-
-        // sorting/pagination supported on last entity only eg /v1/author/1/books? books would be valid
-        final boolean hasSortRules = sorting.isDefaultInstance();
-        final boolean isPaginated = pagination.isDefaultInstance();
-        if ((val instanceof Collection) && (val instanceof AbstractPersistentCollection)
-                && (!filters.isEmpty() || hasSortRules || isPaginated)) {
-            Collection filteredVal = (Collection) val;
-            @SuppressWarnings("unchecked")
-            final Optional<Query> possibleQuery = new HQLTransaction
-                    .Builder<>(session, filteredVal, relationClass, dictionary)
-                    .withPossibleFilters(Optional.of(filters))
-                    .withPossibleSorting(hasSortRules ? Optional.of(sorting) : Optional.empty())
-                    .withPossiblePagination(isPaginated ? Optional.of(pagination) : Optional.empty())
-                    .build();
-            if (possibleQuery.isPresent()) {
-                filteredVal = possibleQuery.get().list();
-            }
-
-            return filteredVal;
-        }
-
-        return val;
     }
 }


### PR DESCRIPTION
Reverting https://github.com/yahoo/elide/pull/250/commits/d2fb23ee4f4db3d2b3aa78723e9d0a353d9fa7a5

We don't want to totally deprecate `filterCollection` in elide-2.0 per discussion with @aklish 