### PR TITLE
Evaluate SharePermission falls back to ReadPermission

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/SharePermission.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/SharePermission.java
@@ -15,7 +15,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * A permission that is checked whenever an object is loaded without the context of a lineage and assigned
- * to a relationship or collection.
+ * to a relationship or collection. If SharePermission is specified, checking SharePermission falls back to checking
+ * ReadPermission. Otherwise, the entity is not shareable.
  */
 @Target({TYPE, PACKAGE})
 @Retention(RUNTIME)
@@ -23,14 +24,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface SharePermission {
 
     /**
-     * An expression of checks that will be parsed via ANTLR. For example:
-     * {@code @SharePermission(expression="Prefab.Role.All")} or
-     * {@code @SharePermission(expression="Prefab.Role.All and Prefab.Role.UpdateOnCreate")}
+     * A boolean value indicating if the entity is shareable. If not specifying, shareable is true. Setting shareable to
+     * false provide a way to override package level SharePermission.
      *
-     * All of {@linkplain com.yahoo.elide.security.checks.prefab the built-in checks} are name-spaced as
-     * {@code Prefab.CHECK} without the {@code Check} suffix
-     *
-     * @return the expression string to be parsed
+     * @return the boolean if entity is shareable
      */
-    String expression() default "";
+    boolean sharable() default true;
 }

--- a/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/Author.java
+++ b/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/Author.java
@@ -22,7 +22,7 @@ import java.util.Collection;
  * Model for authors
  */
 @Entity
-@SharePermission()
+@SharePermission
 @Table(name = "author")
 @Include(rootLevel = true)
 public class Author {

--- a/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/Author.java
+++ b/elide-contrib/dropwizard-elide/src/test/java/com/yahoo/elide/contrib/dropwizard/elide/Author.java
@@ -22,7 +22,7 @@ import java.util.Collection;
  * Model for authors
  */
 @Entity
-@SharePermission(expression = "Prefab.Role.All")
+@SharePermission()
 @Table(name = "author")
 @Include(rootLevel = true)
 public class Author {

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -669,10 +669,8 @@ public class EntityDictionary {
      * @return true if entityClass is shareable.  False otherwise.
      */
     public boolean isShareable(Class<?> entityClass) {
-        return entityHasChecksForPermission(
-                entityClass,
-                SharePermission.class
-        ) && getAnnotation(entityClass, SharePermission.class).sharable();
+        return getAnnotation(entityClass, SharePermission.class) != null
+                && getAnnotation(entityClass, SharePermission.class).sharable();
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -669,7 +669,10 @@ public class EntityDictionary {
      * @return true if entityClass is shareable.  False otherwise.
      */
     public boolean isShareable(Class<?> entityClass) {
-        return getAnnotation(entityClass, SharePermission.class) != null;
+        return entityHasChecksForPermission(
+                entityClass,
+                SharePermission.class
+        ) && getAnnotation(entityClass, SharePermission.class).sharable();
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -75,15 +75,17 @@ public class EntityPermissions implements CheckInstantiator {
                              Collection<AccessibleObject> fieldOrMethodList)  {
         this.dictionary = dictionary;
         for (Class<? extends Annotation> annotationClass : PERMISSION_ANNOTATIONS) {
-            ParseTree classPermission = bindClassPermissions(cls, annotationClass);
             final Map<String, ParseTree> fieldPermissions = new HashMap<>();
             fieldOrMethodList.stream()
                     .forEach(member -> bindMemberPermissions(fieldPermissions, member, annotationClass));
             if (annotationClass == SharePermission.class
                     && EntityDictionary.getFirstAnnotation(cls, Arrays.asList(annotationClass)) != null) {
                 bindings.put(SharePermission.class, new AnnotationBinding(null, fieldPermissions));
-            } else if (classPermission != null || !fieldPermissions.isEmpty()) {
-                bindings.put(annotationClass, new AnnotationBinding(classPermission, fieldPermissions));
+            } else {
+                ParseTree classPermission = bindClassPermissions(cls, annotationClass);
+                if (classPermission != null || !fieldPermissions.isEmpty()) {
+                    bindings.put(annotationClass, new AnnotationBinding(classPermission, fieldPermissions));
+                }
             }
         }
     }
@@ -104,9 +106,6 @@ public class EntityPermissions implements CheckInstantiator {
 
     private ParseTree getPermissionExpressionTree(Class<? extends Annotation> annotationClass, Annotation annotation) {
         try {
-            if (annotationClass == SharePermission.class) {
-                return null;
-            }
             String expression = (String) annotationClass.getMethod("expression").invoke(annotation);
 
             boolean hasExpression = !expression.isEmpty();

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -78,10 +78,7 @@ public class EntityPermissions implements CheckInstantiator {
             final Map<String, ParseTree> fieldPermissions = new HashMap<>();
             fieldOrMethodList.stream()
                     .forEach(member -> bindMemberPermissions(fieldPermissions, member, annotationClass));
-            if (annotationClass == SharePermission.class
-                    && EntityDictionary.getFirstAnnotation(cls, Arrays.asList(annotationClass)) != null) {
-                bindings.put(SharePermission.class, new AnnotationBinding(null, fieldPermissions));
-            } else {
+            if (annotationClass != SharePermission.class) {
                 ParseTree classPermission = bindClassPermissions(cls, annotationClass);
                 if (classPermission != null || !fieldPermissions.isEmpty()) {
                     bindings.put(annotationClass, new AnnotationBinding(classPermission, fieldPermissions));

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -79,7 +79,10 @@ public class EntityPermissions implements CheckInstantiator {
             final Map<String, ParseTree> fieldPermissions = new HashMap<>();
             fieldOrMethodList.stream()
                     .forEach(member -> bindMemberPermissions(fieldPermissions, member, annotationClass));
-            if (classPermission != null || !fieldPermissions.isEmpty()) {
+            if (annotationClass == SharePermission.class
+                    && EntityDictionary.getFirstAnnotation(cls, Arrays.asList(annotationClass)) != null) {
+                bindings.put(SharePermission.class, new AnnotationBinding(null, fieldPermissions));
+            } else if (classPermission != null || !fieldPermissions.isEmpty()) {
                 bindings.put(annotationClass, new AnnotationBinding(classPermission, fieldPermissions));
             }
         }
@@ -101,6 +104,9 @@ public class EntityPermissions implements CheckInstantiator {
 
     private ParseTree getPermissionExpressionTree(Class<? extends Annotation> annotationClass, Annotation annotation) {
         try {
+            if (annotationClass == SharePermission.class) {
+                return null;
+            }
             String expression = (String) annotationClass.getMethod("expression").invoke(annotation);
 
             boolean hasExpression = !expression.isEmpty();

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -114,10 +114,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                 if (requestScope.getDictionary().isShareable(resource.getResourceClass())) {
                     return expressionBuilder.buildAnyFieldExpressions(resource, ReadPermission.class, changeSpec);
                 } else {
-                    ForbiddenAccessException e = new ForbiddenAccessException("Missing SharePermission for "
-                            + resource.getResourceClass().getName());
-                    log.trace("{}", e.getLoggedMessage());
-                    throw e;
+                    return expressionBuilder.FAIL_EXPRESSION;
                 }
             }
             return expressionBuilder.buildAnyFieldExpressions(resource, annotationClass, changeSpec);

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
@@ -43,6 +43,7 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
     private final ExpressionResultCache cache;
 
     private static final Expression SUCCESSFUL_EXPRESSION = OrExpression.SUCCESSFUL_EXPRESSION;
+    public static final Expression FAIL_EXPRESSION = OrExpression.FAILURE_EXPRESSION;
 
     /**
      * Constructor.

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
@@ -97,7 +97,10 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
      *
      * @param resource        Resource
      * @return Commit and operation expressions
+     *
+     * @deprecated Trying to evaluate SharePermission should fall to ReadPermission in elide 4.0
      */
+    @Deprecated
     public Expression buildSharePermissionExpressions(final PersistentResource resource) {
 
         PermissionCondition condition = new PermissionCondition(SharePermission.class, resource);

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
@@ -5,8 +5,11 @@
  */
 package com.yahoo.elide.security.permissions;
 
+import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.FALSE_USER_CHECK_EXPRESSION;
+import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.NO_EVALUATION_EXPRESSION;
+import static com.yahoo.elide.security.permissions.expressions.Expression.Results.FAILURE;
+
 import com.yahoo.elide.annotation.ReadPermission;
-import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.core.CheckInstantiator;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RequestScope;
@@ -22,18 +25,14 @@ import com.yahoo.elide.security.permissions.expressions.AnyFieldExpression;
 import com.yahoo.elide.security.permissions.expressions.CheckExpression;
 import com.yahoo.elide.security.permissions.expressions.Expression;
 import com.yahoo.elide.security.permissions.expressions.OrExpression;
-import com.yahoo.elide.security.permissions.expressions.SharePermissionExpression;
 import com.yahoo.elide.security.permissions.expressions.SpecificFieldExpression;
+
 import org.antlr.v4.runtime.tree.ParseTree;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-
-import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.FALSE_USER_CHECK_EXPRESSION;
-import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.NO_EVALUATION_EXPRESSION;
-import static com.yahoo.elide.security.permissions.expressions.Expression.Results.FAILURE;
 
 /**
  * Expression builder to parse annotations and express the result as the Expression AST.
@@ -91,44 +90,6 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
                 );
 
         return buildExpressionFn.apply(leafBuilderFn);
-    }
-
-    /**
-     * Build an expression that checks share permissions on a bean.
-     *
-     * @param resource        Resource
-     * @return Commit and operation expressions
-     *
-     * @deprecated Trying to evaluate SharePermission should fall to ReadPermission in elide 4.0
-     */
-    @Deprecated
-    public Expression buildSharePermissionExpressions(final PersistentResource resource) {
-
-        PermissionCondition condition = new PermissionCondition(SharePermission.class, resource);
-
-        Class<?> resourceClass = resource.getResourceClass();
-        if (!entityDictionary.entityHasChecksForPermission(resourceClass, SharePermission.class)) {
-            SharePermissionExpression unshared = new SharePermissionExpression(condition);
-            return unshared;
-        }
-
-        final Function<Check, Expression> leafBuilderFn = (check) -> new CheckExpression(
-                check,
-                resource,
-                resource.getRequestScope(),
-                null,
-                cache
-        );
-
-        final Function<Function<Check, Expression>, Expression> expressionFunction =
-                (checkFn) -> {
-                    ParseTree classPermissions = entityDictionary.getPermissionsForClass(resourceClass,
-                            SharePermission.class);
-                    Expression entityExpression = expressionFromParseTree(classPermissions, checkFn);
-                    return new SharePermissionExpression(condition, entityExpression);
-                };
-
-        return expressionFunction.apply(leafBuilderFn);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
@@ -19,6 +19,7 @@ public class OrExpression implements Expression {
     private final Expression right;
 
     public static final OrExpression SUCCESSFUL_EXPRESSION = new OrExpression(Results.SUCCESS, null);
+    public static final OrExpression FAILURE_EXPRESSION = new OrExpression(Results.FAILURE, null);
 
     /**
      * Constructor.

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -2116,7 +2116,7 @@ public class PersistentResourceTest extends PersistentResource {
     @ReadPermission(expression = "allow all")
     @UpdatePermission(expression = "allow all")
     @DeletePermission(expression = "allow all")
-    @SharePermission()
+    @SharePermission
     public static final class ChangeSpecChild {
         @Id
         public long id;

--- a/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
@@ -9,7 +9,6 @@ import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
-import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
@@ -18,13 +17,15 @@ import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.checks.Check;
 import com.yahoo.elide.security.checks.prefab.Role;
 import com.yahoo.elide.security.permissions.expressions.Expression;
+
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.persistence.Entity;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.persistence.Entity;
 
 public class PermissionExpressionBuilderTest {
 
@@ -117,57 +118,6 @@ public class PermissionExpressionBuilderTest {
                         + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");
 
      }
-
-    @Test
-    public void testSharePermissionExpressionText() {
-        @Entity
-        @Include
-        @SharePermission(expression = "user has no access")
-        class Model {
-        }
-
-        dictionary.bindEntity(Model.class);
-
-        PersistentResource resource = newResource(new Model(), Model.class);
-
-        Expression expression = builder.buildSharePermissionExpressions(resource);
-
-
-        Assert.assertEquals(expression.toString(),
-                "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION [SHARE "
-                        + "ENTITY((user has no access \u001B[34mWAS UNEVALUATED\u001B[m))]");
-
-        expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
-
-        Assert.assertEquals(expression.toString(),
-                "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION [SHARE "
-                        + "ENTITY((user has no access \u001B[31mFAILED\u001B[m))]");
-
-    }
-
-    @Test
-    public void testMissingSharePermissionExpressionText() {
-        @Entity
-        @Include
-        class Model {
-        }
-
-        dictionary.bindEntity(Model.class);
-
-        PersistentResource resource = newResource(new Model(), Model.class);
-
-        Expression expression = builder.buildSharePermissionExpressions(resource);
-
-        Assert.assertEquals(expression.toString(),
-                "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION "
-                        + "[SHARE ENTITY(NOT MARKED SHAREABLE)]");
-
-        expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
-
-        Assert.assertEquals(expression.toString(),
-                "SHARE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  FOR EXPRESSION "
-                        + "[SHARE ENTITY(NOT MARKED SHAREABLE)]");
-    }
 
     public <T> PersistentResource newResource(T obj, Class<T> cls) {
         RequestScope requestScope = new RequestScope(null, null, null, null, null, elideSettings);

--- a/elide-core/src/test/java/example/Author.java
+++ b/elide-core/src/test/java/example/Author.java
@@ -25,7 +25,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "author")
 @Include(rootLevel = true)
-@SharePermission()
+@SharePermission
 @Audit(action = Audit.Action.CREATE,
         operation = 10,
         logStatement = "{0}",

--- a/elide-core/src/test/java/example/Author.java
+++ b/elide-core/src/test/java/example/Author.java
@@ -25,7 +25,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "author")
 @Include(rootLevel = true)
-@SharePermission(expression = "allow all")
+@SharePermission()
 @Audit(action = Audit.Action.CREATE,
         operation = 10,
         logStatement = "{0}",

--- a/elide-core/src/test/java/example/Book.java
+++ b/elide-core/src/test/java/example/Book.java
@@ -36,7 +36,7 @@ import javax.persistence.Table;
  * Model for books.
  */
 @Entity
-@SharePermission()
+@SharePermission
 @Table(name = "book")
 @Include(rootLevel = true)
 @Audit(action = Audit.Action.CREATE,

--- a/elide-core/src/test/java/example/Book.java
+++ b/elide-core/src/test/java/example/Book.java
@@ -36,7 +36,7 @@ import javax.persistence.Table;
  * Model for books.
  */
 @Entity
-@SharePermission(expression = "allow all")
+@SharePermission()
 @Table(name = "book")
 @Include(rootLevel = true)
 @Audit(action = Audit.Action.CREATE,

--- a/elide-core/src/test/java/example/Child.java
+++ b/elide-core/src/test/java/example/Child.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 @Entity(name = "childEntity")
 @CreatePermission(expression = "initCheck")
-@SharePermission()
+@SharePermission
 @ReadPermission(expression = "negativeChildId AND negativeIntegerUser AND initCheckOp")
 @Include(rootLevel = true, type = "child")
 @Audit(action = Audit.Action.DELETE,

--- a/elide-core/src/test/java/example/Child.java
+++ b/elide-core/src/test/java/example/Child.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 @Entity(name = "childEntity")
 @CreatePermission(expression = "initCheck")
-@SharePermission(expression = "allow all")
+@SharePermission()
 @ReadPermission(expression = "negativeChildId AND negativeIntegerUser AND initCheckOp")
 @Include(rootLevel = true, type = "child")
 @Audit(action = Audit.Action.DELETE,

--- a/elide-core/src/test/java/example/MapColorShape.java
+++ b/elide-core/src/test/java/example/MapColorShape.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @Entity
 @Table(name = "color_shape")
 @Include(rootLevel = true)
-@SharePermission()
+@SharePermission
 public class MapColorShape {
     private long id;
     private String name;

--- a/elide-core/src/test/java/example/MapColorShape.java
+++ b/elide-core/src/test/java/example/MapColorShape.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @Entity
 @Table(name = "color_shape")
 @Include(rootLevel = true)
-@SharePermission(expression = "allow all")
+@SharePermission()
 public class MapColorShape {
     private long id;
     private String name;

--- a/elide-core/src/test/java/example/NoShareEntity.java
+++ b/elide-core/src/test/java/example/NoShareEntity.java
@@ -6,13 +6,11 @@
 package example;
 
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.SharePermission;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-@SharePermission(expression = "deny all")
 @Include(rootLevel = true, type = "noshare") // optional here because class has this name
 // Hibernate
 @Entity

--- a/elide-core/src/test/java/example/Right.java
+++ b/elide-core/src/test/java/example/Right.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 
 @Include(rootLevel = true, type = "right") // optional here because class has this name
-@SharePermission(expression = "allow all")
+@SharePermission()
 @UpdatePermission(expression = "deny all")
 @Entity
 @Table(name = "xright")     // right is SQL keyword

--- a/elide-core/src/test/java/example/Right.java
+++ b/elide-core/src/test/java/example/Right.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 
 @Include(rootLevel = true, type = "right") // optional here because class has this name
-@SharePermission()
+@SharePermission
 @UpdatePermission(expression = "deny all")
 @Entity
 @Table(name = "xright")     // right is SQL keyword

--- a/elide-core/src/test/java/example/packageshareable/ContainerWithPackageShare.java
+++ b/elide-core/src/test/java/example/packageshareable/ContainerWithPackageShare.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.packageshareable;
+
+import com.yahoo.elide.annotation.Include;
+
+import java.util.Collection;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+/**
+ * Container for ShareableWithPackageShare and UnshareableWithEntityUnshare.
+ */
+@Entity
+@Include(rootLevel = true)
+public class ContainerWithPackageShare {
+    private long id;
+    private Collection<UnshareableWithEntityUnshare> unshareableWithEntityUnshares;
+    private Collection<ShareableWithPackageShare> shareableWithPackageShares;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @OneToMany(fetch = FetchType.LAZY)
+    public Collection<UnshareableWithEntityUnshare> getUnshareableWithEntityUnshares() {
+        return unshareableWithEntityUnshares;
+    }
+
+    public void setUnshareableWithEntityUnshares(Collection<UnshareableWithEntityUnshare> unshareables) {
+        this.unshareableWithEntityUnshares = unshareables;
+    }
+
+    @OneToMany(fetch = FetchType.LAZY)
+    public Collection<ShareableWithPackageShare> getShareableWithPackageShares() {
+        return shareableWithPackageShares;
+    }
+
+    public void setShareableWithPackageShares(Collection<ShareableWithPackageShare> shareableWithPackageShare) {
+        this.shareableWithPackageShares = shareableWithPackageShare;
+    }
+}

--- a/elide-core/src/test/java/example/packageshareable/ShareableWithPackageShare.java
+++ b/elide-core/src/test/java/example/packageshareable/ShareableWithPackageShare.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2017, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package example;
+package example.packageshareable;
 
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.SharePermission;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -14,18 +13,15 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 
 /**
- * A shareable bean.
+ * Package level shareable bean.
  */
 @Entity
-@SharePermission()
-@Table(name = "shareable")
-@Include(rootLevel = true, type = "shareable")
-public class Shareable {
+@Include(rootLevel = true)
+public class ShareableWithPackageShare {
     private long id;
-    private Container container;
+    private ContainerWithPackageShare container;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,11 +34,11 @@ public class Shareable {
     }
 
     @ManyToOne(fetch = FetchType.LAZY)
-    public Container getContainer() {
+    public ContainerWithPackageShare getContainerWithPackageShare() {
         return container;
     }
 
-    public void setContainer(Container container) {
+    public void setContainerWithPackageShare(ContainerWithPackageShare container) {
         this.container = container;
     }
 }

--- a/elide-core/src/test/java/example/packageshareable/UnshareableWithEntityUnshare.java
+++ b/elide-core/src/test/java/example/packageshareable/UnshareableWithEntityUnshare.java
@@ -1,31 +1,29 @@
 /*
- * Copyright 2016, Yahoo Inc.
+ * Copyright 2017, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.example.models;
+package example.packageshareable;
 
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.SharePermission;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.ManyToOne;
 
 /**
- * Model for Users (author of posts and author of comments).
+ * Entity level Unshareable bean.
  */
 @Entity
-@Table(name = "user")
+@SharePermission(sharable = false)
 @Include(rootLevel = true)
-@SharePermission()
-//@CreatePermission(expression = "Prefab.Role.All")
-public class User {
+public class UnshareableWithEntityUnshare {
     private long id;
-    private String name;
-    private Role role;
+    private ContainerWithPackageShare container;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,19 +35,12 @@ public class User {
         this.id = id;
     }
 
-    public String getName() {
-        return name;
+    @ManyToOne(fetch = FetchType.LAZY)
+    public ContainerWithPackageShare getContainerWithPackageShare() {
+        return container;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Role getRole() {
-        return role;
-    }
-
-    public void setRole(Role role) {
-        this.role = role;
+    public void setContainerWithPackageShare(ContainerWithPackageShare container) {
+        this.container = container;
     }
 }

--- a/elide-core/src/test/java/example/packageshareable/package-info.java
+++ b/elide-core/src/test/java/example/packageshareable/package-info.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-@SharePermission()
+@SharePermission
 package example.packageshareable;
 
 import com.yahoo.elide.annotation.SharePermission;

--- a/elide-core/src/test/java/example/packageshareable/package-info.java
+++ b/elide-core/src/test/java/example/packageshareable/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+@SharePermission()
+package example.packageshareable;
+
+import com.yahoo.elide.annotation.SharePermission;

--- a/elide-example/dropwizard-elide-example/src/main/java/com/yahoo/elide/example/Author.java
+++ b/elide-example/dropwizard-elide-example/src/main/java/com/yahoo/elide/example/Author.java
@@ -22,7 +22,7 @@ import java.util.Collection;
  * Model for authors.
  */
 @Entity
-@SharePermission(expression = "Prefab.Role.All")
+@SharePermission()
 @Table(name = "author")
 @Include(rootLevel = true)
 public class Author {

--- a/elide-example/dropwizard-elide-example/src/main/java/com/yahoo/elide/example/Author.java
+++ b/elide-example/dropwizard-elide-example/src/main/java/com/yahoo/elide/example/Author.java
@@ -22,7 +22,7 @@ import java.util.Collection;
  * Model for authors.
  */
 @Entity
-@SharePermission()
+@SharePermission
 @Table(name = "author")
 @Include(rootLevel = true)
 public class Author {

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/models/Comment.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/models/Comment.java
@@ -23,7 +23,7 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "comment")
 @Include
-@SharePermission()
+@SharePermission
 public class Comment {
     private long id;
     private Post post;

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/models/Comment.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/models/Comment.java
@@ -23,7 +23,7 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "comment")
 @Include
-@SharePermission(expression = "Prefab.Role.All")
+@SharePermission()
 public class Comment {
     private long id;
     private Post post;

--- a/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/models/User.java
+++ b/elide-example/elide-blog-example-resteasy/src/main/java/com/yahoo/elide/example/models/User.java
@@ -20,7 +20,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "user")
 @Include(rootLevel = true)
-@SharePermission()
+@SharePermission
 //@CreatePermission(expression = "Prefab.Role.All")
 public class User {
     private long id;

--- a/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/Comment.java
+++ b/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/Comment.java
@@ -23,7 +23,7 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "comment")
 @Include
-@SharePermission()
+@SharePermission
 public class Comment {
     private long id;
     private Post post;

--- a/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/Comment.java
+++ b/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/Comment.java
@@ -23,7 +23,7 @@ import javax.persistence.Transient;
 @Entity
 @Table(name = "comment")
 @Include
-@SharePermission(expression = "Prefab.Role.All")
+@SharePermission()
 public class Comment {
     private long id;
     private Post post;

--- a/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/User.java
+++ b/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/User.java
@@ -20,7 +20,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "user")
 @Include(rootLevel = true)
-@SharePermission(expression = "Prefab.Role.All")
+@SharePermission()
 //@CreatePermission(expression = "Prefab.Role.All")
 public class User {
     private long id;

--- a/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/User.java
+++ b/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/models/User.java
@@ -20,7 +20,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "user")
 @Include(rootLevel = true)
-@SharePermission()
+@SharePermission
 //@CreatePermission(expression = "Prefab.Role.All")
 public class User {
     private long id;

--- a/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Model for anotherFilterExpressionCheckObj.
  */
 @Entity
-@SharePermission(expression = "allow all")
+@SharePermission()
 @Table(name = "anotherFilterExpressionCheckObj")
 @ReadPermission(expression = "checkActsLikeFilter")
 @Include(rootLevel = true)

--- a/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Model for anotherFilterExpressionCheckObj.
  */
 @Entity
-@SharePermission()
+@SharePermission
 @Table(name = "anotherFilterExpressionCheckObj")
 @ReadPermission(expression = "checkActsLikeFilter")
 @Include(rootLevel = true)

--- a/elide-integration-tests/src/test/java/example/AuditEntity.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntity.java
@@ -30,7 +30,7 @@ import java.util.List;
 @CreatePermission(expression = "allow all")
 @DeletePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
-@SharePermission(expression = "allow all")
+@SharePermission()
 public class AuditEntity {
     private Long id;
     private AuditEntity otherEntity;

--- a/elide-integration-tests/src/test/java/example/AuditEntity.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntity.java
@@ -30,7 +30,7 @@ import java.util.List;
 @CreatePermission(expression = "allow all")
 @DeletePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
-@SharePermission()
+@SharePermission
 public class AuditEntity {
     private Long id;
     private AuditEntity otherEntity;

--- a/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
@@ -26,7 +26,7 @@ import java.util.List;
 @CreatePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
 @DeletePermission(expression = "allow all")
-@SharePermission(expression = "allow all")
+@SharePermission()
 public class AuditEntityInverse {
     private Long id;
     private List<AuditEntity> entities;

--- a/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
@@ -26,7 +26,7 @@ import java.util.List;
 @CreatePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
 @DeletePermission(expression = "allow all")
-@SharePermission()
+@SharePermission
 public class AuditEntityInverse {
     private Long id;
     private List<AuditEntity> entities;

--- a/elide-integration-tests/src/test/java/example/Author.java
+++ b/elide-integration-tests/src/test/java/example/Author.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 @Entity
 @Table(name = "author")
 @Include(rootLevel = true)
-@SharePermission()
+@SharePermission
 @Paginate
 @Audit(action = Audit.Action.CREATE,
         operation = 10,

--- a/elide-integration-tests/src/test/java/example/Author.java
+++ b/elide-integration-tests/src/test/java/example/Author.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 @Entity
 @Table(name = "author")
 @Include(rootLevel = true)
-@SharePermission(expression = "allow all")
+@SharePermission()
 @Paginate
 @Audit(action = Audit.Action.CREATE,
         operation = 10,

--- a/elide-integration-tests/src/test/java/example/Book.java
+++ b/elide-integration-tests/src/test/java/example/Book.java
@@ -29,7 +29,7 @@ import java.util.Collection;
  * Model for books.
  */
 @Entity
-@SharePermission(expression = "allow all")
+@SharePermission()
 @Table(name = "book")
 @Include(rootLevel = true)
 @Paginate

--- a/elide-integration-tests/src/test/java/example/Book.java
+++ b/elide-integration-tests/src/test/java/example/Book.java
@@ -29,7 +29,7 @@ import java.util.Collection;
  * Model for books.
  */
 @Entity
-@SharePermission()
+@SharePermission
 @Table(name = "book")
 @Include(rootLevel = true)
 @Paginate

--- a/elide-integration-tests/src/test/java/example/Chapter.java
+++ b/elide-integration-tests/src/test/java/example/Chapter.java
@@ -18,7 +18,7 @@ import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true, type = "chapter")
-@SharePermission(expression = "allow all")
+@SharePermission()
 public class Chapter {
     private Long id;
     @Getter @Setter private String title;

--- a/elide-integration-tests/src/test/java/example/Chapter.java
+++ b/elide-integration-tests/src/test/java/example/Chapter.java
@@ -18,7 +18,7 @@ import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true, type = "chapter")
-@SharePermission()
+@SharePermission
 public class Chapter {
     private Long id;
     @Getter @Setter private String title;

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -42,7 +42,7 @@ import java.util.Set;
  */
 @Entity(name = "childEntity")
 @CreatePermission(expression = "initCheck")
-@SharePermission(expression = "allow all")
+@SharePermission()
 @ReadPermission(expression = "negativeChildId AND negativeIntegerUser AND initCheckOp AND initCheckFilter")
 @Include(rootLevel = true, type = "child")
 @Audit(action = Audit.Action.DELETE,

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -42,7 +42,7 @@ import java.util.Set;
  */
 @Entity(name = "childEntity")
 @CreatePermission(expression = "initCheck")
-@SharePermission()
+@SharePermission
 @ReadPermission(expression = "negativeChildId AND negativeIntegerUser AND initCheckOp AND initCheckFilter")
 @Include(rootLevel = true, type = "child")
 @Audit(action = Audit.Action.DELETE,

--- a/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Entity
 @Table(name = "filterExpressionCheckObj")
 @Include(rootLevel = true)
-@SharePermission(expression = "allow all")
+@SharePermission()
 @ReadPermission(expression = "checkLE OR deny all")  //ReadPermission for object id <= 2
 public class FilterExpressionCheckObj {
     private long id;

--- a/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Entity
 @Table(name = "filterExpressionCheckObj")
 @Include(rootLevel = true)
-@SharePermission()
+@SharePermission
 @ReadPermission(expression = "checkLE OR deny all")  //ReadPermission for object id <= 2
 public class FilterExpressionCheckObj {
     private long id;

--- a/elide-integration-tests/src/test/java/example/MapColorShape.java
+++ b/elide-integration-tests/src/test/java/example/MapColorShape.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @Entity
 @Table(name = "color_shape")
 @Include(rootLevel = true)
-@SharePermission(expression = "allow all")
+@SharePermission()
 public class MapColorShape {
     private long id;
     private Map<Color, Shape> colorShapeMap = new LinkedHashMap<>();

--- a/elide-integration-tests/src/test/java/example/MapColorShape.java
+++ b/elide-integration-tests/src/test/java/example/MapColorShape.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @Entity
 @Table(name = "color_shape")
 @Include(rootLevel = true)
-@SharePermission()
+@SharePermission
 public class MapColorShape {
     private long id;
     private Map<Color, Shape> colorShapeMap = new LinkedHashMap<>();

--- a/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
+++ b/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
@@ -17,7 +17,7 @@ import javax.persistence.OneToOne;
 
 @Entity
 @Include(rootLevel = true, type = "noShareBid")
-@SharePermission(expression = "deny all")
+@SharePermission()
 public class NoShareBiDirectional {
     private Long id;
     private NoShareBiDirectional other;

--- a/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
+++ b/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
@@ -17,7 +17,7 @@ import javax.persistence.OneToOne;
 
 @Entity
 @Include(rootLevel = true, type = "noShareBid")
-@SharePermission
+@SharePermission(sharable = false)
 public class NoShareBiDirectional {
     private Long id;
     private NoShareBiDirectional other;

--- a/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
+++ b/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
@@ -17,7 +17,7 @@ import javax.persistence.OneToOne;
 
 @Entity
 @Include(rootLevel = true, type = "noShareBid")
-@SharePermission()
+@SharePermission
 public class NoShareBiDirectional {
     private Long id;
     private NoShareBiDirectional other;

--- a/elide-integration-tests/src/test/java/example/Parent.java
+++ b/elide-integration-tests/src/test/java/example/Parent.java
@@ -35,7 +35,7 @@ import java.util.Set;
 @ReadPermission(expression = "parentInitCheckOp OR allow all")
 @UpdatePermission(expression = "parentInitCheck OR allow all OR deny all")
 @DeletePermission(expression = "parentInitCheckOp OR allow all OR deny all")
-@SharePermission(expression = "allow all")
+@SharePermission()
 @Include(rootLevel = true, type = "parent") // optional here because class has this name
 @Paginate(maxLimit = 100000)
 // Hibernate

--- a/elide-integration-tests/src/test/java/example/Parent.java
+++ b/elide-integration-tests/src/test/java/example/Parent.java
@@ -35,7 +35,7 @@ import java.util.Set;
 @ReadPermission(expression = "parentInitCheckOp OR allow all")
 @UpdatePermission(expression = "parentInitCheck OR allow all OR deny all")
 @DeletePermission(expression = "parentInitCheckOp OR allow all OR deny all")
-@SharePermission()
+@SharePermission
 @Include(rootLevel = true, type = "parent") // optional here because class has this name
 @Paginate(maxLimit = 100000)
 // Hibernate

--- a/elide-integration-tests/src/test/java/example/Shareable.java
+++ b/elide-integration-tests/src/test/java/example/Shareable.java
@@ -20,7 +20,7 @@ import javax.persistence.Table;
  * A shareable bean.
  */
 @Entity
-@SharePermission()
+@SharePermission
 @Table(name = "shareable")
 @Include(rootLevel = true, type = "shareable")
 public class Shareable {

--- a/elide-standalone/README.md
+++ b/elide-standalone/README.md
@@ -67,7 +67,9 @@ The Elide standalone application is for all new and existing users of Elide. Thi
 
 ## <a name="gettingstarted"></a>Getting Started
 
-A simple example of setting up an Elide service without security.
+Below we'll walk through a complete example of setting up an Elide service without security.
+
+**If you're interested in seeing a more complete example, check out our [ready-to-run example](https://github.com/DennisMcWherter/elide-example-blog-kotlin).**
 
 ### Setup a Database (MySQL)
 


### PR DESCRIPTION
Some changes to SharePermission:

1. An entity with no `SharePermission` is not shareable now. 
2. Whenever SharePermission is evaluated, falls back to ReadPermission of the entity.
3. Remove `expression` from SharePermission since it's useless now.
4. Add a `boolean isShareable()` to SharePermission to allow a way of override package level `SharePermission`.