### PR TITLE
Short circuit OR and AND filter expressions

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
@@ -8,6 +8,8 @@ package com.yahoo.elide.parsers.expression;
 
 import com.yahoo.elide.core.CheckInstantiator;
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.Predicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
@@ -68,13 +70,23 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
         FilterExpression left = visit(ctx.left);
         FilterExpression right = visit(ctx.right);
 
+        // short circuit if TRUE
+        if (operator(left) == Operator.TRUE) {
+            return left;
+        }
+
+        // short circuit if TRUE
+        if (operator(right) == Operator.TRUE) {
+            return right;
+        }
+
         if (left == NO_EVALUATION_EXPRESSION || right == NO_EVALUATION_EXPRESSION) {
             return NO_EVALUATION_EXPRESSION;
         }
 
-        if (left == FALSE_USER_CHECK_EXPRESSION) {
+        if (left == FALSE_USER_CHECK_EXPRESSION || operator(left) == Operator.FALSE) {
             return right;
-        } else if (right == FALSE_USER_CHECK_EXPRESSION) {
+        } else if (right == FALSE_USER_CHECK_EXPRESSION || operator(right) == Operator.FALSE) {
             return left;
         }
 
@@ -111,19 +123,34 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
             return FALSE_USER_CHECK_EXPRESSION;
         }
 
+        if (operator(left) == Operator.FALSE) {
+            return FALSE_USER_CHECK_EXPRESSION;
+        }
+
+        if (operator(right) == Operator.FALSE) {
+            return FALSE_USER_CHECK_EXPRESSION;
+        }
+
         //Case (NO_EVALUATION_EXPRESSION AND FilterExpression): should ignore NO_EVALUATION_EXPRESSION and return
         // FilterExpression.
         //Case (NO_EVALUATION_EXPRESSION AND NO_EVALUATION_EXPRESSION): returns NO_EVALUATION_EXPRESSION.
-        if (left == NO_EVALUATION_EXPRESSION) {
+        if (left == NO_EVALUATION_EXPRESSION || operator(left) == Operator.TRUE) {
             return right;
         }
 
-        if (right == NO_EVALUATION_EXPRESSION) {
+        if (right == NO_EVALUATION_EXPRESSION || operator(right) == Operator.TRUE) {
             return left;
         }
 
         //Case (FilterExpression AND FilterExpression): should return the AND expression of them.
         return new AndFilterExpression(left, right);
+    }
+
+    private Operator operator(FilterExpression expression) {
+        if (expression instanceof Predicate) {
+            return ((Predicate) expression).getOperator();
+        }
+        return null;
     }
 
     @Override

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HQLTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HQLTransaction.java
@@ -142,7 +142,8 @@ public class HQLTransaction {
                 if (filters != null) {
                     for (Predicate predicate : filters) {
                         if (predicate.getOperator().isParameterized()) {
-                            query = query.setParameterList(predicate.getField(), predicate.getValues());
+                            String name = predicate.getFieldPath().replace('.', '_');
+                            query = query.setParameterList(name, predicate.getValues());
                         }
                     }
                 }

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -451,7 +451,8 @@ public class HibernateTransaction implements RequestScopedTransaction {
 
                 for (Predicate predicate : predicates) {
                     if (predicate.getOperator().isParameterized()) {
-                        query = query.setParameterList(predicate.getField(), predicate.getValues());
+                        String name = predicate.getFieldPath().replace('.', '_');
+                        query = query.setParameterList(name, predicate.getValues());
                     }
                 }
 

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HQLTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HQLTransaction.java
@@ -141,7 +141,8 @@ public class HQLTransaction {
                 if (filters != null) {
                     for (Predicate predicate : filters) {
                         if (predicate.getOperator().isParameterized()) {
-                            query = query.setParameterList(predicate.getField(), predicate.getValues());
+                            String name = predicate.getFieldPath().replace('.', '_');
+                            query = query.setParameterList(name, predicate.getValues());
                         }
                     }
                 }

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -307,7 +307,8 @@ public class HibernateTransaction implements DataStoreTransaction {
 
                 for (Predicate predicate : predicates) {
                     if (predicate.getOperator().isParameterized()) {
-                        query = query.setParameterList(predicate.getField(), predicate.getValues());
+                        String name = predicate.getFieldPath().replace('.', '_');
+                        query = query.setParameterList(name, predicate.getValues());
                     }
                 }
 

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RelationshipType;
+import com.yahoo.elide.core.exceptions.HttpStatusException;
 import com.yahoo.elide.core.exceptions.TransactionException;
 import com.yahoo.elide.core.filter.Predicate;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -29,6 +30,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedHashMap;
 
 /**
@@ -71,6 +73,9 @@ public class MultiplexWriteTransaction extends MultiplexTransaction {
             try {
                 entry.getValue().commit();
                 commitList.add(entry.getKey());
+            } catch (HttpStatusException | WebApplicationException e) {
+                reverseTransactions(commitList, e);
+                throw e;
             } catch (Error | RuntimeException e) {
                 TransactionException transactionException = new TransactionException(e);
                 reverseTransactions(commitList, transactionException);


### PR DESCRIPTION
Will process OR and AND shortcuts when building the filterexpression so 
`where id = 1 and (false)` evaluates to `false` which immediately fails