### PR TITLE
Allow for arbitrary relationships that aren't transitive.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Change Log
+## 3.1.3
+ * Add support for @Any relationships through a @MappedInterface
+
 ## 3.1.2
 **Fixes**
  * Fix for issue #508

--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/MappedInterface.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/MappedInterface.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Used to annotate interfaces that represent mapped entities.
+ * Used for returning non related entities, for examaple from HQL or @Any mapped methods.
+ */
+@Target({TYPE})
+@Retention(RUNTIME)
+public @interface MappedInterface {
+}

--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/ToMany.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/ToMany.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a method or field as a relationship that should be exposed via Elide Despite JPA bindings.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface ToMany {
+}

--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/ToOne.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/ToOne.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method or field as a relationship that should be exposed via Elide Despite JPA bindings.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface ToOne {
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -20,6 +20,8 @@ import com.yahoo.elide.annotation.OnReadPreSecurity;
 import com.yahoo.elide.annotation.OnUpdatePostCommit;
 import com.yahoo.elide.annotation.OnUpdatePreCommit;
 import com.yahoo.elide.annotation.OnUpdatePreSecurity;
+import com.yahoo.elide.annotation.ToMany;
+import com.yahoo.elide.annotation.ToOne;
 import com.yahoo.elide.core.exceptions.DuplicateMappingException;
 import lombok.Getter;
 import lombok.Setter;
@@ -60,7 +62,8 @@ class EntityBinding {
 
     private static final List<Method> OBJ_METHODS = Arrays.asList(Object.class.getMethods());
     private static final List<Class<? extends Annotation>> RELATIONSHIP_TYPES =
-            Arrays.asList(ManyToMany.class, ManyToOne.class, OneToMany.class, OneToOne.class);
+            Arrays.asList(ManyToMany.class, ManyToOne.class, OneToMany.class, OneToOne.class,
+                    ToOne.class, ToMany.class);
 
     public final Class<?> entityClass;
     public final String jsonApiType;
@@ -238,6 +241,8 @@ class EntityBinding {
         boolean manyToOne = fieldOrMethod.isAnnotationPresent(ManyToOne.class);
         boolean oneToMany = fieldOrMethod.isAnnotationPresent(OneToMany.class);
         boolean oneToOne = fieldOrMethod.isAnnotationPresent(OneToOne.class);
+        boolean toOne = fieldOrMethod.isAnnotationPresent(ToOne.class);
+        boolean toMany = fieldOrMethod.isAnnotationPresent(ToMany.class);
         boolean computedRelationship = fieldOrMethod.isAnnotationPresent(ComputedRelationship.class);
 
         RelationshipType type;
@@ -258,6 +263,10 @@ class EntityBinding {
         } else if (manyToOne) {
             type = computedRelationship ? RelationshipType.COMPUTED_MANY_TO_ONE : RelationshipType.MANY_TO_ONE;
             cascadeTypes = fieldOrMethod.getAnnotation(ManyToOne.class).cascade();
+        } else if (toOne) {
+            type = RelationshipType.COMPUTED_ONE_TO_ONE;
+        } else if (toMany) {
+            type = RelationshipType.COMPUTED_ONE_TO_MANY;
         } else {
             type = computedRelationship ? RelationshipType.COMPUTED_NONE : RelationshipType.NONE;
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -117,8 +117,10 @@ public class EntityDictionary {
     }
 
     protected EntityBinding getEntityBinding(Class<?> entityClass) {
-        Class<?> entitySearched = isMappedInterface(entityClass) ? entityClass : lookupEntityClass(entityClass);
-        return entityBindings.getOrDefault(entitySearched, EntityBinding.EMPTY_BINDING);
+        if (isMappedInterface(entityClass)) {
+            return EntityBinding.EMPTY_BINDING;
+        }
+        return entityBindings.getOrDefault(lookupEntityClass(entityClass), EntityBinding.EMPTY_BINDING);
     }
 
     public boolean isMappedInterface(Class<?> interfaceClass) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -121,7 +121,7 @@ public class EntityDictionary {
         return entityBindings.getOrDefault(entitySearched, EntityBinding.EMPTY_BINDING);
     }
 
-    protected boolean isMappedInterface(Class<?> interfaceClass) {
+    public boolean isMappedInterface(Class<?> interfaceClass) {
         return interfaceClass.isInterface() && interfaceClass.isAnnotationPresent(MappedInterface.class);
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.ComputedRelationship;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.MappedInterface;
 import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.core.exceptions.DuplicateMappingException;
 import com.yahoo.elide.security.checks.Check;
@@ -116,7 +117,12 @@ public class EntityDictionary {
     }
 
     protected EntityBinding getEntityBinding(Class<?> entityClass) {
-        return entityBindings.getOrDefault(lookupEntityClass(entityClass), EntityBinding.EMPTY_BINDING);
+        Class<?> entitySearched = isMappedInterface(entityClass) ? entityClass : lookupEntityClass(entityClass);
+        return entityBindings.getOrDefault(entitySearched, EntityBinding.EMPTY_BINDING);
+    }
+
+    protected boolean isMappedInterface(Class<?> interfaceClass) {
+        return interfaceClass.isInterface() && interfaceClass.isAnnotationPresent(MappedInterface.class);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -893,8 +893,8 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             throw new InvalidAttributeException(relationName, type);
         }
         if (dictionary.isMappedInterface(entityClass) && interfaceHasFilterExpression(entityClass)) {
-           throw new InvalidOperationException(
-                   "Cannot apply filters to polymorphic relations mapped with MappedInterface");
+            throw new InvalidOperationException(
+                    "Cannot apply filters to polymorphic relations mapped with MappedInterface");
         }
         final String valType = dictionary.getJsonAliasFor(entityClass);
         return requestScope.getFilterExpressionByType(valType);

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -23,6 +23,7 @@ import com.yahoo.elide.core.exceptions.InternalServerErrorException;
 import com.yahoo.elide.core.exceptions.InvalidAttributeException;
 import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 import com.yahoo.elide.core.exceptions.InvalidObjectIdentifierException;
+import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.Operator;
@@ -891,9 +892,29 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         if (entityClass == null) {
             throw new InvalidAttributeException(relationName, type);
         }
+        if (dictionary.isMappedInterface(entityClass) && interfaceHasFilterExpression(entityClass)) {
+           throw new InvalidOperationException(
+                   "Cannot apply filters to polymorphic relations mapped with MappedInterface");
+        }
         final String valType = dictionary.getJsonAliasFor(entityClass);
         return requestScope.getFilterExpressionByType(valType);
     }
+
+    /**
+     * Checks to see if any filters are meant to to applied to a polymorphic Any/ManyToAny relationship
+     * @param entityInterface a @MappedInterface
+     * @return whether or not there are any typed filter expressions meant for this polymorphic interface
+     */
+    private boolean interfaceHasFilterExpression(Class<?> entityInterface) {
+        for (String filterType : requestScope.getExpressionsByType().keySet()) {
+            Class<?> polyMorphicClass = dictionary.getEntityClass(filterType);
+            if (entityInterface.isAssignableFrom(polyMorphicClass)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     /**
      * Gets the relational entities to a entity (author/1/books) - books would be fetched here.

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -75,7 +75,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     @Getter private final boolean mutatingMultipleEntities;
 
     private final MultipleFilterDialect filterDialect;
-    private final Map<String, FilterExpression> expressionsByType;
+    @Getter private final Map<String, FilterExpression> expressionsByType;
 
     /* Used to filter across heterogeneous types during the first load */
     private FilterExpression globalFilterExpression;

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
@@ -36,14 +36,22 @@ public class RecordState extends BaseState {
     public void handle(StateContext state, SubCollectionReadCollectionContext ctx) {
         String subCollection = ctx.term().getText();
         EntityDictionary dictionary = state.getRequestScope().getDictionary();
+        Class<?> entityClass;
+        String entityName;
         try {
             RelationshipType type = dictionary.getRelationshipType(resource.getObject(), subCollection);
             if (type == RelationshipType.NONE) {
                 throw new InvalidCollectionException(subCollection);
             }
-            String entityName =
-                    dictionary.getJsonAliasFor(dictionary.getParameterizedType(resource.getObject(), subCollection));
-            Class<?> entityClass = dictionary.getEntityClass(entityName);
+            Class<?> paramType = dictionary.getParameterizedType(resource.getObject(), subCollection);
+            if (dictionary.isMappedInterface(paramType)) {
+                entityName = paramType.getSimpleName();
+                entityClass = paramType;
+            } else {
+                entityName = dictionary.getJsonAliasFor(paramType);
+                entityClass = dictionary.getEntityClass(entityName);
+
+            }
             if (entityClass == null) {
                 throw new IllegalArgumentException("Unknown type " + entityName);
             }

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.core;
 
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.MappedInterface;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.security.checks.prefab.Collections.AppendOnly;
 import com.yahoo.elide.security.checks.prefab.Collections.RemoveOnly;
@@ -240,5 +241,20 @@ public class EntityDictionaryTest extends EntityDictionary {
             && !attrs.contains("excludedEntityList"));
         Assert.assertTrue(!rels.contains("excludedEntity") && !rels.contains("excludedRelationship")
             && !rels.contains("excludedEntityList"));
+    }
+
+    @MappedInterface
+    public interface SuitableInterface { }
+
+    public interface BadInterface { }
+
+    @Test
+    public void testMappedInterface() {
+        Assert.assertEquals(getEntityBinding(SuitableInterface.class), EntityBinding.EMPTY_BINDING);
+    }
+
+    @Test(expectedExceptions = java.lang.IllegalArgumentException.class)
+    public void testBadInterface() {
+        getEntityBinding(BadInterface.class);
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -16,6 +16,9 @@ public class AnyPolymorphismIT {
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
     private final JsonParser jsonParser = new JsonParser();
 
+    private final int horsepower = 102;
+
+
     @BeforeClass
     public void setUp() {
         //Create a tractor
@@ -49,7 +52,6 @@ public class AnyPolymorphismIT {
         final String includedType = "included[0].type";
         final String includedId = "included[0].id";
         final String includedSize = "included.size()";
-        final int horsepower = 102;
 
         RestAssured
                 .given()
@@ -120,7 +122,6 @@ public class AnyPolymorphismIT {
                         "included[0].attributes.type", equalTo("android"),
                         includedSize, equalTo(1));
 
-
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
@@ -130,6 +131,20 @@ public class AnyPolymorphismIT {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.size()", equalTo(2));
+    }
+
+    public void testAnySubpaths() {
+        final String propertyPath = "/property";
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(jsonParser.getJson("/AnyPolymorphismIT/AddTractorProperty.json"))
+                .post(propertyPath)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED);
 
         RestAssured
                 .given()
@@ -150,7 +165,7 @@ public class AnyPolymorphismIT {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.horsepower", equalTo(horsepower),
-                         "data.id", equalTo("1"));
+                        "data.id", equalTo("1"));
 
         //single entity so no page appropriate stuff
         RestAssured

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -17,7 +17,7 @@ public class AnyPolymorphismIT {
     private final JsonParser jsonParser = new JsonParser();
 
     @BeforeClass
-    public void setup() {
+    public void setUp() {
         //Create a tractor
         RestAssured
                 .given()

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -10,7 +10,7 @@ import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.utils.JsonParser;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
 
 public class AnyPolymorphismIT {
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
@@ -41,12 +41,22 @@ public class AnyPolymorphismIT {
 
     @Test
     public void testAny() {
+        final String propertyPath = "/property";
+        final String relationshipType = "data.relationships.myStuff.data.type";
+        final String relationshipId = "data.relationships.myStuff.data.id";
+        final String tractorType = "tractor";
+        final String smartphoneType = "smartphone";
+        final String includedType = "included[0].type";
+        final String includedId = "included[0].id";
+        final String includedSize = "included.size()";
+        final int horsepower = 102;
+
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .body(jsonParser.getJson("/AnyPolymorphismIT/AddTractorProperty.json"))
-                .post("/property")
+                .post(propertyPath)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED);
@@ -56,7 +66,7 @@ public class AnyPolymorphismIT {
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .body(jsonParser.getJson("/AnyPolymorphismIT/AddSmartphoneProperty.json"))
-                .post("/property")
+                .post(propertyPath)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED);
@@ -65,48 +75,48 @@ public class AnyPolymorphismIT {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get("/property/1")
+                .get(propertyPath + "/1")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.relationships.myStuff.data.type", equalTo("tractor"),
-                        "data.relationships.myStuff.data.id", equalTo("1"));
+                .body(relationshipType, equalTo(tractorType),
+                        relationshipId, equalTo("1"));
 
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get("/property/2")
+                .get(propertyPath + "/2")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.relationships.myStuff.data.type", equalTo("smartphone"),
-                        "data.relationships.myStuff.data.id", equalTo("1"));
+                .body(relationshipType, equalTo(smartphoneType),
+                        relationshipId, equalTo("1"));
 
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get("/property/1?include=myStuff")
+                .get(propertyPath + "/1?include=myStuff")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("included[0].type", equalTo("tractor"),
-                        "included[0].id", equalTo("1"),
-                        "included[0].attributes.horsepower", equalTo(102),
-                        "included.size()", equalTo(1));
+                .body(includedType, equalTo(tractorType),
+                        includedId, equalTo("1"),
+                        "included[0].attributes.horsepower", equalTo(horsepower),
+                        includedSize, equalTo(1));
 
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get("/property/2?include=myStuff")
+                .get(propertyPath + "/2?include=myStuff")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("included[0].type", equalTo("smartphone"),
-                        "included[0].id", equalTo("1"),
+                .body(includedType, equalTo(smartphoneType),
+                        includedId, equalTo("1"),
                         "included[0].attributes.type", equalTo("android"),
-                        "included.size()", equalTo(1));
+                        includedSize, equalTo(1));
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -234,7 +234,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get("/property/" + id + "/device")
+                .get("/device")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_NOT_FOUND)

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -18,8 +18,16 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
     private final JsonParser jsonParser = new JsonParser();
 
+    private final String sep = "/";
+
     private final int horsepower = 102;
     private final String one = "1";
+    private final String tractorType = "tractor";
+    private final String smartphoneType = "smartphone";
+
+    private final String relationshipType = "data.relationships.myStuff.data.type";
+    private final String relationshipId = "data.relationships.myStuff.data.id";
+    private final String idPath = "data.id";
 
     private final String propertyPath = "/property";
 
@@ -52,10 +60,6 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
 
     @Test
     public void testAny() {
-        final String relationshipType = "data.relationships.myStuff.data.type";
-        final String relationshipId = "data.relationships.myStuff.data.id";
-        final String tractorType = "tractor";
-        final String smartphoneType = "smartphone";
         final String includedType = "included[0].type";
         final String includedId = "included[0].id";
         final String includedSize = "included.size()";
@@ -70,7 +74,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED)
                 .extract()
-                .path("data.id");
+                .path(idPath);
 
         String id2 = RestAssured
                 .given()
@@ -82,13 +86,13 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED)
                 .extract()
-                .path("data.id");
+                .path(idPath);
 
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id1)
+                .get(propertyPath + sep + id1)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
@@ -99,18 +103,20 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id2)
+                .get(propertyPath + sep + id2)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body(relationshipType, equalTo(smartphoneType),
                         relationshipId, equalTo(one));
 
+        String query = "?include=myStuff";
+
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id1 + "?include=myStuff")
+                .get(propertyPath + sep + id1 + query)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
@@ -124,7 +130,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/"  + id2 + "?include=myStuff")
+                .get(propertyPath + sep + id2 + query)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
@@ -155,16 +161,18 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED)
-                .body("data.relationships.myStuff.data.type", equalTo("tractor"))
+                .body(relationshipType, equalTo(tractorType))
                 .extract()
-                .path("data.id");
+                .path(idPath);
+
+        String prefix = "{\"data\": {\"id\": \"" + id;
 
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .body("{\"data\": {\"id\": \"" + id + "\", \"type\": \"property\", \"relationships\": {\"myStuff\": {\"data\": {\"type\": \"smartphone\", \"id\": \"1\"}}}}}")
-                .patch(propertyPath + "/" + id)
+                .body(prefix + "\", \"type\": \"property\", \"relationships\": {\"myStuff\": {\"data\": {\"type\": \"smartphone\", \"id\": \"1\"}}}}}")
+                .patch(propertyPath + sep + id)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
@@ -173,19 +181,19 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id)
+                .get(propertyPath + sep + id)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.relationships.myStuff.data.type", equalTo("smartphone"));
+                .body(relationshipType, equalTo(smartphoneType));
 
         //delete relation
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .body("{\"data\": {\"id\": \"" + id + "\", \"type\": \"property\", \"relationships\": {\"myStuff\": {\"data\": null}}}}")
-                .patch(propertyPath + "/" + id)
+                .body(prefix + "\", \"type\": \"property\", \"relationships\": {\"myStuff\": {\"data\": null}}}}")
+                .patch(propertyPath + sep + id)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
@@ -194,7 +202,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id)
+                .get(propertyPath + sep + id)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
@@ -213,7 +221,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .assertThat()
                 .statusCode(HttpStatus.SC_CREATED)
                 .extract()
-                .path("data.id");
+                .path(idPath);
 
         RestAssured
                 .given()
@@ -229,7 +237,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id + "/myStuff")
+                .get(propertyPath + sep + id + "/myStuff")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
@@ -241,7 +249,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id + "/myStuff?page[totals]")
+                .get(propertyPath + sep + id + "/myStuff?page[totals]")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
@@ -252,7 +260,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get(propertyPath + "/" + id + "?filter[tractor]=horsepower==103")
+                .get(propertyPath + sep + id + "?filter[tractor]=horsepower==103")
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_BAD_REQUEST);

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -106,6 +106,7 @@ public class AnyPolymorphismIT {
                         "included[0].attributes.horsepower", equalTo(horsepower),
                         includedSize, equalTo(1));
 
+
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
@@ -118,5 +119,48 @@ public class AnyPolymorphismIT {
                         includedId, equalTo("1"),
                         "included[0].attributes.type", equalTo("android"),
                         includedSize, equalTo(1));
+
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get(propertyPath)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.size()", equalTo(2));
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get(propertyPath + "?page[totals]")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("meta.page.totalRecords", equalTo(2));
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get(propertyPath + "/1/myStuff")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.horsepower", equalTo(horsepower),
+                         "data.id", equalTo("1"));
+
+        //single entity so no page appropriate stuff
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get(propertyPath + "/1/myStuff?page[totals]")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("meta", equalTo(null));
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.tests;
+
+import com.jayway.restassured.RestAssured;
+import com.yahoo.elide.core.HttpStatus;
+import com.yahoo.elide.utils.JsonParser;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import static org.hamcrest.Matchers.*;
+
+public class AnyPolymorphismIT {
+    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
+    private final JsonParser jsonParser = new JsonParser();
+
+    @BeforeClass
+    public void setup() {
+        //Create a tractor
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body("{\"data\": {\"type\": \"tractor\", \"attributes\": {\"horsepower\": 102 }}}")
+                .post("/tractor")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        //Create a smartphone
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body("{\"data\": {\"type\": \"smartphone\", \"attributes\": {\"type\": \"android\" }}}")
+                .post("/smartphone")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+    }
+
+    @Test
+    public void testAny() {
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(jsonParser.getJson("/AnyPolymorphismIT/AddTractorProperty.json"))
+                .post("/property")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(jsonParser.getJson("/AnyPolymorphismIT/AddSmartphoneProperty.json"))
+                .post("/property")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get("/property/1")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.relationships.myStuff.data.type", equalTo("tractor"),
+                        "data.relationships.myStuff.data.id", equalTo("1"));
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get("/property/2")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.relationships.myStuff.data.type", equalTo("smartphone"),
+                        "data.relationships.myStuff.data.id", equalTo("1"));
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get("/property/1?include=myStuff")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("included[0].type", equalTo("tractor"),
+                        "included[0].id", equalTo("1"),
+                        "included[0].attributes.horsepower", equalTo(102),
+                        "included.size()", equalTo(1));
+
+        RestAssured
+                .given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get("/property/2?include=myStuff")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.SC_OK)
+                .body("included[0].type", equalTo("smartphone"),
+                        "included[0].id", equalTo("1"),
+                        "included[0].attributes.type", equalTo("android"),
+                        "included.size()", equalTo(1));
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -17,6 +17,12 @@ public class AnyPolymorphismIT {
     private final JsonParser jsonParser = new JsonParser();
 
     private final int horsepower = 102;
+    private final String one = "1";
+
+    private final String propertyPath = "/property";
+
+    private final String tractorAsPropertyFile = "/AnyPolymorphismIT/AddTractorProperty.json";
+    private final String smartphoneAsPropertyFile = "/AnyPolymorphismIT/AddSmartphoneProperty.json";
 
 
     @BeforeClass
@@ -44,7 +50,6 @@ public class AnyPolymorphismIT {
 
     @Test
     public void testAny() {
-        final String propertyPath = "/property";
         final String relationshipType = "data.relationships.myStuff.data.type";
         final String relationshipId = "data.relationships.myStuff.data.id";
         final String tractorType = "tractor";
@@ -57,7 +62,7 @@ public class AnyPolymorphismIT {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .body(jsonParser.getJson("/AnyPolymorphismIT/AddTractorProperty.json"))
+                .body(jsonParser.getJson(tractorAsPropertyFile))
                 .post(propertyPath)
                 .then()
                 .assertThat()
@@ -67,7 +72,7 @@ public class AnyPolymorphismIT {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .body(jsonParser.getJson("/AnyPolymorphismIT/AddSmartphoneProperty.json"))
+                .body(jsonParser.getJson(smartphoneAsPropertyFile))
                 .post(propertyPath)
                 .then()
                 .assertThat()
@@ -82,7 +87,7 @@ public class AnyPolymorphismIT {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body(relationshipType, equalTo(tractorType),
-                        relationshipId, equalTo("1"));
+                        relationshipId, equalTo(one));
 
         RestAssured
                 .given()
@@ -93,7 +98,7 @@ public class AnyPolymorphismIT {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body(relationshipType, equalTo(smartphoneType),
-                        relationshipId, equalTo("1"));
+                        relationshipId, equalTo(one));
 
         RestAssured
                 .given()
@@ -104,7 +109,7 @@ public class AnyPolymorphismIT {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body(includedType, equalTo(tractorType),
-                        includedId, equalTo("1"),
+                        includedId, equalTo(one),
                         "included[0].attributes.horsepower", equalTo(horsepower),
                         includedSize, equalTo(1));
 
@@ -118,7 +123,7 @@ public class AnyPolymorphismIT {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body(includedType, equalTo(smartphoneType),
-                        includedId, equalTo("1"),
+                        includedId, equalTo(one),
                         "included[0].attributes.type", equalTo("android"),
                         includedSize, equalTo(1));
 
@@ -134,13 +139,11 @@ public class AnyPolymorphismIT {
     }
 
     public void testAnySubpaths() {
-        final String propertyPath = "/property";
-
         RestAssured
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .body(jsonParser.getJson("/AnyPolymorphismIT/AddTractorProperty.json"))
+                .body(jsonParser.getJson(tractorAsPropertyFile))
                 .post(propertyPath)
                 .then()
                 .assertThat()
@@ -165,7 +168,7 @@ public class AnyPolymorphismIT {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.horsepower", equalTo(horsepower),
-                        "data.id", equalTo("1"));
+                        "data.id", equalTo(one));
 
         //single entity so no page appropriate stuff
         RestAssured

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -242,7 +242,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.horsepower", equalTo(horsepower),
-                        "data.id", equalTo(one));
+                        idPath, equalTo(one));
 
         //single entity so no page appropriate stuff
         RestAssured

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -137,7 +137,8 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .body(includedType, equalTo(smartphoneType),
                         includedId, equalTo(one),
                         "included[0].attributes.type", equalTo("android"),
-                        includedSize, equalTo(1));
+                        includedSize, equalTo(1),
+                        "included[0].attributes.operatingSystem", equalTo("some dessert"));
 
         RestAssured
                 .given()

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -240,17 +240,6 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .statusCode(HttpStatus.SC_NOT_FOUND)
                 .body("errors[0]", containsString("Unknown collection"));
 
-        //single entity so no page appropriate stuff
-        RestAssured
-                .given()
-                .contentType(JSONAPI_CONTENT_TYPE)
-                .accept(JSONAPI_CONTENT_TYPE)
-                .get("/property/" + id + "/myStuff?page[totals]")
-                .then()
-                .assertThat()
-                .statusCode(HttpStatus.SC_OK)
-                .body("meta", equalTo(null));
-
         //Filtering is not supported for these types.
         RestAssured
                 .given()

--- a/elide-integration-tests/src/test/java/example/Device.java
+++ b/elide-integration-tests/src/test/java/example/Device.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.MappedInterface;
+
+@MappedInterface
+public interface Device {
+
+}

--- a/elide-integration-tests/src/test/java/example/Property.java
+++ b/elide-integration-tests/src/test/java/example/Property.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.SharePermission;
+import com.yahoo.elide.annotation.ToOne;
+import lombok.Setter;
+import org.hibernate.annotations.Any;
+import org.hibernate.annotations.AnyMetaDef;
+import org.hibernate.annotations.MetaValue;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+
+@Entity
+@Include(rootLevel = true, type = "property")
+@SharePermission(expression = "allow all")
+public class Property extends BaseId {
+    @Setter private Device myStuff;
+
+    @Any(metaColumn = @Column(name = "property_type"))
+    @AnyMetaDef(idType = "long", metaType = "string", metaValues = {
+            @MetaValue(targetEntity = example.Tractor.class, value = "tractor"),
+            @MetaValue(targetEntity = example.Smartphone.class, value = "smartphone")
+    })
+    @JoinColumn(name = "property_id")
+    @ToOne
+    public Device getMyStuff() {
+        return myStuff;
+    }
+}

--- a/elide-integration-tests/src/test/java/example/Smartphone.java
+++ b/elide-integration-tests/src/test/java/example/Smartphone.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.SharePermission;
+
+import javax.persistence.Entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Include(rootLevel = true, type = "smartphone")
+@SharePermission(expression = "allow all")
+public class Smartphone extends BaseId implements Device {
+    @Getter @Setter private String type;
+}

--- a/elide-integration-tests/src/test/java/example/Smartphone.java
+++ b/elide-integration-tests/src/test/java/example/Smartphone.java
@@ -25,7 +25,7 @@ public class Smartphone extends BaseId implements Device {
     @Transient
     public String getOperatingSystem() {
         String os;
-        switch(type) {
+        switch (type) {
             case "android":
                 os = "some dessert";
                 break;

--- a/elide-integration-tests/src/test/java/example/Smartphone.java
+++ b/elide-integration-tests/src/test/java/example/Smartphone.java
@@ -5,10 +5,12 @@
  */
 package example;
 
+import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.SharePermission;
 
 import javax.persistence.Entity;
+import javax.persistence.Transient;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -18,4 +20,22 @@ import lombok.Setter;
 @SharePermission(expression = "allow all")
 public class Smartphone extends BaseId implements Device {
     @Getter @Setter private String type;
+
+    @ComputedAttribute
+    @Transient
+    public String getOperatingSystem() {
+        String os;
+        switch(type) {
+            case "android":
+                os = "some dessert";
+                break;
+            case "iphone":
+                os = "iOS";
+                break;
+            default:
+                os = "who cares?";
+        }
+
+        return os;
+    }
 }

--- a/elide-integration-tests/src/test/java/example/Smartphone.java
+++ b/elide-integration-tests/src/test/java/example/Smartphone.java
@@ -34,6 +34,7 @@ public class Smartphone extends BaseId implements Device {
                 break;
             default:
                 os = "who cares?";
+                break;
         }
 
         return os;

--- a/elide-integration-tests/src/test/java/example/Tractor.java
+++ b/elide-integration-tests/src/test/java/example/Tractor.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.SharePermission;
+
+import javax.persistence.Entity;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Include(rootLevel = true, type = "tractor")
+@SharePermission(expression = "allow all")
+public class Tractor extends BaseId implements Device {
+    @Getter @Setter private int horsepower;
+}

--- a/elide-integration-tests/src/test/resources/AnyPolymorphismIT/AddSmartphoneProperty.json
+++ b/elide-integration-tests/src/test/resources/AnyPolymorphismIT/AddSmartphoneProperty.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "property",
+    "attributes": {},
+    "relationships": {
+      "myStuff": {
+        "data": {
+          "type": "smartphone",
+          "id": "1"
+        }
+      }
+    }
+  }
+}

--- a/elide-integration-tests/src/test/resources/AnyPolymorphismIT/AddTractorProperty.json
+++ b/elide-integration-tests/src/test/resources/AnyPolymorphismIT/AddTractorProperty.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "property",
+    "attributes": {},
+    "relationships": {
+      "myStuff": {
+        "data": {
+          "type": "tractor",
+          "id": "1"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The main use case here is allowing for hibernate's `@Any` annotation.
This allows for polymorphic relationship to unrelated models.
Elide gave me two challenges.

1.) Needed annotations outside of JPA so Elide recognized them as relationships
2.) Needed the EntityDictionary to allow Interfaces (+2 squashed commits)
Squashed commits: