### PR TITLE
Changes to the permission evaluation

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
@@ -45,7 +45,7 @@ public class AnyFieldExpression implements Expression {
 
     @Override
     public String toString() {
-        return String.format("%s FOR EXPRESSION [FIELDS(%s) OR ENTITY(%s)]",
+        return String.format("%s FOR EXPRESSION [(FIELDS(%s)) OR (ENTITY(%s))]",
                 condition, fieldExpression, entityExpression);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/CheckExpression.java
@@ -118,6 +118,6 @@ public class CheckExpression implements Expression {
     @Override
     public String toString() {
         EntityDictionary dictionary = ((com.yahoo.elide.core.RequestScope) requestScope).getDictionary();
-        return String.format("(%s {%s})", dictionary.getCheckIdentifier(check.getClass()), result);
+        return String.format("(%s %s)", dictionary.getCheckIdentifier(check.getClass()), result);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/CheckExpression.java
@@ -118,6 +118,6 @@ public class CheckExpression implements Expression {
     @Override
     public String toString() {
         EntityDictionary dictionary = ((com.yahoo.elide.core.RequestScope) requestScope).getDictionary();
-        return String.format("(%s %s)", dictionary.getCheckIdentifier(check.getClass()), result);
+        return String.format("(%s {%s})", dictionary.getCheckIdentifier(check.getClass()), result);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
@@ -65,17 +65,17 @@ public class PermissionExpressionBuilderTest {
 
         Assert.assertEquals(expression.toString(),
                 "READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
-                        + "FOR EXPRESSION [FIELDS(\u001B[31mFAILURE\u001B[m) OR ENTITY(((user has all access "
-                        + "\u001B[34mWAS UNEVALUATED\u001B[m)) AND ((user has no access "
-                        + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");
+                        + "FOR EXPRESSION [(FIELDS(\u001B[31mFAILURE\u001B[m)) OR (ENTITY(((user has all access "
+                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})) AND ((user has no access "
+                        + "{\u001B[34mWAS UNEVALUATED\u001B[m}))))]");
 
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
         Assert.assertEquals(expression.toString(),
                 "READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
-                        + "FOR EXPRESSION [FIELDS(\u001B[31mFAILURE\u001B[m) OR ENTITY(((user has all access "
-                        + "\u001B[32mPASSED\u001B[m)) AND ((user has no access "
-                        + "\u001B[31mFAILED\u001B[m)))]");
+                        + "FOR EXPRESSION [(FIELDS(\u001B[31mFAILURE\u001B[m)) OR (ENTITY(((user has all access "
+                        + "{\u001B[32mPASSED\u001B[m})) AND ((user has no access "
+                        + "{\u001B[31mFAILED\u001B[m}))))]");
 
     }
 
@@ -104,8 +104,8 @@ public class PermissionExpressionBuilderTest {
                 "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null} WITH CHANGES ChangeSpec { "
                         + "resource=PersistentResource{type=model, id=null}, field=foo, original=1, modified=2} "
                         + "FOR EXPRESSION [FIELD(((user has all access "
-                        + "\u001B[34mWAS UNEVALUATED\u001B[m)) OR ((user has no access "
-                        + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");
+                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})) OR ((user has no access "
+                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})))]");
 
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
@@ -113,8 +113,8 @@ public class PermissionExpressionBuilderTest {
                 "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null} WITH CHANGES ChangeSpec { "
                         + "resource=PersistentResource{type=model, id=null}, field=foo, original=1, modified=2} "
                         + "FOR EXPRESSION [FIELD(((user has all access "
-                        + "\u001B[32mPASSED\u001B[m)) OR ((user has no access "
-                        + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");
+                        + "{\u001B[32mPASSED\u001B[m})) OR ((user has no access "
+                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})))]");
 
      }
 
@@ -135,13 +135,13 @@ public class PermissionExpressionBuilderTest {
 
         Assert.assertEquals(expression.toString(),
                 "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION [SHARE "
-                        + "ENTITY((user has no access \u001B[34mWAS UNEVALUATED\u001B[m))]");
+                        + "ENTITY((user has no access {\u001B[34mWAS UNEVALUATED\u001B[m}))]");
 
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
         Assert.assertEquals(expression.toString(),
                 "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION [SHARE "
-                        + "ENTITY((user has no access \u001B[31mFAILED\u001B[m))]");
+                        + "ENTITY((user has no access {\u001B[31mFAILED\u001B[m}))]");
 
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
@@ -66,16 +66,16 @@ public class PermissionExpressionBuilderTest {
         Assert.assertEquals(expression.toString(),
                 "READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
                         + "FOR EXPRESSION [(FIELDS(\u001B[31mFAILURE\u001B[m)) OR (ENTITY(((user has all access "
-                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})) AND ((user has no access "
-                        + "{\u001B[34mWAS UNEVALUATED\u001B[m}))))]");
+                        + "\u001B[34mWAS UNEVALUATED\u001B[m)) AND ((user has no access "
+                        + "\u001B[34mWAS UNEVALUATED\u001B[m))))]");
 
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
         Assert.assertEquals(expression.toString(),
                 "READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
                         + "FOR EXPRESSION [(FIELDS(\u001B[31mFAILURE\u001B[m)) OR (ENTITY(((user has all access "
-                        + "{\u001B[32mPASSED\u001B[m})) AND ((user has no access "
-                        + "{\u001B[31mFAILED\u001B[m}))))]");
+                        + "\u001B[32mPASSED\u001B[m)) AND ((user has no access "
+                        + "\u001B[31mFAILED\u001B[m))))]");
 
     }
 
@@ -104,8 +104,8 @@ public class PermissionExpressionBuilderTest {
                 "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null} WITH CHANGES ChangeSpec { "
                         + "resource=PersistentResource{type=model, id=null}, field=foo, original=1, modified=2} "
                         + "FOR EXPRESSION [FIELD(((user has all access "
-                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})) OR ((user has no access "
-                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})))]");
+                        + "\u001B[34mWAS UNEVALUATED\u001B[m)) OR ((user has no access "
+                        + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");
 
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
@@ -113,8 +113,8 @@ public class PermissionExpressionBuilderTest {
                 "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null} WITH CHANGES ChangeSpec { "
                         + "resource=PersistentResource{type=model, id=null}, field=foo, original=1, modified=2} "
                         + "FOR EXPRESSION [FIELD(((user has all access "
-                        + "{\u001B[32mPASSED\u001B[m})) OR ((user has no access "
-                        + "{\u001B[34mWAS UNEVALUATED\u001B[m})))]");
+                        + "\u001B[32mPASSED\u001B[m)) OR ((user has no access "
+                        + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");
 
      }
 
@@ -135,13 +135,13 @@ public class PermissionExpressionBuilderTest {
 
         Assert.assertEquals(expression.toString(),
                 "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION [SHARE "
-                        + "ENTITY((user has no access {\u001B[34mWAS UNEVALUATED\u001B[m}))]");
+                        + "ENTITY((user has no access \u001B[34mWAS UNEVALUATED\u001B[m))]");
 
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
         Assert.assertEquals(expression.toString(),
                 "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION [SHARE "
-                        + "ENTITY((user has no access {\u001B[31mFAILED\u001B[m}))]");
+                        + "ENTITY((user has no access \u001B[31mFAILED\u001B[m))]");
 
     }
 


### PR DESCRIPTION
The PR makes changes to the format of the debug string related to the permission evaluation that is returned in elide response. This helps in parsing the string in ralisplitter security testing framework easily.