### PR TITLE
Use IdentityHashMap

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 3.0.10
 **Fixes**
+ * Use IdentityHashMap for ObjectEntityCache
  * Miscellaneous cleanup.
 
 ## 3.0.9

--- a/elide-core/src/main/java/com/yahoo/elide/core/ObjectEntityCache.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/ObjectEntityCache.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -20,7 +21,7 @@ public class ObjectEntityCache {
      */
     public ObjectEntityCache() {
         resourceCache = new LinkedHashMap<>();
-        uuidReverseMap = new LinkedHashMap<>();
+        uuidReverseMap = new IdentityHashMap<>();
     }
 
     /**


### PR DESCRIPTION
A patch extension that changes the hashCode or equals of the target object will be unable to find the previously stored new object in the `ObjectEntityCache`.