### PR TITLE
Reduce build output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@
       - "/^[0-9]+\\.[0-9]+\\.[0-9]+/"
   # build steps
   install: true
-  script: mvn clean verify # coveralls:report
+  script: mvn -B -q clean verify # coveralls:report
   after_success:
-    - test "${TRAVIS_PULL_REQUEST}" == "false" && mvn versioneye:update
-    - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && mvn deploy --settings travis/settings.xml
+    - test "${TRAVIS_PULL_REQUEST}" == "false" && mvn -B versioneye:update
+    - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && mvn -B deploy --settings travis/settings.xml
 #  before_deploy: cat travis/bintray_template.json | sed s/\$\{TRAVIS_TAG\}/${TRAVIS_TAG}/g > travis/release.json
 #  deploy:
 #    on:

--- a/elide-integration-tests/src/test/resources/hibernate.cfg.xml
+++ b/elide-integration-tests/src/test/resources/hibernate.cfg.xml
@@ -20,7 +20,7 @@
         <property name="hibernate.jdbc.batch_size">50</property>
         <property name="hibernate.jdbc.fetch_size">50</property>
 
-        <property name="hibernate.show_sql">true</property>
+        <property name="hibernate.show_sql">false</property>
 
         <property name="hibernate.transaction.factory_class">org.hibernate.transaction.JDBCTransactionFactory</property>
 


### PR DESCRIPTION
Turn on maven `--quiet` mode.  Logs currently exceed the 4MB allowed.