### PR TITLE
Allow to use dasherized resource names in filter expressions

### DIFF
--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/filter/CriterionFilterOperation.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/filter/CriterionFilterOperation.java
@@ -57,7 +57,7 @@ public class CriterionFilterOperation implements FilterOperation<Criterion> {
             sb.append(ALIAS_DELIM);
             sb.append(element.getFieldName());
         }
-        return sb.toString();
+        return sb.toString().replace('-', '_');
     }
 
     /**


### PR DESCRIPTION
I'm using elide with hibernate datastore as backend for my ember-cli application and I stuck with one problem related to ember-data. By default ember-data uses dasherized resource names (like `my-very-own-resource`) and those names work well with elide by using `@Include(rootLevel = true, type = "my-very-own-resource")` annotation to resource class.

Unfortunately when I try to filter using basic syntax I have a problem with dasherized resource names. Filters like `/storage-items?filter[storage-items.manufacturer.id]=1` generate invalid SQL queries which contain table aliases like `storage-it1` and so on.

This pull request replaces dash sign in generated table aliases to underscore to make aliases valid database identifiers.