### PR TITLE
Add support for page totals and JSON-API page meta data

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/Paginate.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/Paginate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Allows pagination options to be set with querying of an entity
+ */
+@Target({TYPE})
+@Retention(RUNTIME)
+@Inherited
+public @interface Paginate {
+
+    /**
+     * Whether or not page totals can be requested
+     * @return the boolean
+     */
+    boolean countable() default true;
+
+    /**
+     * For limiting the number of entities which can be returned from a query.
+     * @return the default limit
+     */
+    int defaultLimit() default 500;
+
+    /**
+     * For setting an upper bound on the limit that can be specified as request parameter when fetching entities.
+     * @return the maximum limit
+     */
+    int maxLimit() default 10000;
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -126,6 +126,19 @@ public interface DataStoreTransaction extends Closeable {
     }
 
     /**
+     * Get total count of entity records satisfying the given filter.
+     *
+     * @param <T>         the type parameter
+     * @param entityClass the entity class
+     * @param filterScope scope for filter processing
+     * @return total matching entities
+     */
+    default <T> Long getTotalRecords(Class<T> entityClass, FilterScope filterScope) {
+        // default to no records
+        return 0L;
+    }
+
+    /**
      * Filter a collection by the Predicates in filterScope.
      *
      * @param <T>         the type parameter

--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -130,10 +130,9 @@ public interface DataStoreTransaction extends Closeable {
      *
      * @param <T>         the type parameter
      * @param entityClass the entity class
-     * @param filterScope scope for filter processing
      * @return total matching entities
      */
-    default <T> Long getTotalRecords(Class<T> entityClass, FilterScope filterScope) {
+    default <T> Long getTotalRecords(Class<T> entityClass) {
         // default to no records
         return 0L;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -327,6 +327,27 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
     }
 
     /**
+     * Gets the total number of records that could be loaded from the data store ignoring any pagination limits
+     *
+     * @param <T> the type parameter
+     * @param loadClass the load class
+     * @param requestScope the request scope
+     * @return total number of records that could be loaded
+     */
+    public static <T> Long getTotalRecords(Class<T> loadClass, RequestScope requestScope) {
+        DataStoreTransaction tx = requestScope.getTransaction();
+
+        if (shouldSkipCollection(loadClass, ReadPermission.class, requestScope)) {
+            return 0L;
+        }
+
+        FilterScope filterScope = new FilterScope(requestScope, loadClass);
+        Long totalRecords = tx.getTotalRecords(loadClass, filterScope);
+
+        return totalRecords;
+    }
+
+    /**
      * Update attribute in existing resource.
      *
      * @param fieldName the field name

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -341,10 +341,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             return 0L;
         }
 
-        FilterScope filterScope = new FilterScope(requestScope, loadClass);
-        Long totalRecords = tx.getTotalRecords(loadClass, filterScope);
-
-        return totalRecords;
+        return tx.getTotalRecords(loadClass);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/pagination/Pagination.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/pagination/Pagination.java
@@ -5,8 +5,8 @@
  */
 package com.yahoo.elide.core.pagination;
 
+import com.yahoo.elide.annotation.Paginate;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -19,19 +19,21 @@ import java.util.Map;
  * Encapsulates the pagination strategy.
  */
 
-@AllArgsConstructor
 @ToString
 public class Pagination {
 
     /**
      * Denotes the internal field names for paging.
      */
-    public enum PaginationKey { offset, limit, page }
+    public enum PaginationKey { offset, limit, page, totals }
 
     public static final int DEFAULT_PAGE_SIZE = 500;
     public static final int MAX_PAGE_SIZE = 10000;
 
-    private static final Pagination DEFAULT_PAGINATION = new Pagination(0, 0, false);
+    private static final Pagination DEFAULT_PAGINATION = new Pagination(new HashMap<>());
+
+    // For requesting total pages/records be included in the response
+    public static String PAGE_TOTALS_KEY = "page[totals]";
 
     public static final Map<String, PaginationKey> PAGE_KEYS = new HashMap<>();
     static {
@@ -39,10 +41,11 @@ public class Pagination {
         PAGE_KEYS.put("page[limit]", PaginationKey.limit);
         PAGE_KEYS.put("page[number]", PaginationKey.page);
         PAGE_KEYS.put("page[offset]", PaginationKey.offset);
+        PAGE_KEYS.put(PAGE_TOTALS_KEY, PaginationKey.totals);
     }
 
-    // For requesting total pages/records be included in the response
-    public static String PAGE_TOTAL_KEY = "page[totals]";
+    // For holding the page query parameters until they can be evaluated
+    private Map<PaginationKey, Integer> pageData;
 
     @Getter
     private int offset;
@@ -51,14 +54,19 @@ public class Pagination {
     private int limit;
 
     @Getter
-    private boolean pageTotalsRequested = false;
+    private boolean generateTotals;
+
+
+    private Pagination(Map<PaginationKey, Integer> pageData) {
+        this.pageData = pageData;
+    }
 
     /**
      * Know if this is the default instance.
      * @return The default pagination values.
      */
     public boolean isDefaultInstance() {
-        return this.offset == 0 && this.limit == 0;
+        return pageData.isEmpty();
     }
 
     /**
@@ -83,46 +91,57 @@ public class Pagination {
                 .forEach(paramEntry -> {
                     final String queryParamKey = paramEntry.getKey();
                     if (PAGE_KEYS.containsKey(queryParamKey)) {
-                        final String value = paramEntry.getValue().get(0);
-                        try {
-                            pageData.put(PAGE_KEYS.get(queryParamKey), Integer.parseInt(value, 10));
-                        } catch (ClassCastException e) {
-                            throw new InvalidValueException("page values must be integers");
+                        PaginationKey paginationKey = PAGE_KEYS.get(queryParamKey);
+                        if (queryParamKey.equals(PAGE_TOTALS_KEY)) {
+                            // page[totals] is a valueless parameter, use value of 0 just so that its presence can
+                            // be recorded in the map
+                            pageData.put(paginationKey, 0);
                         }
-                    } else if (queryParamKey.equals(PAGE_TOTAL_KEY)) {
-                        final String value = paramEntry.getValue().get(0);
-                        if (value.equals("true")) {
-                            pageTotalsRequested.setTrue();
-                        } else if (value.equals("false")) {
-                            pageTotalsRequested.setFalse();
-                        } else {
-                            throw new InvalidValueException(PAGE_TOTAL_KEY + " must be either true or false");
+                        else {
+                            final String value = paramEntry.getValue().get(0);
+                            try {
+                                int intValue = Integer.parseInt(value, 10);
+                                if (paginationKey == PaginationKey.limit && intValue <= 0) {
+                                    throw new InvalidValueException(
+                                            "page[size] and page[limit] must contain positive values.");
+                                }
+                                pageData.put(paginationKey, intValue);
+                            } catch (ClassCastException e) {
+                                throw new InvalidValueException("page values must be integers");
+                            }
                         }
                     } else if (queryParamKey.startsWith("page[")) {
                         throw new InvalidValueException("Invalid Pagination Parameter. Accepted values are page[number]"
                                 + ",page[size],page[offset],page[limit],page[totals]");
                     }
                 });
+        return new Pagination(pageData).evaluate(null);
+    }
 
-        if (pageData.isEmpty()) {
-            return DEFAULT_PAGINATION;
-        }
+    /**
+     * Evaluates the pagination variables. Uses the Paginate annotation if it has been set for the entity to be
+     * queried.
+     * @param entityClass
+     */
+    public Pagination evaluate(final Class entityClass) {
+        Paginate paginate = entityClass != null ? (Paginate) entityClass.getAnnotation(Paginate.class) : null;
 
-        boolean isPageBased = pageData.containsKey(PaginationKey.page);
-        int limit = !pageData.containsKey(PaginationKey.limit) ? DEFAULT_PAGE_SIZE : pageData.get(PaginationKey.limit);
-        if (limit < 0) {
-            throw new InvalidValueException("page[size] and page[limit] must contain positive values.");
-        }
+        int defaultLimit = paginate != null ? paginate.defaultLimit() : this.DEFAULT_PAGE_SIZE;
+        int maxLimit = paginate != null ? paginate.maxLimit() : this.MAX_PAGE_SIZE;
 
-        if (isPageBased && !pageData.containsKey(PaginationKey.offset)) {
-            int page = pageData.get(PaginationKey.page);
+        limit = pageData.containsKey(PaginationKey.limit) ? pageData.get(PaginationKey.limit) : defaultLimit;
+        limit = Math.min(maxLimit, limit);
+
+        Integer page = pageData.get(PaginationKey.page);
+        if (page != null) {
             pageData.put(PaginationKey.offset, (page > 0 ? page - 1 : 0) * limit);
         }
-        if (!pageData.containsKey(PaginationKey.offset)) {
-            pageData.put(PaginationKey.offset, 0);
-        }
-        // offset, page, limit, pageTotalsRequested
-        return new Pagination(pageData.get(PaginationKey.offset), limit, pageTotalsRequested.getValue());
+
+        offset = pageData.getOrDefault(PaginationKey.offset, 0);
+
+        generateTotals = pageData.containsKey(PaginationKey.totals) && (paginate == null || paginate.countable());
+
+        return this;
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/KeyValMap.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/KeyValMap.java
@@ -14,7 +14,7 @@ import java.util.Map;
  */
 @AllArgsConstructor
 public abstract class KeyValMap {
-    private final Map<String, Object> map;
+    protected final Map<String, Object> map;
 
     /**
      * Get an object from map.

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Meta.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Meta.java
@@ -5,20 +5,33 @@
  */
 package com.yahoo.elide.jsonapi.models;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
 import java.util.Map;
 
 /**
  * Model for representing JSON API meta information.
  */
+@JsonAutoDetect
 public class Meta extends KeyValMap {
+
     /**
      * Constructor.
      *
-     * @param meta Object containing meta information
+     * @param map Object containing meta information
      */
-    private Meta(@JsonProperty("meta") Map<String, Object> meta) {
-        super(meta);
+    public Meta(Map<String, Object> map) {
+        super(map);
+    }
+
+    /**
+     * Expose the meta map so that it will be included in the returned JSON-API document
+     *
+     * @return the meta map
+     */
+    @JsonAnyGetter
+    public Map<String, Object> getMetaMap() {
+        return map;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
@@ -81,10 +81,10 @@ public class CollectionTerminalState extends BaseState {
             pageMetaData.put("limit", pagination.getLimit());
 
             // Get total records if it has been requested and add to the page meta data
-            if (pagination.isPageTotalsRequested()) {
+            if (pagination.isGenerateTotals()) {
                 Long totalRecords = PersistentResource.getTotalRecords(entityClass, requestScope);
-                pageMetaData.put("totalPages",
-                        totalRecords / pagination.getLimit() + ((totalRecords % pagination.getLimit()) > 0 ? 1 : 0));
+                pageMetaData.put("totalPages", totalRecords / pagination.getLimit()
+                        + ((totalRecords % pagination.getLimit()) > 0 ? 1 : 0));
                 pageMetaData.put("totalRecords", totalRecords);
             }
 

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -35,6 +35,7 @@ import org.hibernate.Session;
 import org.hibernate.collection.AbstractPersistentCollection;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
 import java.io.IOException;
@@ -265,6 +266,20 @@ public class HibernateTransaction implements RequestScopedTransaction {
             return criteria.list();
         }
         return new ScrollableIterator(criteria.scroll(scrollMode));
+    }
+
+    @Override
+    public <T> Long getTotalRecords(Class<T> entityClass, FilterScope filterScope) {
+        final Criterion criterion = filterScope.getCriterion(NOT, AND, OR);
+        final CriteriaExplorer criteriaExplorer = new CriteriaExplorer(
+                entityClass, filterScope.getRequestScope(), criterion);
+        final Criteria sessionCriteria = session.createCriteria(entityClass);
+
+        criteriaExplorer.buildCriteria(sessionCriteria, session);
+
+        sessionCriteria.setProjection(Projections.rowCount());
+
+        return (Long) sessionCriteria.uniqueResult();
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -248,6 +248,7 @@ public class HibernateTransaction implements RequestScopedTransaction {
 
         if (pagination.isPresent()) {
             final Pagination paginationData = pagination.get();
+            paginationData.evaluate(loadClass);
             criteria.setFirstResult(paginationData.getOffset());
             criteria.setMaxResults(paginationData.getLimit());
         } else {
@@ -269,16 +270,9 @@ public class HibernateTransaction implements RequestScopedTransaction {
     }
 
     @Override
-    public <T> Long getTotalRecords(Class<T> entityClass, FilterScope filterScope) {
-        final Criterion criterion = filterScope.getCriterion(NOT, AND, OR);
-        final CriteriaExplorer criteriaExplorer = new CriteriaExplorer(
-                entityClass, filterScope.getRequestScope(), criterion);
+    public <T> Long getTotalRecords(Class<T> entityClass) {
         final Criteria sessionCriteria = session.createCriteria(entityClass);
-
-        criteriaExplorer.buildCriteria(sessionCriteria, session);
-
         sessionCriteria.setProjection(Projections.rowCount());
-
         return (Long) sessionCriteria.uniqueResult();
     }
 

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -221,6 +221,7 @@ public class HibernateTransaction implements DataStoreTransaction {
 
         if (pagination.isPresent()) {
             final Pagination paginationData = pagination.get();
+            paginationData.evaluate(loadClass);
             criteria.setFirstResult(paginationData.getOffset());
             criteria.setMaxResults(paginationData.getLimit());
         }
@@ -272,16 +273,9 @@ public class HibernateTransaction implements DataStoreTransaction {
     }
 
     @Override
-    public <T> Long getTotalRecords(Class<T> entityClass, FilterScope filterScope) {
-        final Criterion criterion = filterScope.getCriterion(NOT, AND, OR);
-        final CriteriaExplorer criteriaExplorer = new CriteriaExplorer(
-                entityClass, filterScope.getRequestScope(), criterion);
+    public <T> Long getTotalRecords(Class<T> entityClass) {
         final Criteria sessionCriteria = session.createCriteria(entityClass);
-
-        criteriaExplorer.buildCriteria(sessionCriteria, session);
-
         sessionCriteria.setProjection(Projections.rowCount());
-
         return (Long) sessionCriteria.uniqueResult();
     }
 

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -27,6 +27,7 @@ import org.hibernate.Session;
 import org.hibernate.collection.internal.AbstractPersistentCollection;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
@@ -268,6 +269,20 @@ public class HibernateTransaction implements DataStoreTransaction {
         }
 
         return val;
+    }
+
+    @Override
+    public <T> Long getTotalRecords(Class<T> entityClass, FilterScope filterScope) {
+        final Criterion criterion = filterScope.getCriterion(NOT, AND, OR);
+        final CriteriaExplorer criteriaExplorer = new CriteriaExplorer(
+                entityClass, filterScope.getRequestScope(), criterion);
+        final Criteria sessionCriteria = session.createCriteria(entityClass);
+
+        criteriaExplorer.buildCriteria(sessionCriteria, session);
+
+        sessionCriteria.setProjection(Projections.rowCount());
+
+        return (Long) sessionCriteria.uniqueResult();
     }
 
     @Override

--- a/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/PaginateIT.groovy
+++ b/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/PaginateIT.groovy
@@ -482,6 +482,12 @@ public class PaginateIT extends AbstractIntegrationTestInitializer {
     }
 
     @Test
+    public void testPaginateInvalidParameter() {
+        def response = RestAssured.get("/entityWithoutPaginate?page[bad]=2&page[totals]").asString();
+        Assert.assertTrue(response.contains("Invalid Pagination Parameter"), "Response should contain invalid parameter message");
+    }
+
+    @Test
     public void testPaginateAnnotationTotals() {
         def result = mapper.readTree(RestAssured.get("/entityWithoutPaginate?page[size]=2&page[totals]").asString())
         Assert.assertEquals(result.get("data").size(), 2)

--- a/elide-integration-tests/src/test/java/example/EntityWithPaginateCountableFalse.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithPaginateCountableFalse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.Paginate;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Include(rootLevel = true)
+@Paginate(countable = false)
+public class EntityWithPaginateCountableFalse {
+    @Setter
+    private Long id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long getId () {
+        return id;
+    }
+
+    @Getter
+    @Setter
+    private String name;
+}

--- a/elide-integration-tests/src/test/java/example/EntityWithPaginateDefaultLimit.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithPaginateDefaultLimit.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.Paginate;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Include(rootLevel = true)
+@Paginate(defaultLimit = 5)
+public class EntityWithPaginateDefaultLimit {
+    @Setter
+    private Long id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long getId () {
+        return id;
+    }
+
+    @Getter
+    @Setter
+    private String name;
+}

--- a/elide-integration-tests/src/test/java/example/EntityWithPaginateMaxLimit.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithPaginateMaxLimit.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.Paginate;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Include(rootLevel = true)
+@Paginate(maxLimit = 10)
+public class EntityWithPaginateMaxLimit {
+    @Setter
+    private Long id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long getId () {
+        return id;
+    }
+
+    @Getter
+    @Setter
+    private String name;
+}

--- a/elide-integration-tests/src/test/java/example/EntityWithoutPaginate.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithoutPaginate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/**
+ * Entity that does not have the Paginate annotation that modifies pagination behavior.
+ */
+@Entity
+@Include(rootLevel = true)
+public class EntityWithoutPaginate {
+    @Setter
+    private Long id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long getId () {
+        return id;
+    }
+
+    @Getter
+    @Setter
+    private String name;
+}


### PR DESCRIPTION
For enhancement proposal https://github.com/yahoo/elide/issues/264.

The page meta data will be returned in the JSON-API response if the page size/limit/number/offset query parameters have been specified.

If the query parameter "page[totals]=true" is also specified, the page totals will be determined and included in the returned page meta data.