### PR TITLE
Added additional constructor for json api mapper.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/JsonApiMapper.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/JsonApiMapper.java
@@ -33,6 +33,17 @@ public class JsonApiMapper {
     }
 
     /**
+     * Instantiates a new Json Api Mapper.
+     *
+     * @param dictionary the dictionary
+     * @param mapper Custom object mapper to use internally for serializing/deserializing
+     */
+    public JsonApiMapper(EntityDictionary dictionary, ObjectMapper mapper) {
+        this.mapper = mapper;
+        mapper.registerModule(JsonApiSerializer.getModule(dictionary));
+    }
+
+    /**
      * Write out JSON API Document as a string.
      *
      * @param jsonApiDocument the json api document


### PR DESCRIPTION
This should make it more obvious on how to add custom (de)serializers to elide. Rather than requiring `jsonApiMapper.getMapper().registerModule(...)` or similar, you can now pass in your own pre-constructed `ObjectMapper` for Elide to use.