### PR TITLE
Enable filter expressions in Elide 2 RequestScope

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -428,14 +428,19 @@ public class Elide {
         try (DataStoreTransaction transaction = dataStore.beginTransaction()) {
             User user = transaction.accessUser(opaqueUser);
             JsonApiDocument doc = mapper.readJsonApiDocument(jsonApiDocument);
-            requestScope = new RequestScope(path, doc,
+            requestScope = new RequestScope(
+                    path,
+                    doc,
                     transaction,
                     user,
                     dictionary,
                     mapper,
                     auditLogger,
+                    null,
                     securityMode,
-                    permissionExecutor);
+                    permissionExecutor,
+                    new MultipleFilterDialect(joinFilterDialects, subqueryFilterDialects),
+                    useFilterExpressions);
             isVerbose = requestScope.getPermissionExecutor().isVerbose();
             PostVisitor visitor = new PostVisitor(requestScope);
             Supplier<Pair<Integer, JsonNode>> responder = visitor.visit(parse(path));
@@ -515,8 +520,19 @@ public class Elide {
                 responder = JsonApiPatch.processJsonPatch(dataStore, path, jsonApiDocument, patchRequestScope);
             } else {
                 JsonApiDocument doc = mapper.readJsonApiDocument(jsonApiDocument);
-                requestScope = new RequestScope(path, doc, transaction, user, dictionary, mapper, auditLogger,
-                        securityMode, permissionExecutor);
+                requestScope = new RequestScope(
+                        path,
+                        doc,
+                        transaction,
+                        user,
+                        dictionary,
+                        mapper,
+                        auditLogger,
+                        null,
+                        securityMode,
+                        permissionExecutor,
+                        new MultipleFilterDialect(joinFilterDialects, subqueryFilterDialects),
+                        useFilterExpressions);
                 isVerbose = requestScope.getPermissionExecutor().isVerbose();
                 PatchVisitor visitor = new PatchVisitor(requestScope);
                 responder = visitor.visit(parse(path));
@@ -595,7 +611,18 @@ public class Elide {
                 doc = new JsonApiDocument();
             }
             requestScope = new RequestScope(
-                    path, doc, transaction, user, dictionary, mapper, auditLogger, securityMode, permissionExecutor);
+                    path,
+                    doc,
+                    transaction,
+                    user,
+                    dictionary,
+                    mapper,
+                    auditLogger,
+                    null,
+                    securityMode,
+                    permissionExecutor,
+                    new MultipleFilterDialect(joinFilterDialects, subqueryFilterDialects),
+                    useFilterExpressions);
             isVerbose = requestScope.getPermissionExecutor().isVerbose();
             DeleteVisitor visitor = new DeleteVisitor(requestScope);
             Supplier<Pair<Integer, JsonNode>> responder = visitor.visit(parse(path));

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -168,6 +168,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         }
     }
 
+    @Deprecated
     public RequestScope(String path,
                         JsonApiDocument jsonApiDocument,
                         DataStoreTransaction transaction,
@@ -193,6 +194,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         );
     }
 
+    @Deprecated
     public RequestScope(String path,
                         JsonApiDocument jsonApiDocument,
                         DataStoreTransaction transaction,
@@ -217,6 +219,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         );
     }
 
+    @Deprecated
     public RequestScope(String path,
                         JsonApiDocument jsonApiDocument,
                         DataStoreTransaction transaction,


### PR DESCRIPTION
Deprecated a number of old RequestScope constructors and fixed the Elide 2.0 instantiations.  This had been effectively disabling FilterExpression use in Elide 2.

There may still be a problem in Elide 2 where `any` will instead processes as `all` when FilterExpressions are used but not enabled.  So be sure to enable filter expressions.  This problem will go away entirely in Elide 3.