### PR TITLE
changed the way changeSpec is created

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1358,21 +1358,22 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             // Compute the ChangeSpec for the inverse relation and check whether or not we have access
             // to apply this change to that field.
             final Object originalValue = toDelete.getValueUnchecked(inverseField);
-            final Collection originalBidirectional;
+            final Object originalBidirectional;
+            final Object removedBidirectional;
 
             if (originalValue instanceof Collection) {
                 originalBidirectional = copyCollection((Collection) originalValue);
+                removedBidirectional = CollectionUtils
+                        .disjunction(Collections.singleton(this.getObject()), (Collection) originalBidirectional);
             } else {
-                originalBidirectional = Collections.singleton(originalValue);
+                originalBidirectional = originalValue;
+                removedBidirectional = null;
             }
-
-            final Collection removedBidrectional = CollectionUtils
-                    .disjunction(Collections.singleton(this.getObject()), originalBidirectional);
 
             toDelete.checkFieldAwareDeferPermissions(
                     UpdatePermission.class,
                     inverseField,
-                    removedBidrectional,
+                    removedBidirectional,
                     originalBidirectional
             );
         }


### PR DESCRIPTION
Changed the arguments passed for constructing changeSpec in the method delFromCollection in PersistentResource. This is required for conforming to the general convention of representing a ToOne relationship with an object and a ToMany relationship with a collection. 