### PR TITLE
Add newly required dependency for example blog.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 **Fixes**
  * Fix for issue #508
  * Fix for issue #521
+ * Fix blog example
 
 ## 3.1.1
 **Fixes**

--- a/elide-example/elide-blog-example/pom.xml
+++ b/elide-example/elide-blog-example/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>jersey-container-jetty-servlet</artifactId>
             <version>RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>RELEASE</version>
+        </dependency>
         <!-- JAX RS -->
         <dependency>
             <groupId>javax.ws.rs</groupId>


### PR DESCRIPTION
Latest jersey requires we now include `jersey-hk2`. See: https://github.com/jersey/jersey/issues/3584