### PR TITLE
fix NPE in InMemoryDataStore

### DIFF
--- a/elide-datastore/elide-datastore-inmemorydb/src/test/java/com/yahoo/elide/datastores/inmemory/InMemoryDataStoreTest.java
+++ b/elide-datastore/elide-datastore-inmemorydb/src/test/java/com/yahoo/elide/datastores/inmemory/InMemoryDataStoreTest.java
@@ -5,17 +5,24 @@
  */
 package com.yahoo.elide.datastores.inmemory;
 
+
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.example.beans.ExcludedBean;
 import com.yahoo.elide.example.beans.FirstBean;
 import com.yahoo.elide.example.beans.NonEntity;
 import com.yahoo.elide.example.beans.SecondBean;
-import org.testng.annotations.BeforeTest;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -27,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 public class InMemoryDataStoreTest {
     private InMemoryDataStore inMemoryDataStore;
 
-    @BeforeTest
+    @BeforeMethod
     public void setup() {
         final EntityDictionary entityDictionary = new EntityDictionary(new HashMap<>());
         inMemoryDataStore = new InMemoryDataStore(FirstBean.class.getPackage());
@@ -46,7 +53,7 @@ public class InMemoryDataStoreTest {
     @Test
     public void testValidCommit() throws Exception {
         FirstBean object = new FirstBean();
-        object.id = 0;
+        object.id = "0";
         object.name = "Test";
         try (DataStoreTransaction t = inMemoryDataStore.beginTransaction()) {
             assertFalse(t.loadObjects(FirstBean.class).iterator().hasNext());
@@ -59,7 +66,41 @@ public class InMemoryDataStoreTest {
             assertNotNull(beans);
             assertTrue(beans.iterator().hasNext());
             FirstBean bean = beans.iterator().next();
-            assertTrue(bean.id == 1 && bean.name.equals("Test"));
+            assertTrue(!bean.id.equals("0") && bean.name.equals("Test"));
         }
+    }
+
+    @Test
+    public void testCanGenerateIdsAfterDataCommitted() throws Exception {
+        // given an object with a non-generated ID has been created
+        FirstBean object = new FirstBean();
+        object.id = "1";
+        object.name = "number one";
+
+        try (DataStoreTransaction t = inMemoryDataStore.beginTransaction()) {
+            t.save(object);
+            t.commit();
+        }
+
+        // when an object without ID is created, that works
+        FirstBean object2 = new FirstBean();
+        object2.id = null;
+        object2.name = "number two";
+
+        try (DataStoreTransaction t = inMemoryDataStore.beginTransaction()) {
+            t.save(object2);
+            t.commit();
+        }
+
+        // and a meaningful ID is assigned
+        Set<String> names = new HashSet<>();
+        try (DataStoreTransaction t = inMemoryDataStore.beginTransaction()) {
+            for (FirstBean bean : t.loadObjects(FirstBean.class)) {
+                names.add(bean.name);
+                assertFalse(bean.id == null);
+            }
+        }
+
+        assertEquals(names, ImmutableSet.of("number one", "number two"));
     }
 }

--- a/elide-datastore/elide-datastore-inmemorydb/src/test/java/com/yahoo/elide/example/beans/FirstBean.java
+++ b/elide-datastore/elide-datastore-inmemorydb/src/test/java/com/yahoo/elide/example/beans/FirstBean.java
@@ -16,16 +16,16 @@ import javax.persistence.Id;
 @Entity
 @Include
 public class FirstBean {
-    public int id;
+    public String id;
 
     public String name;
 
     @Id
-    public int getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(String id) {
         this.id = id;
     }
 }

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexManagerTest.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexManagerTest.java
@@ -51,7 +51,7 @@ public class MultiplexManagerTest {
     @Test
     public void testValidCommit() throws IOException {
         final FirstBean object = new FirstBean();
-        object.id = 0;
+        object.id = null;
         object.name = "Test";
         try (DataStoreTransaction t = multiplexManager.beginTransaction()) {
             assertFalse(t.loadObjects(FirstBean.class).iterator().hasNext());
@@ -64,7 +64,7 @@ public class MultiplexManagerTest {
             assertNotNull(beans);
             assertTrue(beans.iterator().hasNext());
             FirstBean bean = beans.iterator().next();
-            assertTrue(bean.id == 1 && bean.name.equals("Test"));
+            assertTrue(bean.id != null && bean.name.equals("Test"));
         }
     }
 

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/FirstBean.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/FirstBean.java
@@ -16,16 +16,16 @@ import javax.persistence.Id;
 @Entity
 @Include
 public class FirstBean {
-    public int id;
+    public String id;
 
     public String name;
 
     @Id
-    public int getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(String id) {
         this.id = id;
     }
 }


### PR DESCRIPTION
This change makes it possible to first add an entry without a generated id,
and then later to generate one. Before this, an NPE would be thrown
at the second step. It also somewhat decreases the risk of ID collision
when combining generated and user-specified IDs.