### PR TITLE
Move the in-memory store to elide-core

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 #Change Log
 
+## 3.0.5
+**Features**
+* Move `InMemoryDataStore` to Elide core. The `InMemoryDataStore` from the `elide-datastore-inmemorydb` package has
+    been deprecated and will be removed in Elide 4.0
+
 ## 3.0.4
 **Fixes**
 * Do not save deleted objects even if referenced as an inverse from a relationship.

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>jansi</artifactId>
             <version>1.14</version>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.10</version>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -154,9 +154,9 @@ public interface DataStoreTransaction extends Closeable {
             Optional<Sorting> sorting,
             Optional<Pagination> pagination,
             RequestScope scope) {
-        com.yahoo.elide.core.RequestScope requestScope;
+        RequestScope requestScope;
         try {
-            requestScope = (com.yahoo.elide.core.RequestScope) scope;
+            requestScope = scope;
         } catch (ClassCastException e) {
             throw new ClassCastException("Fail trying to cast requestscope");
         }
@@ -212,9 +212,9 @@ public interface DataStoreTransaction extends Closeable {
     default Object getAttribute(Object entity,
                                 String attributeName,
                                 RequestScope scope) {
-        com.yahoo.elide.core.RequestScope requestScope;
+        RequestScope requestScope;
         try {
-            requestScope = (com.yahoo.elide.core.RequestScope) scope;
+            requestScope = scope;
         } catch (ClassCastException e) {
             throw new ClassCastException("Fail trying to cast requestscope");
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryDataStore.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryDataStore.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Simple non-persistent in-memory database.
+ * Simple in-memory only database.
  */
 public class InMemoryDataStore implements DataStore {
     private final ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore = new ConcurrentHashMap<>();
@@ -39,7 +39,10 @@ public class InMemoryDataStore implements DataStore {
         reflections.getTypesAnnotatedWith(Entity.class).stream()
                 .filter(entityAnnotatedClass -> entityAnnotatedClass.getPackage().getName()
                         .startsWith(beanPackage.getName()))
-                .forEach(dictionary::bindEntity);
+                .forEach((cls) -> {
+                    dictionary.bindEntity(cls);
+                    dataStore.put(cls, new ConcurrentHashMap<>());
+                });
         this.dictionary = dictionary;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryDataStore.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryDataStore.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.datastore.inmemory;
+
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.EntityDictionary;
+import lombok.Getter;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+
+import javax.persistence.Entity;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Simple non-persistent in-memory database.
+ */
+public class InMemoryDataStore implements DataStore {
+    private final ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore = new ConcurrentHashMap<>();
+    @Getter private EntityDictionary dictionary;
+    @Getter private final Package beanPackage;
+
+    public InMemoryDataStore(Package beanPackage) {
+        this.beanPackage = beanPackage;
+    }
+
+    @Override
+    public void populateEntityDictionary(EntityDictionary dictionary) {
+        Reflections reflections = new Reflections(new ConfigurationBuilder()
+                .addUrls(ClasspathHelper.forPackage(beanPackage.getName()))
+                .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner()));
+        reflections.getTypesAnnotatedWith(Entity.class).stream()
+                .filter(entityAnnotatedClass -> entityAnnotatedClass.getPackage().getName()
+                        .startsWith(beanPackage.getName()))
+                .forEach(dictionary::bindEntity);
+        this.dictionary = dictionary;
+    }
+
+    @Override
+    public DataStoreTransaction beginTransaction() {
+        return new InMemoryTransaction(dataStore, dictionary);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Data store contents ");
+        for (Class<?> cls : dataStore.keySet()) {
+            sb.append("\n Table ").append(cls).append(" contents \n");
+            ConcurrentHashMap<String, Object> data = dataStore.get(cls);
+            for (Map.Entry<String, Object> e : data.entrySet()) {
+                sb.append(" Id: ").append(e.getKey()).append(" Value: ").append(e.getValue());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.datastore.inmemory;
+
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.expression.InMemoryFilterVisitor;
+import com.yahoo.elide.core.pagination.Pagination;
+import com.yahoo.elide.core.sort.Sorting;
+import com.yahoo.elide.utils.coerce.CoerceUtil;
+
+import javax.persistence.Id;
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * InMemoryDataStore transaction handler.
+ */
+public class InMemoryTransaction implements DataStoreTransaction {
+    private static final ConcurrentHashMap<Class<?>, AtomicLong> TYPEIDS = new ConcurrentHashMap<>();
+
+    private final ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore;
+    private final List<Operation> operations;
+    private final EntityDictionary dictionary;
+
+    public InMemoryTransaction(ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore,
+                               EntityDictionary dictionary) {
+        this.dataStore = dataStore;
+        this.dictionary = dictionary;
+        this.operations = new ArrayList<>();
+    }
+
+    @Override
+    public void flush(RequestScope requestScope) {
+        // Do nothing
+    }
+
+    @Override
+    public void save(Object object, RequestScope requestScope) {
+        if (object == null) {
+            return;
+        }
+        String id = dictionary.getId(object);
+        if (id == null || id.equals("null") || id.equals("0")) {
+            createObject(object, requestScope);
+        }
+        id = dictionary.getId(object);
+        operations.add(new Operation(id, object, object.getClass(), false));
+    }
+
+    @Override
+    public void delete(Object object, RequestScope requestScope) {
+        if (object == null) {
+            return;
+        }
+        String id = dictionary.getId(object);
+        operations.add(new Operation(id, object, object.getClass(), true));
+    }
+
+    @Override
+    public void commit(RequestScope scope) {
+        operations.forEach(op -> {
+            Class<?> cls = op.getType();
+            ConcurrentHashMap<String, Object> data = dataStore.get(cls);
+            Object instance = op.getInstance();
+            if (instance == null) {
+                return;
+            }
+            String id = op.getId();
+            if (op.getDelete()) {
+                if (data != null) {
+                    data.remove(id);
+                }
+            } else {
+                if (data == null) {
+                    data = new ConcurrentHashMap<>();
+                    dataStore.put(cls, data);
+                }
+                data.put(id, instance);
+            }
+        });
+        operations.clear();
+    }
+
+    @Override
+    public void createObject(Object entity, RequestScope scope) {
+        Class entityClass = entity.getClass();
+        if (dataStore.get(entityClass) == null) {
+            dataStore.putIfAbsent(entityClass, new ConcurrentHashMap<>());
+        }
+        AtomicLong idValue = TYPEIDS.computeIfAbsent(entityClass, this::newRandomId);
+        String id = String.valueOf(idValue.getAndIncrement());
+        setId(entity, id);
+        operations.add(new Operation(id, entity, entity.getClass(), false));
+    }
+
+    private AtomicLong newRandomId(Class<?> entityClass) {
+        return new AtomicLong(new Random().nextLong());
+    }
+
+    public void setId(Object value, String id) {
+        for (Class<?> cls = value.getClass(); cls != null; cls = cls.getSuperclass()) {
+            for (Method method : cls.getMethods()) {
+                if (method.isAnnotationPresent(Id.class)) {
+                    if (method.getName().startsWith("get")) {
+                        String setName = "set" + method.getName().substring(3);
+                        for (Method setMethod : cls.getMethods()) {
+                            if (setMethod.getName().equals(setName) && setMethod.getParameterCount() == 1) {
+                                try {
+                                    setMethod.invoke(value,
+                                            CoerceUtil.coerce(id, setMethod.getParameters()[0].getType()));
+                                } catch (ReflectiveOperationException e) {
+                                    e.printStackTrace();
+                                }
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public Object loadObject(Class<?> entityClass,
+                             Serializable id,
+                             Optional<FilterExpression> filterExpression,
+                             RequestScope scope) {
+        ConcurrentHashMap<String, Object> objs = dataStore.get(entityClass);
+        if (objs == null) {
+            return null;
+        }
+        return objs.get(id.toString());
+    }
+
+    @Override
+    public Iterable<Object> loadObjects(
+            Class<?> entityClass,
+            Optional<FilterExpression> filterExpression,
+            Optional<Sorting> sorting,
+            Optional<Pagination> pagination,
+            RequestScope scope) {
+        ConcurrentHashMap<String, Object> objs = dataStore.get(entityClass);
+        if (objs == null) {
+            return Collections.emptyList();
+        }
+        // Support for filtering
+        if (filterExpression.isPresent()) {
+            Predicate predicate = filterExpression.get()
+                    .accept(new InMemoryFilterVisitor((com.yahoo.elide.core.RequestScope) scope));
+            return (Collection) objs.values().stream()
+                    .filter(predicate::test)
+                    .collect(Collectors.toList());
+        }
+        List<Object> results = new ArrayList<>();
+        objs.forEachValue(1, results::add);
+        return results;
+    }
+
+    @Override
+    public void close() throws IOException {
+        operations.clear();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/Operation.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/Operation.java
@@ -1,9 +1,9 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2017, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.datastores.inmemory;
+package com.yahoo.elide.core.datastore.inmemory;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -24,16 +24,14 @@ import java.util.function.Predicate;
 public enum Operator {
     IN("in", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.in(field, values, requestScope);
         }
     },
 
     NOT("not", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.notIn(field, values, requestScope);
         }
     },
@@ -47,16 +45,14 @@ public enum Operator {
 
     PREFIX("prefix", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.prefix(field, values, requestScope);
         }
     },
 
     POSTFIX("postfix", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.postfix(field, values, requestScope);
         }
     },
@@ -70,8 +66,7 @@ public enum Operator {
 
     INFIX("infix", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.infix(field, values, requestScope);
         }
     },
@@ -85,32 +80,28 @@ public enum Operator {
 
     ISNULL("isnull", false) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.isNull(field, requestScope);
         }
     },
 
     NOTNULL("notnull", false) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.isNotNull(field, requestScope);
         }
     },
 
     LT("lt", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.lt(field, values, requestScope);
         }
     },
 
     LE("le", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.le(field, values, requestScope);
         }
     },
@@ -125,24 +116,21 @@ public enum Operator {
 
     GE("ge", true) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.ge(field, values, requestScope);
         }
     },
 
     TRUE("true", false) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.isTrue();
         }
     },
 
     FALSE("false", false) {
         @Override
-        public <T> Predicate<T> contextualize(
-                String field, List<Object> values, RequestScope requestScope) {
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
             return Operator.isFalse();
         }
     };
@@ -166,15 +154,12 @@ public enum Operator {
         throw new InvalidPredicateException("Unknown operator in filter: " + string);
     }
 
-    public abstract <T> Predicate<T> contextualize(
-            String field, List<Object> values, RequestScope requestScope);
+    public abstract <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope);
 
     //
     // Predicate generation
     //
-
-    private static <T> Predicate<T> in(
-            String field, List<Object> values, RequestScope requestScope) {
+    private static <T> Predicate<T> in(String field, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
             Object val = getFieldValue(entity, field, requestScope);
 
@@ -194,13 +179,12 @@ public enum Operator {
         };
     }
 
-    private static <T> Predicate<T> prefix(
-            String field, List<Object> values, RequestScope requestScope) {
+    private static <T> Predicate<T> prefix(String field, List<Object> values, RequestScope requestScope) {
         return prefix(field, values, requestScope, Function.identity());
     }
 
-    private static <T> Predicate<T> prefix(
-            String field, List<Object> values, RequestScope requestScope, Function<String, String> transform) {
+    private static <T> Predicate<T> prefix(String field, List<Object> values,
+                                           RequestScope requestScope, Function<String, String> transform) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("PREFIX can only take one argument");
@@ -216,13 +200,12 @@ public enum Operator {
         };
     }
 
-    private static <T> Predicate<T> postfix(
-            String field, List<Object> values, RequestScope requestScope) {
+    private static <T> Predicate<T> postfix(String field, List<Object> values, RequestScope requestScope) {
         return postfix(field, values, requestScope, Function.identity());
     }
 
-    private static <T> Predicate<T> postfix(
-            String field, List<Object> values, RequestScope requestScope, Function<String, String> transform) {
+    private static <T> Predicate<T> postfix(String field, List<Object> values,
+                                            RequestScope requestScope, Function<String, String> transform) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("POSTFIX can only take one argument");
@@ -242,8 +225,8 @@ public enum Operator {
         return infix(field, values, requestScope, Function.identity());
     }
 
-    private static <T> Predicate<T> infix(
-            String field, List<Object> values, RequestScope requestScope, Function<String, String> transform) {
+    private static <T> Predicate<T> infix(String field, List<Object> values,
+                                          RequestScope requestScope, Function<String, String> transform) {
         return (T entity) -> {
             if (values.size() != 1) {
                 throw new InvalidPredicateException("INFIX can only take one argument");

--- a/elide-datastore/elide-datastore-inmemorydb/pom.xml
+++ b/elide-datastore/elide-datastore-inmemorydb/pom.xml
@@ -4,7 +4,8 @@
   ~ See LICENSE file in project root for terms.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>elide-datastore-inmemorydb</artifactId>
     <packaging>jar</packaging>
@@ -51,32 +52,13 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
+        <!-- Test deps -->
         <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>
             <artifactId>hibernate-jpa-2.1-api</artifactId>
             <version>1.0.0.Final</version>
+            <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.9.10</version>
-        </dependency>
-        <!-- Jackson data-binder -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.8.7</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.8.7</version>
-        </dependency>
-        <!-- Test deps -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/elide-datastore/elide-datastore-inmemorydb/src/main/java/com/yahoo/elide/datastores/inmemory/InMemoryDataStore.java
+++ b/elide-datastore/elide-datastore-inmemorydb/src/main/java/com/yahoo/elide/datastores/inmemory/InMemoryDataStore.java
@@ -5,64 +5,13 @@
  */
 package com.yahoo.elide.datastores.inmemory;
 
-import com.yahoo.elide.core.DataStore;
-import com.yahoo.elide.core.DataStoreTransaction;
-import com.yahoo.elide.core.EntityDictionary;
-
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
-
-import lombok.Getter;
-
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-
-import javax.persistence.Entity;
-
 /**
  * Simple non-persistent in-memory database.
+ * @deprecated Use {@link com.yahoo.elide.core.datastore.inmemory.InMemoryDataStore}
  */
-public class InMemoryDataStore implements DataStore {
-    private final ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore =
-            new ConcurrentHashMap<>();
-    @Getter private EntityDictionary dictionary;
-    @Getter private final Package beanPackage;
-
+@Deprecated
+public class InMemoryDataStore extends com.yahoo.elide.core.datastore.inmemory.InMemoryDataStore {
     public InMemoryDataStore(Package beanPackage) {
-        this.beanPackage = beanPackage;
-    }
-
-    @Override
-    public void populateEntityDictionary(EntityDictionary dictionary) {
-        Reflections reflections = new Reflections(new ConfigurationBuilder()
-                .addUrls(ClasspathHelper.forPackage(beanPackage.getName()))
-                .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner()));
-        reflections.getTypesAnnotatedWith(Entity.class).stream()
-                .filter(entityAnnotatedClass -> entityAnnotatedClass.getPackage().getName()
-                        .startsWith(beanPackage.getName()))
-                .forEach(dictionary::bindEntity);
-        this.dictionary = dictionary;
-    }
-
-    @Override
-    public DataStoreTransaction beginTransaction() {
-        return new InMemoryTransaction(dataStore, dictionary);
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Data store contents ");
-        for (Class<?> cls : dataStore.keySet()) {
-            sb.append("\n Table ").append(cls).append(" contents \n");
-            ConcurrentHashMap<String, Object> data = dataStore.get(cls);
-            for (Entry<String, Object> e : data.entrySet()) {
-                sb.append(" Id: ").append(e.getKey()).append(" Value: ").append(e.getValue());
-            }
-        }
-        return sb.toString();
+        super(beanPackage);
     }
 }

--- a/elide-datastore/elide-datastore-inmemorydb/src/main/java/com/yahoo/elide/datastores/inmemory/InMemoryTransaction.java
+++ b/elide-datastore/elide-datastore-inmemorydb/src/main/java/com/yahoo/elide/datastores/inmemory/InMemoryTransaction.java
@@ -5,176 +5,18 @@
  */
 package com.yahoo.elide.datastores.inmemory;
 
-import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.RequestScope;
-import com.yahoo.elide.core.filter.expression.FilterExpression;
-import com.yahoo.elide.core.filter.expression.InMemoryFilterVisitor;
-import com.yahoo.elide.core.pagination.Pagination;
-import com.yahoo.elide.core.sort.Sorting;
-import com.yahoo.elide.utils.coerce.CoerceUtil;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import javax.persistence.Id;
 
 /**
  * InMemoryDataStore transaction handler.
+ * @deprecated Use {@link com.yahoo.elide.core.datastore.inmemory.InMemoryTransaction}
  */
-public class InMemoryTransaction implements DataStoreTransaction {
-    private static final ConcurrentHashMap<Class<?>, AtomicLong> TYPEIDS = new ConcurrentHashMap<>();
-
-    private final ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore;
-    private final List<Operation> operations;
-    private final EntityDictionary dictionary;
-
+@Deprecated
+public class InMemoryTransaction extends com.yahoo.elide.core.datastore.inmemory.InMemoryTransaction {
     public InMemoryTransaction(ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore,
                                EntityDictionary dictionary) {
-        this.dataStore = dataStore;
-        this.dictionary = dictionary;
-        this.operations = new ArrayList<>();
-    }
-
-    @Override
-    public void flush(RequestScope requestScope) {
-        // Do nothing
-    }
-
-    @Override
-    public void save(Object object, RequestScope requestScope) {
-        if (object == null) {
-            return;
-        }
-        String id = dictionary.getId(object);
-        if (id == null || id.equals("null") || id.equals("0")) {
-            createObject(object, requestScope);
-        }
-        id = dictionary.getId(object);
-        operations.add(new Operation(id, object, object.getClass(), false));
-    }
-
-    @Override
-    public void delete(Object object, RequestScope requestScope) {
-        if (object == null) {
-            return;
-        }
-        String id = dictionary.getId(object);
-        operations.add(new Operation(id, object, object.getClass(), true));
-    }
-
-    @Override
-    public void commit(RequestScope scope) {
-        operations.forEach(op -> {
-            Class<?> cls = op.getType();
-            ConcurrentHashMap<String, Object> data = dataStore.get(cls);
-            Object instance = op.getInstance();
-            if (instance == null) {
-                return;
-            }
-            String id = op.getId();
-            if (op.getDelete()) {
-                if (data != null) {
-                    data.remove(id);
-                }
-            } else {
-                if (data == null) {
-                    data = new ConcurrentHashMap<>();
-                    dataStore.put(cls, data);
-                }
-                data.put(id, instance);
-            }
-        });
-        operations.clear();
-    }
-
-    @Override
-    public void createObject(Object entity, RequestScope scope) {
-        Class entityClass = entity.getClass();
-        if (dataStore.get(entityClass) == null) {
-            dataStore.putIfAbsent(entityClass, new ConcurrentHashMap<>());
-        }
-        AtomicLong idValue = TYPEIDS.computeIfAbsent(entityClass, this::newRandomId);
-        String id = String.valueOf(idValue.getAndIncrement());
-        setId(entity, id);
-        operations.add(new Operation(id, entity, entity.getClass(), false));
-    }
-
-    private AtomicLong newRandomId(Class<?> entityClass) {
-        return new AtomicLong(new Random().nextLong());
-    }
-
-    public void setId(Object value, String id) {
-        for (Class<?> cls = value.getClass(); cls != null; cls = cls.getSuperclass()) {
-            for (Method method : cls.getMethods()) {
-                if (method.isAnnotationPresent(Id.class)) {
-                    if (method.getName().startsWith("get")) {
-                        String setName = "set" + method.getName().substring(3);
-                        for (Method setMethod : cls.getMethods()) {
-                            if (setMethod.getName().equals(setName) && setMethod.getParameterCount() == 1) {
-                                try {
-                                    setMethod.invoke(value,
-                                            CoerceUtil.coerce(id, setMethod.getParameters()[0].getType()));
-                                } catch (ReflectiveOperationException e) {
-                                    e.printStackTrace();
-                                }
-                                return;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    @Override
-    public Object loadObject(Class<?> entityClass,
-                             Serializable id,
-                             Optional<FilterExpression> filterExpression,
-                             RequestScope scope) {
-        ConcurrentHashMap<String, Object> objs = dataStore.get(entityClass);
-        if (objs == null) {
-            return null;
-        }
-        return objs.get(id.toString());
-    }
-
-    @Override
-    public Iterable<Object> loadObjects(
-            Class<?> entityClass,
-            Optional<FilterExpression> filterExpression,
-            Optional<Sorting> sorting,
-            Optional<Pagination> pagination,
-            RequestScope scope) {
-        ConcurrentHashMap<String, Object> objs = dataStore.get(entityClass);
-        if (objs == null) {
-            return Collections.emptyList();
-        }
-        // Support for filtering
-        if (filterExpression.isPresent()) {
-            Predicate predicate = filterExpression.get()
-                    .accept(new InMemoryFilterVisitor((com.yahoo.elide.core.RequestScope) scope));
-            return (Collection) objs.values().stream()
-                    .filter(predicate::test)
-                    .collect(Collectors.toList());
-        }
-        List<Object> results = new ArrayList<>();
-        objs.forEachValue(1, results::add);
-        return results;
-    }
-
-    @Override
-    public void close() throws IOException {
-        operations.clear();
+        super(dataStore, dictionary);
     }
 }


### PR DESCRIPTION
Tests have not been moved at this time.

Also, I'm pretty sure that our *reference implementation* is much more bare-bones than we had intended. For instance, we don't support rolling back transactions since we give the real backing object out to the `PersistentResource` and don't track the modifications that occur to it.