### PR TITLE
Allow application to process the uncaught exceptions.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -42,7 +42,9 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedMap;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -208,6 +210,9 @@ public class Elide {
             }
 
             return response;
+
+        } catch (WebApplicationException e) {
+            throw e;
 
         } catch (ForbiddenAccessException e) {
             log.debug("{}", e.getLoggedMessage());

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.core.exceptions.HttpStatusException;
+import com.yahoo.elide.core.exceptions.InternalServerErrorException;
 import com.yahoo.elide.core.exceptions.InvalidURLException;
 import com.yahoo.elide.core.exceptions.JsonPatchExtensionException;
 import com.yahoo.elide.core.exceptions.TransactionException;
@@ -224,8 +225,11 @@ public class Elide {
         } catch (ParseCancellationException e) {
             return buildErrorResponse(new InvalidURLException(e), isVerbose);
 
-        } catch (RuntimeException | Error e) {
-            log.error("Exception uncaught by Elide", e);
+        } catch (Exception e) {
+            return buildErrorResponse(new InternalServerErrorException(e), isVerbose);
+
+        } catch (Error e) {
+            log.error("Error uncaught by Elide", e);
             throw e;
 
         } finally {
@@ -260,6 +264,9 @@ public class Elide {
     }
 
     protected ElideResponse buildErrorResponse(HttpStatusException error, boolean isVerbose) {
+        if (error instanceof InternalServerErrorException) {
+            log.error("Internal Server Error", error);
+        }
         return buildResponse(isVerbose ? error.getVerboseErrorResponse() : error.getErrorResponse());
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InternalServerErrorException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InternalServerErrorException.java
@@ -18,7 +18,7 @@ public class InternalServerErrorException extends HttpStatusException {
     public InternalServerErrorException(String message) {
         super(HttpStatus.SC_INTERNAL_SERVER_ERROR, message);
     }
-    public InternalServerErrorException(Exception e) {
+    public InternalServerErrorException(Throwable e) {
         super(HttpStatus.SC_INTERNAL_SERVER_ERROR, e.toString(), e, null);
     }
 }


### PR DESCRIPTION
While attempting to handle a custom exception that currently generates 500, I found it was not possible by over-riding `buildErrorResponse`.

Even an "unknown" exception should be converted into a 500 so the application can handle it correctly.