### PR TITLE
Add deferred ID

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.graphql;
+
+import com.yahoo.elide.core.PersistentResource;
+
+public class DeferredId {
+    private PersistentResource resource;
+
+    public DeferredId(PersistentResource resource) {
+        this.resource = resource;
+    }
+
+    @Override
+    public String toString() {
+        return resource.getId();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
@@ -6,17 +6,28 @@
 
 package com.yahoo.elide.graphql;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.yahoo.elide.core.PersistentResource;
+import lombok.Getter;
 
+import java.io.IOException;
+
+@JsonSerialize(using = SerializeId.class)
 public class DeferredId {
-    private PersistentResource resource;
+    @Getter private PersistentResource resource;
 
     public DeferredId(PersistentResource resource) {
         this.resource = resource;
     }
+}
 
+class SerializeId extends JsonSerializer<DeferredId> {
     @Override
-    public String toString() {
-        return resource.getId();
+    public void serialize(DeferredId deferredId, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeObject(deferredId.getResource().getId());
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
@@ -16,7 +16,9 @@ import lombok.Getter;
 import java.io.IOException;
 
 /**
- * Simple encapsulation to serialize the id field from a {@link PersistentResource} object.
+ * The id for any given entity might be populated at transaction commit (as opposed to inline with the data fetch).
+ * This class wraps a {@link PersistentResource} object and allows deferred deserialization of the ID field until
+ * when it is populated and when the GraphQL response is generated.
  */
 @JsonSerialize(using = SerializeId.class)
 public class DeferredId {

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/DeferredId.java
@@ -15,6 +15,9 @@ import lombok.Getter;
 
 import java.io.IOException;
 
+/**
+ * Simple encapsulation to serialize the id field from a {@link PersistentResource} object.
+ */
 @JsonSerialize(using = SerializeId.class)
 public class DeferredId {
     @Getter private PersistentResource resource;
@@ -24,6 +27,9 @@ public class DeferredId {
     }
 }
 
+/**
+ * Serializer for the id value of a {@link DeferredId} object.
+ */
 class SerializeId extends JsonSerializer<DeferredId> {
     @Override
     public void serialize(DeferredId deferredId, JsonGenerator jsonGenerator,

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -7,7 +7,6 @@
 package com.yahoo.elide.graphql;
 
 import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RelationshipType;
 import graphql.Scalars;
 import graphql.schema.Coercing;
@@ -209,8 +208,8 @@ public class ModelBuilder {
         String id = dictionary.getIdFieldName(entityClass);
         GraphQLScalarType customIdType = new GraphQLScalarType(id, "custom id type", new Coercing() {
             @Override
-            public String serialize(Object o) {
-                return new DeferredId((PersistentResource) o).toString();
+            public Object serialize(Object o) {
+                return o;
             }
 
             @Override
@@ -332,26 +331,9 @@ public class ModelBuilder {
         builder.name(entityName + ARGUMENT_INPUT);
 
         String id = dictionary.getIdFieldName(clazz);
-        GraphQLScalarType customIdType = new GraphQLScalarType(id, "custom id type", new Coercing() {
-            @Override
-            public Object serialize(Object o) {
-                return o;
-            }
-
-            @Override
-            public String parseValue(Object o) {
-                return o.toString();
-            }
-
-            @Override
-            public String parseLiteral(Object o) {
-                return o.toString();
-            }
-        });
-
         builder.field(newInputObjectField()
                 .name(id)
-                .type(customIdType));
+                .type(Scalars.GraphQLID));
 
         for (String attribute : dictionary.getAttributes(clazz)) {
             Class<?> attributeClass = dictionary.getType(clazz, attribute);

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -206,6 +206,8 @@ public class ModelBuilder {
         builder.name(entityName);
 
         String id = dictionary.getIdFieldName(entityClass);
+
+        /* our id types are DeferredId objects (not Scalars.GraphQLID) */
         GraphQLScalarType customIdType = new GraphQLScalarType(id, "custom id type", new Coercing() {
             @Override
             public Object serialize(Object o) {

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 
 import static com.yahoo.elide.graphql.ModelBuilder.ARGUMENT_OPERATION;
 
-
 @Slf4j
 public class PersistentResourceFetcher implements DataFetcher {
     private final ElideSettings settings;
@@ -149,7 +148,7 @@ public class PersistentResourceFetcher implements DataFetcher {
             } else if(dictionary.isRelation(parentClass, fieldName)) { /* fetch relationship properties */
                 return fetchRelationship(context.parentResource, fieldName, context.ids);
             } else if(Objects.equals(idFieldName, fieldName)) {
-                return context.parentResource.getId();
+                return context.parentResource;
             } else {
                 throw new BadRequestException("Unrecognized object: " + fieldName + " for: " + parentClass.getName());
             }

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -148,7 +148,7 @@ public class PersistentResourceFetcher implements DataFetcher {
             } else if(dictionary.isRelation(parentClass, fieldName)) { /* fetch relationship properties */
                 return fetchRelationship(context.parentResource, fieldName, context.ids);
             } else if(Objects.equals(idFieldName, fieldName)) {
-                return context.parentResource;
+                return new DeferredId(context.parentResource);
             } else {
                 throw new BadRequestException("Unrecognized object: " + fieldName + " for: " + parentClass.getName());
             }

--- a/elide-core/src/test/java/com/yahoo/elide/graphql/FetcherUpsertTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/graphql/FetcherUpsertTest.java
@@ -38,6 +38,7 @@ public class FetcherUpsertTest extends PersistentResourceFetcherTest {
         String graphQLRequest =
                 "mutation { " +
                     "book(op: UPSERT, data: [{title: \"Book Numero Dos\"},{title:\"Book Numero Tres\"}] ) { " +
+                        "id " +
                         "title " +
                     "} " +
                 "}";


### PR DESCRIPTION
This PR contains the code for lazy loading of the `id` field from `PersistentResource` by delayed jackson serialization. 
IIRC, we're now left with the following TODOs -   
- Pagination/filtering/sorting for `FETCH`.
- Passing filter expression to `getRelation()` to reduce number of sql queries while fetching a relationship.
- The actual `/graphql` endpoint. 
- A lot of IT/unit tests. 