### PR TITLE
Unique HQL parameter names

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
@@ -73,6 +73,13 @@ public class Predicate implements FilterExpression, Function<EntityDictionary, j
         return fieldPath.toString();
     }
 
+    /**
+     * get a unique name for this predicate to be used as a parameter name
+     * @return unique name
+     */
+    public String getParameterName() {
+        return getFieldPath().replace('.', '_') + '_' + Integer.toHexString(hashCode());
+    }
 
     public String getEntityType() {
         PathElement last = path.get(path.size() - 1);

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HQLFilterOperation.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HQLFilterOperation.java
@@ -22,31 +22,32 @@ public class HQLFilterOperation implements FilterOperation<String> {
     @Override
     public String apply(Predicate predicate) {
         String fieldPath = predicate.getFieldPath();
+        String alias = predicate.getParameterName();
         switch (predicate.getOperator()) {
             case IN:
                 Preconditions.checkState(!predicate.getValues().isEmpty());
-                return String.format("%s IN (:%s)", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s IN (:%s)", fieldPath, alias);
             case NOT:
                 Preconditions.checkState(!predicate.getValues().isEmpty());
-                return String.format("%s NOT IN (:%s)", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s NOT IN (:%s)", fieldPath, alias);
             case PREFIX:
-                return String.format("%s LIKE CONCAT(:%s, '%%')", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s LIKE CONCAT(:%s, '%%')", fieldPath, alias);
             case POSTFIX:
-                return String.format("%s LIKE CONCAT('%%', :%s)", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s LIKE CONCAT('%%', :%s)", fieldPath, alias);
             case INFIX:
-                return String.format("%s LIKE CONCAT('%%', :%s, '%%')", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s LIKE CONCAT('%%', :%s, '%%')", fieldPath, alias);
             case ISNULL:
                 return String.format("%s IS NULL", fieldPath);
             case NOTNULL:
                 return String.format("%s IS NOT NULL", fieldPath);
             case LT:
-                return String.format("%s < :%s", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s < :%s", fieldPath, alias);
             case LE:
-                return String.format("%s <= :%s", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s <= :%s", fieldPath, alias);
             case GT:
-                return String.format("%s > :%s", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s > :%s", fieldPath, alias);
             case GE:
-                return String.format("%s >= :%s", fieldPath, fieldPath.replace('.', '_'));
+                return String.format("%s >= :%s", fieldPath, alias);
             case TRUE:
                 return "(1 = 1)";
             case FALSE:

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/HQLFilterOperationTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/HQLFilterOperationTest.java
@@ -54,6 +54,8 @@ public class HQLFilterOperationTest {
         HQLFilterOperation filterOp = new HQLFilterOperation();
         String query = filterOp.apply(not);
 
-        Assert.assertEquals(query, "WHERE NOT (((name IN (:name) OR genre IN (:genre)) AND authors.name IN (:authors_name)))");
+        String expected = "WHERE NOT (((name IN (:" + p2.getParameterName() + ") OR genre IN (:"
+                + p3.getParameterName() + ")) AND authors.name IN (:" + p1.getParameterName() + ")))";
+        Assert.assertEquals(query, expected);
     }
 }

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HQLTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HQLTransaction.java
@@ -142,7 +142,7 @@ public class HQLTransaction {
                 if (filters != null) {
                     for (Predicate predicate : filters) {
                         if (predicate.getOperator().isParameterized()) {
-                            String name = predicate.getFieldPath().replace('.', '_');
+                            String name = predicate.getParameterName();
                             query = query.setParameterList(name, predicate.getValues());
                         }
                     }

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -471,7 +471,7 @@ public class HibernateTransaction implements RequestScopedTransaction {
 
                 for (Predicate predicate : predicates) {
                     if (predicate.getOperator().isParameterized()) {
-                        String name = predicate.getFieldPath().replace('.', '_');
+                        String name = predicate.getParameterName();
                         query = query.setParameterList(name, predicate.getValues());
                     }
                 }

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HQLTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HQLTransaction.java
@@ -141,7 +141,7 @@ public class HQLTransaction {
                 if (filters != null) {
                     for (Predicate predicate : filters) {
                         if (predicate.getOperator().isParameterized()) {
-                            String name = predicate.getFieldPath().replace('.', '_');
+                            String name = predicate.getParameterName();
                             query = query.setParameterList(name, predicate.getValues());
                         }
                     }

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -333,7 +333,7 @@ public class HibernateTransaction implements RequestScopedTransaction {
 
                 for (Predicate predicate : predicates) {
                     if (predicate.getOperator().isParameterized()) {
-                        String name = predicate.getFieldPath().replace('.', '_');
+                        String name = predicate.getParameterName();
                         query = query.setParameterList(name, predicate.getValues());
                     }
                 }


### PR DESCRIPTION
Found a problem where multiple Predicates for the same field attempted to use the same parameter name, causing a name collision.

Added Predicate.getParameterName to generate a unique name based on the predicate properties.