### PR TITLE
@ManyToAny support for polymorphic relations

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -14,7 +14,6 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.OnReadPreSecurity;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.SharePermission;
-import com.yahoo.elide.annotation.ToMany;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.audit.InvalidSyntaxException;
 import com.yahoo.elide.audit.LogMessage;
@@ -932,9 +931,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         }
 
         final Class<?> relationClass = dictionary.getParameterizedType(obj, relationName);
-        boolean isAnyToMany = dictionary.isMappedInterface(relationClass)
-                && dictionary.getAttributeOrRelationAnnotation(obj.getClass(), ToMany.class, relationName) != null;
-        if (isAnyToMany || (! requestScope.getPagination().isDefaultInstance()
+        if (dictionary.isMappedInterface(relationClass) || (! requestScope.getPagination().isDefaultInstance()
                 && !CanPaginateVisitor.canPaginate(relationClass, dictionary, requestScope))) {
             throw new InvalidPredicateException(String.format("Cannot paginate %s",
                     dictionary.getJsonAliasFor(relationClass)));

--- a/elide-integration-tests/src/test/java/example/StuffBox.java
+++ b/elide-integration-tests/src/test/java/example/StuffBox.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.SharePermission;
+
+import com.yahoo.elide.annotation.ToMany;
+import lombok.Setter;
+import org.hibernate.annotations.AnyMetaDef;
+import org.hibernate.annotations.ManyToAny;
+import org.hibernate.annotations.MetaValue;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+
+import java.util.Collection;
+
+@Entity
+@Include(rootLevel = true, type = "stuffbox")
+@SharePermission(expression = "allow all")
+public class StuffBox extends BaseId {
+    @Setter private Collection<Device> myStuff;
+
+    @ManyToAny(metaColumn = @Column(name = "property_type"))
+    @AnyMetaDef(idType = "long", metaType = "string", metaValues = {
+            @MetaValue(targetEntity = example.Tractor.class, value = "tractor"),
+            @MetaValue(targetEntity = example.Smartphone.class, value = "smartphone")
+    })
+    @JoinTable(
+            name = "property_in_box",
+            joinColumns = @JoinColumn(name = "stuff_id"),
+            inverseJoinColumns = @JoinColumn(name = "property_id")
+    )
+    @ToMany
+    public Collection<Device> getMyStuff() {
+        return myStuff;
+    }
+}

--- a/elide-integration-tests/src/test/resources/AnyPolymorphismIT/AddBoxOfStuff.json
+++ b/elide-integration-tests/src/test/resources/AnyPolymorphismIT/AddBoxOfStuff.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "type": "stuffbox",
+    "attributes": {},
+    "relationships": {
+      "myStuff": {
+        "data": [
+          {
+            "type": "smartphone",
+            "id": "1"
+          },
+          {
+            "type": "tractor",
+            "id": "1"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/elide-integration-tests/src/test/resources/AnyPolymorphismIT/PatchBoxOfStuff.json
+++ b/elide-integration-tests/src/test/resources/AnyPolymorphismIT/PatchBoxOfStuff.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "id": "1",
+    "type": "stuffbox",
+    "relationships": {
+      "myStuff": {
+        "data": [
+          {
+            "type": "smartphone",
+            "id": "1"
+          },
+          {
+            "type": "tractor",
+            "id": "1"
+          },
+          {
+            "type": "smartphone",
+            "id": "2"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/elide-integration-tests/src/test/resources/AnyPolymorphismIT/RemoveAllStuff.json
+++ b/elide-integration-tests/src/test/resources/AnyPolymorphismIT/RemoveAllStuff.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "1",
+    "type": "stuffbox",
+    "relationships": {
+      "myStuff": {
+        "data": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
Other than writing tests, the biggest changes were making sure that the system sent 400s for filtering that's not supported on this @ManyToAny (pagination and filtering are not supported due to limitations on hibernate's HQL generator)

The biggest change was to the orderedById tree, when serializing the model, this tree ended up squashing objects with the same id together, even though they had different types.  So that is why you see me adding the type to the key.