### PR TITLE
Update swagger code to support large and complex entity graphs.

### DIFF
--- a/elide-contrib/elide-swagger/pom.xml
+++ b/elide-contrib/elide-swagger/pom.xml
@@ -87,7 +87,7 @@
        </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet</artifactId>
+	    <artifactId>jersey-container-servlet</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/SwaggerBuilder.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/SwaggerBuilder.java
@@ -5,11 +5,13 @@
  */
 package com.yahoo.elide.contrib.swagger;
 
+import com.google.common.collect.Sets;
 import com.yahoo.elide.contrib.swagger.model.Data;
 import com.yahoo.elide.contrib.swagger.model.Datum;
 import com.yahoo.elide.contrib.swagger.property.Relationship;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RelationshipType;
+import com.yahoo.elide.core.filter.Operator;
 import io.swagger.converter.ModelConverters;
 import io.swagger.models.Info;
 import io.swagger.models.Model;
@@ -46,9 +48,11 @@ import java.util.stream.Collectors;
 public class SwaggerBuilder {
     protected EntityDictionary dictionary;
     protected Set<Class<?>> rootClasses;
+    protected Set<Class<?>> allClasses;
     protected Swagger swagger;
     protected Map<Integer, Response> globalResponses;
     protected Set<Parameter> globalParams;
+    protected Set<Operator> filterOperators;
 
     public static final Response UNAUTHORIZED_RESPONSE = new Response().description("Unauthorized");
     public static final Response FORBIDDEN_RESPONSE = new Response().description("Forbidden");
@@ -122,17 +126,18 @@ public class SwaggerBuilder {
             return baseUrl + "/relationships/" + name;
         }
 
+        @Override
+        public String toString() {
+            return getInstanceUrl();
+        }
+
         /**
-         * All Paths are 'tagged' in swagger with the root entity name in the path.
-         * This allows swaggerUI to group the paths by the root entities.
-         * @return the root entity name
+         * All Paths are 'tagged' in swagger with the final entity type name in the path.
+         * This allows swaggerUI to group the paths by entities.
+         * @return the entity type name
          */
         private String getTag() {
-            if (lineage.isEmpty()) {
-                return name;
-            } else {
-                return lineage.get(0).getName();
-            }
+            return dictionary.getJsonAliasFor(type);
         }
 
         /**
@@ -487,9 +492,6 @@ public class SwaggerBuilder {
 
             List<Parameter> params = new ArrayList<>();
 
-            String[] filterOps = new String[] {"in", "not", "prefix", "postfix", "infix",
-                    "isnull", "notnull", "lt", "gt", "le", "ge"};
-
             /* Add RSQL Disjoint Filter Query Param */
             params.add(new QueryParameter()
                     .type("string")
@@ -504,7 +506,7 @@ public class SwaggerBuilder {
                         .description("Filters the collection of " + typeName + " using a 'joined' RSQL expression"));
             }
 
-            for (String op : filterOps) {
+            for (Operator op : filterOperators) {
                 attributeNames.forEach((name) -> {
                     Class<?> attributeClass = dictionary.getType(type, name);
 
@@ -512,9 +514,9 @@ public class SwaggerBuilder {
                     if (attributeClass.isPrimitive() || String.class.isAssignableFrom(attributeClass)) {
                         params.add(new QueryParameter()
                                 .type("string")
-                                .name("filter[" + typeName + "." + name + "][" + op + "]")
+                                .name("filter[" + typeName + "." + name + "][" + op.getNotation() + "]")
                                 .description("Filters the collection of " + typeName + " by the attribute "
-                                        + name + " " + "using the operator " + op));
+                                        + name + " " + "using the operator " + op.getNotation()));
                     }
                 });
             }
@@ -531,6 +533,27 @@ public class SwaggerBuilder {
             fullLineage.addAll(lineage);
             fullLineage.add(this);
             return fullLineage;
+        }
+
+        /**
+         * Returns true if this path is a shorter path to the same entity than the given path.
+         * @param compare The path to compare against.
+         * @return
+         */
+        public boolean shorterThan(PathMetaData compare) {
+            if (lineage.isEmpty()) {
+                return this.type.equals(compare.type);
+            }
+
+            if (!this.type.equals(compare.type) || !this.name.equals(compare.name)) {
+                return false;
+            }
+
+            if (compare.lineage.isEmpty()) {
+                return false;
+            }
+
+            return lineage.peek().shorterThan(compare.lineage.peek());
         }
 
         @Override
@@ -597,6 +620,20 @@ public class SwaggerBuilder {
         this.dictionary = dictionary;
         globalResponses = new HashMap<>();
         globalParams = new HashSet<>();
+        allClasses = new HashSet<>();
+        filterOperators = Sets.newHashSet(
+                Operator.IN,
+                Operator.NOT,
+                Operator.INFIX,
+                Operator.PREFIX,
+                Operator.POSTFIX,
+                Operator.GE,
+                Operator.GT,
+                Operator.LE,
+                Operator.LT,
+                Operator.ISNULL,
+                Operator.NOTNULL
+        );
         swagger = new Swagger();
         swagger.info(info);
     }
@@ -623,6 +660,27 @@ public class SwaggerBuilder {
     }
 
     /**
+     * The classes for which API paths will be generated.  All paths that include other entities
+     * are dropped.
+     * @param classes A subset of the entities in the entity dictionary.
+     * @return the builder
+     */
+    public SwaggerBuilder withExplicitClassList(Set<Class<?>> classes) {
+        allClasses = new HashSet<>(classes);
+        return this;
+    }
+
+    /**
+     * Assigns a subset of the complete set of filter operations to support for each GET operation.
+     * @param ops The subset of filter operations to support.
+     * @return the builder
+     */
+    public SwaggerBuilder withFilterOps(Set<Operator> ops) {
+        filterOperators = new HashSet<>(ops);
+        return this;
+    }
+
+    /**
      * @return the constructed 'Swagger' object
      */
     public Swagger build() {
@@ -631,7 +689,14 @@ public class SwaggerBuilder {
         ModelConverters converters = ModelConverters.getInstance();
         converters.addConverter(new JsonApiModelResolver(dictionary));
 
-        Set<Class<?>> allClasses = dictionary.getBindings();
+        if (allClasses.isEmpty()) {
+            allClasses = dictionary.getBindings();
+        } else {
+            allClasses = Sets.intersection(dictionary.getBindings(), allClasses);
+            if (allClasses.isEmpty()) {
+                throw new IllegalArgumentException("None of the provided classes are exported by Elide");
+            }
+        }
 
         /* Create a Model for each Elide entity */
         Map<String, Model> models = new HashMap<>();
@@ -644,11 +709,31 @@ public class SwaggerBuilder {
                 .filter(dictionary::isRoot)
                 .collect(Collectors.toSet());
 
-        /* Find all the paths starting from the root entities */
+        /* Find all the paths starting from the root entities.  Filter to only the entities we care about. */
         Set<PathMetaData> pathData =  rootClasses.stream()
                 .map(this::find)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
+
+        /* Prune the discovered paths to remove redundant elements */
+        Set<PathMetaData> toRemove = new HashSet<>();
+        for (PathMetaData path : pathData) {
+            for (PathMetaData compare : pathData) {
+
+                /*
+                 * We don't prune paths that are redundant with root collections to allow both BOTH
+                 * root collection urls as well as relationship urls.
+                 */
+                if (path.equals(compare) || compare.lineage.isEmpty()) {
+                    continue;
+                }
+                if (compare.shorterThan(path)) {
+                    toRemove.add(path);
+                    break;
+                }
+            }
+        }
+        pathData = Sets.difference(pathData, toRemove);
 
         /* Each path constructs 3 URLs (collection, instance, and relationship) */
         for (PathMetaData pathDatum : pathData) {
@@ -662,8 +747,8 @@ public class SwaggerBuilder {
             }
         }
 
-        /* We create Swagger 'tags' for each root entity so Swagger UI organizes the paths by root entities */
-        List<Tag> tags = rootClasses.stream()
+        /* We create Swagger 'tags' for each entity so Swagger UI organizes the paths by entities */
+        List<Tag> tags = allClasses.stream()
                 .map((clazz) -> dictionary.getJsonAliasFor(clazz))
                 .map((alias) -> new Tag().name(alias))
                 .collect(Collectors.toList());
@@ -688,21 +773,27 @@ public class SwaggerBuilder {
         while (! toVisit.isEmpty()) {
             PathMetaData current = toVisit.remove();
 
-            List<String> relationshipNames = dictionary.getRelationships(current.getType());
+            List<String> relationshipNames;
+            try {
+                relationshipNames = dictionary.getRelationships(current.getType());
+
+            /* If the entity is not bound in the dictionary, skip it */
+            } catch (IllegalArgumentException e) {
+                continue;
+            }
 
             for (String relationshipName : relationshipNames) {
                 Class<?> relationshipClass = dictionary.getParameterizedType(current.getType(), relationshipName);
 
                 PathMetaData next = new PathMetaData(current.getFullLineage(), relationshipName, relationshipClass);
 
-                /* We don't allow cycles */
-                if (current.lineageContainsType(next)) {
+                /* We don't allow cycles AND we only record paths that traverse through the provided subgraph */
+                if (current.lineageContainsType(next) || !allClasses.contains(relationshipClass)) {
                     continue;
                 }
 
                 toVisit.add(next);
             }
-
             paths.add(current);
         }
         return paths;

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
@@ -57,7 +57,6 @@ public class SwaggerBuilderTest {
 
         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
         swagger = builder.build();
-
     }
 
     @Test
@@ -68,9 +67,6 @@ public class SwaggerBuilderTest {
         Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/books"));
         Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/books/{bookId}"));
         Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/relationships/books"));
-        Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/books/{bookId}/authors"));
-        Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/books/{bookId}/authors/{authorId}"));
-        Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/books/{bookId}/relationships/authors"));
 
         Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors"));
         Assert.assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}"));
@@ -92,11 +88,8 @@ public class SwaggerBuilderTest {
         Assert.assertTrue(swagger.getPaths().containsKey("/book/{bookId}/publisher"));
         Assert.assertTrue(swagger.getPaths().containsKey("/book/{bookId}/publisher/{publisherId}"));
         Assert.assertTrue(swagger.getPaths().containsKey("/book/{bookId}/relationships/publisher"));
-        Assert.assertTrue(swagger.getPaths().containsKey("/book/{bookId}/publisher/{publisherId}/exclusiveAuthors"));
-        Assert.assertTrue(swagger.getPaths().containsKey("/book/{bookId}/publisher/{publisherId}/exclusiveAuthors/{authorId}"));
-        Assert.assertTrue(swagger.getPaths().containsKey("/book/{bookId}/publisher/{publisherId}/relationships/exclusiveAuthors"));
 
-        Assert.assertEquals(swagger.getPaths().size(), 28);
+        Assert.assertEquals(swagger.getPaths().size(), 22);
     }
 
     @Test
@@ -478,7 +471,7 @@ public class SwaggerBuilderTest {
     public void testTagGeneration() throws Exception {
 
         /* Check for the global tag definitions */
-        Assert.assertEquals(swagger.getTags().size(), 2);
+        Assert.assertEquals(swagger.getTags().size(), 3);
 
         Tag bookTag = swagger.getTags().stream()
                 .filter((tag) -> tag.getName().equals("book"))
@@ -494,26 +487,28 @@ public class SwaggerBuilderTest {
 
         /* For each operation, ensure its tagged with the root collection name */
         swagger.getPaths().forEach((url, path) -> {
-            Tag expectedTag;
-            if (url.startsWith("/publisher")) {
-                expectedTag = publisherTag;
-            } else {
-                expectedTag = bookTag;
-            }
-
-            path.getGet().getTags().contains(expectedTag);
-
-            if (url.contains("relationship") || url.endsWith("Id}")) {
-                if (path.getDelete() != null) {
-                    path.getDelete().getTags().contains(expectedTag);
-                }
-                path.getPatch().getTags().contains(expectedTag);
-            }
-
-            if (url.contains("relationship") || ! url.endsWith("Id}")) {
-                if (path.getPost() != null) {
-                    path.getPost().getTags().contains(expectedTag);
-                }
+            if (url.endsWith("relationships/books")) {
+                path.getGet().getTags().contains(bookTag);
+                path.getPost().getTags().contains(bookTag);
+                path.getDelete().getTags().contains(bookTag);
+                path.getPatch().getTags().contains(bookTag);
+            } else if (url.endsWith("/books")) {
+                path.getGet().getTags().contains(bookTag);
+                path.getPost().getTags().contains(bookTag);
+            } else if (url.endsWith("{bookId}")) {
+                path.getGet().getTags().contains(bookTag);
+                path.getPatch().getTags().contains(bookTag);
+                path.getDelete().getTags().contains(bookTag);
+            } else if (url.endsWith("relationships/publisher")) {
+                path.getGet().getTags().contains(publisherTag);
+                path.getPatch().getTags().contains(publisherTag);
+            } else if (url.endsWith("/publisher")) {
+                path.getGet().getTags().contains(publisherTag);
+                path.getPost().getTags().contains(publisherTag);
+            } else if (url.endsWith("{publisherId}")) {
+                path.getGet().getTags().contains(publisherTag);
+                path.getPatch().getTags().contains(publisherTag);
+                path.getDelete().getTags().contains(publisherTag);
             }
         });
     }

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerIT.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerIT.java
@@ -7,58 +7,21 @@ package com.yahoo.elide.contrib.swagger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Maps;
 import com.jayway.restassured.RestAssured;
-import com.yahoo.elide.contrib.swagger.models.Author;
-import com.yahoo.elide.contrib.swagger.models.Book;
-import com.yahoo.elide.contrib.swagger.models.Publisher;
 import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
-import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.initialization.AbstractApiResourceInitializer;
-import io.swagger.models.Info;
-import io.swagger.models.Swagger;
-import org.glassfish.hk2.api.Factory;
-import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.glassfish.jersey.server.ResourceConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class SwaggerIT extends AbstractApiResourceInitializer {
     public SwaggerIT() {
         super(SwaggerResourceConfig.class, DocEndpoint.class.getPackage().getName());
-        ResourceConfig config = new ResourceConfig();
-        config.register(new AbstractBinder() {
-            @Override
-            protected void configure() {
-                bindFactory(new Factory<Swagger>() {
-                    @Override
-                    public Swagger provide() {
-                        EntityDictionary dictionary = new EntityDictionary(Maps.newHashMap());
-
-                        dictionary.bindEntity(Book.class);
-                        dictionary.bindEntity(Author.class);
-                        dictionary.bindEntity(Publisher.class);
-                        Info info = new Info().title("Test Service").version("1.0");
-
-                        SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
-                        Swagger swagger = builder.build();
-
-                        return swagger;
-                    }
-
-                    @Override
-                    public void dispose(Swagger instance) {
-                        //NOP
-                    }
-                }).to(Swagger.class).named("swagger");
-            }
-        });
     }
 
     @Test
     void testDocumentFetch() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode node = mapper.readTree(RestAssured.get("/doc").asString());
+        JsonNode node = mapper.readTree(RestAssured.get("/doc/test").asString());
         Assert.assertNotNull(node.get("paths").get("/book"));
     }
 }

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerResourceConfig.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerResourceConfig.java
@@ -13,8 +13,12 @@ import com.yahoo.elide.core.EntityDictionary;
 import io.swagger.models.Info;
 import io.swagger.models.Swagger;
 import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class SwaggerResourceConfig extends ResourceConfig {
 
@@ -22,10 +26,10 @@ public class SwaggerResourceConfig extends ResourceConfig {
         register(new AbstractBinder() {
             @Override
             protected void configure() {
-                bindFactory(new Factory<Swagger>() {
+                bindFactory(new Factory<Map<String, Swagger>>() {
 
                     @Override
-                    public Swagger provide() {
+                    public Map<String, Swagger> provide() {
                         EntityDictionary dictionary = new EntityDictionary(Maps.newHashMap());
 
                         dictionary.bindEntity(Book.class);
@@ -36,14 +40,17 @@ public class SwaggerResourceConfig extends ResourceConfig {
                         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
                         Swagger swagger = builder.build();
 
-                        return swagger;
+                        Map<String, Swagger> docs = new HashMap<>();
+                        docs.put("test", swagger);
+                        return docs;
                     }
 
                     @Override
-                    public void dispose(Swagger instance) {
+                    public void dispose(Map<String, Swagger> instance) {
                         //NOP
                     }
-                }).to(Swagger.class).named("swagger");
+                }).to(new TypeLiteral<Map<String, Swagger>>() {
+                }).named("swagger");
             }
         });
     }

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Publisher.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Publisher.java
@@ -22,6 +22,12 @@ public class Publisher {
         public String city;
         public String state;
         public String zip;
+
+        /*
+         * Adding an Elide entity as an attribute is a test case for making sure the Swagger ModelResolver creates
+         * a ref back to our existing model for Book (rather than create a new model).
+         */
+        public Book hmmm;
     }
 
     @OneToMany


### PR DESCRIPTION
A number of fixes:
 - The model resolver now correctly handles Elide entities that were attributes.
 - Aggressively prune redundant paths.
 - Allow options to generate docs for subgraphs of the entity model.
 - Allow options to limit the filtering operators for each GET 
 - The JAXRS resource now supports serving multiple swagger documents.