### PR TITLE
Support object-level reads through Noop Store and RequestScope params for Computed Fields

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -158,9 +158,7 @@ public interface DataStoreTransaction extends Closeable {
             throw new ClassCastException("Fail trying to cast requestscope");
         }
 
-        EntityDictionary dictionary = requestScope.getDictionary();
-
-        return PersistentResource.getValue(entity, relationName, dictionary);
+        return PersistentResource.getValue(entity, relationName, requestScope);
     }
 
 
@@ -215,7 +213,7 @@ public interface DataStoreTransaction extends Closeable {
             throw new ClassCastException("Fail trying to cast requestscope");
         }
 
-        Object val = PersistentResource.getValue(entity, attributeName, requestScope.getDictionary());
+        Object val = PersistentResource.getValue(entity, attributeName, requestScope);
         return val;
 
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -288,6 +288,28 @@ public class EntityDictionary {
     }
 
     /**
+     * Determine whether or not a method is request scopeable.
+     *
+     * @param entity  Entity instance
+     * @param method  Method on entity to check
+     * @return True if method accepts a RequestScope, false otherwise.
+     */
+    public boolean isMethodRequestScopeable(Object entity, Method method) {
+        return isMethodRequestScopeable(entity.getClass(), method);
+    }
+
+    /**
+     * Determine whether or not a method is request scopeable.
+     *
+     * @param entityClass  Entity to check
+     * @param method  Method on entity to check
+     * @return True if method accepts a RequestScope, false otherwise.
+     */
+    public boolean isMethodRequestScopeable(Class<?> entityClass, Method method) {
+        return getEntityBinding(entityClass).requestScopeableMethods.getOrDefault(method, false);
+    }
+
+    /**
      * Get a list of all fields including both relationships and attributes.
      *
      * @param entityClass entity name

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1345,7 +1345,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         runTriggers(OnReadPreSecurity.class, "");
         runTriggers(OnReadPreSecurity.class, fieldName);
         checkFieldAwareDeferPermissions(ReadPermission.class, fieldName, (Object) null, (Object) null);
-        return getValue(getObject(), fieldName, dictionary);
+        return getValue(getObject(), fieldName, requestScope);
     }
 
     /**
@@ -1360,7 +1360,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         // Run the pre-security checks:
         runTriggers(OnReadPreSecurity.class, "");
         runTriggers(OnReadPreSecurity.class, fieldName);
-        return getValue(getObject(), fieldName, dictionary);
+        return getValue(getObject(), fieldName, requestScope);
     }
 
     /**
@@ -1594,10 +1594,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * Invoke the get[fieldName] method on the target object OR get the field with the corresponding name.
      * @param target the object to get
      * @param fieldName the field name to get or invoke equivalent get method
-     * @param dictionary the dictionary
+     * @param requestScope the request scope
      * @return the value
      */
-    public static Object getValue(Object target, String fieldName, EntityDictionary dictionary) {
+    public static Object getValue(Object target, String fieldName, RequestScope requestScope) {
+        EntityDictionary dictionary = requestScope.getDictionary();
         AccessibleObject accessor = dictionary.getAccessibleObject(target, fieldName);
         try {
             if (accessor instanceof Method) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -9,8 +9,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.yahoo.elide.annotation.Audit;
-import com.yahoo.elide.annotation.ComputedAttribute;
-import com.yahoo.elide.annotation.ComputedRelationship;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.OnReadPreSecurity;
@@ -72,7 +70,6 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.persistence.GeneratedValue;
 import javax.ws.rs.ServerErrorException;
@@ -1606,11 +1603,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         try {
             if (accessor instanceof Method) {
                 // Pass RequestScope into @Computed fields if requested
-                if (Stream.of(accessor.getAnnotations())
-                        .map(Annotation::annotationType)
-                        .anyMatch(c -> c == ComputedAttribute.class || c == ComputedRelationship.class)
-                        && ((Method) accessor).getParameterCount() == 1
-                        && ((Method) accessor).getParameterTypes()[0].isAssignableFrom(RequestScope.class)) {
+                if (dictionary.isMethodRequestScopeable(target, (Method) accessor)) {
                     return ((Method) accessor).invoke(target, requestScope);
                 }
                 return ((Method) accessor).invoke(target);

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InMemoryFilterOperation.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InMemoryFilterOperation.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.core.filter;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
 
 import java.util.Collections;
 import java.util.Set;
@@ -15,10 +16,10 @@ import java.util.stream.Collectors;
  * InMemoryFilterOperation
  */
 public class InMemoryFilterOperation implements FilterOperation<Set<java.util.function.Predicate>> {
-    private final EntityDictionary dictionary;
+    private final RequestScope requestScope;
 
-    public InMemoryFilterOperation(EntityDictionary dictionary) {
-        this.dictionary = dictionary;
+    public InMemoryFilterOperation(RequestScope requestScope) {
+        this.requestScope = requestScope;
     }
 
     @Override
@@ -34,10 +35,10 @@ public class InMemoryFilterOperation implements FilterOperation<Set<java.util.fu
     }
 
     private java.util.function.Predicate applyOperator(Predicate predicate) {
-        return predicate.apply(dictionary);
+        return predicate.apply(requestScope);
     }
 
     public EntityDictionary getDictionary() {
-        return dictionary;
+        return requestScope.getDictionary();
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -5,8 +5,8 @@
  */
 package com.yahoo.elide.core.filter;
 
-import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 import lombok.Getter;
@@ -23,95 +23,95 @@ public enum Operator {
     IN("in", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.in(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.in(field, values, requestScope);
         }
     },
 
     NOT("not", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.notIn(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.notIn(field, values, requestScope);
         }
     },
 
     PREFIX("prefix", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.prefix(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.prefix(field, values, requestScope);
         }
     },
 
     POSTFIX("postfix", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.postfix(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.postfix(field, values, requestScope);
         }
     },
 
     INFIX("infix", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.infix(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.infix(field, values, requestScope);
         }
     },
 
     ISNULL("isnull", false) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.isNull(field, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.isNull(field, requestScope);
         }
     },
 
     NOTNULL("notnull", false) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.isNotNull(field, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.isNotNull(field, requestScope);
         }
     },
 
     LT("lt", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.lt(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.lt(field, values, requestScope);
         }
     },
 
     LE("le", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.le(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.le(field, values, requestScope);
         }
     },
 
     GT("gt", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.gt(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.gt(field, values, requestScope);
         }
     },
 
     GE("ge", true) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
-            return Operator.ge(field, values, dictionary);
+                String field, List<Object> values, RequestScope requestScope) {
+            return Operator.ge(field, values, requestScope);
         }
     },
 
     TRUE("true", false) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
+                String field, List<Object> values, RequestScope requestScope) {
             return Operator.isTrue();
         }
     },
@@ -119,7 +119,7 @@ public enum Operator {
     FALSE("false", false) {
         @Override
         public <T> Predicate<T> contextualize(
-                String field, List<Object> values, EntityDictionary dictionary) {
+                String field, List<Object> values, RequestScope requestScope) {
             return Operator.isFalse();
         }
     };
@@ -144,16 +144,16 @@ public enum Operator {
     }
 
     public abstract <T> Predicate<T> contextualize(
-            String field, List<Object> values, EntityDictionary dictionary);
+            String field, List<Object> values, RequestScope requestScope);
 
     //
     // Predicate generation
     //
 
     private static <T> Predicate<T> in(
-            String field, List<Object> values, EntityDictionary dictionary) {
+            String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
 
             return val != null && values.stream()
                     .map(v -> CoerceUtil.coerce(v, val.getClass()))
@@ -161,9 +161,9 @@ public enum Operator {
         };
     }
 
-    private static <T> Predicate<T> notIn(String field, List<Object> values, EntityDictionary dictionary) {
+    private static <T> Predicate<T> notIn(String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
 
             return val == null || values.stream()
                     .map(v -> CoerceUtil.coerce(v, val.getClass()))
@@ -172,13 +172,13 @@ public enum Operator {
     }
 
     private static <T> Predicate<T> prefix(
-            String field, List<Object> values, EntityDictionary dictionary) {
+            String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("PREFIX can only take one argument");
             }
 
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
             String valStr = CoerceUtil.coerce(val, String.class);
             String filterStr = CoerceUtil.coerce(values.get(0), String.class);
 
@@ -189,13 +189,13 @@ public enum Operator {
     }
 
     private static <T> Predicate<T> postfix(
-            String field, List<Object> values, EntityDictionary dictionary) {
+            String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("POSTFIX can only take one argument");
             }
 
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
             String valStr = CoerceUtil.coerce(val, String.class);
             String filterStr = CoerceUtil.coerce(values.get(0), String.class);
 
@@ -205,13 +205,13 @@ public enum Operator {
         };
     }
 
-    private static <T> Predicate<T> infix(String field, List<Object> values, EntityDictionary dictionary) {
+    private static <T> Predicate<T> infix(String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("INFIX can only take one argument");
             }
 
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
             String valStr = CoerceUtil.coerce(val, String.class);
             String filterStr = CoerceUtil.coerce(values.get(0), String.class);
 
@@ -221,63 +221,63 @@ public enum Operator {
         };
     }
 
-    private static <T> Predicate<T> isNull(String field, EntityDictionary dictionary) {
+    private static <T> Predicate<T> isNull(String field, RequestScope requestScope) {
         return (T entity) -> {
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
             return val == null;
         };
     }
 
-    private static <T> Predicate<T> isNotNull(String field, EntityDictionary dictionary) {
+    private static <T> Predicate<T> isNotNull(String field, RequestScope requestScope) {
         return (T entity) -> {
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
 
             return val != null;
         };
     }
 
-    private static <T> Predicate<T> lt(String field, List<Object> values, EntityDictionary dictionary) {
+    private static <T> Predicate<T> lt(String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("LT can only take one argument");
             }
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
 
             return val != null
                     && getComparisonResult(val, values.get(0)) < 0;
         };
     }
 
-    private static <T> Predicate<T> le(String field, List<Object> values, EntityDictionary dictionary) {
+    private static <T> Predicate<T> le(String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("LE can only take one argument");
             }
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
 
             return val != null
                     && getComparisonResult(val, values.get(0)) <= 0;
         };
     }
 
-    private static <T> Predicate<T> gt(String field, List<Object> values, EntityDictionary dictionary) {
+    private static <T> Predicate<T> gt(String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("GT can only take one argument");
             }
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
 
             return val != null
                     && getComparisonResult(val, values.get(0)) > 0;
         };
     }
 
-    private static <T> Predicate<T> ge(String field, List<Object> values, EntityDictionary dictionary) {
+    private static <T> Predicate<T> ge(String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("GE can only take one argument");
             }
-            Object val = getFieldValue(entity, field, dictionary);
+            Object val = getFieldValue(entity, field, requestScope);
 
             return val != null
                     && getComparisonResult(val, values.get(0)) >= 0;
@@ -300,16 +300,16 @@ public enum Operator {
      * Return value of field/path for given entity.  For example this.book.author
      * @param entity Entity bean
      * @param fieldPath field value/path
-     * @param dictionary
+     * @param requestScope Request scope
      * @return
      */
-    public static <T> Object getFieldValue(T entity, String fieldPath, EntityDictionary dictionary) {
+    public static <T> Object getFieldValue(T entity, String fieldPath, RequestScope requestScope) {
         Object val = entity;
         for (String field : fieldPath.split("\\.")) {
             if ("this".equals(field)) {
                 continue;
             }
-            val = PersistentResource.getValue(val, field, dictionary);
+            val = PersistentResource.getValue(val, field, requestScope);
         }
         return val;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Predicate.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.core.filter;
 
-import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.Visitor;
 import lombok.AllArgsConstructor;
@@ -24,7 +24,7 @@ import java.util.function.Function;
  */
 @AllArgsConstructor
 @EqualsAndHashCode
-public class Predicate implements FilterExpression, Function<EntityDictionary, java.util.function.Predicate> {
+public class Predicate implements FilterExpression, Function<RequestScope, java.util.function.Predicate> {
 
     /**
      * The path taken through data model associations to
@@ -92,8 +92,8 @@ public class Predicate implements FilterExpression, Function<EntityDictionary, j
     }
 
     @Override
-    public java.util.function.Predicate apply(EntityDictionary dictionary) {
-        return operator.contextualize(getFieldPath(), values, dictionary);
+    public java.util.function.Predicate apply(RequestScope requestScope) {
+        return operator.contextualize(getFieldPath(), values, requestScope);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/InMemoryFilterVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/InMemoryFilterVisitor.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.core.filter.expression;
 
-import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
 
 import java.util.function.Predicate;
 
@@ -13,15 +13,15 @@ import java.util.function.Predicate;
  * Visitor for in memory filterExpressions
  */
 public class InMemoryFilterVisitor implements Visitor<Predicate> {
-    private final EntityDictionary dictionary;
+    private final RequestScope requestScope;
 
-    public InMemoryFilterVisitor(EntityDictionary dictionary) {
-        this.dictionary = dictionary;
+    public InMemoryFilterVisitor(RequestScope requestScope) {
+        this.requestScope = requestScope;
     }
 
     @Override
     public Predicate visitPredicate(com.yahoo.elide.core.filter.Predicate predicate) {
-        return predicate.apply(dictionary);
+        return predicate.apply(requestScope);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
@@ -6,7 +6,6 @@
 
 package com.yahoo.elide.security;
 
-import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.Predicate;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.parsers.expression.FilterExpressionCheckEvaluationVisitor;
@@ -60,9 +59,9 @@ public abstract class FilterExpressionCheck<T> extends InlineCheck<T> {
      */
     public boolean applyPredicateToObject(T object, Predicate predicate, RequestScope requestScope) {
         String fieldPath = predicate.getFieldPath();
-        EntityDictionary dictionary = ((com.yahoo.elide.core.RequestScope) requestScope).getDictionary();
+        com.yahoo.elide.core.RequestScope scope = (com.yahoo.elide.core.RequestScope) requestScope;
         java.util.function.Predicate fn = predicate.getOperator()
-                .contextualize(fieldPath, predicate.getValues(), dictionary);
+                .contextualize(fieldPath, predicate.getValues(), scope);
         return fn.test(object);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -44,6 +44,7 @@ import com.yahoo.elide.security.User;
 import com.yahoo.elide.security.checks.OperationCheck;
 import example.Child;
 import example.Color;
+import example.ComputedBean;
 import example.FirstClassFields;
 import example.FunWithPermissions;
 import example.Invoice;
@@ -125,6 +126,7 @@ public class PersistentResourceTest extends PersistentResource {
         dictionary.bindEntity(ChangeSpecChild.class);
         dictionary.bindEntity(Invoice.class);
         dictionary.bindEntity(LineItem.class);
+        dictionary.bindEntity(ComputedBean.class);
     }
 
     @Test
@@ -438,8 +440,26 @@ public class PersistentResourceTest extends PersistentResource {
         Assert.assertTrue(children.contains(testChild), "getValue should set the correct relation.");
         Assert.assertEquals(children.size(), 1, "getValue should set the relation with the correct number of elements");
 
+        ComputedBean computedBean = new ComputedBean();
+
+        String computedTest1 = (String) getValue(computedBean, "test", getRequestScope());
+        String computedTest2 = (String) getValue(computedBean, "testWithScope", getRequestScope());
+        String computedTest3 = (String) getValue(computedBean, "testWithSecurityScope", getRequestScope());
+
+        Assert.assertEquals(computedTest1, "test1");
+        Assert.assertEquals(computedTest2, "test2");
+        Assert.assertEquals(computedTest3, "test3");
+
+        try {
+            getValue(computedBean, "NonComputedWithScope", getRequestScope());
+            Assert.fail("Getting a bad relation should throw an InvalidAttributeException.");
+        } catch (InvalidAttributeException e) {
+            // Do nothing
+        }
+
         try {
             getValue(fun, "badRelation", getRequestScope());
+            Assert.fail("Getting a bad relation should throw an InvalidAttributeException.");
         } catch (InvalidAttributeException e) {
             return;
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -421,25 +421,25 @@ public class PersistentResourceTest extends PersistentResource {
         FunWithPermissions fun = new FunWithPermissions();
         fun.field3 = "testValue";
         String result;
-        result = (String) getValue(fun, "field3",  dictionary);
+        result = (String) getValue(fun, "field3",  getRequestScope());
         Assert.assertEquals(result, "testValue", "getValue should set the appropriate value in the resource");
 
         fun.setField1("testValue2");
 
-        result = (String) getValue(fun, "field1", dictionary);
+        result = (String) getValue(fun, "field1", getRequestScope());
         Assert.assertEquals(result, "testValue2", "getValue should set the appropriate value in the resource");
 
         Child testChild = newChild(3);
         fun.setRelation1(Sets.newHashSet(testChild));
 
         @SuppressWarnings("unchecked")
-        Set<Child> children = (Set<Child>) getValue(fun, "relation1", dictionary);
+        Set<Child> children = (Set<Child>) getValue(fun, "relation1", getRequestScope());
 
         Assert.assertTrue(children.contains(testChild), "getValue should set the correct relation.");
         Assert.assertEquals(children.size(), 1, "getValue should set the relation with the correct number of elements");
 
         try {
-            getValue(fun, "badRelation", dictionary);
+            getValue(fun, "badRelation", getRequestScope());
         } catch (InvalidAttributeException e) {
             return;
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterVisitorTest.java
@@ -6,10 +6,12 @@
 package com.yahoo.elide.core.filter.expression;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.Operator;
 import com.yahoo.elide.core.filter.Predicate;
 import com.yahoo.elide.security.checks.Check;
 
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -19,6 +21,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.mockito.Mockito.when;
 
 /**
  * Tests InMemoryFilterVisitor
@@ -49,7 +53,9 @@ public class InMemoryFilterVisitorTest {
     InMemoryFilterVisitorTest() {
         dictionary = new TestEntityDictionary(new HashMap<>());
         dictionary.bindEntity(Author.class);
-        visitor = new InMemoryFilterVisitor(dictionary);
+        RequestScope requestScope = Mockito.mock(RequestScope.class);
+        when(requestScope.getDictionary()).thenReturn(dictionary);
+        visitor = new InMemoryFilterVisitor(requestScope);
     }
 
     @Test

--- a/elide-core/src/test/java/example/ComputedBean.java
+++ b/elide-core/src/test/java/example/ComputedBean.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.ComputedAttribute;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.core.RequestScope;
+
+import javax.persistence.Entity;
+
+/**
+ * Bean with only computed fields
+ */
+@Include
+@Entity
+public class ComputedBean {
+
+    @ComputedAttribute
+    public String getTest() {
+        return "test1";
+    }
+
+    @ComputedAttribute
+    public String getTestWithScope(RequestScope requestScope) {
+        return "test2";
+    }
+
+    @ComputedAttribute
+    public String getTestWithSecurityScope(com.yahoo.elide.security.RequestScope requestScope) {
+        return "test3";
+    }
+
+    public String getNonComputedWithScope(RequestScope requestScope) {
+        return "should not run!";
+    }
+}

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -359,14 +359,14 @@ public class HibernateTransaction implements DataStoreTransaction {
             throw new ClassCastException("Fail trying to cast requestscope");
         }
         EntityDictionary dictionary = requestScope.getDictionary();
-        Object val = com.yahoo.elide.core.PersistentResource.getValue(entity, relationName, dictionary);
+        Object val = com.yahoo.elide.core.PersistentResource.getValue(entity, relationName, requestScope);
         if (val instanceof Collection) {
             Collection filteredVal = (Collection) val;
             if (filteredVal instanceof AbstractPersistentCollection) {
                 if (scope instanceof PatchRequestScope && filterExpression.isPresent()) {
                     Class relationClass = dictionary.getType(entity, relationName);
                     return patchRequestFilterCollection(filteredVal,
-                            relationClass, filterExpression.get(), ((PatchRequestScope) scope).getDictionary());
+                            relationClass, filterExpression.get(), (PatchRequestScope) scope);
                 }
 
                 @SuppressWarnings("unchecked")
@@ -393,15 +393,15 @@ public class HibernateTransaction implements DataStoreTransaction {
      * @param collection  the collection to filter
      * @param entityClass the class of the entities in the collection
      * @param filterExpression the filter expression
-     * @param dictionary  Entity dictionary
+     * @param requestScope  The request scope
      * @return the filtered collection
      */
     protected <T> Collection patchRequestFilterCollection(
             Collection collection,
             Class<T> entityClass,
             FilterExpression filterExpression,
-            EntityDictionary dictionary) {
-        InMemoryFilterVisitor inMemoryFilterVisitor = new InMemoryFilterVisitor(dictionary);
+            com.yahoo.elide.core.RequestScope requestScope) {
+        InMemoryFilterVisitor inMemoryFilterVisitor = new InMemoryFilterVisitor(requestScope);
         java.util.function.Predicate inMemoryFilterFn =
                 filterExpression.accept(inMemoryFilterVisitor);
         return (Collection) collection.stream()

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -217,14 +217,14 @@ public class HibernateTransaction implements DataStoreTransaction {
             throw new ClassCastException("Fail trying to cast requestscope");
         }
         EntityDictionary dictionary = requestScope.getDictionary();
-        Object val = com.yahoo.elide.core.PersistentResource.getValue(entity, relationName, dictionary);
+        Object val = com.yahoo.elide.core.PersistentResource.getValue(entity, relationName, requestScope);
         if (val instanceof Collection) {
             Collection filteredVal = (Collection) val;
             if (filteredVal instanceof AbstractPersistentCollection) {
                 if (scope instanceof PatchRequestScope && filterExpression.isPresent()) {
                     Class relationClass = dictionary.getType(entity, relationName);
                     return patchRequestFilterCollection(filteredVal,
-                            relationClass, filterExpression.get(), ((PatchRequestScope) scope).getDictionary());
+                            relationClass, filterExpression.get(), (PatchRequestScope) scope);
                 }
 
                 @SuppressWarnings("unchecked")
@@ -257,15 +257,15 @@ public class HibernateTransaction implements DataStoreTransaction {
      * @param collection  the collection to filter
      * @param entityClass the class of the entities in the collection
      * @param filterExpression the filter expression
-     * @param dictionary  Entity dictionary
+     * @param requestScope  the request scope
      * @return the filtered collection
      */
     protected <T> Collection patchRequestFilterCollection(
             Collection collection,
             Class<T> entityClass,
             FilterExpression filterExpression,
-            EntityDictionary dictionary) {
-        InMemoryFilterVisitor inMemoryFilterVisitor = new InMemoryFilterVisitor(dictionary);
+            com.yahoo.elide.core.RequestScope requestScope) {
+        InMemoryFilterVisitor inMemoryFilterVisitor = new InMemoryFilterVisitor(requestScope);
         java.util.function.Predicate inMemoryFilterFn =
                 filterExpression.accept(inMemoryFilterVisitor);
         return (Collection) collection.stream()

--- a/elide-datastore/elide-datastore-inmemorydb/src/main/java/com/yahoo/elide/datastores/inmemory/InMemoryTransaction.java
+++ b/elide-datastore/elide-datastore-inmemorydb/src/main/java/com/yahoo/elide/datastores/inmemory/InMemoryTransaction.java
@@ -163,7 +163,7 @@ public class InMemoryTransaction implements DataStoreTransaction {
         // Support for filtering
         if (filterExpression.isPresent()) {
             java.util.function.Predicate predicate = filterExpression.get()
-                    .accept(new InMemoryFilterVisitor(dictionary));
+                    .accept(new InMemoryFilterVisitor((com.yahoo.elide.core.RequestScope) scope));
             return (Collection) objs.values().stream()
                     .filter(predicate::test)
                     .collect(Collectors.toList());

--- a/elide-datastore/elide-datastore-noop/pom.xml
+++ b/elide-datastore/elide-datastore-noop/pom.xml
@@ -61,6 +61,12 @@
             <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/elide-datastore/elide-datastore-noop/src/main/java/com/yahoo/elide/datastores/noop/NoopTransaction.java
+++ b/elide-datastore/elide-datastore-noop/src/main/java/com/yahoo/elide/datastores/noop/NoopTransaction.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.datastores.noop;
 
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.PersistentResource;
-import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
@@ -16,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -77,8 +77,8 @@ public class NoopTransaction implements DataStoreTransaction {
                                         Optional<Sorting> sorting,
                                         Optional<Pagination> pagination,
                                         RequestScope scope) {
-        // Loads unsupported since nothing is persisted in this store
-        throw new InvalidOperationException("Cannot load object of type: " + entityClass);
+        // Default behavior: load object 1 and return as an array
+        return Collections.singletonList(this.loadObject(entityClass, 1L, filterExpression, scope));
     }
 
     @Override

--- a/elide-datastore/elide-datastore-noop/src/main/java/com/yahoo/elide/datastores/noop/NoopTransaction.java
+++ b/elide-datastore/elide-datastore-noop/src/main/java/com/yahoo/elide/datastores/noop/NoopTransaction.java
@@ -6,11 +6,13 @@
 package com.yahoo.elide.datastores.noop;
 
 import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 import com.yahoo.elide.security.RequestScope;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -19,6 +21,7 @@ import java.util.Optional;
 /**
  * Noop transaction. Specifically, this transaction does not perform any actions (i.e. no operation).
  */
+@Slf4j
 public class NoopTransaction implements DataStoreTransaction {
     @Override
     public void save(Object entity, RequestScope scope) {
@@ -50,8 +53,22 @@ public class NoopTransaction implements DataStoreTransaction {
                              Serializable id,
                              Optional<FilterExpression> filterExpression,
                              RequestScope scope) {
-        // Loads unsupported since nothing is persisted in this store
-        throw new InvalidOperationException("Cannot load object of type: " + entityClass);
+        // Loads are supported but empty object (with specified id) is returned.
+        // NOTE: This is primarily useful for enabling objects of solely computed properties
+        //       to be fetched.
+        Object entity;
+        try {
+            entity = entityClass.newInstance();
+        } catch (IllegalAccessException | InstantiationException e) {
+            log.error("Could not load object {} through NoopStore", entityClass, e);
+            throw new RuntimeException(e);
+        }
+
+        // Side-effecting method of the PersistentResource :( however, it enables us to do this without reinventing
+        // the wheel. Should probably be refactored eventually nonetheless.
+        new PersistentResource<>(entity, (com.yahoo.elide.core.RequestScope) scope).setId(id.toString());
+
+        return entity;
     }
 
     @Override

--- a/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/beans/NoopBean.java
+++ b/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/beans/NoopBean.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.beans;
 import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
+import javax.persistence.Id;
 
 /**
  * Simple bean intended to not be persisted
@@ -15,7 +16,17 @@ import javax.persistence.Entity;
 @Entity
 @Include(type = "theNoopBean")
 public class NoopBean {
+    private Long id;
     private String test;
+
+    @Id
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 
     public String getTest() {
         return test;

--- a/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopTransactionTest.java
+++ b/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopTransactionTest.java
@@ -7,16 +7,33 @@ package com.yahoo.elide.datastores.noop;
 
 import com.yahoo.elide.beans.NoopBean;
 import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.ObjectEntityCache;
+import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
 import java.util.Optional;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
 public class NoopTransactionTest {
     DataStoreTransaction tx = new NoopTransaction();
     NoopBean bean = new NoopBean();
+    RequestScope requestScope;
+
+    @BeforeClass
+    public void setup() {
+        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
+        dictionary.bindEntity(NoopBean.class);
+        requestScope = mock(RequestScope.class);
+        when(requestScope.getDictionary()).thenReturn(dictionary);
+        when(requestScope.getObjectEntityCache()).thenReturn(new ObjectEntityCache());
+    }
 
     @Test
     public void testSave() throws Exception {
@@ -48,10 +65,12 @@ public class NoopTransactionTest {
         tx.createObject(bean, null);
     }
 
-    @Test(expectedExceptions = InvalidOperationException.class)
+    @Test
     public void testLoadObject() throws Exception {
-        // Should throw
-        tx.loadObject(NoopBean.class, 1, Optional.empty(), null);
+
+        // Should return bean with id set
+        NoopBean bean = (NoopBean) tx.loadObject(NoopBean.class, 1, Optional.empty(), requestScope);
+        assertEquals(bean.getId(), (Long) 1L);
     }
 
     @Test(expectedExceptions = InvalidOperationException.class)

--- a/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopTransactionTest.java
+++ b/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopTransactionTest.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.ObjectEntityCache;
 import com.yahoo.elide.core.RequestScope;
-import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -73,10 +72,11 @@ public class NoopTransactionTest {
         assertEquals(bean.getId(), (Long) 1L);
     }
 
-    @Test(expectedExceptions = InvalidOperationException.class)
+    @Test
     public void testLoadObjects() throws Exception {
-        // Should throw
-        tx.loadObjects(NoopBean.class, Optional.empty(), Optional.empty(), Optional.empty(), null);
+        Iterable<NoopBean> iterable = (Iterable) tx.loadObjects(NoopBean.class, Optional.empty(), Optional.empty(), Optional.empty(), requestScope);
+        NoopBean bean = iterable.iterator().next();
+        assertEquals(bean.getId(), (Long) 1L);
     }
 
     @Test


### PR DESCRIPTION
This PR offers support for performing object-level reads in the noop store. Moreover, it enables `@ComputedAttribute`'s and `@ComputedRelationship`'s to accept a `RequestScope` as a parameter.