### PR TITLE
Fix regression. StringUtils behavior != WordUtils behavior.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -43,7 +43,7 @@ import com.yahoo.elide.utils.coerce.CoerceUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.WordUtils;
 
 import javax.persistence.GeneratedValue;
 import javax.ws.rs.ServerErrorException;
@@ -1397,7 +1397,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             Class<?> fieldClass = dictionary.getType(targetClass, fieldName);
             String realName = dictionary.getNameFromAlias(obj, fieldName);
             fieldName = (realName != null) ? realName : fieldName;
-            String setMethod = "set" + StringUtils.capitalize(fieldName);
+            String setMethod = "set" + WordUtils.capitalize(fieldName);
             Method method = EntityDictionary.findMethod(targetClass, setMethod, fieldClass);
             method.invoke(obj, coerce(value, fieldName, fieldClass));
         } catch (IllegalAccessException e) {


### PR DESCRIPTION
`StringUtils` does not behave properly. If we have a field beginning with the letter `i` (i.e. `iOSDevice`) then the UI would provide `iOSDevice` as expected and Elide will happily accept. However, when we lookup the method, we'll look for `setIOSDevice` instead of `setiOSDevice`. This distinction is critical in behaving properly. If the UI were instead to try `IOSDevice` Elide would kick back with an error since that field does not actually exist.

As a result, reverting this back to `WordUtils`.