### PR TITLE
Handle invalid relationship field name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,12 @@
 # Change Log
+## 3.0.14
+**Fixes**
+ * Properly handle incorrect relationship field name in Patch request instead of `Entity is null`
+ 
+## 3.0.13
+**Fixes**
+ * Fixing regression in deferred permissions for updates
+ 
 ## 3.0.12
 **Misc**
  * Cleanup hibernate stores to not care about multi edit transactions

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -817,8 +817,10 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         Class<?> entityType = dictionary.getParameterizedType(getResourceClass(), relation);
 
         /* If this is a bulk edit request and the ID we are fetching for is newly created... */
-        if (requestScope.isMutatingMultipleEntities()
-                        && requestScope.getObjectById(dictionary.getJsonAliasFor(entityType), id) != null) {
+        if (entityType == null) {
+            throw new InvalidAttributeException(relation, type);
+        } else if (requestScope.isMutatingMultipleEntities()
+                && requestScope.getObjectById(dictionary.getJsonAliasFor(entityType), id) != null) {
             filterExpression = Optional.empty();
             // NOTE: We can safely _skip_ tests here since we are only skipping READ checks on
             // NEWLY created objects. We assume a user can READ their object in the midst of creation.
@@ -827,9 +829,6 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             // already).
             skipNew = true;
         } else {
-            if (entityType == null) {
-                throw new InvalidAttributeException(relation, type);
-            }
             Class<?> idType = dictionary.getIdType(entityType);
             Object idVal = CoerceUtil.coerce(id, idType);
             String idField = dictionary.getIdFieldName(entityType);


### PR DESCRIPTION
Fixed `Unknown Entity null` when passed an incorrect field name.