### PR TITLE
Cache User permission result to avoid duplicate evaluations

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/ImmediateCheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/ImmediateCheckExpression.java
@@ -50,12 +50,17 @@ public class ImmediateCheckExpression implements Expression {
                                     final ExpressionResultCache cache) {
         this.check = check;
         this.requestScope = requestScope;
-        this.changeSpec = Optional.ofNullable(changeSpec);
         this.cache = cache;
         this.result = UNEVALUATED;
 
-        // UserCheck does not use resource
-        this.resource = (check instanceof UserCheck) ? null : resource;
+        // UserCheck does not use resource or changeSpec
+        if (check instanceof UserCheck) {
+            this.resource = null;
+            this.changeSpec = Optional.empty();
+        } else {
+            this.resource = resource;
+            this.changeSpec = Optional.ofNullable(changeSpec);
+        }
     }
 
     @Override


### PR DESCRIPTION
Vastly improves processing of user permission checks for filter collection.
Ignores changeSpec for User checks allowing the cached results to be used.