### PR TITLE
Refactor persistent resource for graphQL

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -20,6 +20,7 @@ import com.yahoo.elide.annotation.OnUpdatePreCommit;
 import com.yahoo.elide.annotation.OnUpdatePreSecurity;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.core.exceptions.InternalServerErrorException;
+import com.yahoo.elide.core.exceptions.InvalidAttributeException;
 import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
 import com.yahoo.elide.core.filter.dialect.ParseException;
@@ -318,6 +319,21 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         } else {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Get the filter expression for a particular relationship
+     * @param parent The object which has the relationship
+     * @param relationName The relationship name
+     * @return A type specific filter expression for the given relationship
+     */
+    public Optional<FilterExpression> getExpressionForRelation(PersistentResource parent, String relationName) {
+        final Class<?> entityClass = dictionary.getParameterizedType(parent.getObject(), relationName);
+        if (entityClass == null) {
+            throw new InvalidAttributeException(relationName, parent.getType());
+        }
+        final String valType = dictionary.getJsonAliasFor(entityClass);
+        return getFilterExpressionByType(valType);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -230,7 +230,8 @@ public class PersistentResourceFetcher implements DataFetcher {
                 relations.add(parentResource.getRelation(fieldName, id));
             }
         } else {
-            relations = parentResource.getRelationCheckedFiltered(fieldName);
+            relations = parentResource.getRelationCheckedFiltered(fieldName,
+                    Optional.empty(), Optional.empty(), Optional.empty());
         }
 
         /* check for toOne relationships */

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -277,7 +277,7 @@ public class PersistentResourceFetcher implements DataFetcher {
         } else {
             parentEntity = Optional.empty();
         }
-        Set<Entity> entitySet = new HashSet<>();
+        LinkedHashSet<Entity> entitySet = new LinkedHashSet<>();
         for (Map<String, Object> input : context.data.get()) {
             entitySet.add(new Entity(parentEntity, input, entityClass, context.requestScope));
         }

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -25,6 +25,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -290,7 +291,9 @@ public class PersistentResourceFetcher implements DataFetcher {
             }
         }
 
-        return entitySet.stream().map(Entity::toPersistentResource).collect(Collectors.toSet());
+        return entitySet.stream()
+                .map(Entity::toPersistentResource)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-core/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -177,8 +177,11 @@ public class PersistentResourceFetcher implements DataFetcher {
         /* fetching a collection */
         if (!ids.isPresent()) {
             Set<PersistentResource> records = PersistentResource.loadRecords(entityClass,
-                    requestScope,
-                    Optional.empty());
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    requestScope);
+
             //TODO: paginate/filter/sort
             return records;
         } else { /* fetching by id(s) */
@@ -205,7 +208,8 @@ public class PersistentResourceFetcher implements DataFetcher {
                             idField),
                     Operator.IN,
                     new ArrayList<>(idList)));
-            return PersistentResource.loadRecords(entityClass, requestScope, filterExpression);
+            return PersistentResource.loadRecords(entityClass,
+                    filterExpression, Optional.empty(), Optional.empty(), requestScope);
         }
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.jsonapi.document.processors;
 
 import com.google.common.collect.Lists;
 import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -77,7 +78,12 @@ public class IncludedProcessor implements DocumentProcessor {
         //Pop off a relation of relation path
         String relation = relationPath.remove(0);
 
-        rec.getRelationCheckedFiltered(relation).forEach(resource -> {
+        Optional<FilterExpression> filterExpression = rec.getRequestScope().getExpressionForRelation(rec, relation);
+
+        Set<PersistentResource> resources = rec.getRelationCheckedFiltered(relation,
+                filterExpression, Optional.empty(), Optional.empty());
+
+        resources.forEach(resource -> {
             jsonApiDocument.addIncluded(resource.toResource());
 
             //If more relations left in the path, process a level deeper

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
@@ -17,7 +17,9 @@ import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 import com.yahoo.elide.core.exceptions.InvalidObjectIdentifierException;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.exceptions.UnknownEntityException;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.Pagination;
+import com.yahoo.elide.core.sort.Sorting;
 import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.jsonapi.document.processors.DocumentProcessor;
 import com.yahoo.elide.jsonapi.document.processors.IncludedProcessor;
@@ -126,11 +128,16 @@ public class CollectionTerminalState extends BaseState {
                 collection = parent.get().getRelationCheckedFiltered(relationName.get());
             }
         } else {
-            if (hasSortingOrPagination) {
-                collection = (Set) PersistentResource.loadRecordsWithSortingAndPagination(entityClass, requestScope);
-            } else {
-                collection = (Set) PersistentResource.loadRecords(entityClass, requestScope, Optional.empty());
-            }
+            Optional<FilterExpression> filterExpression = requestScope.getLoadFilterExpression(entityClass);
+            Optional<Pagination> pagination = Optional.ofNullable(requestScope.getPagination());
+            Optional<Sorting> sorting = Optional.ofNullable(requestScope.getSorting());
+
+            collection = (Set) PersistentResource.loadRecords(
+                entityClass,
+                filterExpression,
+                sorting,
+                pagination,
+                requestScope);
         }
 
         return collection;

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RelationshipType;
 import com.yahoo.elide.core.exceptions.InvalidAttributeException;
 import com.yahoo.elide.core.exceptions.InvalidCollectionException;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.jsonapi.models.SingleElementSet;
 import com.yahoo.elide.generated.parsers.CoreParser.SubCollectionReadCollectionContext;
 import com.yahoo.elide.generated.parsers.CoreParser.SubCollectionReadEntityContext;
@@ -52,7 +53,10 @@ public class RecordState extends BaseState {
                     new CollectionTerminalState(entityClass, Optional.of(resource), Optional.of(subCollection));
             Set<PersistentResource> collection = null;
             if (type.isToOne()) {
-                collection = resource.getRelationCheckedFiltered(subCollection);
+                Optional<FilterExpression> filterExpression =
+                        state.getRequestScope().getExpressionForRelation(resource, subCollection);
+                collection = resource.getRelationCheckedFiltered(subCollection,
+                        filterExpression, Optional.empty(), Optional.empty());
             }
             if (collection instanceof SingleElementSet) {
                 PersistentResource record = ((SingleElementSet<PersistentResource>) collection).getValue();
@@ -104,7 +108,9 @@ public class RecordState extends BaseState {
 
         String relationName = ctx.relationship().term().getText();
         try {
-            childRecord.getRelationCheckedFiltered(relationName);
+            Optional<FilterExpression> filterExpression =
+                        state.getRequestScope().getExpressionForRelation(resource, subCollection);
+            childRecord.getRelationCheckedFiltered(relationName, filterExpression, Optional.empty(), Optional.empty());
         } catch (InvalidAttributeException e) {
             throw new InvalidCollectionException(relationName);
         }

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.exceptions.InvalidAttributeException;
 import com.yahoo.elide.core.exceptions.InvalidCollectionException;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.generated.parsers.CoreParser.RootCollectionLoadEntitiesContext;
 import com.yahoo.elide.generated.parsers.CoreParser.RootCollectionLoadEntityContext;
 import com.yahoo.elide.generated.parsers.CoreParser.RootCollectionRelationshipContext;
@@ -74,7 +75,9 @@ public class StartState extends BaseState {
 
         String relationName = ctx.relationship().term().getText();
         try {
-            record.getRelationCheckedFiltered(relationName);
+            Optional<FilterExpression> filterExpression =
+                    state.getRequestScope().getExpressionForRelation(record, relationName);
+            record.getRelationCheckedFiltered(relationName, filterExpression, Optional.empty(), Optional.empty());
         } catch (InvalidAttributeException e) {
             throw new InvalidCollectionException(relationName);
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -23,6 +23,7 @@ import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.core.exceptions.InvalidAttributeException;
 import com.yahoo.elide.core.exceptions.InvalidObjectIdentifierException;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Relationship;
@@ -755,7 +756,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
-        Set<PersistentResource> results = funResource.getRelationCheckedFiltered("relation2");
+        Set<PersistentResource> results = getRelation(funResource, "relation2");
 
         Assert.assertEquals(results.size(), 3, "All of relation elements should be returned.");
     }
@@ -770,7 +771,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
-        Set<PersistentResource> results = funResource.getRelationCheckedFiltered("relation2");
+        Set<PersistentResource> results = getRelation(funResource, "relation2");
 
         Assert.assertEquals(results.size(), 2, "Only filtered relation elements should be returned.");
     }
@@ -794,7 +795,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<Parent> parentResource = new PersistentResource<>(parent, null, "1", goodScope);
 
-        Set<PersistentResource> results = parentResource.getRelationCheckedFiltered("children");
+        Set<PersistentResource> results = getRelation(parentResource, "children");
 
         Assert.assertEquals(results.size(), 1);
         Assert.assertEquals(((Child) results.iterator().next().getObject()).getName(), "paul john");
@@ -805,7 +806,7 @@ public class PersistentResourceTest extends PersistentResource {
         NoReadEntity noread = new NoReadEntity();
 
         PersistentResource<NoReadEntity> noreadResource = new PersistentResource<>(noread, null, "3", goodUserScope);
-        noreadResource.getRelationCheckedFiltered("child");
+        getRelation(noreadResource, "child");
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -814,7 +815,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", badUserScope);
 
-        funResource.getRelationCheckedFiltered("relation1");
+        getRelation(funResource, "relation1");
     }
 
     @Test
@@ -823,7 +824,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FirstClassFields> fcResource = new PersistentResource<>(firstClassFields, null, "3", badUserScope);
 
-        fcResource.getRelationCheckedFiltered("public2");
+        getRelation(fcResource, "public2");
     }
 
     @Test
@@ -841,7 +842,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FirstClassFields> fcResource = new PersistentResource<>(firstClassFields, null, "3", badUserScope);
 
-        fcResource.getRelationCheckedFiltered("private2");
+        getRelation(fcResource, "private2");
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -860,7 +861,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
-        funResource.getRelationCheckedFiltered("invalid");
+        getRelation(funResource, "invalid");
     }
 
     @Test
@@ -911,7 +912,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
-        Set set = funResource.getRelationCheckedFiltered("relation4");
+        Set set = getRelation(funResource, "relation4");
         Assert.assertEquals(0,  set.size());
     }
 
@@ -921,7 +922,7 @@ public class PersistentResourceTest extends PersistentResource {
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
-        Set set = funResource.getRelationCheckedFiltered("relation5");
+        Set set  = getRelation(funResource, "relation5");
         Assert.assertEquals(0,  set.size());
     }
 
@@ -1370,7 +1371,7 @@ public class PersistentResourceTest extends PersistentResource {
         User goodUser = new User(1);
         RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
         PersistentResource<Left> leftResource = new PersistentResource<>(left, null, "1", goodScope);
-        leftResource.updateRelation("noUpdateOne2One", leftResource.getRelationCheckedFiltered("noUpdateOne2One"));
+        leftResource.updateRelation("noUpdateOne2One", getRelation(leftResource, "noUpdateOne2One"));
         // Modifications have a deferred check component:
         leftResource.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
@@ -2096,5 +2097,12 @@ public class PersistentResourceTest extends PersistentResource {
             }
             throw new IllegalStateException("Something is terribly wrong :(");
         }
+    }
+
+    public static Set<PersistentResource> getRelation(PersistentResource resource, String relation) {
+        Optional<FilterExpression> filterExpression =
+                resource.getRequestScope().getExpressionForRelation(resource, relation);
+
+        return resource.getRelationCheckedFiltered(relation, filterExpression, Optional.empty(), Optional.empty());
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -1504,7 +1504,8 @@ public class PersistentResourceTest extends PersistentResource {
                 .thenReturn(Lists.newArrayList(child1, child2, child3, child4, child5));
 
         RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
-        Set<PersistentResource> loaded = PersistentResource.loadRecords(Child.class, goodScope, Optional.empty());
+        Set<PersistentResource> loaded = PersistentResource.loadRecords(Child.class,
+                Optional.empty(), Optional.empty(), Optional.empty(), goodScope);
 
         Set<Child> expected = Sets.newHashSet(child1, child4, child5);
 

--- a/elide-core/src/test/java/com/yahoo/elide/graphql/FetcherUpsertTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/graphql/FetcherUpsertTest.java
@@ -94,8 +94,7 @@ public class FetcherUpsertTest extends PersistentResourceFetcherTest {
                 + "}]"
                 + "}";
 
-        //TODO - order of books is out of sync with expected response.
-        //assertQueryEquals(graphQLRequest, expectedResponse);
+        assertQueryEquals(graphQLRequest, expectedResponse);
     }
 
     /* ========================= */

--- a/elide-core/src/test/java/com/yahoo/elide/graphql/FetcherUpsertTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/graphql/FetcherUpsertTest.java
@@ -153,9 +153,9 @@ public class FetcherUpsertTest extends PersistentResourceFetcherTest {
                 + "\"book\":[{"
                 + "\"title\":\"my id\""
                 + "},{"
-                + "\"title\":\"abc\""
-                + "},{"
                 + "\"title\":\"xyz\""
+                + "},{"
+                + "\"title\":\"abc\""
                 + "}]"
                 + "}";
 


### PR DESCRIPTION
This PR opens up loadRecords and getRelation allowing the passing of filters, sorting, and pagination params.

Another PR is needed to refactor RequestScope (this is not needed for functionality but for code organization).