### PR TITLE
Multiplex close

### DIFF
--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
@@ -110,7 +110,6 @@ public abstract class MultiplexTransaction implements RequestScopedTransaction {
         // flush all before commit
         flush();
         transactions.values().forEach(DataStoreTransaction::commit);
-        transactions.clear();
     }
 
     @Override
@@ -130,6 +129,7 @@ public abstract class MultiplexTransaction implements RequestScopedTransaction {
                 }
             }
         }
+        transactions.clear();
         if (cause != null) {
             throw cause;
         }

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
@@ -82,7 +82,6 @@ public class MultiplexWriteTransaction extends MultiplexTransaction {
                 throw transactionException;
             }
         }
-        transactions.clear();
     }
 
     /**


### PR DESCRIPTION
Multiplex Transaction was leaving orphaned child transactions on close.  Moved the clear to the correct location after `close`.