### PR TITLE
Fix parameter order

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 **Fixes**
  * Properly handle incorrect relationship field name in Patch request instead of `Entity is null`
  * Properly handle invalid filtering input in HQL filtering
+ * Properly handle NOT in filterexpressionchecks
+ * Fix parameter order in commit permission check
  
 ## 3.0.13
 **Fixes**

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -127,8 +127,8 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         };
 
         return checkPermissions(
-                annotationClass,
                 resource.getResourceClass(),
+                annotationClass,
                 Optional.empty(),
                 expressionSupplier,
                 expressionExecutor);


### PR DESCRIPTION
Found uncaught compile error where parameters were accidentally swapped.

This could cause extra unnecessary execution of commit checks when the results were already cached.  I am not sure why we have no compiler error.