### PR TITLE
Avoid jcabi Mysql complaining too long socket path

### DIFF
--- a/elide-datastore/pom.xml
+++ b/elide-datastore/pom.xml
@@ -175,6 +175,7 @@
                             <configuration>
                                 <port>${mysql.port}</port>
                                 <data>${mysql.data.directory}</data>
+                                <socket>/tmp/elide.sock</socket>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
Not sure if it's just me, but I got this error from jcabi on my laptop when building elide:
`The socket file path is too long (> 103): /Users/xiaoyaoqian/projects/elide/elide-datastore/elide-datastore-hibernate5/target/mysql-data/mysql.sock`

So I made this change to avoid it. Thought it might be helpful for others. 