### PR TITLE
Enable filter expression handling in 3.0 patch extension

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -514,7 +514,8 @@ public class Elide {
             if (JsonApiPatch.isPatchExtension(contentType) && JsonApiPatch.isPatchExtension(accept)) {
                 // build Outer RequestScope to be used for each action
                 PatchRequestScope patchRequestScope = new PatchRequestScope(path,
-                        transaction, user, dictionary, mapper, auditLogger, permissionExecutor);
+                        transaction, user, dictionary, mapper, auditLogger, permissionExecutor,
+                        new MultipleFilterDialect(joinFilterDialects, subqueryFilterDialects), useFilterExpressions);
                 requestScope = patchRequestScope;
                 isVerbose = requestScope.getPermissionExecutor().isVerbose();
                 responder = JsonApiPatch.processJsonPatch(dataStore, path, jsonApiDocument, patchRequestScope);

--- a/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
 import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.security.PermissionExecutor;
@@ -39,9 +40,12 @@ public class PatchRequestScope extends RequestScope {
             EntityDictionary dictionary,
             JsonApiMapper mapper,
             AuditLogger auditLogger,
-            Function<RequestScope, PermissionExecutor> permissionExecutorGenerator) {
-        super(path, null, transaction, user, dictionary, mapper, auditLogger, SecurityMode.SECURITY_ACTIVE,
-                permissionExecutorGenerator);
+            Function<RequestScope, PermissionExecutor> permissionExecutorGenerator,
+            MultipleFilterDialect filterDialect,
+            boolean useFilterExpressions) {
+        super(path, null, transaction, user, dictionary, mapper, auditLogger, null, SecurityMode.SECURITY_ACTIVE,
+                permissionExecutorGenerator, filterDialect, useFilterExpressions);
+
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.filter.HQLFilterOperation;
 import com.yahoo.elide.core.filter.InMemoryFilterOperation;
 import com.yahoo.elide.core.filter.Predicate;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.expression.InMemoryFilterVisitor;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 import com.yahoo.elide.datastores.hibernate3.filter.CriterionFilterOperation;
@@ -432,6 +433,10 @@ public class HibernateTransaction implements RequestScopedTransaction {
         if (val instanceof Collection) {
             Collection filteredVal = (Collection) val;
             if (filteredVal instanceof AbstractPersistentCollection) {
+                if (getRequestScope() instanceof PatchRequestScope && filterExpression.isPresent()) {
+                    return patchRequestFilterCollection(filteredVal, relationClass, filterExpression.get());
+                }
+
                 Optional<Sorting> sortingRules = sorting != null ? Optional.of(sorting) : Optional.empty();
                 Optional<Pagination> paginationRules = pagination != null ? Optional.of(pagination) : Optional.empty();
 
@@ -476,6 +481,27 @@ public class HibernateTransaction implements RequestScopedTransaction {
         }
 
         return collection;
+    }
+
+    /**
+     * for PatchRequest use only inMemory tests since objects in the collection may be new and unsaved
+     * @param <T>         the type parameter
+     * @param collection  the collection to filter
+     * @param entityClass the class of the entities in the collection
+     * @param filterExpression the filter expression
+     * @return the filtered collection
+     */
+    protected <T> Collection patchRequestFilterCollection(
+            Collection collection,
+            Class<T> entityClass,
+            FilterExpression filterExpression) {
+        final EntityDictionary dictionary = getRequestScope().getDictionary();
+        InMemoryFilterVisitor inMemoryFilterVisitor = new InMemoryFilterVisitor(dictionary);
+        java.util.function.Predicate inMemoryFilterFn =
+                filterExpression.accept(inMemoryFilterVisitor);
+        return (Collection) collection.stream()
+                .filter(e -> inMemoryFilterFn.test(e))
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
Expands on https://github.com/yahoo/elide/pull/354

Handles RequestScopedTransaction in 3.0 and with filter expressions in 2.0