### PR TITLE
JsonApiEndpoint: Allow delete resource requests without body and content-type header

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.UriInfo;
  */
 @Singleton
 @Produces("application/vnd.api+json")
-@Consumes("application/vnd.api+json")
 @Path("/")
 public class JsonApiEndpoint {
     protected final Elide elide;
@@ -56,6 +55,7 @@ public class JsonApiEndpoint {
      */
     @POST
     @Path("{path:.*}")
+    @Consumes("application/vnd.api+json")
     public Response post(
         @PathParam("path") String path,
         @Context SecurityContext securityContext,
@@ -93,6 +93,7 @@ public class JsonApiEndpoint {
      */
     @PATCH
     @Path("{path:.*}")
+    @Consumes("application/vnd.api+json")
     public Response patch(
         @HeaderParam("Content-Type") String contentType,
         @HeaderParam("accept") String accept,
@@ -103,7 +104,7 @@ public class JsonApiEndpoint {
     }
 
     /**
-     * Delete handler.
+     * Delete relationship handler (expects body with resource ids and types).
      *
      * @param path request path
      * @param securityContext security context
@@ -112,11 +113,27 @@ public class JsonApiEndpoint {
      */
     @DELETE
     @Path("{path:.*}")
+    @Consumes("application/vnd.api+json")
     public Response delete(
         @PathParam("path") String path,
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
         return build(elide.delete(path, jsonApiDocument, getUser.apply(securityContext)));
+    }
+
+    /**
+     * Delete resource handler (expects no body and no content-type header).
+     *
+     * @param path request path
+     * @param securityContext security context
+     * @return response
+     */
+    @DELETE
+    @Path("{path:.*}")
+    public Response deleteWithoutBody(
+            @PathParam("path") String path,
+            @Context SecurityContext securityContext) {
+        return build(elide.delete(path, null, getUser.apply(securityContext)));
     }
 
     private static Response build(ElideResponse response) {

--- a/elide-example/elide-blog-example-resteasy/README.md
+++ b/elide-example/elide-blog-example-resteasy/README.md
@@ -1,0 +1,112 @@
+# Elide Example
+
+## Usage
+
+1. Install and start a MySQL server
+
+2. Create ```elide``` database
+
+        mysql> create database elide;
+
+3. Create ```elide``` user with password ```elide123```
+
+        mysql> grant all on elide.* to 'elide'@'localhost' identified by 'elide123';
+
+4. Launch the example webservice
+
+        ~/elide $ mvn install
+        ~/elide $ cd elide-example/elide-blog-example
+        ~/elide/elide-example/elide-blog-example $ mvn exec:java -Dexec.mainClass="com.yahoo.elide.example.persistence.Main"
+
+5. Create an admin user
+
+        $ curl -H'Content-Type: application/vnd.api+json' \
+               -H'Accept: application/vnd.api+json' --data '
+          {
+            "data": {
+              "type": "user",
+              "attributes": {
+                "name": "Michael Admin",
+                "role": "Admin"
+              }
+            }
+          }
+          ' -X POST http://localhost:4080/user
+
+6. Create a registered user
+
+        $ curl -H'Content-Type: application/vnd.api+json' \
+               -H'Accept: application/vnd.api+json' --data '
+          {
+            "data": {
+              "type": "user",
+              "attributes": {
+                "name": "Ken Registered",
+                "role": "Registered"
+              }
+            }
+          }
+          ' -X POST http://localhost:4080/user
+
+7. Create an unregistered user
+
+        $ curl -H'Content-Type: application/vnd.api+json' \
+               -H'Accept: application/vnd.api+json' --data '
+          {
+            "data": {
+              "type": "user",
+              "attributes": {
+                "name": "Shad Unreg",
+                "role": "Unregistered"
+              }
+            }
+          }
+          ' -X POST http://localhost:4080/user
+
+8. Create a post as an admin:
+
+        $ curl -H'Content-Type: application/vnd.api+json' \
+               -H'Accept: application/vnd.api+json' --data '
+          {
+            "data": {
+              "type": "post",
+              "attributes": {
+                "content": "The greatest thing ever by Michael",
+                "me": "1"
+              },
+              "relationships": {
+                "author": {
+                  "data": {
+                    "type": "user",
+                    "id": "1"
+                  }
+                }
+              }
+            }
+          }
+          ' -X POST http://localhost:4080/post
+
+9. Create a post as a registered user:
+
+        $ curl -H'Content-Type: application/vnd.api+json' \
+               -H'Accept: application/vnd.api+json' --data '
+          {
+            "data": {
+              "type": "post",
+              "attributes": {
+                "content": "The 2nd best thing ever by Ken",
+                "me": "2"
+              },
+              "relationships": {
+                "author": {
+                  "data": {
+                    "type": "user",
+                    "id": "2"
+                  }
+                }
+              }
+            }
+          }
+          ' -X POST http://localhost:4080/post
+
+You can also load some data using `load_blog.sh` in `src/main/scripts/`

--- a/elide-example/elide-blog-example-resteasy/pom.xml
+++ b/elide-example/elide-blog-example-resteasy/pom.xml
@@ -1,0 +1,137 @@
+<!--
+  ~ Copyright 2016, Yahoo Inc.
+  ~ Licensed under the Apache License, Version 2.0
+  ~ See LICENSE file in project root for terms.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>elide-blog-example-resteasy</artifactId>
+    <packaging>jar</packaging>
+    <name>Elide Example: Persistence API with Security (Resteasy)</name>
+    <description>Elide example using javax.persistence, MySQL and Elide Security</description>
+    <parent>
+        <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-example-parent-pom</artifactId>
+        <version>2.3.14-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <mysql.data.directory>${project.build.directory}/mysql-data</mysql.data.directory>
+    </properties>
+
+    <dependencies>
+        <!-- Persistence -->
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>5.0.2.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.37</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Elide dependencies for example -->
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-core</artifactId>
+            <version>2.3.14-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-datastore-hibernate5</artifactId>
+            <version>2.3.14-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Jetty -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+        </dependency>
+        <!-- Resteasy -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxrs</artifactId>
+            <version>3.0.19.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>3.0.19.Final</version>
+        </dependency>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <!-- JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.6.3</version>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.yahoo.elide.example.persistence.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <!-- Do not deploy -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/ElideResourceConfig.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/ElideResourceConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.example.persistence;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.audit.Slf4jLogger;
+import com.yahoo.elide.datastores.hibernate5.PersistenceStore;
+import com.yahoo.elide.resources.JsonApiEndpoint;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.ws.rs.core.Application;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Example application for resource config.
+ */
+public class ElideResourceConfig extends Application {
+
+    @Override
+    public Set<Object> getSingletons() {
+        EntityManagerFactory entityManagerFactory =
+                Persistence.createEntityManagerFactory("com.yahoo.elide.example");
+
+        Elide elide = new Elide.Builder(new Slf4jLogger(), new PersistenceStore(entityManagerFactory)).build();
+
+        Set<Object> set = new HashSet<>();
+        set.add(new JsonApiEndpoint(elide, v -> null));
+        return set;
+    }
+}

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/Main.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/Main.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.example.persistence;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+
+/**
+ * Example backend using Elide library.
+ */
+@Slf4j
+public class Main {
+    public static void main(String[] args) throws Exception {
+        final Server server = new Server(4080);
+        final ServletContextHandler servletContextHandler = new ServletContextHandler();
+        servletContextHandler.setContextPath("/");
+        servletContextHandler.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getName());
+        server.setHandler(servletContextHandler);
+
+        final ServletHolder servletHolder = servletContextHandler.addServlet(HttpServletDispatcher.class, "/*");
+        servletHolder.setInitOrder(1);
+
+        log.info("Web service starting...");
+        server.start();
+
+        log.info("Web service running...");
+        server.join();
+        server.destroy();
+    }
+}

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/Comment.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/Comment.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.example.persistence.models;
+
+import com.yahoo.elide.annotation.ComputedAttribute;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.SharePermission;
+import com.yahoo.elide.security.checks.prefab.Role;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+/**
+ * Model for Comments on Posts
+ */
+@Entity
+@Table(name = "comment")
+@Include
+@SharePermission(any = { Role.ALL.class })
+public class Comment {
+    private long id;
+    private Post post;
+    private User author;
+    private String content;
+    private long me;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @ManyToOne
+    public Post getPost() {
+        return post;
+    }
+
+    public void setPost(Post post) {
+        this.post = post;
+    }
+
+    @ManyToOne
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    @Transient
+    @ComputedAttribute
+    public long getMe() {
+        return me;
+    }
+
+    public void setMe(long me) {
+        this.me = me;
+    }
+}

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/Post.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/Post.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.example.persistence.models;
+
+import com.yahoo.elide.annotation.ComputedAttribute;
+import com.yahoo.elide.annotation.Include;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.util.Collection;
+
+/**
+ * Model for Posts
+ */
+@Entity
+@Table(name = "post")
+@Include(rootLevel = true)
+public class Post {
+    private long id;
+    private User author;
+    private String content;
+    private Collection<Comment> comments;
+    private long me;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @ManyToOne
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    @OneToMany(mappedBy = "post")
+    public Collection<Comment> getComments() {
+        return comments;
+    }
+
+    public void setComments(Collection<Comment> comments) {
+        this.comments = comments;
+    }
+
+    @Transient
+    @ComputedAttribute
+    public long getMe() {
+        return me;
+    }
+
+    public void setMe(long me) {
+        this.me = me;
+        System.out.println(me);
+    }
+}

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/Role.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/Role.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.example.persistence.models;
+
+/**
+ * User Role (Admin, Registered, Unregistered)
+ */
+public enum Role {
+    Admin,
+    Registered,
+    Unregistered;
+}

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/User.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/persistence/models/User.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.example.persistence.models;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.SharePermission;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * Model for Users (author of posts and author of comments).
+ */
+@Entity
+@Table(name = "user")
+@Include(rootLevel = true)
+@SharePermission(any = { com.yahoo.elide.security.checks.prefab.Role.ALL.class})
+//@CreatePermission(expression = "Prefab.Role.All")
+public class User {
+    private long id;
+    private String name;
+    private Role role;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+}

--- a/elide-example/elide-blog-example-resteasy/src/main/resources/META-INF/persistence.xml
+++ b/elide-example/elide-blog-example-resteasy/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,20 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="com.yahoo.elide.example">
+        <class>com.yahoo.elide.example.persistence.models.User</class>
+        <class>com.yahoo.elide.example.persistence.models.Post</class>
+        <class>com.yahoo.elide.example.persistence.models.Comment</class>
+
+        <properties>
+            <property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver" />
+            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost/elide" />
+            <property name="javax.persistence.jdbc.user" value="elide" />
+            <property name="javax.persistence.jdbc.password" value="elide123" />
+
+            <property name="hibernate.show_sql" value="true" />
+            <property name="hibernate.hbm2ddl.auto" value="create" />
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/elide-example/elide-blog-example-resteasy/src/main/resources/log4j2.xml
+++ b/elide-example/elide-blog-example-resteasy/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/elide-example/elide-blog-example-resteasy/src/main/scripts/load_blog.sh
+++ b/elide-example/elide-blog-example-resteasy/src/main/scripts/load_blog.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# Example that exercises security features in Elide
+
+# Entities:
+# Post
+#
+# - Author (User)
+# - Date Posted
+# - Content (String)
+# - Comments (Collection)
+#
+# User
+#
+# - Name
+# - Email
+# - Type (Admin, Registered, Unregistered)
+#
+# Comment
+#
+# - Author (User)
+# - Date Posted
+# - Content (String)
+#
+# Relationships:
+# Post -1> User
+# Post -oo> Comment
+# Comment -1> User
+#
+# Security:
+#
+# - Admin User can:
+#     - Do anything
+# - Registered User can:
+#     - Create post
+#     - Edit their post
+#     - Comment on a post
+#     - Edit their comment
+#     - Delete their comment
+# - Registered User cannot:
+#     - Delete their post
+#     - Delete comments on their post
+#     - Edit other people’s comments
+#     - Delete other people’s comments
+# - Unregistered User can:
+#     - Read posts
+# - Unregistered User cannot:
+#     - Create posts
+#     - Create comments
+#     - Read comments
+#     - Delete anything
+#     - Edit anything
+
+# Allowed: Create user 1
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "user",
+    "attributes": {
+      "name": "Michael Admin",
+      "role": "Admin"
+    }
+  }
+}
+' -X POST http://localhost:4080/user
+
+# Allowed: Create user 2
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "user",
+    "attributes": {
+      "name": "Ken Registered",
+      "role": "Registered"
+    }
+  }
+}
+' -X POST http://localhost:4080/user
+
+# Allowed: Create user 3
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "user",
+    "attributes": {
+      "name": "Shad Unreg",
+      "role": "Unregistered"
+    }
+  }
+}
+' -X POST http://localhost:4080/user
+
+# Allowed: Create post 1 - admin (me=1) creates a post:
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "post",
+    "attributes": {
+      "content": "The greatest thing ever by Michael",
+      "me": "1"
+    },
+    "relationships": {
+      "author": {
+        "data": {
+          "type": "user",
+          "id": "1"
+        }
+      }
+    }
+  }
+}
+' -X POST http://localhost:4080/post
+
+# Allowed: Create post 2 - registered user (me=2) creates a post:
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "post",
+    "attributes": {
+      "content": "The 2nd best thing ever by Ken",
+      "me": "2"
+    },
+    "relationships": {
+      "author": {
+        "data": {
+          "type": "user",
+          "id": "2"
+        }
+      }
+    }
+  }
+}
+' -X POST http://localhost:4080/post
+
+# Not Allowed: Create post - registered user (me=2) creates a post that doesn't belong to me
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "post",
+    "attributes": {
+      "content": "Ken tries to put words into Shads mouth",
+      "me": "2"
+    },
+    "relationships": {
+      "author": {
+        "data": {
+          "type": "user",
+          "id": "3"
+        }
+      }
+    }
+  }
+}
+' -X POST http://localhost:4080/post
+
+# Not Allowed: Create post - unregistered user (me=3) creates a post
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "post",
+    "attributes": {
+      "content": "Shad tries to post",
+      "me": "3"
+    },
+    "relationships": {
+      "author": {
+        "data": {
+          "type": "user",
+          "id": "3"
+        }
+      }
+    }
+  }
+}
+' -X POST http://localhost:4080/post
+
+# Allowed: Michael Admin comments on Ken's Post
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "comment",
+    "attributes": {
+      "content": "That is truly the 2nd best post ever",
+      "me": "1"
+    },
+    "relationships": {
+      "author": {
+        "data": {
+          "type": "user",
+          "id": "1"
+        }
+      }
+    }
+  }
+}
+' -X POST http://localhost:4080/post/2/comments
+
+# Not Allowed: Shad Unreg comments on Ken Reg's Post
+curl -H'Content-Type: application/vnd.api+json' \
+     -H'Accept: application/vnd.api+json' --data '
+{
+  "data": {
+    "type": "comment",
+    "attributes": {
+      "content": "I think this is the 3rd best post ever",
+      "me": "3"
+    },
+    "relationships": {
+      "author": {
+        "data": {
+          "type": "user",
+          "id": "3"
+        }
+      }
+    }
+  }
+}
+' -X POST http://localhost:4080/post/2/comments

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -737,8 +737,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
 
     @Test(priority = 11)
     public void testDeleteParent() {
-        //Should work without content-type and body
         given()
+            .contentType(JSONAPI_CONTENT_TYPE)
             .accept(JSONAPI_CONTENT_TYPE)
             .delete("/parent/1")
             .then()

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -737,8 +737,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
 
     @Test(priority = 11)
     public void testDeleteParent() {
+        //Should work without content-type and body
         given()
-            .contentType(JSONAPI_CONTENT_TYPE)
             .accept(JSONAPI_CONTENT_TYPE)
             .delete("/parent/1")
             .then()


### PR DESCRIPTION
Should fix issue described in https://github.com/yahoo/elide/issues/321 and allow HTTP DELETE requests without body and content-type header when using JsonApiEndpoint in JAX-RS environment