### PR TITLE
Patch extension read permission

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 **Misc**
  * Cleanup hibernate stores to not care about multi edit transactions
  * Removed dead code from hibernate3 transaction
+ * Special read permissions handling of newly created objects in Patch Extension
 
 ## 3.0.11
 **Fixes**

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1039,8 +1039,10 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         InMemoryFilterVisitor inMemoryFilterVisitor = new InMemoryFilterVisitor(requestScope);
         Predicate inMemoryFilterFn = filterExpression.get().accept(inMemoryFilterVisitor);
+        // NOTE: We can safely _skip_ tests on NEWLY created objects.
+        // We assume a user can READ their object they are allowed to create.
         return (Collection) collection.stream()
-                .filter(e -> inMemoryFilterFn.test(e))
+                .filter(e -> requestScope.isNewResource(e) || inMemoryFilterFn.test(e))
                 .collect(Collectors.toList());
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -565,7 +565,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
     public boolean clearRelation(String relationName) {
         Set<PersistentResource> mine = filter(ReadPermission.class,
                 getRelationUncheckedUnfiltered(relationName), false);
-        checkFieldAwarePermissions(UpdatePermission.class, relationName, Collections.emptySet(),
+        checkFieldAwareDeferPermissions(UpdatePermission.class, relationName, Collections.emptySet(),
                 mine.stream().map(PersistentResource::getObject).collect(Collectors.toSet()));
 
         if (mine.isEmpty()) {
@@ -636,7 +636,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             );
         }
 
-        checkFieldAwarePermissions(UpdatePermission.class, fieldName, modified, original);
+        checkFieldAwareDeferPermissions(UpdatePermission.class, fieldName, modified, original);
 
         if (relation instanceof Collection) {
             if (!((Collection) relation).contains(removeResource.getObject())) {
@@ -1308,7 +1308,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         }
         String inverseField = getInverseRelationField(fieldName);
         if (!inverseField.isEmpty()) {
-            oldValue.checkFieldAwarePermissions(UpdatePermission.class, inverseField, null, getObject());
+            oldValue.checkFieldAwareDeferPermissions(UpdatePermission.class, inverseField, null, getObject());
         }
         this.setValueChecked(fieldName, null);
     }
@@ -1782,19 +1782,10 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         ChangeSpec changeSpec = (UpdatePermission.class.isAssignableFrom(annotationClass))
                 ? new ChangeSpec(this, fieldName, original, modified)
                 : null;
-        // Defer checks for newly created objects if:
-        //   1. This is a bulk edit request
-        //   2. This is an update request (note: changeSpec != null is a faster change check than rechecking permission)
-        if (requestScope.getNewResources().contains(this)
-                && ((requestScope.isMutatingMultipleEntities())
-                || changeSpec != null)) {
-            return requestScope
-                    .getPermissionExecutor()
-                    .checkSpecificFieldPermissionsDeferred(this, changeSpec, annotationClass, fieldName);
-        }
+
         return requestScope
                 .getPermissionExecutor()
-                .checkSpecificFieldPermissions(this, changeSpec, annotationClass, fieldName);
+                .checkSpecificFieldPermissionsDeferred(this, changeSpec, annotationClass, fieldName);
     }
 
     protected static boolean checkIncludeSparseField(Map<String, Set<String>> sparseFields, String type,

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -245,8 +245,13 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         this.mutatingMultipleEntities = outerRequestScope.mutatingMultipleEntities;
     }
 
+    @Override
     public Set<com.yahoo.elide.security.PersistentResource> getNewResources() {
         return (Set<com.yahoo.elide.security.PersistentResource>) (Set) newPersistentResources;
+    }
+
+    public boolean isNewResource(Object entity) {
+        return newPersistentResources.stream().filter(r -> r.getObject() == entity).findAny().isPresent();
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -201,8 +201,11 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
-            commitCheckQueue.add(new QueuedCheck(expression, annotationClass));
-            return ExpressionResult.DEFERRED;
+            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
+                    && requestScope.getNewPersistentResources().contains(resource)) {
+                return executeUserChecksDeferInline(annotationClass, expression);
+            }
+            return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
         };
 
         return checkPermissions(

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -166,11 +166,6 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
-            // for newly created object in PatchRequest limit to User checks
-            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
-                    && requestScope.getNewPersistentResources().contains(resource)) {
-                return executeUserChecksDeferInline(annotationClass, expression);
-            }
             return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
         };
 

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -116,6 +116,16 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
+            // for newly created object in PatchRequest limit to User checks
+            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
+                    && requestScope.getNewPersistentResources().contains(resource)) {
+                ExpressionResult result =
+                        executeExpressions(expression, annotationClass, Expression.EvaluationMode.USER_CHECKS_ONLY);
+                if (result == DEFERRED) {
+                    commitCheckQueue.add(new QueuedCheck(expression, annotationClass));
+                }
+                return result;
+            }
             return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
         };
 
@@ -146,6 +156,16 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
+            // for newly created object in PatchRequest limit to User checks
+            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
+                    && requestScope.getNewPersistentResources().contains(resource)) {
+                ExpressionResult result =
+                        executeExpressions(expression, annotationClass, Expression.EvaluationMode.USER_CHECKS_ONLY);
+                if (result == DEFERRED) {
+                    commitCheckQueue.add(new QueuedCheck(expression, annotationClass));
+                }
+                return result;
+            }
             return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
         };
 
@@ -344,6 +364,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
      * @param resourceClass Resource class
      * @return the filter expression for the class, if any
      */
+    @Override
     public Optional<FilterExpression> getReadPermissionFilter(Class<?> resourceClass) {
         FilterExpression filterExpression =
                 expressionBuilder.buildAnyFieldFilterExpression(resourceClass, requestScope);

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -5,14 +5,8 @@
  */
 package com.yahoo.elide.tests;
 
-import static com.jayway.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.startsWith;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.mockito.Mockito.*;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Sets;
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.ElideSettingsBuilder;
@@ -31,10 +25,7 @@ import com.yahoo.elide.jsonapi.models.ResourceIdentifier;
 import com.yahoo.elide.security.checks.Check;
 import com.yahoo.elide.security.executors.BypassPermissionExecutor;
 import com.yahoo.elide.utils.JsonParser;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.Sets;
-
+import example.Book;
 import example.Child;
 import example.ExceptionThrowingBean;
 import example.FunWithPermissions;
@@ -43,26 +34,34 @@ import example.LineItem;
 import example.Parent;
 import example.TestCheckMappings;
 import example.User;
-import example.Book;
-
 import org.apache.http.HttpStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.HashMap;
-
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response.Status;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * The type Config resource test.
@@ -1763,7 +1762,7 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
-    @Test
+    @Test(priority = 1000)
     public void elideBypassSecurity() {
         String expected = jsonParser.getJson("/ResourceIT/elideBypassSecurity.json");
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -1762,7 +1762,7 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
-    @Test(priority = 1000)
+    @Test
     public void elideBypassSecurity() {
         String expected = jsonParser.getJson("/ResourceIT/elideBypassSecurity.json");
 

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -170,7 +170,9 @@ public class Child {
     static public class FailOpPatchExtension extends OperationCheck<Child> {
         @Override
         public boolean ok(Child child, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
-            if (requestScope instanceof PatchRequestScope && child.getParents().isEmpty()) {
+            if (requestScope instanceof PatchRequestScope
+                    && ((PatchRequestScope) requestScope).isNewResource(child)
+                    && child.getParents().isEmpty()) {
                 throw new IllegalStateException("Patch extension should test operation checks only at commit");
             }
             return false;

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -17,7 +17,6 @@ import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.FilterPredicate.PathElement;
 import com.yahoo.elide.core.filter.Operator;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
-import com.yahoo.elide.extensions.PatchRequestScope;
 import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.FilterExpressionCheck;
 import com.yahoo.elide.security.RequestScope;

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -127,7 +127,7 @@ public class Child {
 
     @Transient
     @ComputedAttribute
-    @ReadPermission(expression = "FailOpPatchExtension")
+    @ReadPermission(expression = "FailCheckOp")
     public String getComputedFailTest() {
         return "computed";
     }
@@ -166,7 +166,7 @@ public class Child {
         }
     }
 
-    static public class FailOpPatchExtension extends OperationCheck<Child> {
+    static public class FailCheckOp extends OperationCheck<Child> {
         @Override
         public boolean ok(Child child, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
             return false;

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -170,11 +170,6 @@ public class Child {
     static public class FailOpPatchExtension extends OperationCheck<Child> {
         @Override
         public boolean ok(Child child, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
-            if (requestScope instanceof PatchRequestScope
-                    && ((PatchRequestScope) requestScope).isNewResource(child)
-                    && child.getParents().isEmpty()) {
-                throw new IllegalStateException("Patch extension should test operation checks only at commit");
-            }
             return false;
         }
     }

--- a/elide-integration-tests/src/test/java/example/TestCheckMappings.java
+++ b/elide-integration-tests/src/test/java/example/TestCheckMappings.java
@@ -23,7 +23,7 @@ public class TestCheckMappings {
                     put("adminRoleCheck", User.AdminRoleCheck.class);
                     put("initCheck", Child.InitCheck.class);
                     put("initCheckOp", Child.InitCheckOp.class);
-                    put("FailOpPatchExtension", Child.FailOpPatchExtension.class);
+                    put("FailCheckOp", Child.FailCheckOp.class);
                     put("initCheckFilter", Child.InitCheckFilter.class);
                     put("parentInitCheck", Parent.InitCheck.class);
                     put("parentInitCheckOp", Parent.InitCheckOp.class);

--- a/elide-integration-tests/src/test/java/example/TestCheckMappings.java
+++ b/elide-integration-tests/src/test/java/example/TestCheckMappings.java
@@ -23,6 +23,7 @@ public class TestCheckMappings {
                     put("adminRoleCheck", User.AdminRoleCheck.class);
                     put("initCheck", Child.InitCheck.class);
                     put("initCheckOp", Child.InitCheckOp.class);
+                    put("FailOpPatchExtension", Child.FailOpPatchExtension.class);
                     put("initCheckFilter", Child.InitCheckFilter.class);
                     put("parentInitCheck", Parent.InitCheck.class);
                     put("parentInitCheckOp", Parent.InitCheckOp.class);

--- a/elide-integration-tests/src/test/resources/ResourceIT/elideBypassSecurity.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/elideBypassSecurity.json
@@ -3,6 +3,7 @@
         "type":"child",
         "id":"1",
         "attributes":{
+            "computedFailTest":"computed",
             "name":null
         },
         "relationships":{


### PR DESCRIPTION
Not all FilterExpressionChecks are able to run in memory for newly created objects during a Patch Extension create.  This is an attempt to avoid the failure in filter for these newly created objects.