### PR TITLE
Adding check whether data store can paginate based on execution of in…

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/CanPaginateVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/CanPaginateVisitor.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.parsers.expression;
+
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.core.CheckInstantiator;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.generated.parsers.ExpressionBaseVisitor;
+import com.yahoo.elide.generated.parsers.ExpressionParser;
+import com.yahoo.elide.security.FilterExpressionCheck;
+import com.yahoo.elide.security.checks.Check;
+import com.yahoo.elide.security.checks.UserCheck;
+import org.antlr.v4.runtime.tree.ParseTree;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Walks a permission expression to determine if any part of the expression must be evaluated in memory.
+ * If part of the expression must be evaluated in memory, the data store cannot paginate the result.
+ *
+ * Here are some examples of what the expected behavior is for combining user and filter expression checks:
+ *
+ * User Check (TRUE) OR Filter Expression (TRUE)
+ *  - Elide will not push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The entire result set will be paginated.
+ *  - The entire result set will be returned.
+ *
+ * User Check (TRUE) OR Filter Expression (FALSE)
+ *  - Elide will not push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The entire result set will be paginated.
+ *  - The entire result set will be returned.
+ *
+ * User Check (FALSE) OR Filter Expression (TRUE)
+ *  - Elide will push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered result set will be paginated.
+ *  - The filtered result set will be returned.
+ *
+ * User Check (FALSE) OR Filter Expression (FALSE)
+ *  - Elide will push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The empty result set will be paginated.
+ *  - The empty result set will be returned.
+ *
+ * User Check (TRUE) AND Filter Expression (TRUE)
+ *  - Elide will push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered result set will be paginated.
+ *  - The filtered result set will be returned.
+ *
+ * User Check (TRUE) AND Filter Expression (FALSE)
+ *  - Elide will push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The empty result set will be paginated.
+ *  - The empty result set will be returned.
+ *
+ * User Check (FALSE) AND Filter Expression (TRUE)
+ *  - Elide will push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered result set will be paginated.
+ *  - The empty result set will be returned.
+ *
+ * User Check (FALSE) AND Filter Expression (FALSE)
+ *  - Elide will push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The empty result set will be paginated.
+ *  - The empty result set will be returned.
+ *
+ * More Complex Scenarios:
+ *
+ * (User Check (TRUE) OR Filter Expression 1 (FALSE)) AND Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered (2) result set will be paginated.
+ *  - The filtered (2) result set will be returned.
+ *
+ * (User Check (TRUE) OR Filter Expression 1 (TRUE)) AND Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate (2) to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered (2) result set will be paginated.
+ *  - The filtered (2) result set will be returned.
+ *
+ * (User Check (FALSE) OR Filter Expression 1 (TRUE)) AND Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate (1 and 2) to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered (1 and 2) result set will be paginated.
+ *  - The filtered (1 and 2) result set will be returned.
+ *
+ * (User Check (FALSE) OR Filter Expression 1 (FALSE)) AND Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate (1 and 2) to the data store.
+ *  - Elide will allow pagination.
+ *  - The empty result set will be paginated.
+ *  - The empty result set will be returned.
+ *
+ * (User Check (TRUE) AND Filter Expression 1 (FALSE)) OR Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate (1 or 2) to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered (2) result set will be paginated.
+ *  - The filtered (2) result set will be returned.
+ *
+ * (User Check (TRUE) AND Filter Expression 1 (TRUE)) OR Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate (1 or 2) to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered (1 or 2) result set will be paginated.
+ *  - The filtered (1 or 2) result set will be returned.
+ *
+ * (User Check (FALSE) AND Filter Expression 1 (TRUE)) OR Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate (2) to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered (2) result set will be paginated.
+ *  - The filtered (2) result set will be returned
+ *
+ * (User Check (FALSE) AND Filter Expression 1 (FALSE)) OR Filter Expression 2 (TRUE)
+ *  - Elide WILL push the filter predicate (2) to the data store.
+ *  - Elide will allow pagination.
+ *  - The filtered (2) result set will be paginated.
+ *  - The filtered (2) result set will be returned
+ *
+ */
+public class CanPaginateVisitor extends ExpressionBaseVisitor<Boolean> implements CheckInstantiator {
+
+    public static final Boolean CAN_PAGINATE = true;
+    public static final Boolean CANNOT_PAGINATE = false;
+
+    private final EntityDictionary dictionary;
+
+
+    public CanPaginateVisitor(EntityDictionary dictionary) {
+        this.dictionary = dictionary;
+    }
+
+
+    @Override
+    public Boolean visitNOT(ExpressionParser.NOTContext ctx) {
+        return visit(ctx.expression());
+    }
+
+    @Override
+    public Boolean visitOR(ExpressionParser.ORContext ctx) {
+        boolean lhs = visit(ctx.left);
+        boolean rhs = visit(ctx.right);
+
+        /* If either side requires in memory filtering, the data store cannot paginate */
+        if (lhs == CANNOT_PAGINATE || rhs == CANNOT_PAGINATE) {
+            return CANNOT_PAGINATE;
+        }
+        return CAN_PAGINATE;
+    }
+
+    @Override
+    public Boolean visitAND(ExpressionParser.ANDContext ctx) {
+        boolean lhs = visit(ctx.left);
+        boolean rhs = visit(ctx.right);
+
+        /* If either side requires in memory filtering, the data store cannot paginate */
+        if (lhs == CANNOT_PAGINATE || rhs == CANNOT_PAGINATE) {
+            return CANNOT_PAGINATE;
+        }
+        return CAN_PAGINATE;
+    }
+
+    @Override
+    public Boolean visitPAREN(ExpressionParser.PARENContext ctx) {
+        return visit(ctx.expression());
+    }
+
+    @Override
+    public Boolean visitPermissionClass(ExpressionParser.PermissionClassContext ctx) {
+        Check check = getCheck(dictionary, ctx.getText());
+
+        //Filter expression checks can always be pushed to the DataStore so pagination is possible
+        if (FilterExpressionCheck.class.isAssignableFrom(check.getClass())) {
+            return CAN_PAGINATE;
+
+        //User Checks have no bearing on pagination since they are true or false for every item in the collection
+        } else if (UserCheck.class.isAssignableFrom(check.getClass())) {
+            return CAN_PAGINATE;
+        //Any in memory check will alter (incorrectly) the paginated result
+        } else {
+            return CANNOT_PAGINATE;
+        }
+    }
+
+    /**
+     * Determines whether a data store can correctly paginate a collection of resources of a given
+     * class for a requested set of fields.
+     * @param resourceClass The class of resources that will be paginated
+     * @param dictionary Used to look up permissions
+     * @param scope Contains the request info including any sparse fields that were requested
+     * @return true if the data store can paginate.  false otherwise.
+     */
+    public static boolean canPaginate(Class<?> resourceClass, EntityDictionary dictionary, RequestScope scope) {
+
+        CanPaginateVisitor visitor = new CanPaginateVisitor(dictionary);
+
+        Class<? extends Annotation> annotationClass = ReadPermission.class;
+        ParseTree classPermissions = dictionary.getPermissionsForClass(resourceClass, annotationClass);
+        Boolean canPaginateClass = CAN_PAGINATE;
+        if (classPermissions != null) {
+            canPaginateClass = visitor.visit(classPermissions);
+        }
+
+        List<String> fields = dictionary.getAllFields(resourceClass);
+        String resourceName = dictionary.getJsonAliasFor(resourceClass);
+        Set<String> requestedFields = scope.getSparseFields().getOrDefault(resourceName, Collections.EMPTY_SET);
+
+        for (String field : fields) {
+            if (! requestedFields.isEmpty() && ! requestedFields.contains(field)) {
+                continue;
+            }
+            Boolean canPaginateField = canPaginateClass;
+            ParseTree fieldPermissions = dictionary.getPermissionsForField(resourceClass, field, annotationClass);
+            if (fieldPermissions != null) {
+                canPaginateField = visitor.visit(fieldPermissions);
+            }
+            if (canPaginateField == CANNOT_PAGINATE) {
+                return CANNOT_PAGINATE;
+            }
+        }
+        return CAN_PAGINATE;
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
@@ -28,6 +28,12 @@ public abstract class FilterExpressionCheck<T> extends InlineCheck<T> {
      */
     public abstract FilterExpression getFilterExpression(RequestScope requestScope);
 
+    /* NOTE: Filter Expression checks and user checks are intended to be _distinct_ */
+    @Override
+    public final boolean ok(User user) {
+        throw new UnsupportedOperationException();
+    }
+
 
     /**
      * The filter expression is evaluated in memory if it cannot be pushed to the data store by elide for any reason.

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/CanPaginateVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/CanPaginateVisitorTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.parsers.expression;
+
+import com.google.common.collect.Sets;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.security.ChangeSpec;
+import com.yahoo.elide.security.FilterExpressionCheck;
+import com.yahoo.elide.security.User;
+import com.yahoo.elide.security.checks.Check;
+import com.yahoo.elide.security.checks.OperationCheck;
+import com.yahoo.elide.security.checks.UserCheck;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import javax.persistence.Entity;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CanPaginateVisitorTest {
+
+    private Map<String, Class<? extends Check>> checkMappings;
+
+    public static final class TestOperationCheck extends OperationCheck<Object> {
+        @Override
+        public boolean ok(Object object,
+                          com.yahoo.elide.security.RequestScope requestScope,
+                          Optional<ChangeSpec> changeSpec) {
+            return false;
+        }
+    }
+
+    public static final class TestUserCheck extends UserCheck {
+        @Override
+        public boolean ok(User user) {
+            return true;
+        }
+    }
+
+    public static final class TestFilterExpressionCheck extends FilterExpressionCheck<Object> {
+        @Override
+        public FilterExpression getFilterExpression(com.yahoo.elide.security.RequestScope requestScope) {
+            return null;
+        }
+    }
+
+
+    @BeforeSuite
+    void init() {
+        checkMappings = new HashMap<>();
+        checkMappings.put("In Memory Check", TestOperationCheck.class);
+        checkMappings.put("User Check", TestUserCheck.class);
+        checkMappings.put("Filter Expression Check", TestFilterExpressionCheck.class);
+    }
+
+
+    @Test
+    public void testNoPermissions() throws Exception {
+        @Entity
+        @Include
+        class Book {
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertTrue(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testClassOperationPermissions() throws Exception {
+        @Entity
+        @Include
+        @ReadPermission(expression = "In Memory Check")
+        class Book {
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertFalse(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testClassUserPermissions() throws Exception {
+        @Entity
+        @Include
+        @ReadPermission(expression = "User Check")
+        class Book {
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertTrue(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testFieldFilterPermissions() throws Exception {
+        @Entity
+        @Include
+        class Book {
+            @ReadPermission(expression = "Filter Expression Check")
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertTrue(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testComplexTrueExpression() throws Exception {
+        @Entity
+        @Include
+        class Book {
+            @ReadPermission(expression =
+                    "(Filter Expression Check AND User Check) OR (Filter Expression Check OR NOT User Check)")
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertTrue(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testUserOROperationExpression() throws Exception {
+        @Entity
+        @Include
+        class Book {
+            @ReadPermission(expression = "User Check OR In Memory Check")
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertFalse(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testUserAndOperationExpression() throws Exception {
+        @Entity
+        @Include
+        class Book {
+            @ReadPermission(expression = "User Check AND In Memory Check")
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertFalse(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testNotOperationExpression() throws Exception {
+        @Entity
+        @Include
+        class Book {
+            @ReadPermission(expression = "NOT In Memory Check")
+            public String title;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertFalse(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testMultipleFieldsNoPagination() throws Exception {
+        @Entity
+        @Include
+        class Book {
+            @ReadPermission(expression = "Filter Expression Check")
+            public String title;
+
+            @ReadPermission(expression = "In Memory Check")
+            public Date publicationDate;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertFalse(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testMultipleFieldsPagination() throws Exception {
+        @Entity
+        @Include
+        @ReadPermission(expression = "In Memory Check")
+        class Book {
+            @ReadPermission(expression = "Filter Expression Check")
+            public String title;
+
+            @ReadPermission(expression = "Filter Expression Check")
+            public Date publicationDate;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Assert.assertTrue(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+
+    @Test
+    public void testSparseFields() throws Exception {
+        @Entity
+        @Include
+        @ReadPermission(expression = "In Memory Check")
+        class Book {
+            @ReadPermission(expression = "Filter Expression Check")
+            public String title;
+
+            @ReadPermission(expression = "Filter Expression Check")
+            public Date publicationDate;
+
+            public boolean outOfPrint;
+        }
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(Book.class);
+        RequestScope scope = mock(RequestScope.class);
+
+        Map<String, Set<String>> sparseFields = new HashMap<>();
+        when(scope.getSparseFields()).thenReturn(sparseFields);
+
+        Assert.assertFalse(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+
+        sparseFields.put("book", Sets.newHashSet("title", "publicationDate"));
+
+        Assert.assertTrue(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+
+        sparseFields.put("book", Sets.newHashSet("outOfPrint"));
+
+        Assert.assertFalse(CanPaginateVisitor.canPaginate(Book.class, dictionary, scope));
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -6,8 +6,6 @@
 
 package com.yahoo.elide.parsers.expression;
 
-import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.NO_EVALUATION_EXPRESSION;
-
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
@@ -28,14 +26,17 @@ import com.yahoo.elide.security.checks.UserCheck;
 import com.yahoo.elide.security.checks.prefab.Role;
 import com.yahoo.elide.security.permissions.ExpressionResult;
 import com.yahoo.elide.security.permissions.expressions.Expression;
-
+import lombok.AllArgsConstructor;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import lombok.AllArgsConstructor;
-
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,11 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
+import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.NO_EVALUATION_EXPRESSION;
 
 public class PermissionToFilterExpressionVisitorTest {
     private EntityDictionary dictionary;
@@ -425,11 +422,6 @@ public class PermissionToFilterExpressionVisitorTest {
         @Override
         public Predicate getFilterExpression(RequestScope requestScope) {
             return createDummyPredicate();
-        }
-
-        @Override
-        public boolean ok(User user) {
-            return true;
         }
 
         public FilterExpressionCheck1() {

--- a/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
@@ -92,11 +92,6 @@ public class AnotherFilterExpressionCheckObj {
             return createFilterPredicate();
         }
 
-        @Override
-        public boolean ok(com.yahoo.elide.security.User user) {
-            return true;
-        }
-
         public CheckActsLikeFilter() {
 
         }

--- a/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
@@ -89,11 +89,6 @@ public class FilterExpressionCheckObj {
             return createUserPredicate(requestScope, false, 1L);
         }
 
-        @Override
-        public boolean ok(com.yahoo.elide.security.User user) {
-            return true;
-        }
-
         public CheckRestrictUser() {
 
         }
@@ -110,11 +105,6 @@ public class FilterExpressionCheckObj {
             List<Object> value = new ArrayList<>();
             value.add((long) 2);
             return new Predicate(pathList, op, value);
-        }
-
-        @Override
-        public boolean ok(com.yahoo.elide.security.User user) {
-            return true;
         }
 
         public CheckLE() {


### PR DESCRIPTION
This is the first of three edits to make sure pagination doesn't return an incorrect result:

1) Disallow paginating collections where the security checks are not user checks or filter expression checks.  That is the subject of this PR.

2) Disallow paginating collections where a filter/sort resulted in a join across a ToMany collection.

3) If either (1) or (2) is true AND the pagination annotation says it is OK, paginate in memory.