### PR TITLE
Queue empty field hooks even when field is modified.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 3.0.9
+Fixes
+ * Fix exception handler to pass verbose log even with unexpected exceptions.
+ * Fix life cycle hooks to trigger "general" hooks even when specific field acted upon.
+
+## 3.0.8
+Features
+ * Add support for FieldSetToNull check.
+
 ## 3.0.7
 **Features**
  * Add support for sorting by id values

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -368,7 +368,14 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      * @param crudAction CRUD Action
      */
     protected void queueTriggers(PersistentResource resource, String fieldName, CRUDAction crudAction) {
-        Consumer<Class> queueTrigger = (cls) -> queuedTriggers.get(cls).add(() -> resource.runTriggers(cls, fieldName));
+        Consumer<Class> queueTrigger = (cls) -> {
+            // Queue trigger for specific field
+            queuedTriggers.get(cls).add(() -> resource.runTriggers(cls, fieldName));
+            if (!fieldName.isEmpty()) {
+                // Ensure to queue trigger for all fields as well
+                queuedTriggers.get(cls).add(() -> resource.runTriggers(cls, ""));
+            }
+        };
 
         switch (crudAction) {
             case CREATE:

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -187,18 +187,21 @@ public class LifeCycleTest {
         verify(book, times(0)).onDeleteBook(scope);
         verify(book, times(1)).onUpdateTitle(scope);
         verify(book, times(1)).preRead(scope);
+        verify(book, times(0)).alwaysOnUpdate();
 
         scope.runQueuedPreCommitTriggers();
         verify(book, times(0)).preCreateBook(scope);
         verify(book, times(0)).preDeleteBook(scope);
         verify(book, times(1)).preUpdateTitle(scope);
         verify(book, times(1)).preCommitRead(scope);
+        verify(book, times(1)).alwaysOnUpdate();
 
         scope.runQueuedPostCommitTriggers();
         verify(book, times(0)).postCreateBook(scope);
         verify(book, times(0)).postDeleteBook(scope);
         verify(book, times(1)).postUpdateTitle(scope);
         verify(book, times(1)).postRead(scope);
+        verify(book, times(1)).alwaysOnUpdate();
     }
 
     @Test

--- a/elide-core/src/test/java/example/Book.java
+++ b/elide-core/src/test/java/example/Book.java
@@ -161,4 +161,9 @@ public class Book {
     public void postRead(RequestScope requestScope) {
         // book being read post commit
     }
+
+    @OnUpdatePreCommit
+    public void alwaysOnUpdate() {
+        // should be called on _any_ update
+    }
 }


### PR DESCRIPTION
This fixes a bug in the lifecycle hooks. In short, when queuing an update hook, the general update hooks (i.e. `@OnUpdate*`) without a field does not get executed.