### PR TITLE
Improved Filter performance

### DIFF
--- a/elide-core/src/main/antlr4/com/yahoo/elide/generated/parsers/Core.g4
+++ b/elide-core/src/main/antlr4/com/yahoo/elide/generated/parsers/Core.g4
@@ -1,17 +1,7 @@
 /*
- * Copyright (c) 2015 Yahoo! Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License. See accompanying LICENSE file.
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
  */
 
 grammar Core;

--- a/elide-core/src/main/antlr4/com/yahoo/elide/generated/parsers/Expression.g4
+++ b/elide-core/src/main/antlr4/com/yahoo/elide/generated/parsers/Expression.g4
@@ -1,17 +1,7 @@
 /*
- * Copyright (c) 2016 Yahoo! Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License. See accompanying LICENSE file.
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
  */
 
 grammar Expression;

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -25,7 +25,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.persistence.CascadeType;
@@ -286,9 +286,9 @@ class EntityBinding {
                     || isRequestScopeableMethod((Method) fieldOrMethod);
 
             if (name.startsWith("get") && hasValidParameterCount) {
-                name = WordUtils.uncapitalize(name.substring("get".length()));
+                name = StringUtils.uncapitalize(name.substring("get".length()));
             } else if (name.startsWith("is") && hasValidParameterCount) {
-                name = WordUtils.uncapitalize(name.substring("is".length()));
+                name = StringUtils.uncapitalize(name.substring("is".length()));
             } else {
                 return null;
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -21,7 +21,7 @@ import com.yahoo.elide.security.checks.prefab.Common;
 import com.yahoo.elide.security.checks.prefab.Role;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -583,7 +583,7 @@ public class EntityDictionary {
 
         String type;
         if ("".equals(include.type())) {
-            type = WordUtils.uncapitalize(cls.getSimpleName());
+            type = StringUtils.uncapitalize(cls.getSimpleName());
         } else {
             type = include.type();
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -44,12 +44,13 @@ import com.yahoo.elide.utils.coerce.CoerceUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.GeneratedValue;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
@@ -155,6 +156,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @deprecated Will be removed in Elide 4. Instead use
      *  {@link PersistentResource#createObject(PersistentResource, Class, RequestScope, String)}
      */
+    @Deprecated
     public static <T> PersistentResource<T> createObject(Class<T> entityClass, RequestScope requestScope, String uuid) {
         return createObject(null, entityClass, requestScope, uuid);
     }
@@ -187,6 +189,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @deprecated Will be removed in Elide 4, instead use
      *  {@code PersistentResource(T,PersistentResource,String,RequestScope)}
      */
+    @Deprecated
     public PersistentResource(PersistentResource<?> parent, T obj, RequestScope requestScope) {
         this(obj, parent, requestScope.getUUIDFor(obj), requestScope);
     }
@@ -199,6 +202,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @deprecated Will be removed in Elide 4, instead use
      *  {@code PersistentResource(T,PersistentResource,String,RequestScope)}
      */
+    @Deprecated
     public PersistentResource(T obj, RequestScope requestScope) {
         this(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
@@ -212,6 +216,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @deprecated Will be removed in Elide 4, instead use
      *  {@code PersistentResource(T,PersistentResource,String,RequestScope)}
      */
+    @Deprecated
     protected PersistentResource(T obj, PersistentResource<?> parent, RequestScope requestScope) {
         this(obj, parent, requestScope.getUUIDFor(obj), requestScope);
     }
@@ -222,6 +227,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @param checkId the check id
      * @return True if matches false otherwise
      */
+    @Override
     public boolean matchesId(String checkId) {
         if (checkId == null) {
             return false;
@@ -532,7 +538,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             }
         }
 
-        if (newValue != null) {
+        if (newResource != null) {
             if (hasInverseRelation(fieldName)) {
                 addInverseRelation(fieldName, newValue);
                 newResource.markDirty();
@@ -752,6 +758,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      *
      * @return ID id
      */
+    @Override
     public String getId() {
         return dictionary.getId(getObject());
     }
@@ -787,6 +794,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * Gets UUID.
      * @return the UUID
      */
+    @Override
     public Optional<String> getUUID() {
         return uuid;
     }
@@ -1042,6 +1050,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      *
      * @return bean object
      */
+    @Override
     public T getObject() {
         return obj;
     }
@@ -1059,6 +1068,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      *
      * @return type resource class
      */
+    @Override
     @JsonIgnore
     public Class<T> getResourceClass() {
         return (Class) dictionary.lookupEntityClass(obj.getClass());
@@ -1068,6 +1078,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * Gets type.
      * @return the type
      */
+    @Override
     public String getType() {
         return type;
     }
@@ -1129,6 +1140,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * Gets request scope.
      * @return the request scope
      */
+    @Override
     public RequestScope getRequestScope() {
         return requestScope;
     }
@@ -1391,7 +1403,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             Class<?> fieldClass = dictionary.getType(targetClass, fieldName);
             String realName = dictionary.getNameFromAlias(obj, fieldName);
             fieldName = (realName != null) ? realName : fieldName;
-            String setMethod = "set" + WordUtils.capitalize(fieldName);
+            String setMethod = "set" + StringUtils.capitalize(fieldName);
             Method method = EntityDictionary.findMethod(targetClass, setMethod, fieldClass);
             method.invoke(obj, coerce(value, fieldName, fieldClass));
         } catch (IllegalAccessException e) {
@@ -1648,6 +1660,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @return Filtered set of resources
      * @deprecated use {@link PersistentResource#filter(Class, Set, boolean)}
      */
+    @Deprecated
     protected static Set<PersistentResource> filter(Class<? extends Annotation> permission,
                                                     Set<PersistentResource> resources) {
         return filter(permission, resources, false);

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.core.sort.Sorting;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 
 import javax.persistence.Id;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -22,8 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -33,7 +34,6 @@ import java.util.stream.Collectors;
  */
 public class InMemoryTransaction implements DataStoreTransaction {
     private static final ConcurrentHashMap<Class<?>, AtomicLong> TYPEIDS = new ConcurrentHashMap<>();
-    public static final Random RANDOM = new Random();
 
     private final ConcurrentHashMap<Class<?>, ConcurrentHashMap<String, Object>> dataStore;
     private final List<Operation> operations;
@@ -101,7 +101,7 @@ public class InMemoryTransaction implements DataStoreTransaction {
     }
 
     private AtomicLong newRandomId(Class<?> ignored) {
-        return new AtomicLong(RANDOM.nextLong());
+        return new AtomicLong(ThreadLocalRandom.current().nextLong());
     }
 
     public void setId(Object value, String id) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.core.filter.expression.InMemoryFilterVisitor;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.Id;
 
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 /**
  * InMemoryDataStore transaction handler.
  */
+@Slf4j
 public class InMemoryTransaction implements DataStoreTransaction {
     private static final ConcurrentHashMap<Class<?>, AtomicLong> TYPEIDS = new ConcurrentHashMap<>();
 
@@ -114,7 +116,7 @@ public class InMemoryTransaction implements DataStoreTransaction {
                             try {
                                 setMethod.invoke(value, CoerceUtil.coerce(id, setMethod.getParameters()[0].getType()));
                             } catch (ReflectiveOperationException e) {
-                                e.printStackTrace();
+                                log.error("set {}", setMethod, e);
                             }
                             return;
                         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ForbiddenAccessException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ForbiddenAccessException.java
@@ -29,7 +29,7 @@ public class ForbiddenAccessException extends HttpStatusException {
     }
 
     public ForbiddenAccessException(String message, Expression expression, Expression.EvaluationMode mode) {
-        super(HttpStatus.SC_FORBIDDEN, null, message + ": " + expression);
+        super(HttpStatus.SC_FORBIDDEN, null, null, () -> message + ": " + expression);
         this.expression = Optional.of(expression);
         this.evaluationMode = Optional.of(mode);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Superclass for exceptions that return a Http error status.
@@ -23,29 +24,30 @@ public abstract class HttpStatusException extends RuntimeException {
     private static final long serialVersionUID = 1L;
     protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     protected final int status;
-
-    public int getStatus() {
-        return status;
-    }
-
-    private final String verboseMessage;
+    private final Supplier<String> verboseMessageSupplier;
 
     public HttpStatusException(int status) {
         this(status, null);
     }
 
     public HttpStatusException(int status, String message) {
-        this(status, message, null);
+        this(status, message, (Throwable) null, null);
     }
 
+    @Deprecated
     public HttpStatusException(int status, String message, String verboseMessage) {
         this(status, message, verboseMessage, null);
     }
 
+    @Deprecated
     public HttpStatusException(int status, String message, String verboseMessage, Throwable cause) {
+        this(status, message, cause, () -> verboseMessage);
+    }
+
+    public HttpStatusException(int status, String message, Throwable cause, Supplier<String> verboseMessageSupplier) {
         super(message, cause, true, log.isTraceEnabled());
         this.status = status;
-        this.verboseMessage = verboseMessage;
+        this.verboseMessageSupplier = verboseMessageSupplier;
     }
 
     protected static String formatExceptionCause(Throwable e) {
@@ -78,9 +80,14 @@ public abstract class HttpStatusException extends RuntimeException {
     }
 
     public String getVerboseMessage() {
+        String verboseMessage = (verboseMessageSupplier == null) ? null : verboseMessageSupplier.get();
         return verboseMessage != null
                 ? verboseMessage
                 : toString();
+    }
+
+    public int getStatus() {
+        return status;
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InternalServerErrorException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InternalServerErrorException.java
@@ -19,6 +19,6 @@ public class InternalServerErrorException extends HttpStatusException {
         super(HttpStatus.SC_INTERNAL_SERVER_ERROR, message);
     }
     public InternalServerErrorException(Exception e) {
-        super(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.toString(), null, e);
+        super(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.toString(), e, null);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidValueException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidValueException.java
@@ -14,11 +14,11 @@ import com.yahoo.elide.core.HttpStatus;
 public class InvalidValueException extends HttpStatusException {
 
     public InvalidValueException(Object value) {
-        super(HttpStatus.SC_BAD_REQUEST, "Invalid value: " + value.toString());
+        this(value, null);
     }
 
     public InvalidValueException(Object value, String verboseMessage) {
-        super(HttpStatus.SC_BAD_REQUEST, "Invalid value: " + value.toString(), verboseMessage);
+        super(HttpStatus.SC_BAD_REQUEST, "Invalid value: " + value, verboseMessage);
     }
 
     public InvalidValueException(String message, Throwable cause) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.core.RelationshipType;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.Visitor;
-
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -69,7 +68,6 @@ public class FilterPredicate implements FilterExpression, Function<RequestScope,
         this.path = path;
         this.operator = op;
         this.values = values;
-        alias = getEntityType().getSimpleName();
     }
 
     public String getField() {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
@@ -133,8 +133,8 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
             }
 
             String entityType = filterPredicate.getRootEntityType();
-            if (expressionMap.containsKey(entityType)) {
-                FilterExpression filterExpression = expressionMap.get(entityType);
+            FilterExpression filterExpression = expressionMap.get(entityType);
+            if (filterExpression != null) {
                 expressionMap.put(entityType, new AndFilterExpression(filterExpression, filterPredicate));
             } else {
                 expressionMap.put(entityType, filterPredicate);

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialect.java
@@ -70,6 +70,9 @@ public class MultipleFilterDialect implements JoinFilterDialect, SubqueryFilterD
                 }
             }
         }
+        if (lastFailure == null) {
+            lastFailure = new ParseException("No dialects");
+        }
         throw lastFailure;
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
@@ -5,12 +5,11 @@
  */
 package com.yahoo.elide.audit;
 
+import com.google.common.collect.Sets;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
-
-import com.google.common.collect.Sets;
 import example.Child;
 import example.Parent;
 import org.testng.Assert;
@@ -20,7 +19,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Optional;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class LogMessageTest {
     private transient PersistentResource<Child> childRecord;
@@ -101,7 +100,7 @@ public class LogMessageTest {
         };
         try {
             testAuditLogger.log(failMessage);
-            Thread.sleep(Math.floorMod(new Random().nextInt(), 100));
+            Thread.sleep(Math.floorMod(ThreadLocalRandom.current().nextInt(), 100));
             testAuditLogger.commit((RequestScope) null);
             Assert.fail("Exception expected");
         } catch (TestLoggerException e) {

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -21,9 +21,9 @@ import javax.ws.rs.core.MultivaluedMap;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,7 +107,7 @@ public class LifeCycleTest {
 
         Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
 
-        when(book.getId()).thenReturn(new Long(1));
+        when(book.getId()).thenReturn(1L);
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(eq(Book.class), eq(1L), any(), any())).thenReturn(book);
 
@@ -132,7 +132,7 @@ public class LifeCycleTest {
 
         Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
 
-        when(book.getId()).thenReturn(new Long(1));
+        when(book.getId()).thenReturn(1L);
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(eq(Book.class), eq(1L), any(), any())).thenReturn(book);
 

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -97,7 +97,6 @@ public class PermissionToFilterExpressionVisitorTest {
         Class g6 = Good6.class;
         Class g7 = Good7.class;
         Class g8 = GOOD8.class;
-        Class b1 = BAD1.class;
         Class b2 = BAD2.class;
         Class b4 = BAD4.class;
         Class g9 = GOOD9.class;

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HQLFilterOperation.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HQLFilterOperation.java
@@ -36,7 +36,11 @@ public class HQLFilterOperation implements FilterOperation<String> {
         String fieldPath = filterPredicate.getFieldPath();
 
         if (prefixWithAlias) {
-            fieldPath = filterPredicate.getAlias() + "." + fieldPath;
+            String alias = filterPredicate.getAlias();
+            if (alias == null) {
+                alias = filterPredicate.getEntityType().getSimpleName();
+            }
+            fieldPath = alias + "." + fieldPath;
         }
 
         String alias = filterPredicate.getParameterName();

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.datastores.hibernate3;
 
+import com.google.common.base.Objects;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
@@ -25,8 +26,6 @@ import com.yahoo.elide.extensions.PatchRequestScope;
 import com.yahoo.elide.security.PersistentResource;
 import com.yahoo.elide.security.User;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
-
-import com.google.common.base.Objects;
 import org.hibernate.Criteria;
 import org.hibernate.FetchMode;
 import org.hibernate.FlushMode;
@@ -91,7 +90,8 @@ public class HibernateTransaction implements DataStoreTransaction {
         try {
             deferredTasks.forEach(Runnable::run);
             deferredTasks.clear();
-            if (session.getFlushMode() != FlushMode.COMMIT && session.getFlushMode() != FlushMode.NEVER) {
+            FlushMode flushMode = session.getFlushMode();
+            if (flushMode != FlushMode.COMMIT && flushMode != FlushMode.MANUAL && flushMode != FlushMode.NEVER) {
                 session.flush();
             }
         } catch (HibernateException e) {

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/filter/CriterionFilterOperation.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/filter/CriterionFilterOperation.java
@@ -80,7 +80,7 @@ public class CriterionFilterOperation implements FilterOperation<Criterion> {
 
         for (int i = 1; i < path.size() - 1; i++) {
             FilterPredicate.PathElement element = path.get(i);
-            sb.append(".");
+            sb.append('.');
             sb.append(element.getFieldName());
         }
         return sb.toString();

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/filter/CriterionFilterOperation.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/filter/CriterionFilterOperation.java
@@ -80,7 +80,7 @@ public class CriterionFilterOperation implements FilterOperation<Criterion> {
 
         for (int i = 1; i < path.size() - 1; i++) {
             FilterPredicate.PathElement element = path.get(i);
-            sb.append(".");
+            sb.append('.');
             sb.append(element.getFieldName());
         }
         return sb.toString();

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -11,13 +11,13 @@ import static org.hamcrest.Matchers.equalTo;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.initialization.AbstractIntegrationTestInitializer;
 import com.yahoo.elide.utils.JsonParser;
-
+import example.Filtered;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpStatus;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import example.Filtered;
-
+@Slf4j
 public class DataStoreIT extends AbstractIntegrationTestInitializer {
     private final JsonParser jsonParser = new JsonParser();
 
@@ -35,10 +35,8 @@ public class DataStoreIT extends AbstractIntegrationTestInitializer {
             tx.createObject(filtered3, null);
             tx.save(filtered3, null);
             tx.commit(null);
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
+        } catch (InstantiationException | IllegalAccessException e) {
+            log.error("", e);
         }
     }
 

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexManagerTest.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexManagerTest.java
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.google.common.collect.Lists;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
@@ -18,9 +19,7 @@ import com.yahoo.elide.core.exceptions.TransactionException;
 import com.yahoo.elide.datastores.inmemory.InMemoryDataStore;
 import com.yahoo.elide.example.beans.FirstBean;
 import com.yahoo.elide.example.other.OtherBean;
-
-import com.google.common.collect.Lists;
-
+import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -32,6 +31,7 @@ import java.util.Optional;
 /**
  * MultiplexManager tests.
  */
+@Slf4j
 public class MultiplexManagerTest {
     private MultiplexManager multiplexManager;
 
@@ -93,10 +93,8 @@ public class MultiplexManagerTest {
             //t.save(firstBean);
             assertFalse(t.loadObjects(FirstBean.class, Optional.empty(), Optional.empty(), Optional.empty(), null).iterator().hasNext());
             t.commit(null);
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
+        } catch (InstantiationException | IllegalAccessException e) {
+            log.error("", e);
         }
         try (DataStoreTransaction t = multiplexManager.beginTransaction()) {
             FirstBean firstBean = (FirstBean) t.loadObjects(FirstBean.class, Optional.empty(), Optional.empty(), Optional.empty(), null).iterator().next();
@@ -111,10 +109,8 @@ public class MultiplexManagerTest {
             } catch (TransactionException expected) {
                 // expected
             }
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
+        } catch (InstantiationException | IllegalAccessException e) {
+            log.error("", e);
         }
         // verify state
         try (DataStoreTransaction t = ds1.beginTransaction()) {

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableRedisStore.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableRedisStore.java
@@ -75,7 +75,7 @@ public class BridgeableRedisStore implements DataStore {
                 RedisFilter filter = fe.accept(new FilterExpressionParser());
                 if ("user_id".equals(filter.getFieldName())) {
                     Iterable values = fetchValues(key,
-                            v -> v.equals("user" + filter.getValues().get(0).toString() + ":" + id.toString()));
+                            v -> v.equals("user" + filter.getValues().get(0) + ":" + id));
                     for (Object value : values) {
                         return value;
                     }
@@ -104,7 +104,7 @@ public class BridgeableRedisStore implements DataStore {
                         RedisFilter filter = fe.accept(new FilterExpressionParser());
                         if ("user_id".equals(filter.getFieldName())) {
                             return fetchValues(key,
-                                    v -> v.startsWith("user" + filter.getValues().get(0).toString() + ":"));
+                                    v -> v.startsWith("user" + filter.getValues().get(0) + ":"));
                         }
                         log.error("Received bad filter: {} for type: {}", filter, entityClass);
                         throw new UnsupportedOperationException("Cannot filter object of that type");


### PR DESCRIPTION
Avoid `Class.getSimpleName()` in FilterExpression by loading the correct alias when needed. 

Made a few runtime improvements, and some other code cleanup as well.