### PR TITLE
Adding prefabricated check

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/security/checks/prefab/Common.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/security/checks/prefab/Common.java
@@ -41,9 +41,8 @@ public class Common {
     public static class FieldSetToNull<T> extends CommitCheck<T> {
         @Override
         public boolean ok(T record, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
-            return changeSpec.isPresent()
-                    && changeSpec.get().getOriginal() != null
-                    && changeSpec.get().getModified() == null;
+            return changeSpec.map((c) -> { return c.getOriginal() != null && c.getModified() == null; })
+                    .orElse(false);
         }
     }
 }

--- a/elide-annotations/src/main/java/com/yahoo/elide/security/checks/prefab/Common.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/security/checks/prefab/Common.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.PersistentResource;
 import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.CommitCheck;
-
 import java.util.Optional;
 
 /**
@@ -32,6 +31,19 @@ public class Common {
                 }
             }
             return false;
+        }
+    }
+
+    /**
+     * A check that enables Only teh removal of an object from a relationship.
+     * @param <T> the type of object that this check guards
+     */
+    public static class FieldSetToNull<T> extends CommitCheck<T> {
+        @Override
+        public boolean ok(T record, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            return changeSpec.isPresent()
+                    && changeSpec.get().getOriginal() != null
+                    && changeSpec.get().getModified() == null;
         }
     }
 }


### PR DESCRIPTION
We are adding a new generic check which denies any mutation that sets a field value to anything other than null. 
We were facing an issue where we couldn't remove a child entity from a relationship with a parent, when the field in the child was marked as UpdateOnlyOnCreate. We needed some permission which prevents the sharing of the child entity with a different parent but at the same time allows the removal of the child from the relationship with the parent.
We couldn't solve the above case by placing a @SharePermission check. In the case where we make a POST request on the child entity, setting the relationship to a different parent, the share permissions were not coming into effect. So we needed to add a new permission which can be used on the child side of the relationship to allow the update operation only in the case when the child is removed from the relationship.