### PR TITLE
Default loadObjectsWithSortingAndPagination calls correct loadObjects

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -97,6 +97,7 @@ public interface DataStoreTransaction extends Closeable {
      * @param entityClass the entity class
      * @return records iterable
      */
+    @Deprecated
     <T> Iterable<T> loadObjects(Class<T> entityClass);
 
     /**
@@ -121,8 +122,7 @@ public interface DataStoreTransaction extends Closeable {
      * @return records iterable
      */
     default <T> Iterable<T> loadObjectsWithSortingAndPagination(Class<T> entityClass, FilterScope filterScope) {
-        // default to ignoring criteria
-        return loadObjects(entityClass);
+        return loadObjects(entityClass, filterScope);
     }
 
     /**

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
@@ -185,4 +185,17 @@ public abstract class MultiplexTransaction implements DataStoreTransaction {
         return transaction.getRelationWithSortingAndPagination(entity, relationshipType, relationName,
                 relationClass, dictionary, filters, sorting, pagination);
     }
+
+    @Override
+    public <T> Iterable<T> loadObjectsWithSortingAndPagination(Class<T> entityClass, FilterScope filterScope) {
+        return getTransaction(entityClass).loadObjectsWithSortingAndPagination(entityClass, filterScope);
+    }
+
+    @Override
+    public <T> Collection filterCollectionWithSortingAndPagination(Collection collection, Class<T> entityClass,
+            EntityDictionary dictionary, Optional<Set<Predicate>> filters, Optional<Sorting> sorting,
+            Optional<Pagination> pagination) {
+        return getTransaction(entityClass).filterCollectionWithSortingAndPagination(
+                collection, entityClass, dictionary, filters, sorting, pagination);
+    }
 }

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
@@ -178,6 +178,7 @@ public class MultiplexWriteTransaction extends MultiplexTransaction {
     }
 
     @Override
+    @Deprecated
     public <T> Iterable<T> loadObjects(Class<T> loadClass) {
         DataStoreTransaction transaction = getTransaction(loadClass);
         return hold(transaction, transaction.loadObjects(loadClass));


### PR DESCRIPTION
When pagination was called the filter was lost in Multiplex transactions.