### PR TITLE
Properly handle proxy beans in HQL Builder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
  * Fix for issue #508
  * Fix for issue #521
  * Fix blog example
+ * Properly handle proxy beans in HQL Builder
 
 ## 3.1.1
 **Fixes**

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
@@ -158,13 +158,16 @@ public class FilterPredicate implements FilterExpression, Function<RequestScope,
 
     @Override
     public String toString() {
-        String formattedPath = path.isEmpty() ? "" : StringUtils.uncapitalize(path.get(0).getType().getSimpleName());
-
-        for (PathElement element : path) {
-            formattedPath = formattedPath + PERIOD + element.getFieldName();
+        StringBuilder formattedPath = new StringBuilder();
+        if (!path.isEmpty()) {
+            formattedPath.append(StringUtils.uncapitalize(path.get(0).getType().getSimpleName()));
         }
 
-        return String.format("%s %s %s", formattedPath, operator, values);
+        for (PathElement element : path) {
+            formattedPath.append(PERIOD).append(element.getFieldName());
+        }
+
+        return formattedPath.append(" ").append(operator).append(" ").append(values).toString();
     }
 
     public void negate() {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
@@ -167,7 +167,7 @@ public class FilterPredicate implements FilterExpression, Function<RequestScope,
             formattedPath.append(PERIOD).append(element.getFieldName());
         }
 
-        return formattedPath.append(" ").append(operator).append(" ").append(values).toString();
+        return formattedPath.append(' ').append(operator).append(' ').append(values).toString();
     }
 
     public void negate() {

--- a/elide-core/src/main/java/com/yahoo/elide/core/pagination/Pagination.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/pagination/Pagination.java
@@ -195,7 +195,7 @@ public class Pagination {
             throw new InvalidValueException("page[number] must contain a positive value.");
         }
 
-        offset = pageNumber > 0 ? (pageNumber - 1) * limit : 0;
+        offset = (pageNumber - 1) * limit;
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -142,18 +142,18 @@ public abstract class AbstractHQLQueryBuilder {
      * @return A HQL string representing the join
      */
     private String extractJoinClause(FilterPredicate predicate, Set<String> alreadyJoined) {
-        String joinClause = "";
+        StringBuilder joinClause = new StringBuilder();
 
         String previousAlias = null;
 
         for (FilterPredicate.PathElement pathElement : predicate.getPath()) {
             String fieldName = pathElement.getFieldName();
-            Class<?> typeClass = pathElement.getType();
+            Class<?> typeClass = dictionary.lookupEntityClass(pathElement.getType());
             String typeAlias = FilterPredicate.getTypeAlias(typeClass);
 
             //Nothing left to join.
             if (! dictionary.isRelation(pathElement.getType(), fieldName)) {
-                return joinClause;
+                return joinClause.toString();
             }
 
             String alias = typeAlias + UNDERSCORE + fieldName;
@@ -168,14 +168,14 @@ public abstract class AbstractHQLQueryBuilder {
             }
 
             if (!alreadyJoined.contains(joinFragment)) {
-                joinClause += joinFragment;
+                joinClause.append(joinFragment);
                 alreadyJoined.add(joinFragment);
             }
 
             previousAlias = alias;
         }
 
-        return joinClause;
+        return joinClause.toString();
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
@@ -25,7 +25,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                                            EntityDictionary dictionary,
                                            Session session) {
         super(dictionary, session);
-        this.entityClass = entityClass;
+        this.entityClass = dictionary.lookupEntityClass(entityClass);
     }
 
     /**
@@ -35,7 +35,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
      */
     @Override
     public Query build() {
-        String entityName = dictionary.lookupEntityClass(entityClass).getCanonicalName();
+        String entityName = entityClass.getCanonicalName();
         String entityAlias = FilterPredicate.getTypeAlias(entityClass);
 
         Query query;

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
@@ -35,7 +35,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
      */
     @Override
     public Query build() {
-        String entityName = entityClass.getCanonicalName();
+        String entityName = dictionary.lookupEntityClass(entityClass).getCanonicalName();
         String entityAlias = FilterPredicate.getTypeAlias(entityClass);
 
         Query query;

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
@@ -29,7 +29,7 @@ public class RootCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilde
                                                 EntityDictionary dictionary,
                                                 Session session) {
         super(dictionary, session);
-        this.entityClass = entityClass;
+        this.entityClass = dictionary.lookupEntityClass(entityClass);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class RootCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilde
      */
     @Override
     public Query build() {
-        String entityName = dictionary.lookupEntityClass(entityClass).getCanonicalName();
+        String entityName = entityClass.getCanonicalName();
         String entityAlias = FilterPredicate.getTypeAlias(entityClass);
 
         Collection<FilterPredicate> predicates;

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
@@ -54,7 +54,7 @@ public class RootCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilde
      */
     @Override
     public Query build() {
-        String entityName = entityClass.getCanonicalName();
+        String entityName = dictionary.lookupEntityClass(entityClass).getCanonicalName();
         String entityAlias = FilterPredicate.getTypeAlias(entityClass);
 
         Collection<FilterPredicate> predicates;

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
@@ -65,7 +65,7 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
      */
     @Override
     public Query build() {
-        Class<?> parentType = relationship.getParentType();
+        Class<?> parentType = dictionary.lookupEntityClass(relationship.getParentType());
         Class<?> idType = dictionary.getIdType(parentType);
         Object idVal = CoerceUtil.coerce(dictionary.getId(relationship.getParent()), idType);
         String idField = dictionary.getIdFieldName(parentType);
@@ -82,7 +82,6 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
         Collection<FilterPredicate> predicates = new ArrayList<>();
         String joinClause = "";
         String filterClause = "";
-        FilterExpression joinedExpression = idExpression;
 
         String relationshipName = relationship.getRelationshipName();
 
@@ -110,7 +109,7 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
             predicates.add(idExpression);
 
             //Join together the provided filter expression with the expression which selects the collection owner.
-            joinedExpression = new AndFilterExpression(copy, idExpression);
+            FilterExpression joinedExpression = new AndFilterExpression(copy, idExpression);
 
             //Build the JOIN clause from the filter predicate
             joinClause = getJoinClauseFromFilters(joinedExpression);


### PR DESCRIPTION
We found a problem when the HQL Builder was used with a Hibernate proxy bean.  The `bean.getClass()` should be passed through the dictionary lookup Entity class.

Also fixed a couple string concats with StringBuilder for improved performance.