### PR TITLE
Pin jersey container version for example projects

### DIFF
--- a/elide-example/elide-blog-example/pom.xml
+++ b/elide-example/elide-blog-example/pom.xml
@@ -50,12 +50,12 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
-            <version>RELEASE</version>
+            <version>2.25.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jetty-servlet</artifactId>
-            <version>RELEASE</version>
+            <version>2.25.1</version>
         </dependency>
         <!-- Logging -->
         <dependency>

--- a/elide-example/elide-hibernate3-mysql-example/pom.xml
+++ b/elide-example/elide-hibernate3-mysql-example/pom.xml
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
-            <version>RELEASE</version>
+            <version>2.25.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jetty-servlet</artifactId>
-            <version>RELEASE</version>
+            <version>2.25.1</version>
         </dependency>
         <!-- Logging -->
         <dependency>

--- a/elide-example/elide-persistence-mysql-example/pom.xml
+++ b/elide-example/elide-persistence-mysql-example/pom.xml
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
-            <version>RELEASE</version>
+            <version>2.25.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-jetty-servlet</artifactId>
-            <version>RELEASE</version>
+            <version>2.25.1</version>
         </dependency>
         <!-- Logging -->
         <dependency>


### PR DESCRIPTION
Jersey container is now pulling version 2.26-b02 as RELEASE, and it is causing "java.lang.ClassNotFoundException: javax.ws.rs.client.RxInvokerProvider" with that version. We should pin to last good version.

- Pin jersey container to version 2.25.1 for example projects.