### PR TITLE
Adding FilterExpressionCheck support. 

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -90,6 +90,10 @@ public interface DataStoreTransaction extends Closeable {
      */
     <T> T loadObject(Class<T> entityClass, Serializable id);
 
+    default <T> T loadObject(Class<T> entityClass, Serializable id, Optional<FilterExpression> filterExpression) {
+        return loadObject(entityClass, id);
+    }
+
     /**
      * Read entity records from database table.
      *
@@ -112,6 +116,7 @@ public interface DataStoreTransaction extends Closeable {
         return loadObjects(entityClass);
     }
 
+
     /**
      * Read entity records from database table with applied criteria.
      *
@@ -124,6 +129,7 @@ public interface DataStoreTransaction extends Closeable {
         // default to ignoring criteria
         return loadObjects(entityClass);
     }
+
 
     /**
      * Filter a collection by the Predicates in filterScope.

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -23,6 +23,7 @@ import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 import com.yahoo.elide.core.exceptions.InvalidObjectIdentifierException;
 import com.yahoo.elide.core.filter.Operator;
 import com.yahoo.elide.core.filter.Predicate;
+import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.PredicateExtractionVisitor;
 import com.yahoo.elide.extensions.PatchRequestScope;
@@ -256,8 +257,10 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         T obj = (T) cache.get(dictionary.getJsonAliasFor(loadClass), id);
         if (obj == null) {
             // try to load object
+            Optional<FilterExpression> permissionFilter = getPermissionFilterExpression(loadClass,
+                    requestScope);
             Class<?> idType = dictionary.getIdType(loadClass);
-            obj = tx.loadObject(loadClass, (Serializable) CoerceUtil.coerce(id, idType));
+            obj = tx.loadObject(loadClass, (Serializable) CoerceUtil.coerce(id, idType), permissionFilter);
             if (obj == null) {
                 throw new InvalidObjectIdentifierException(id, loadClass.getSimpleName());
             }
@@ -297,6 +300,23 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             requestScope.queueCommitTrigger(resource);
         }
         return resources;
+    }
+
+    /**
+     * Get a FilterExpression parsed from FilterExpressionCheck.
+     *
+     * @param <T> the type parameter
+     * @param loadClass the load class
+     * @param requestScope the request scope
+     * @return a FilterExpression defined by FilterExpressionCheck.
+     */
+    private static <T> Optional<FilterExpression> getPermissionFilterExpression(Class<T> loadClass,
+                                                                      RequestScope requestScope) {
+        try {
+            return requestScope.getPermissionExecutor().getReadPermissionFilter(loadClass);
+        } catch (ForbiddenAccessException e) {
+            return Optional.empty();
+        }
     }
 
     /**
@@ -909,6 +929,18 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                                                          Optional<FilterExpression> filterExpression) {
         RelationshipType type = getRelationshipType(relationName);
         final Class<?> relationClass = dictionary.getParameterizedType(obj, relationName);
+
+        //Invoke filterExpressionCheck and then merge with filterExpression.
+        Optional<FilterExpression> permissionFilter = getPermissionFilterExpression(relationClass, requestScope);
+        if (permissionFilter.isPresent()) {
+            if (filterExpression.isPresent()) {
+                FilterExpression mergedExpression =
+                        new AndFilterExpression(filterExpression.get(), permissionFilter.get());
+                filterExpression = Optional.of(mergedExpression);
+            } else {
+                filterExpression = permissionFilter;
+            }
+        }
 
         Object val;
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
@@ -9,9 +9,11 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.Visitor;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.ToString;
+import lombok.NonNull;
+
 
 import java.util.Collections;
 import java.util.List;
@@ -21,6 +23,7 @@ import java.util.function.Function;
  * Predicate class.
  */
 @AllArgsConstructor
+@EqualsAndHashCode
 public class Predicate implements FilterExpression, Function<EntityDictionary, java.util.function.Predicate> {
 
     /**
@@ -30,6 +33,7 @@ public class Predicate implements FilterExpression, Function<EntityDictionary, j
      */
     @AllArgsConstructor
     @ToString
+    @EqualsAndHashCode
     public static class PathElement {
         @Getter Class type;
         @Getter String typeName;

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/AndFilterExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/AndFilterExpression.java
@@ -5,11 +5,13 @@
  */
 package com.yahoo.elide.core.filter.expression;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
  * An 'And' Filter FilterExpression.
  */
+@EqualsAndHashCode
 public class AndFilterExpression implements FilterExpression {
 
     @Getter private FilterExpression left;

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/NotFilterExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/NotFilterExpression.java
@@ -5,11 +5,13 @@
  */
 package com.yahoo.elide.core.filter.expression;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
  * A 'Not' Filter FilterExpression.
  */
+@EqualsAndHashCode
 public class NotFilterExpression implements FilterExpression {
 
     @Getter private FilterExpression negated;

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/OrFilterExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/OrFilterExpression.java
@@ -6,11 +6,13 @@
 
 package com.yahoo.elide.core.filter.expression;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
  * An 'Or' Filter FilterExpression.
  */
+@EqualsAndHashCode
 public class OrFilterExpression implements FilterExpression {
 
     @Getter private FilterExpression left;

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/FilterExpressionCheckEvaluationVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/FilterExpressionCheckEvaluationVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.parsers.expression;
+
+
+import com.yahoo.elide.core.filter.Predicate;
+import com.yahoo.elide.core.filter.expression.AndFilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.expression.NotFilterExpression;
+import com.yahoo.elide.core.filter.expression.OrFilterExpression;
+import com.yahoo.elide.core.filter.expression.Visitor;
+import com.yahoo.elide.security.FilterExpressionCheck;
+import com.yahoo.elide.security.RequestScope;
+
+/**
+ * FilterExpressionCheckEvaluationVisitor evaluate a check against fields of a returning object from datastore.
+ */
+
+public class FilterExpressionCheckEvaluationVisitor implements Visitor<Boolean> {
+    private final Object object;
+    private final FilterExpressionCheck filterExpressionCheck;
+    private final RequestScope requestScope;
+    public FilterExpressionCheckEvaluationVisitor(Object object,
+                                                  FilterExpressionCheck filterExpressionCheck,
+                                                  RequestScope requestScope) {
+        this.object = object;
+        this.filterExpressionCheck = filterExpressionCheck;
+        this.requestScope = requestScope;
+    }
+
+    @Override
+    public Boolean visitPredicate(Predicate predicate) {
+        return filterExpressionCheck.applyPredicateToObject(object, predicate, requestScope);
+    }
+
+    @Override
+    public Boolean visitAndExpression(AndFilterExpression expression) {
+        FilterExpression left = expression.getLeft();
+        FilterExpression right = expression.getRight();
+        return left.accept(this) && right.accept(this);
+    }
+
+    @Override
+    public Boolean visitOrExpression(OrFilterExpression expression) {
+        FilterExpression left = expression.getLeft();
+        FilterExpression right = expression.getRight();
+        return left.accept(this) || right.accept(this);
+    }
+
+    @Override
+    public Boolean visitNotExpression(NotFilterExpression expression) {
+        FilterExpression negation = expression.getNegated();
+        return !negation.accept(this);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.parsers.expression;
+
+import com.yahoo.elide.core.CheckInstantiator;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.expression.AndFilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.expression.OrFilterExpression;
+import com.yahoo.elide.core.filter.expression.Visitor;
+import com.yahoo.elide.generated.parsers.ExpressionBaseVisitor;
+import com.yahoo.elide.generated.parsers.ExpressionParser;
+import com.yahoo.elide.security.FilterExpressionCheck;
+import com.yahoo.elide.security.RequestScope;
+import com.yahoo.elide.security.checks.Check;
+import com.yahoo.elide.security.checks.UserCheck;
+
+
+/**
+ * PermissionToFilterExpressionVisitor parses a permission parseTree and returns the corresponding FilterExpression
+ * representation of it. This allows passing a security permission predicate down to datastore level to reduce
+ * in-memory permission verification workload.
+ * A few cases is not allow and will throw exception:
+ *      1. User define FilterExpressionCheck which returns null in getFilterExpression function.
+ *      2. User put a FilterExpressionCheck with a non-userCheck type check in OR relation.
+ */
+public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<FilterExpression>
+        implements CheckInstantiator {
+    private final EntityDictionary dictionary;
+    private final RequestScope requestScope;
+
+    public static final FilterExpression NO_EVALUATION_EXPRESSION = new FilterExpression() {
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return null;
+        }
+    };
+    public static final FilterExpression USER_CHECK_EXPRESSION = new FilterExpression() {
+        @Override
+        public <T> T accept(Visitor<T> visitor) {
+            return null;
+        }
+    };
+
+    public PermissionToFilterExpressionVisitor(EntityDictionary dictionary, RequestScope requestScope) {
+        this.dictionary = dictionary;
+        this.requestScope = requestScope;
+    }
+
+    @Override
+    public FilterExpression visitOR(ExpressionParser.ORContext ctx) {
+        FilterExpression left = visit(ctx.left);
+        FilterExpression right = visit(ctx.right);
+
+        if (left == NO_EVALUATION_EXPRESSION || right == NO_EVALUATION_EXPRESSION) {
+            return NO_EVALUATION_EXPRESSION;
+        }
+
+        //This special case require future reconsideration.
+        if (left == USER_CHECK_EXPRESSION || right == USER_CHECK_EXPRESSION) {
+            return USER_CHECK_EXPRESSION;
+        }
+
+        return new OrFilterExpression(left, right);
+    }
+
+    @Override
+    public FilterExpression visitPermissionClass(ExpressionParser.PermissionClassContext ctx) {
+        Check check = getCheck(dictionary, ctx.getText());
+        if (FilterExpressionCheck.class.isAssignableFrom(check.getClass())) {
+            FilterExpression filterExpression = ((FilterExpressionCheck) check).getFilterExpression(requestScope);
+            if (filterExpression == null) {
+                throw new IllegalStateException("FilterExpression null is not permitted.");
+            }
+            return ((FilterExpressionCheck) check).getFilterExpression(requestScope);
+        } else if (UserCheck.class.isAssignableFrom(check.getClass())) {
+            return USER_CHECK_EXPRESSION;
+        } else {
+            return NO_EVALUATION_EXPRESSION;
+        }
+    }
+
+    @Override
+    public FilterExpression visitAND(ExpressionParser.ANDContext ctx) {
+        FilterExpression left = visit(ctx.left);
+        FilterExpression right = visit(ctx.right);
+
+        // (NO_EVA and UserCheck) should return NO_EVA let the upper level know.
+        // For example, FilterExpressionCheck Or (NO_EVA and UserCheck) should evaluate to  NO_EVALUATION_EXPRESSION.
+        if (left == NO_EVALUATION_EXPRESSION && right == USER_CHECK_EXPRESSION) {
+            return left;
+        }
+
+        if (right == NO_EVALUATION_EXPRESSION && left == USER_CHECK_EXPRESSION) {
+            return right;
+        }
+
+        if (left == NO_EVALUATION_EXPRESSION || left == USER_CHECK_EXPRESSION) {
+            return right;
+        }
+
+        if (right == NO_EVALUATION_EXPRESSION || right == USER_CHECK_EXPRESSION) {
+            return left;
+        }
+        return new AndFilterExpression(left, right);
+    }
+
+    @Override
+    public FilterExpression visitPAREN(ExpressionParser.PARENContext ctx) {
+        return visit(ctx.expression());
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.security;
+
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.Predicate;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.parsers.expression.FilterExpressionCheckEvaluationVisitor;
+import com.yahoo.elide.security.checks.InlineCheck;
+
+import java.util.Optional;
+
+/**
+ * Check for FilterExpression. This is a super class for user defined FilterExpression check. The subclass should
+ * override getFilterExpression function and return a FilterExpression which will be passed down to datastore.
+ * @param <T> Type of class
+ */
+public abstract class FilterExpressionCheck<T> extends InlineCheck<T> {
+
+    /**
+     * Returns a FilterExpression from FilterExpressionCheck.
+     * @param requestScope Request scope object
+     * @return FilterExpression for FilterExpressionCheck.
+     */
+    public abstract FilterExpression getFilterExpression(RequestScope requestScope);
+
+
+    /**
+     * The filter expression is evaluated in memory if it cannot be pushed to the data store by elide for any reason.
+     * @param object object returned from datastore
+     * @param requestScope Request scope object
+     * @param changeSpec Summary of modifications
+     * @return true if the object pass evaluation against FilterExpression.
+     */
+    @Override
+    public final boolean ok(T object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+        FilterExpression filterExpression = getFilterExpression(requestScope);
+        return filterExpression.accept(new FilterExpressionCheckEvaluationVisitor(object, this, requestScope));
+    }
+
+    /**
+     *
+     * @param object object returned from datastore
+     * @param predicate A predicate from filterExpressionCheck
+     * @param requestScope Request scope object
+     * @return true if the object pass evaluation against Predicate.
+     */
+    public boolean applyPredicateToObject(T object, Predicate predicate, RequestScope requestScope) {
+        Predicate.PathElement path = predicate.getPath().get(predicate.getPath().size() - 1);
+        Class type = path.getType();
+        String fieldName = path.getFieldName();
+        if (fieldName == null) {
+            return false;
+        }
+        EntityDictionary dictionary = ((com.yahoo.elide.core.RequestScope) requestScope).getDictionary();
+        java.util.function.Predicate fn = predicate.getOperator()
+                .contextualize(fieldName, predicate.getValues(), dictionary);
+        return fn.test(object);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/security/PermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/PermissionExecutor.java
@@ -5,9 +5,11 @@
  */
 package com.yahoo.elide.security;
 
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -94,6 +96,8 @@ public interface PermissionExecutor {
      * @param <A> type parameter
      */
     <A extends Annotation> void checkUserPermissions(Class<?> resourceClass, Class<A> annotationClass);
+
+    Optional<FilterExpression> getReadPermissionFilter(Class<?> resourceClass);
 
     /**
      * Execute commmit checks.

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/BypassPermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/BypassPermissionExecutor.java
@@ -5,11 +5,13 @@
  */
 package com.yahoo.elide.security.executors;
 
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.PermissionExecutor;
 import com.yahoo.elide.security.PersistentResource;
 
 import java.lang.annotation.Annotation;
+import java.util.Optional;
 
 /**
  * Permission executor intended to bypass all security checks. I.e. this is effectively a no-op.
@@ -52,6 +54,11 @@ public class BypassPermissionExecutor implements PermissionExecutor {
     public <A extends Annotation> void checkUserPermissions(Class<?> resourceClass,
                                                             Class<A> annotationClass) {
 
+    }
+
+    @Override
+    public Optional<FilterExpression> getReadPermissionFilter(Class<?> resourceClass) {
+        return Optional.empty();
     }
 
     @Override

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
@@ -94,7 +95,7 @@ public class LifeCycleTest {
         Elide elide = builder.build();
 
         when(store.beginReadTransaction()).thenReturn(tx);
-        when(tx.loadObject(Book.class, new Long(1))).thenReturn(book);
+        when(tx.loadObject(eq(Book.class), eq(1L), anyObject())).thenReturn(book);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         elide.get("/book/1", headers, null);
@@ -118,7 +119,7 @@ public class LifeCycleTest {
 
         when(book.getId()).thenReturn(new Long(1));
         when(store.beginTransaction()).thenReturn(tx);
-        when(tx.loadObject(Book.class, new Long(1))).thenReturn(book);
+        when(tx.loadObject(eq(Book.class), eq(1L), anyObject())).thenReturn(book);
 
         String bookBody = "{\"data\":{\"type\":\"book\",\"id\":1,\"attributes\": {\"title\":\"Grapes of Wrath\"}}}";
 
@@ -146,7 +147,7 @@ public class LifeCycleTest {
 
         when(book.getId()).thenReturn(new Long(1));
         when(store.beginTransaction()).thenReturn(tx);
-        when(tx.loadObject(Book.class, new Long(1))).thenReturn(book);
+        when(tx.loadObject(eq(Book.class), eq(1L), anyObject())).thenReturn(book);
 
         elide.delete("/book/1", "", null);
         verify(tx).accessUser(null);
@@ -193,7 +194,7 @@ public class LifeCycleTest {
     public void loadRecordOnCommit() {
         Book book = mock(Book.class);
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
-        when(tx.loadObject(Book.class, 1L)).thenReturn(book);
+        when(tx.loadObject(eq(Book.class), eq(1L), anyObject())).thenReturn(book);
         RequestScope scope = new RequestScope(null, null, tx, new User(1), dictionary, null, MOCK_AUDIT_LOGGER);
         PersistentResource resource = PersistentResource.loadRecord(Book.class, "1", scope);
         scope.runCommitTriggers();

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.parsers.expression;
+
+import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.NO_EVALUATION_EXPRESSION;
+import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.USER_CHECK_EXPRESSION;
+
+import com.yahoo.elide.annotation.*;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.Predicate;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.expression.OrFilterExpression;
+import com.yahoo.elide.security.*;
+import com.yahoo.elide.security.checks.Check;
+import com.yahoo.elide.security.checks.OperationCheck;
+import com.yahoo.elide.security.checks.UserCheck;
+import com.yahoo.elide.security.checks.prefab.Role;
+import com.yahoo.elide.security.permissions.ExpressionResult;
+import com.yahoo.elide.security.permissions.expressions.Expression;
+import lombok.AllArgsConstructor;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.persistence.*;
+import java.lang.annotation.Annotation;
+import java.util.*;
+
+public class PermissionToFilterExpressionVisitorTest {
+    private EntityDictionary dictionary;
+    private RequestScope requestScope;
+
+    @BeforeMethod
+    public void setupEntityDictionary() {
+        Map<String, Class<? extends Check>> checks = new HashMap<>();
+        checks.put("Allow", Permissions.Succeeds.class);
+        checks.put("Deny", Permissions.Fails.class);
+        checks.put("user has all access", Role.ALL.class);
+        checks.put("owner is user", FilterExpressionCheck1.class);
+        checks.put("user has no access", Role.NONE.class);
+
+        dictionary = new EntityDictionary(checks);
+        dictionary.bindEntity(Model.class);
+        dictionary.bindEntity(ComplexEntity.class);
+        dictionary.bindEntity(Good1.class);
+        dictionary.bindEntity(Good2.class);
+        dictionary.bindEntity(Good3.class);
+        dictionary.bindEntity(Good4.class);
+        dictionary.bindEntity(Good5.class);
+        dictionary.bindEntity(Good6.class);
+        dictionary.bindEntity(Good7.class);
+        dictionary.bindEntity(GOOD8.class);
+        dictionary.bindEntity(BAD1.class);
+        dictionary.bindEntity(BAD2.class);
+        dictionary.bindEntity(BAD4.class);
+        dictionary.bindEntity(GOOD9.class);
+        dictionary.bindEntity(GOOD10.class);
+        requestScope = newRequestScope();
+    }
+
+    @Test
+    public void testParseCombinationExpression() {
+        ParseTree g1 = dictionary.getPermissionsForClass(Good1.class, ReadPermission.class);
+        ParseTree g2 = dictionary.getPermissionsForClass(Good2.class, ReadPermission.class);
+        ParseTree g3 = dictionary.getPermissionsForClass(Good3.class, ReadPermission.class);
+        ParseTree g4 = dictionary.getPermissionsForClass(Good4.class, ReadPermission.class);
+        ParseTree g5 = dictionary.getPermissionsForClass(Good5.class, ReadPermission.class);
+        ParseTree g6 = dictionary.getPermissionsForClass(Good6.class, ReadPermission.class);
+        ParseTree g7 = dictionary.getPermissionsForClass(Good7.class, ReadPermission.class);
+        ParseTree g8 = dictionary.getPermissionsForClass(GOOD8.class, ReadPermission.class);
+        ParseTree b1 = dictionary.getPermissionsForClass(BAD1.class, ReadPermission.class);
+        ParseTree b2 = dictionary.getPermissionsForClass(BAD2.class, ReadPermission.class);
+        ParseTree b4 = dictionary.getPermissionsForClass(BAD4.class, ReadPermission.class);
+        ParseTree g9 = dictionary.getPermissionsForClass(GOOD9.class, ReadPermission.class);
+        ParseTree g10 = dictionary.getPermissionsForClass(GOOD10.class, ReadPermission.class);
+        PermissionToFilterExpressionVisitor fev = new PermissionToFilterExpressionVisitor(dictionary, requestScope);
+        FilterExpression expected = createDummyPredicate();
+        FilterExpression feg1 = fev.visit(g1);
+        Assert.assertEquals(expected, feg1);
+        FilterExpression feg2 = fev.visit(g2);
+        Assert.assertTrue(feg2 == USER_CHECK_EXPRESSION);
+        //Assert.assertEquals(expected, feg2);
+        FilterExpression feg3 = fev.visit(g3);
+        Assert.assertTrue(feg3 == USER_CHECK_EXPRESSION);
+        FilterExpression feg4 = fev.visit(g4);
+        Assert.assertEquals(new OrFilterExpression(expected, expected), feg4);
+        FilterExpression feg5 = fev.visit(g5);
+        Assert.assertTrue(feg5 == USER_CHECK_EXPRESSION);
+        FilterExpression feg6 = fev.visit(g6);
+        Assert.assertEquals(new OrFilterExpression(expected, expected), feg6);
+        FilterExpression feg7 = fev.visit(g7);
+        Assert.assertTrue(feg7 == NO_EVALUATION_EXPRESSION);
+        FilterExpression feg8 = fev.visit(g8);
+        Assert.assertTrue(feg8 == USER_CHECK_EXPRESSION);
+        FilterExpression feb2 = fev.visit(b2);
+        Assert.assertTrue(feb2 == NO_EVALUATION_EXPRESSION || feb2 == USER_CHECK_EXPRESSION);
+        FilterExpression feb4 = fev.visit(b4);
+        Assert.assertTrue(feb4 == NO_EVALUATION_EXPRESSION || feb4 == USER_CHECK_EXPRESSION);
+        FilterExpression feg9 = fev.visit(g9);
+        Assert.assertTrue(feg9 == NO_EVALUATION_EXPRESSION || feg9 == USER_CHECK_EXPRESSION);
+        FilterExpression feg10 = fev.visit(g10);
+        Assert.assertTrue(feg10 == NO_EVALUATION_EXPRESSION || feg10 == USER_CHECK_EXPRESSION);
+    }
+
+    @Test
+    public void testAndExpression() {
+        Expression expression = getExpressionForPermission(ReadPermission.class);
+        Assert.assertEquals(expression.evaluate(), ExpressionResult.PASS);
+    }
+
+    @Test
+    public void testOrExpression() {
+        Expression expression = getExpressionForPermission(UpdatePermission.class);
+        Assert.assertEquals(expression.evaluate(), ExpressionResult.PASS);
+    }
+
+    @Test
+    public void testNotExpression() {
+        Expression expression = getExpressionForPermission(DeletePermission.class);
+        Assert.assertEquals(expression.evaluate(), ExpressionResult.PASS);
+    }
+
+    @Test
+    public void testComplexExpression() {
+        Expression expression = getExpressionForPermission(UpdatePermission.class);
+        Assert.assertEquals(expression.evaluate(), ExpressionResult.PASS);
+    }
+
+    @Test
+    public void testComplexModelCreate() {
+        Expression expression = getExpressionForPermission(CreatePermission.class, ComplexEntity.class);
+        Assert.assertEquals(expression.evaluate(), ExpressionResult.PASS);
+    }
+
+    @Test
+    public void testNamesWithSpaces() {
+        Expression expression = getExpressionForPermission(DeletePermission.class, ComplexEntity.class);
+        Expression expression2 = getExpressionForPermission(UpdatePermission.class, ComplexEntity.class);
+        Assert.assertEquals(expression.evaluate(), ExpressionResult.PASS);
+        Assert.assertEquals(expression2.evaluate(), ExpressionResult.PASS);
+    }
+
+    private Expression getExpressionForPermission(Class<? extends Annotation> permission) {
+        return getExpressionForPermission(permission, Model.class);
+    }
+
+    private Expression getExpressionForPermission(Class<? extends Annotation> permission, Class model) {
+        PermissionExpressionVisitor v = new PermissionExpressionVisitor(dictionary, DummyExpression::new);
+        ParseTree permissions = dictionary.getPermissionsForClass(model, permission);
+
+        return v.visit(permissions);
+    }
+
+    public RequestScope newRequestScope() {
+        User john = new User("John");
+        return requestScope = new com.yahoo.elide.core.RequestScope(null, null, null, john, dictionary, null, null);
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "user has all access AND Allow")
+    @UpdatePermission(expression = "Allow or Deny")
+    @DeletePermission(expression = "Not Deny")
+    @CreatePermission(expression = "not Allow or not (Deny and Allow)")
+    static class Model {
+    }
+
+    public static class Permissions {
+        public static class Succeeds extends OperationCheck<Model> {
+            @Override
+            public boolean ok(Model object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+                return true;
+            }
+        }
+
+        public static class Fails extends OperationCheck<Model> {
+            @Override
+            public boolean ok(Model object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+                return false;
+            }
+        }
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR (user has all access OR Allow)")
+    @CreatePermission(expression = "(Deny or Allow) and (not Deny)")
+    @DeletePermission(expression = "user has all access or user has no access")
+    @UpdatePermission(expression = "user has all access and (user has no access or user has all access)")
+    static class ComplexEntity {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user AND Allow")
+    static class Good1 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR user has all access")
+    static class Good2 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR (user has all access AND user has all access)")
+    static class Good3 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR (owner is user AND user has all access)")
+    static class Good4 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR (owner is user OR user has all access)")
+    static class Good5 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "Allow AND (owner is user OR owner is user)")
+    static class Good6 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "Allow")
+    static class Good7 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR (Allow OR user has all access)")
+    static class BAD1 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR (Allow AND user has all access)")
+    static class BAD2 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "owner is user OR (Allow OR owner is user)")
+    static class BAD4 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "user has all access OR (Allow AND user has all access)")
+    static class GOOD9 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "user has all access AND (Allow OR user has all access)")
+    static class GOOD10 {
+    }
+
+    @Entity
+    @Include
+    @ReadPermission(expression = "user has all access AND (user has all access OR user has all access)")
+    static class GOOD8 {
+    }
+
+    @Entity
+    @Include(rootLevel = true)
+    @ReadPermission(expression = "owner is user AND user has all access")
+    @CreatePermission(expression = "(Deny or Allow) and (not Deny)")
+    @DeletePermission(expression = "user has all access or user has no access")
+    @UpdatePermission(expression = "user has all access and (user has no access or user has all access)")
+    public class Author {
+        private long id;
+        private String name;
+        private Collection<Book> books = new ArrayList<>();
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @ManyToMany(mappedBy = "authors")
+        public Collection<Book> getBooks() {
+            return books;
+        }
+
+        public void setBooks(Collection<Book> books) {
+            this.books = books;
+        }
+    }
+
+    @Entity
+    @Include(rootLevel = true)
+    @ReadPermission(expression = "owner is user AND user has all access")
+    @CreatePermission(expression = "(Deny or Allow) and (not Deny)")
+    @DeletePermission(expression = "user has all access or user has no access")
+    @UpdatePermission(expression = "user has all access and (user has no access or user has all access)")
+    public class Book {
+        private long id;
+        private String title;
+        private String genre;
+        private String language;
+        private Collection<Author> authors = new ArrayList<>();
+
+        @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getGenre() {
+            return genre;
+        }
+
+        public void setGenre(String genre) {
+            this.genre = genre;
+        }
+
+        public String getLanguage() {
+            return language;
+        }
+
+        public void setLanguage(String language) {
+            this.language = language;
+        }
+
+        @ManyToMany
+        public Collection<Author> getAuthors() {
+            return authors;
+        }
+
+        public void setAuthors(Collection<Author> authors) {
+            this.authors = authors;
+        }
+    }
+
+    @AllArgsConstructor
+    public static class DummyExpression implements Expression {
+        Check check;
+
+        @Override
+        public ExpressionResult evaluate() {
+            boolean result;
+            if (check instanceof UserCheck) {
+                result = ((UserCheck) check).ok(null);
+            } else {
+                result = check.ok(null, null, null);
+            }
+
+            if (result) {
+                return ExpressionResult.PASS;
+            } else {
+                return ExpressionResult.FAIL;
+            }
+        }
+    }
+
+    public static Predicate createDummyPredicate() {
+        List<Predicate.PathElement> pathList = new ArrayList<>();
+        Predicate.PathElement path1 = new Predicate.PathElement(Author.class, "Author", Book.class, "books");
+        Predicate.PathElement path2 = new Predicate.PathElement(Book.class, "Book", String.class, "title");
+        pathList.add(path1);
+        pathList.add(path2);
+        Operator op = Operator.IN;
+        List<Object> value = new ArrayList<>();
+        value.add("Harry Potter");
+        return new Predicate(pathList, op, value);
+    }
+
+    public static class FilterExpressionCheck1 extends FilterExpressionCheck {
+
+        @Override
+        public Predicate getFilterExpression(RequestScope requestScope) {
+            return createDummyPredicate();
+        }
+
+        @Override
+        public boolean ok(User user) {
+            return true;
+        }
+
+        public FilterExpressionCheck1() {
+
+        }
+    }
+}

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -162,6 +162,32 @@ public class HibernateTransaction implements RequestScopedTransaction {
         }
     }
 
+    /**
+     * load a single record with id and filter.
+     *
+     * @param loadClass class of query object
+     * @param id id of the query object
+     * @param filterExpression FilterExpression contains the predicates
+     */
+    @Override
+    public <T> T loadObject(Class<T> loadClass, Serializable id, Optional<FilterExpression> filterExpression) {
+
+        try {
+            Criteria criteria = session.createCriteria(loadClass).add(Restrictions.idEq(id));
+            if (requestScope != null && isJoinQuery()) {
+                joinCriteria(criteria, loadClass);
+            }
+            if (filterExpression.isPresent()) {
+                CriterionFilterOperation filterOpn = new CriterionFilterOperation(criteria);
+                criteria = filterOpn.apply(filterExpression.get());
+            }
+            T record = (T) criteria.uniqueResult();
+            return record;
+        } catch (ObjectNotFoundException e) {
+            return null;
+        }
+    }
+
     @Deprecated
     @Override
     public <T> Iterable<T> loadObjects(Class<T> loadClass) {
@@ -172,7 +198,8 @@ public class HibernateTransaction implements RequestScopedTransaction {
     public <T> Iterable<T> loadObjects(Class<T> loadClass, FilterScope filterScope) {
         Criterion securityCriterion = filterScope.getCriterion(NOT, AND, OR);
 
-        Optional<FilterExpression> filterExpression = filterScope.getRequestScope().getLoadFilterExpression(loadClass);
+        Optional<FilterExpression> filterExpression =
+                filterScope.getRequestScope().getLoadFilterExpression(loadClass);
 
         Criteria criteria = session.createCriteria(loadClass);
         if (securityCriterion != null) {
@@ -188,7 +215,8 @@ public class HibernateTransaction implements RequestScopedTransaction {
     }
 
     @Override
-    public <T> Iterable<T> loadObjectsWithSortingAndPagination(Class<T> entityClass, FilterScope filterScope) {
+    public <T> Iterable<T> loadObjectsWithSortingAndPagination(Class<T> entityClass,
+                                                               FilterScope filterScope) {
         Criterion securityCriterion = filterScope.getCriterion(NOT, AND, OR);
 
         Optional<FilterExpression> filterExpression =

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -122,6 +122,29 @@ public class HibernateTransaction implements DataStoreTransaction {
         }
     }
 
+    /**
+     * load a single record with id and filter.
+     *
+     * @param loadClass class of query object
+     * @param id id of the query object
+     * @param filterExpression FilterExpression contains the predicates
+     */
+    @Override
+    public <T> T loadObject(Class<T> loadClass, Serializable id,  Optional<FilterExpression> filterExpression) {
+
+        try {
+            Criteria criteria = session.createCriteria(loadClass).add(Restrictions.idEq(id));
+            if (filterExpression.isPresent()) {
+                CriterionFilterOperation filterOpn = new CriterionFilterOperation(criteria);
+                criteria = filterOpn.apply(filterExpression.get());
+            }
+            T record = (T) criteria.uniqueResult();
+            return record;
+        } catch (ObjectNotFoundException e) {
+            return null;
+        }
+    }
+
     @Override
     public <T> T loadObject(Class<T> loadClass, Serializable id) {
         try {

--- a/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.SharePermission;
+import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.Predicate;
+import com.yahoo.elide.security.*;
+import com.yahoo.elide.security.checks.prefab.Role;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Model for anotherFilterExpressionCheckObj.
+ */
+@Entity
+@SharePermission(any = {Role.ALL.class})
+@Table(name = "anotherFilterExpressionCheckObj")
+@ReadPermission(any = {AnotherFilterExpressionCheckObj.CheckActsLikeFilter.class})
+@Include(rootLevel = true)
+public class AnotherFilterExpressionCheckObj {
+    private long id;
+    private String anotherName;
+    private long createDate = 0;
+
+    private Collection<FilterExpressionCheckObj> linkToParent = new ArrayList<>();
+
+    @ManyToMany
+    public Collection<FilterExpressionCheckObj> getLinkToParent() {
+        return linkToParent;
+    }
+
+    public void setLinkToParent(Collection<FilterExpressionCheckObj> linkToParent) {
+        this.linkToParent = linkToParent;
+    }
+
+    public String getAnotherName() {
+        return anotherName;
+    }
+
+    public void setAnotherName(String anotherName) {
+        this.anotherName = anotherName;
+    }
+
+    public long getCreateDate() {
+        return createDate;
+    }
+
+    public void setCreateDate(long createDate) {
+        this.createDate = createDate;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public static Predicate createFilterPredicate() {
+        List<Predicate.PathElement> pathList = new ArrayList<>();
+        Predicate.PathElement path1 = new Predicate.PathElement(AnotherFilterExpressionCheckObj.class,
+                "anotherFilterExpressionCheckObj",
+                long.class, "createDate");
+        pathList.add(path1);
+        Operator op = Operator.IN;
+        List<Object> value = new ArrayList<>();
+        value.add(1999L);
+        return new Predicate(pathList, op, value);
+    }
+
+    public static class CheckActsLikeFilter extends FilterExpressionCheck {
+
+        @Override
+        public Predicate getFilterExpression(RequestScope requestScope) {
+            return createFilterPredicate();
+        }
+
+        @Override
+        public boolean ok(com.yahoo.elide.security.User user) {
+            return true;
+        }
+
+        public CheckActsLikeFilter() {
+
+        }
+    }
+}

--- a/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.SharePermission;
+import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.Predicate;
+import com.yahoo.elide.security.*;
+import com.yahoo.elide.security.checks.prefab.Role;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Model for filterExpressionCheckObj.
+ */
+@Entity
+@Table(name = "filterExpressionCheckObj")
+@Include(rootLevel = true)
+@SharePermission(any = {Role.ALL.class})
+@ReadPermission(any = {FilterExpressionCheckObj.CheckLE.class})  //ReadPermission for object id <= 2
+public class FilterExpressionCheckObj {
+    private long id;
+    private String name;
+
+    private Collection<AnotherFilterExpressionCheckObj> listOfAnotherObjs = new ArrayList<>();
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    //This field only display for id == User.id (which is 1 in IT)
+    @ReadPermission(all = {CheckRestrictUser.class})
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @ManyToMany(mappedBy = "linkToParent")
+    public Collection<AnotherFilterExpressionCheckObj> getListOfAnotherObjs() {
+        return listOfAnotherObjs;
+    }
+
+    public void setListOfAnotherObjs(Collection<AnotherFilterExpressionCheckObj> listOfAnotherObjs) {
+        this.listOfAnotherObjs = listOfAnotherObjs;
+    }
+
+    //Predicate that restrict resource's id to be the same as cuurent User's id.
+    public static Predicate createUserPredicate(RequestScope requestScope, boolean setUserId, long setId) {
+        List<Predicate.PathElement> pathList = new ArrayList<>();
+        Predicate.PathElement path1 = new Predicate.PathElement(FilterExpressionCheckObj.class, "filterExpressionCheckObj", long.class, "id");
+        pathList.add(path1);
+        Operator op = Operator.IN;
+        List<Object> value = new ArrayList<>();
+        int userId = (int) requestScope.getUser().getOpaqueUser();
+        if (setUserId) {
+            value.add(setId);
+        } else {
+            value.add((long) userId);
+        }
+        return new Predicate(pathList, op, value);
+    }
+
+    public static class CheckRestrictUser extends FilterExpressionCheck {
+
+        @Override
+        public Predicate getFilterExpression(RequestScope requestScope) {
+            return createUserPredicate(requestScope, false, 1L);
+        }
+
+        @Override
+        public boolean ok(com.yahoo.elide.security.User user) {
+            return true;
+        }
+
+        public CheckRestrictUser() {
+
+        }
+    }
+
+    public static class CheckLE extends FilterExpressionCheck {
+
+        @Override
+        public Predicate getFilterExpression(RequestScope requestScope) {
+            List<Predicate.PathElement> pathList = new ArrayList<>();
+            Predicate.PathElement path1 = new Predicate.PathElement(FilterExpressionCheckObj.class, "filterExpressionCheckObj", long.class, "id");
+            pathList.add(path1);
+            Operator op = Operator.LE;
+            List<Object> value = new ArrayList<>();
+            value.add((long) 2);
+            return new Predicate(pathList, op, value);
+        }
+
+        @Override
+        public boolean ok(com.yahoo.elide.security.User user) {
+            return true;
+        }
+
+        public CheckLE() {
+
+        }
+    }
+}

--- a/elide-integration-tests/src/test/resources/ResourceIT/createAnotherFilterExpressionCheckObj.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/createAnotherFilterExpressionCheckObj.json
@@ -1,0 +1,18 @@
+{
+    "data":{
+        "type":"anotherFilterExpressionCheckObj",
+        "id":"1",
+        "attributes":{
+            "anotherName":"anotherObj1",
+            "createDate":"1999"
+        },
+        "relationships": {
+            "linkToParent": {
+                "data": {
+                    "type": "filterExpressionCheckObj",
+                    "id": "1"
+                }
+            }
+        }
+    }
+}

--- a/elide-integration-tests/src/test/resources/ResourceIT/createFilterExpressionCheckObj.1.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/createFilterExpressionCheckObj.1.json
@@ -1,0 +1,9 @@
+{
+    "data":{
+        "type":"filterExpressionCheckObj",
+        "id":"1",
+        "attributes":{
+            "name":"obj1"
+        }
+    }
+}

--- a/elide-integration-tests/src/test/resources/ResourceIT/createFilterExpressionCheckObj.2.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/createFilterExpressionCheckObj.2.json
@@ -1,0 +1,9 @@
+{
+    "data":{
+        "type":"filterExpressionCheckObj",
+        "id":"2",
+        "attributes":{
+            "name":"obj2"
+        }
+    }
+}

--- a/elide-integration-tests/src/test/resources/ResourceIT/createFilterExpressionCheckObj.3.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/createFilterExpressionCheckObj.3.json
@@ -1,0 +1,9 @@
+{
+    "data":{
+        "type":"filterExpressionCheckObj",
+        "id":"3",
+        "attributes":{
+            "name":"obj3"
+        }
+    }
+}


### PR DESCRIPTION
This PR allows merging permission restriction(especially ReadPermission)  to `FilterExpression` which transfer the workload of checking permission from elide layer to datastore layer. 

Finished: implemented the corresponding check interface and AST visitor. 
                integrating the check in datastore query building process. 