### PR TITLE
Remove unused parameter

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -201,7 +201,7 @@ public class Elide {
             ElideResponse response = buildResponse(responder.get());
 
             requestScope.runQueuedPreCommitTriggers();
-            auditLogger.commit(requestScope);
+            auditLogger.commit();
             tx.commit(requestScope);
             requestScope.runQueuedPostCommitTriggers();
 

--- a/elide-core/src/main/java/com/yahoo/elide/audit/AuditLogger.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/AuditLogger.java
@@ -5,8 +5,6 @@
  */
 package com.yahoo.elide.audit;
 
-import com.yahoo.elide.core.RequestScope;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +25,7 @@ public abstract class AuditLogger {
         messages.get().add(message);
     }
 
-    public abstract void commit(RequestScope requestScope) throws IOException;
+    public abstract void commit() throws IOException;
 
     public void clear() {
         List<LogMessage> remainingMessages = messages.get();

--- a/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.audit;
 
-import com.yahoo.elide.core.RequestScope;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -17,7 +16,7 @@ import java.io.IOException;
 public class Slf4jLogger extends AuditLogger {
 
     @Override
-    public void commit(RequestScope requestScope) throws IOException {
+    public void commit() throws IOException {
         try {
             for (LogMessage message : messages.get()) {
                 log.info("{} {} {}", System.currentTimeMillis(), message.getOperationCode(), message.getMessage());

--- a/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
@@ -101,7 +101,7 @@ public class LogMessageTest {
         try {
             testAuditLogger.log(failMessage);
             Thread.sleep(Math.floorMod(ThreadLocalRandom.current().nextInt(), 100));
-            testAuditLogger.commit((RequestScope) null);
+            testAuditLogger.commit();
             Assert.fail("Exception expected");
         } catch (TestLoggerException e) {
             Assert.assertSame(e, testException);
@@ -109,7 +109,7 @@ public class LogMessageTest {
 
         // should not cause another exception
         try {
-            testAuditLogger.commit((RequestScope) null);
+            testAuditLogger.commit();
         } catch (TestLoggerException e) {
             Assert.fail("Exception not cleared from previous logger commit");
         }

--- a/elide-core/src/test/java/com/yahoo/elide/audit/TestAuditLogger.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/TestAuditLogger.java
@@ -5,15 +5,13 @@
  */
 package com.yahoo.elide.audit;
 
-import com.yahoo.elide.core.RequestScope;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class TestAuditLogger extends AuditLogger {
     @Override
-    public void commit(RequestScope requestScope) throws IOException {
+    public void commit() throws IOException {
     }
 
     public List<LogMessage> getMessages() {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/audit/InMemoryLogger.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/audit/InMemoryLogger.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.audit;
 
-import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.security.ChangeSpec;
 import org.eclipse.jetty.util.ConcurrentHashSet;
 
@@ -18,7 +17,7 @@ public class InMemoryLogger extends AuditLogger {
     public final ConcurrentHashSet<String> logMessages = new ConcurrentHashSet<>();
 
     @Override
-    public void commit(RequestScope requestScope) throws IOException {
+    public void commit() throws IOException {
         for (LogMessage message : messages.get()) {
             if (message.getChangeSpec().isPresent()) {
                 logMessages.add(changeSpecToString(message.getChangeSpec().get()));

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/audit/TestAuditLogger.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/audit/TestAuditLogger.java
@@ -5,8 +5,6 @@
  */
 package com.yahoo.elide.audit;
 
-import com.yahoo.elide.core.RequestScope;
-
 import java.io.IOException;
 
 /**
@@ -23,7 +21,7 @@ public class TestAuditLogger extends AuditLogger {
     }
 
     @Override
-    public void commit(RequestScope requestScope) throws IOException {
+    public void commit() throws IOException {
         commitCount++;
     }
 }


### PR DESCRIPTION
I found that `RequestScope` is not used at all in all `commit()` used across project.