### PR TITLE
Allowing CreatePermissions to be specified on attributes and relations

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/CreatePermission.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/CreatePermission.java
@@ -9,14 +9,16 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Assign custom Create permission checks.
  */
-@Target({TYPE, PACKAGE})
+@Target({TYPE, PACKAGE, METHOD, FIELD})
 @Retention(RUNTIME)
 @Inherited
 public @interface CreatePermission {

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1791,6 +1791,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                 ? new ChangeSpec(this, fieldName, original, modified)
                 : null;
 
+        if (UpdatePermission.class.isAssignableFrom(annotationClass)
+                && this.requestScope.isNewResource(this)) {
+            return requestScope.getPermissionExecutor()
+                    .checkSpecificFieldPermissions(this, changeSpec, CreatePermission.class, fieldName);
+        }
         return requestScope.getPermissionExecutor()
                 .checkSpecificFieldPermissions(this, changeSpec, annotationClass, fieldName);
     }
@@ -1803,6 +1808,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                 ? new ChangeSpec(this, fieldName, original, modified)
                 : null;
 
+        if (UpdatePermission.class.isAssignableFrom(annotationClass)
+                && this.requestScope.isNewResource(this.getObject())) {
+            return requestScope.getPermissionExecutor()
+                    .checkSpecificFieldPermissionsDeferred(this, changeSpec, CreatePermission.class, fieldName);
+        }
         return requestScope
                 .getPermissionExecutor()
                 .checkSpecificFieldPermissionsDeferred(this, changeSpec, annotationClass, fieldName);

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1764,7 +1764,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         for (String field : fields) {
             try {
                 if (checkIncludeSparseField(requestScope.getSparseFields(), type, field)) {
-                    checkFieldAwarePermissions(ReadPermission.class, field, (Object) null, (Object) null);
+                    checkFieldAwareReadPermissions(field);
                     filteredSet.add(field);
                 }
             } catch (ForbiddenAccessException e) {
@@ -1783,21 +1783,9 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         return requestScope.getPermissionExecutor().checkPermission(annotationClass, this);
     }
 
-    private <A extends Annotation> ExpressionResult checkFieldAwarePermissions(Class<A> annotationClass,
-                                                                   String fieldName,
-                                                                   Object modified,
-                                                                   Object original) {
-        ChangeSpec changeSpec = (UpdatePermission.class.isAssignableFrom(annotationClass))
-                ? new ChangeSpec(this, fieldName, original, modified)
-                : null;
-
-        if (UpdatePermission.class.isAssignableFrom(annotationClass)
-                && this.requestScope.isNewResource(this)) {
-            return requestScope.getPermissionExecutor()
-                    .checkSpecificFieldPermissions(this, changeSpec, CreatePermission.class, fieldName);
-        }
+    private <A extends Annotation> ExpressionResult checkFieldAwareReadPermissions(String fieldName) {
         return requestScope.getPermissionExecutor()
-                .checkSpecificFieldPermissions(this, changeSpec, annotationClass, fieldName);
+                .checkSpecificFieldPermissions(this, null, ReadPermission.class, fieldName);
     }
 
     private <A extends Annotation> ExpressionResult checkFieldAwareDeferPermissions(Class<A> annotationClass,
@@ -1808,11 +1796,6 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                 ? new ChangeSpec(this, fieldName, original, modified)
                 : null;
 
-        if (UpdatePermission.class.isAssignableFrom(annotationClass)
-                && this.requestScope.isNewResource(this.getObject())) {
-            return requestScope.getPermissionExecutor()
-                    .checkSpecificFieldPermissionsDeferred(this, changeSpec, CreatePermission.class, fieldName);
-        }
         return requestScope
                 .getPermissionExecutor()
                 .checkSpecificFieldPermissionsDeferred(this, changeSpec, annotationClass, fieldName);

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -5,10 +5,11 @@
  */
 package com.yahoo.elide.security.executors;
 
-import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.ReadPermission;
-import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import com.yahoo.elide.annotation.SharePermission;
+import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -203,7 +204,8 @@ public class ActivePermissionExecutor implements PermissionExecutor {
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             if ((((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
-                    || annotationClass == UpdatePermission.class)
+                    || annotationClass == UpdatePermission.class
+                    || annotationClass == CreatePermission.class)
                     && requestScope.getNewPersistentResources().contains(resource)) {
                 return executeUserChecksDeferInline(annotationClass, expression);
             }

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -198,33 +198,32 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                                                                                          ChangeSpec changeSpec,
                                                                                          Class<A> annotationClass,
                                                                                          String field) {
+        //We would want to evaluate the expression in the CreatePermission in case of
+        // update checks on newly created entities
+        Class expressionAnnotation = annotationClass.isAssignableFrom(UpdatePermission.class)
+                && requestScope.getNewResources().contains(resource)
+                ? CreatePermission.class
+                : annotationClass;
+
         Supplier<Expression> expressionSupplier = () -> {
-            if (annotationClass == UpdatePermission.class
-                    && requestScope.getNewResources().contains(resource)) {
                 return expressionBuilder.buildSpecificFieldExpressions(resource,
-                        CreatePermission.class,
+                        expressionAnnotation,
                         field,
                         changeSpec);
-            } else {
-                return expressionBuilder.buildSpecificFieldExpressions(resource,
-                        annotationClass,
-                        field,
-                        changeSpec);
-            }
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             if ((((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
                     || annotationClass == UpdatePermission.class)
                     && requestScope.getNewPersistentResources().contains(resource)) {
-                return executeUserChecksDeferInline(annotationClass, expression);
+                return executeUserChecksDeferInline(expressionAnnotation, expression);
             }
-            return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
+            return executeExpressions(expression, expressionAnnotation, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
         };
 
         return checkPermissions(
                 resource.getResourceClass(),
-                annotationClass,
+                expressionAnnotation,
                 Optional.of(field),
                 expressionSupplier,
                 expressionExecutor);

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -123,8 +123,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             // for newly created object in PatchRequest limit to User checks
-            if ((((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
-                    || annotationClass == UpdatePermission.class)
+            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
                     && requestScope.getNewPersistentResources().contains(resource)) {
                 return executeUserChecksDeferInline(annotationClass, expression);
             }
@@ -213,8 +212,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
-            if ((((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
-                    || annotationClass == UpdatePermission.class)
+            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
                     && requestScope.getNewPersistentResources().contains(resource)) {
                 return executeUserChecksDeferInline(expressionAnnotation, expression);
             }

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -199,13 +199,23 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                                                                                          Class<A> annotationClass,
                                                                                          String field) {
         Supplier<Expression> expressionSupplier = () -> {
-            return expressionBuilder.buildSpecificFieldExpressions(resource, annotationClass, field, changeSpec);
+            if (annotationClass == UpdatePermission.class
+                    && requestScope.getNewResources().contains(resource)) {
+                return expressionBuilder.buildSpecificFieldExpressions(resource,
+                        CreatePermission.class,
+                        field,
+                        changeSpec);
+            } else {
+                return expressionBuilder.buildSpecificFieldExpressions(resource,
+                        annotationClass,
+                        field,
+                        changeSpec);
+            }
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             if ((((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
-                    || annotationClass == UpdatePermission.class
-                    || annotationClass == CreatePermission.class)
+                    || annotationClass == UpdatePermission.class)
                     && requestScope.getNewPersistentResources().contains(resource)) {
                 return executeUserChecksDeferInline(annotationClass, expression);
             }

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -123,8 +123,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             // for newly created object in PatchRequest limit to User checks
-            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
-                    && requestScope.getNewPersistentResources().contains(resource)) {
+            if (requestScope.getNewPersistentResources().contains(resource)) {
                 return executeUserChecksDeferInline(annotationClass, expression);
             }
             return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
@@ -212,8 +211,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
-            if (((RequestScope) resource.getRequestScope()).isMutatingMultipleEntities()
-                    && requestScope.getNewPersistentResources().contains(resource)) {
+            if (requestScope.getNewPersistentResources().contains(resource)) {
                 return executeUserChecksDeferInline(expressionAnnotation, expression);
             }
             return executeExpressions(expression, expressionAnnotation, Expression.EvaluationMode.INLINE_CHECKS_ONLY);

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.audit.AuditLogger;
+import example.Child;
+import example.TestCheckMappings;
+
+import static org.mockito.Mockito.mock;
+
+public class PersistenceResourceTestSetup extends PersistentResource {
+
+    private static final AuditLogger MOCK_AUDIT_LOGGER = mock(AuditLogger.class);
+
+    protected final ElideSettings elideSettings;
+
+    public PersistenceResourceTestSetup() {
+        super(
+                new Child(),
+                null,
+                null, // new request scope + new Child == cannot possibly be a UUID for this object
+                new RequestScope(null, null, null, null, null,
+                        new ElideSettingsBuilder(null)
+                                .withEntityDictionary(new EntityDictionary(TestCheckMappings.MAPPINGS))
+                                .withAuditLogger(MOCK_AUDIT_LOGGER)
+                                .withDefaultMaxPageSize(10)
+                                .withDefaultPageSize(10)
+                                .build()
+                )
+        );
+
+        elideSettings = new ElideSettingsBuilder(null)
+                .withEntityDictionary(dictionary)
+                .withAuditLogger(MOCK_AUDIT_LOGGER)
+                .withDefaultMaxPageSize(10)
+                .withDefaultPageSize(10)
+                .build();
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -30,7 +30,8 @@ public class PersistenceResourceTestSetup extends PersistentResource {
                                 .withAuditLogger(MOCK_AUDIT_LOGGER)
                                 .withDefaultMaxPageSize(10)
                                 .withDefaultPageSize(10)
-                                .build()
+                                .build(),
+                        false
                 )
         );
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.core;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.CreatePermission;
@@ -48,7 +47,6 @@ import example.NoUpdateEntity;
 import example.Parent;
 import example.Right;
 import example.Shape;
-import example.TestCheckMappings;
 import example.packageshareable.ContainerWithPackageShare;
 import example.packageshareable.ShareableWithPackageShare;
 import example.packageshareable.UnshareableWithEntityUnshare;
@@ -93,35 +91,12 @@ import static org.mockito.Mockito.when;
 /**
  * Test PersistentResource.
  */
-public class PersistentResourceTest extends PersistentResource {
+public class PersistentResourceTest extends PersistenceResourceTestSetup {
+
     private final RequestScope goodUserScope;
     private final RequestScope badUserScope;
-    private static final AuditLogger MOCK_AUDIT_LOGGER = mock(AuditLogger.class);
-
-    private final ElideSettings elideSettings;
 
     public PersistentResourceTest() {
-        super(
-                new Child(),
-                null,
-                null, // new request scope + new Child == cannot possibly be a UUID for this object
-                new RequestScope(null, null, null, null, null,
-                        new ElideSettingsBuilder(null)
-                            .withEntityDictionary(new EntityDictionary(TestCheckMappings.MAPPINGS))
-                            .withAuditLogger(MOCK_AUDIT_LOGGER)
-                            .withDefaultMaxPageSize(10)
-                            .withDefaultPageSize(10)
-                            .build(),
-                        false)
-        );
-
-        elideSettings = new ElideSettingsBuilder(null)
-                .withEntityDictionary(dictionary)
-                .withAuditLogger(MOCK_AUDIT_LOGGER)
-                .withDefaultMaxPageSize(10)
-                .withDefaultPageSize(10)
-                .build();
-
         goodUserScope = new RequestScope(null, null, mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS),
                 new User(1), null, elideSettings, false);
         badUserScope = new RequestScope(null, null, mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS),

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2017, Oath Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
+import com.yahoo.elide.security.User;
+import com.yahoo.elide.utils.coerce.CoerceUtil;
+import example.Author;
+import example.Book;
+import example.UpdateAndCreate;
+import org.mockito.Answers;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
+
+    private User userOne;
+    private User userTwo;
+    private User userThree;
+
+    private RequestScope userOneScope;
+    private RequestScope userTwoScope;
+    private RequestScope userThreeScope;
+
+    private DataStoreTransaction tx;
+
+
+    public UpdateOnCreateTest() {
+        super();
+    }
+
+    @BeforeTest
+    public void init() {
+        dictionary.bindEntity(Author.class);
+        dictionary.bindEntity(Book.class);
+        dictionary.bindEntity(UpdateAndCreate.class);
+
+        UpdateAndCreate updateAndCreateNewObject = new UpdateAndCreate();
+        updateAndCreateNewObject.setId(1L);
+        UpdateAndCreate updateAndCreateExistingObject = new UpdateAndCreate();
+        updateAndCreateExistingObject.setId(2L);
+        Book book = new Book();
+        Author author = new Author();
+
+        tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
+
+        userOne = new User(1);
+        userOneScope = new RequestScope(null, null, tx, userOne, null, elideSettings);
+        userTwo = new User(2);
+        userTwoScope = new RequestScope(null, null, tx, userTwo, null, elideSettings);
+        userThree = new User(3);
+        userThreeScope = new RequestScope(null, null, tx, userThree, null, elideSettings);
+
+        when(tx.createNewObject(UpdateAndCreate.class)).thenReturn(updateAndCreateNewObject);
+        when(tx.loadObject(eq(UpdateAndCreate.class),
+                eq((Serializable) CoerceUtil.coerce(1, Long.class)),
+                eq(Optional.empty()),
+                any(RequestScope.class)
+        )).thenReturn(updateAndCreateExistingObject);
+        when(tx.loadObject(eq(Book.class),
+                eq((Serializable) CoerceUtil.coerce(1, Long.class)),
+                eq(Optional.empty()),
+                any(RequestScope.class)
+        )).thenReturn(book);
+        when(tx.loadObject(eq(Author.class),
+                eq((Serializable) CoerceUtil.coerce(1, Long.class)),
+                eq(Optional.empty()),
+                any(RequestScope.class)
+        )).thenReturn(author);
+    }
+
+    @Test
+    public void testUpdateOnCreateUserOne() {
+
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userOneScope);
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userOneScope);
+
+        created.updateAttribute("name", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            created.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
+            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        created.updateAttribute("alias", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        created.addRelation("books", loadedBook);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            created.addRelation("author", loadedAuthor);
+            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+
+        });
+    }
+
+    @Test
+    public void testNormalUpdateUserOne() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userOneScope);
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userOneScope);
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userOneScope);
+
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.updateAttribute("name", "");
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.updateAttribute("alias", "");
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.addRelation("books", loadedBook);
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.addRelation("author", loadedAuthor);
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+
+        });
+    }
+
+    @Test
+    public void testUpdateOnCreateUserTwo() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userTwoScope, Optional.of("uuid"));
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userTwoScope);
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userTwoScope);
+
+        created.updateAttribute("name", "");
+        created.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
+        created.updateAttribute("alias", "");
+        created.addRelation("books", loadedBook);
+        created.addRelation("author", loadedAuthor);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test
+    public void testNormalUpdateUserTwo() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userTwoScope);
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userTwoScope);
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userTwoScope);
+
+        loaded.updateAttribute("name", "");
+        loaded.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
+        loaded.updateAttribute("alias", "");
+        loaded.addRelation("books", loadedBook);
+        loaded.addRelation("author", loadedAuthor);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+
+    @Test
+    public void testUpdateOnCreateUserThree() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userThreeScope);
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userThreeScope);
+
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            created.updateAttribute("name", "");
+            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            created.addRelation("books", loadedBook);
+            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            created.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
+            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            created.addRelation("author", loadedAuthor);
+            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+
+        });
+
+        created.updateAttribute("alias", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+
+    }
+
+    @Test
+    public void testNormalUpdateUserThree() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userThreeScope);
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userThreeScope);
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userThreeScope);
+
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.updateAttribute("name", "");
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.updateAttribute("alias", "");
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.addRelation("books", loadedBook);
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+        });
+        Assert.assertThrows(ForbiddenAccessException.class, () -> {
+            loaded.addRelation("author", loadedAuthor);
+            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+
+        });
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -30,10 +30,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     private RequestScope userTwoScope;
     private RequestScope userThreeScope;
 
-    public UpdateOnCreateTest() {
-        super();
-    }
-
     @BeforeTest
     public void init() {
         dictionary.bindEntity(Author.class);

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -76,19 +76,16 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     @Test
     public void createPermissionCheckClassAnnotationForCreatingAnEntitySuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test
     public void createPermissionCheckFieldAnnotationForCreatingAnEntitySuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
     public void createPermissionCheckFieldAnnotationForCreatingAnEntityFailureCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userFourScope, Optional.of("uuid"));
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     //----------------------------------------- ** Update Attribute ** ------------------------------------------------
@@ -98,7 +95,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userTwoScope);
         loaded.updateAttribute("name", "");
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -107,7 +103,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userOneScope);
         loaded.updateAttribute("name", "");
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test
@@ -116,7 +111,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userFourScope);
         loaded.updateAttribute("alias", "");
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -125,7 +119,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userThreeScope);
         loaded.updateAttribute("alias", "");
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
 
@@ -139,7 +132,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userTwoScope);
         loaded.addRelation("books", loadedBook);
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -151,7 +143,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userOneScope);
         loaded.addRelation("books", loadedBook);
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test
@@ -163,7 +154,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userThreeScope);
         loaded.addRelation("author", loadedAuthor);
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -175,7 +165,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userTwoScope);
         loaded.addRelation("author", loadedAuthor);
-        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     //----------------------------------------- ** Update Attribute On Create ** --------------------------------------
@@ -183,28 +172,24 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     public void createPermissionInheritedForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
         created.updateAttribute("name", "");
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
     public void createPermissionInheritedForAttributeFailureCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
         created.updateAttribute("name", "");
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test
     public void createPermissionOverwrittenForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
         created.updateAttribute("alias", "");
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
     public void createPermissionOverwrittenForAttributeFailureCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userFourScope, Optional.of("uuid"));
         created.updateAttribute("alias", "");
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
 
@@ -216,7 +201,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userOneScope);
         created.addRelation("books", loadedBook);
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -226,7 +210,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userThreeScope);
         created.addRelation("books", loadedBook);
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test
@@ -236,7 +219,6 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userTwoScope);
         created.addRelation("author", loadedAuthor);
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -246,6 +228,5 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userOneScope);
         created.addRelation("author", loadedAuthor);
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -12,7 +12,6 @@ import example.Author;
 import example.Book;
 import example.UpdateAndCreate;
 import org.mockito.Answers;
-import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -29,6 +28,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     private RequestScope userOneScope;
     private RequestScope userTwoScope;
     private RequestScope userThreeScope;
+    private RequestScope userFourScope;
 
     @BeforeTest
     public void init() {
@@ -51,6 +51,8 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         userTwoScope = new RequestScope(null, null, tx, userTwo, null, elideSettings, false);
         User userThree = new User(3);
         userThreeScope = new RequestScope(null, null, tx, userThree, null, elideSettings, false);
+        User userFour = new User(4);
+        userFourScope = new RequestScope(null, null, tx, userFour, null, elideSettings, false);
 
         when(tx.createNewObject(UpdateAndCreate.class)).thenReturn(updateAndCreateNewObject);
         when(tx.loadObject(eq(UpdateAndCreate.class),
@@ -70,173 +72,180 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         )).thenReturn(author);
     }
 
+    //----------------------------------------- ** Entity Creation ** -------------------------------------------------
     @Test
-    public void testUpdateOnCreateUserOne() {
-
+    public void createPermissionCheckClassAnnotationForCreatingAnEntitySuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
-        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
-                "1",
-                userOneScope);
-        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
-                "1",
-                userOneScope);
-
-        created.updateAttribute("name", "");
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            created.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
-            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        created.updateAttribute("alias", "");
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        created.addRelation("books", loadedBook);
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            created.addRelation("author", loadedAuthor);
-            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-
-        });
-    }
-
-    @Test
-    public void testNormalUpdateUserOne() {
-        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
-                "1",
-                userOneScope);
-        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
-                "1",
-                userOneScope);
-        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
-                "1",
-                userOneScope);
-
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.updateAttribute("name", "");
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.updateAttribute("alias", "");
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.addRelation("books", loadedBook);
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.addRelation("author", loadedAuthor);
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-
-        });
-    }
-
-    @Test
-    public void testUpdateOnCreateUserTwo() {
-        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userTwoScope, Optional.of("uuid"));
-        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
-                "1",
-                userTwoScope);
-        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
-                "1",
-                userTwoScope);
-
-        created.updateAttribute("name", "");
-        created.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
-        created.updateAttribute("alias", "");
-        created.addRelation("books", loadedBook);
-        created.addRelation("author", loadedAuthor);
         created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test
-    public void testNormalUpdateUserTwo() {
+    public void createPermissionCheckFieldAnnotationForCreatingAnEntitySuccessCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void createPermissionCheckFieldAnnotationForCreatingAnEntityFailureCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userFourScope, Optional.of("uuid"));
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    //----------------------------------------- ** Update Attribute ** ------------------------------------------------
+    @Test
+    public void updatePermissionInheritedForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
                 "1",
                 userTwoScope);
-        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
-                "1",
-                userTwoScope);
-        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
-                "1",
-                userTwoScope);
-
         loaded.updateAttribute("name", "");
-        loaded.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void updatePermissionInheritedForAttributeFailureCase() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userOneScope);
+        loaded.updateAttribute("name", "");
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test
+    public void updatePermissionOverwrittenForAttributeSuccessCase() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userFourScope);
         loaded.updateAttribute("alias", "");
-        loaded.addRelation("books", loadedBook);
-        loaded.addRelation("author", loadedAuthor);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void updatePermissionOverwrittenForAttributeFailureCase() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userThreeScope);
+        loaded.updateAttribute("alias", "");
         loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
 
+    //----------------------------------------- ** Update Relation  ** -----------------------------------------------
     @Test
-    public void testUpdateOnCreateUserThree() {
-        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
-        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+    public void updatePermissionInheritedForRelationSuccessCase() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
                 "1",
-                userThreeScope);
+                userTwoScope);
         PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
                 "1",
-                userThreeScope);
+                userTwoScope);
+        loaded.addRelation("books", loadedBook);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
 
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            created.updateAttribute("name", "");
-            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            created.addRelation("books", loadedBook);
-            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            created.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
-            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            created.addRelation("author", loadedAuthor);
-            created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-
-        });
-
-        created.updateAttribute("alias", "");
-        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
-
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void updatePermissionInheritedForRelationFailureCase() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userOneScope);
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userOneScope);
+        loaded.addRelation("books", loadedBook);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test
-    public void testNormalUpdateUserThree() {
+    public void updatePermissionOverwrittenForRelationSuccessCase() {
         PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
                 "1",
                 userThreeScope);
         PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
                 "1",
                 userThreeScope);
+        loaded.addRelation("author", loadedAuthor);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void updatePermissionOverwrittenForRelationFailureCase() {
+        PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
+                "1",
+                userTwoScope);
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userTwoScope);
+        loaded.addRelation("author", loadedAuthor);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    //----------------------------------------- ** Update Attribute On Create ** --------------------------------------
+    @Test
+    public void createPermissionInheritedForAttributeSuccessCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
+        created.updateAttribute("name", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void createPermissionInheritedForAttributeFailureCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
+        created.updateAttribute("name", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test
+    public void createPermissionOverwrittenForAttributeSuccessCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
+        created.updateAttribute("alias", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void createPermissionOverwrittenForAttributeFailureCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userFourScope, Optional.of("uuid"));
+        created.updateAttribute("alias", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+
+    //----------------------------------------- ** Update Relation On Create ** --------------------------------------
+    @Test
+    public void createPermissionInheritedForRelationSuccessCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
+        PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
+                "1",
+                userOneScope);
+        created.addRelation("books", loadedBook);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
+
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void createPermissionInheritedForRelationFailureCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
         PersistentResource<Book> loadedBook = PersistentResource.loadRecord(Book.class,
                 "1",
                 userThreeScope);
+        created.addRelation("books", loadedBook);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
 
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.updateAttribute("name", "");
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.updateAttribute("type", UpdateAndCreate.AuthorType.CONTRACTED);
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.updateAttribute("alias", "");
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.addRelation("books", loadedBook);
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
-        });
-        Assert.assertThrows(ForbiddenAccessException.class, () -> {
-            loaded.addRelation("author", loadedAuthor);
-            loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    @Test
+    public void createPermissionOverwrittenForRelationSuccessCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userTwoScope, Optional.of("uuid"));
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userTwoScope);
+        created.addRelation("author", loadedAuthor);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+    }
 
-        });
+    @Test(expectedExceptions = ForbiddenAccessException.class)
+    public void createPermissionOverwrittenForRelationFailureCase() {
+        PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
+        PersistentResource<Author> loadedAuthor = PersistentResource.loadRecord(Author.class,
+                "1",
+                userOneScope);
+        created.addRelation("author", loadedAuthor);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -102,6 +102,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userTwoScope);
         loaded.updateAttribute("name", "");
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -119,6 +120,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userFourScope);
         loaded.updateAttribute("alias", "");
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -141,6 +143,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userTwoScope);
         loaded.addRelation("books", loadedBook);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -164,6 +167,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userThreeScope);
         loaded.addRelation("author", loadedAuthor);
+        loaded.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -183,6 +187,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     public void createPermissionInheritedForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
         created.updateAttribute("name", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -196,6 +201,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     public void createPermissionOverwrittenForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
         created.updateAttribute("alias", "");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -214,6 +220,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userOneScope);
         created.addRelation("books", loadedBook);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)
@@ -233,6 +240,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
                 "1",
                 userTwoScope);
         created.addRelation("author", loadedAuthor);
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -73,22 +73,29 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     }
 
     //----------------------------------------- ** Entity Creation ** -------------------------------------------------
+
+    //Create allowed based on class level expression
     @Test
     public void createPermissionCheckClassAnnotationForCreatingAnEntitySuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
+    //Create allowed based on field level expression
     @Test
     public void createPermissionCheckFieldAnnotationForCreatingAnEntitySuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
     }
 
+    //Create denied based on field level expression
     @Test(expectedExceptions = ForbiddenAccessException.class)
     public void createPermissionCheckFieldAnnotationForCreatingAnEntityFailureCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userFourScope, Optional.of("uuid"));
     }
 
     //----------------------------------------- ** Update Attribute ** ------------------------------------------------
+    //Expression for field inherited from class level expression
     @Test
     public void updatePermissionInheritedForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
@@ -105,6 +112,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         loaded.updateAttribute("name", "");
     }
 
+    //Class level expression overwritten by field level expression
     @Test
     public void updatePermissionOverwrittenForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
@@ -123,6 +131,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
 
 
     //----------------------------------------- ** Update Relation  ** -----------------------------------------------
+    //Expression for relation inherited from class level expression
     @Test
     public void updatePermissionInheritedForRelationSuccessCase() {
         PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
@@ -145,6 +154,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         loaded.addRelation("books", loadedBook);
     }
 
+    //Class level expression overwritten by field level expression
     @Test
     public void updatePermissionOverwrittenForRelationSuccessCase() {
         PersistentResource<UpdateAndCreate> loaded = PersistentResource.loadRecord(UpdateAndCreate.class,
@@ -168,6 +178,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
     }
 
     //----------------------------------------- ** Update Attribute On Create ** --------------------------------------
+    //Expression for field inherited from class level expression
     @Test
     public void createPermissionInheritedForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
@@ -180,6 +191,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         created.updateAttribute("name", "");
     }
 
+    //Class level expression overwritten by field level expression
     @Test
     public void createPermissionOverwrittenForAttributeSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userThreeScope, Optional.of("uuid"));
@@ -194,6 +206,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
 
 
     //----------------------------------------- ** Update Relation On Create ** --------------------------------------
+    //Expression for relation inherited from class level expression
     @Test
     public void createPermissionInheritedForRelationSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userOneScope, Optional.of("uuid"));
@@ -212,6 +225,7 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         created.addRelation("books", loadedBook);
     }
 
+    //Class level expression overwritten by field level expression
     @Test
     public void createPermissionOverwrittenForRelationSuccessCase() {
         PersistentResource<UpdateAndCreate> created = PersistentResource.createObject(null, UpdateAndCreate.class, userTwoScope, Optional.of("uuid"));

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -26,16 +26,9 @@ import static org.mockito.Mockito.when;
 
 public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
 
-    private User userOne;
-    private User userTwo;
-    private User userThree;
-
     private RequestScope userOneScope;
     private RequestScope userTwoScope;
     private RequestScope userThreeScope;
-
-    private DataStoreTransaction tx;
-
 
     public UpdateOnCreateTest() {
         super();
@@ -54,14 +47,14 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         Book book = new Book();
         Author author = new Author();
 
-        tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
 
-        userOne = new User(1);
-        userOneScope = new RequestScope(null, null, tx, userOne, null, elideSettings);
-        userTwo = new User(2);
-        userTwoScope = new RequestScope(null, null, tx, userTwo, null, elideSettings);
-        userThree = new User(3);
-        userThreeScope = new RequestScope(null, null, tx, userThree, null, elideSettings);
+        User userOne = new User(1);
+        userOneScope = new RequestScope(null, null, tx, userOne, null, elideSettings, false);
+        User userTwo = new User(2);
+        userTwoScope = new RequestScope(null, null, tx, userTwo, null, elideSettings, false);
+        User userThree = new User(3);
+        userThreeScope = new RequestScope(null, null, tx, userThree, null, elideSettings, false);
 
         when(tx.createNewObject(UpdateAndCreate.class)).thenReturn(updateAndCreateNewObject);
         when(tx.loadObject(eq(UpdateAndCreate.class),

--- a/elide-core/src/test/java/example/TestCheckMappings.java
+++ b/elide-core/src/test/java/example/TestCheckMappings.java
@@ -40,6 +40,9 @@ public class TestCheckMappings {
                     put("shouldCache", PermissionExecutorTest.ShouldCache.class);
                     put("peUserCheck", PermissionExecutorTest.UserCheckTest.class);
                     put("passingCommit", PermissionExecutorTest.PassingCommitCheck.class);
+                    put("isUserOne", UserIdChecks.UserOneCheck.class);
+                    put("isUserTwo", UserIdChecks.UserTwoCheck.class);
+                    put("isUserThree", UserIdChecks.UserThreeCheck.class);
                 }
             };
 

--- a/elide-core/src/test/java/example/TestCheckMappings.java
+++ b/elide-core/src/test/java/example/TestCheckMappings.java
@@ -40,10 +40,10 @@ public class TestCheckMappings {
                     put("shouldCache", PermissionExecutorTest.ShouldCache.class);
                     put("peUserCheck", PermissionExecutorTest.UserCheckTest.class);
                     put("passingCommit", PermissionExecutorTest.PassingCommitCheck.class);
-                    put("isUserOne", UserIdChecks.UserOneCheck.class);
-                    put("isUserTwo", UserIdChecks.UserTwoCheck.class);
-                    put("isUserThree", UserIdChecks.UserThreeCheck.class);
-                    put("isUserFour", UserIdChecks.UserFourCheck.class);
+                    put("Principal is user one", UserIdChecks.UserOneCheck.class);
+                    put("Principal is user two", UserIdChecks.UserTwoCheck.class);
+                    put("Principal is user three", UserIdChecks.UserThreeCheck.class);
+                    put("Principal is user four", UserIdChecks.UserFourCheck.class);
                 }
             };
 

--- a/elide-core/src/test/java/example/TestCheckMappings.java
+++ b/elide-core/src/test/java/example/TestCheckMappings.java
@@ -43,6 +43,7 @@ public class TestCheckMappings {
                     put("isUserOne", UserIdChecks.UserOneCheck.class);
                     put("isUserTwo", UserIdChecks.UserTwoCheck.class);
                     put("isUserThree", UserIdChecks.UserThreeCheck.class);
+                    put("isUserFour", UserIdChecks.UserFourCheck.class);
                 }
             };
 

--- a/elide-core/src/test/java/example/UpdateAndCreate.java
+++ b/elide-core/src/test/java/example/UpdateAndCreate.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017, Oath Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Model for authors.
+ */
+@Entity
+@Table(name = "author")
+@Include(rootLevel = true)
+@CreatePermission(expression = "isUserOne OR isUserTwo")
+@UpdatePermission(expression = "isUserTwo")
+@SharePermission(expression = "allow all")
+@Audit(action = Audit.Action.CREATE,
+        operation = 10,
+        logStatement = "{0}",
+        logExpressions = {"${author.name}"})
+public class UpdateAndCreate {
+    public enum AuthorType {
+        EXCLUSIVE,
+        CONTRACTED,
+        FREELANCE
+    }
+
+    private Long id;
+    private String name;
+    private String alias;
+    private Collection<Book> books = new ArrayList<>();
+    private Author author;
+    private AuthorType type;
+
+
+    @Getter
+    @Setter
+    private Address homeAddress;
+
+    @Id
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @CreatePermission(expression = "isUserOne OR isUserTwo OR isUserThree")
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    @CreatePermission(expression = "isUserTwo")
+    public AuthorType getType() {
+        return type;
+    }
+
+    public void setType(AuthorType type) {
+        this.type = type;
+    }
+
+    @OneToMany
+    public Collection<Book> getBooks() {
+        return books;
+    }
+
+    public void setBooks(Collection<Book> books) {
+        this.books = books;
+    }
+
+    @CreatePermission(expression = "isUserTwo")
+    @OneToOne
+    public Author getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Author author) {
+        this.author = author;
+    }
+}

--- a/elide-core/src/test/java/example/UpdateAndCreate.java
+++ b/elide-core/src/test/java/example/UpdateAndCreate.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
-import javax.persistence.Table;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.OneToMany;
@@ -21,7 +20,6 @@ import java.util.Collection;
  * Model for authors.
  */
 @Entity
-@Table(name = "author")
 @Include(rootLevel = true)
 @CreatePermission(expression = "isUserOne OR isUserTwo")
 @UpdatePermission(expression = "isUserTwo")
@@ -68,6 +66,7 @@ public class UpdateAndCreate {
     }
 
     @CreatePermission(expression = "isUserOne OR isUserTwo OR isUserThree")
+    @UpdatePermission(expression = "isUserTwo OR isUserFour")
     public String getAlias() {
         return alias;
     }
@@ -95,6 +94,7 @@ public class UpdateAndCreate {
     }
 
     @CreatePermission(expression = "isUserTwo")
+    @UpdatePermission(expression = "isUserThree")
     @OneToOne
     public Author getAuthor() {
         return author;

--- a/elide-core/src/test/java/example/UpdateAndCreate.java
+++ b/elide-core/src/test/java/example/UpdateAndCreate.java
@@ -21,8 +21,8 @@ import java.util.Collection;
  */
 @Entity
 @Include(rootLevel = true)
-@CreatePermission(expression = "isUserOne OR isUserTwo")
-@UpdatePermission(expression = "isUserTwo")
+@CreatePermission(expression = "Principal is user one OR Principal is user two")
+@UpdatePermission(expression = "Principal is user two")
 @SharePermission
 @Audit(action = Audit.Action.CREATE,
         operation = 10,
@@ -65,8 +65,8 @@ public class UpdateAndCreate {
         this.name = name;
     }
 
-    @CreatePermission(expression = "isUserOne OR isUserTwo OR isUserThree")
-    @UpdatePermission(expression = "isUserTwo OR isUserFour")
+    @CreatePermission(expression = "Principal is user one OR Principal is user two OR Principal is user three")
+    @UpdatePermission(expression = "Principal is user two OR Principal is user four")
     public String getAlias() {
         return alias;
     }
@@ -75,7 +75,7 @@ public class UpdateAndCreate {
         this.alias = alias;
     }
 
-    @CreatePermission(expression = "isUserTwo")
+    @CreatePermission(expression = "Principal is user two")
     public AuthorType getType() {
         return type;
     }
@@ -93,8 +93,8 @@ public class UpdateAndCreate {
         this.books = books;
     }
 
-    @CreatePermission(expression = "isUserTwo")
-    @UpdatePermission(expression = "isUserThree")
+    @CreatePermission(expression = "Principal is user two")
+    @UpdatePermission(expression = "Principal is user three")
     @OneToOne
     public Author getAuthor() {
         return author;

--- a/elide-core/src/test/java/example/UpdateAndCreate.java
+++ b/elide-core/src/test/java/example/UpdateAndCreate.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 @Include(rootLevel = true)
 @CreatePermission(expression = "isUserOne OR isUserTwo")
 @UpdatePermission(expression = "isUserTwo")
-@SharePermission(expression = "allow all")
+@SharePermission
 @Audit(action = Audit.Action.CREATE,
         operation = 10,
         logStatement = "{0}",

--- a/elide-core/src/test/java/example/UserIdChecks.java
+++ b/elide-core/src/test/java/example/UserIdChecks.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017, Oath Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.security.checks.UserCheck;
+import com.yahoo.elide.security.User;
+
+/**
+ * Useful for testing permissions based on different users.
+ */
+public class UserIdChecks {
+
+    public static class UserOneCheck extends UserCheck {
+        @Override
+        public boolean ok(User user) {
+            Integer id = (Integer) user.getOpaqueUser();
+            return id.equals(1);
+        }
+
+        @Override
+        public String checkIdentifier() {
+            return "UserOne";
+        }
+    }
+
+    public static class UserTwoCheck extends UserCheck {
+        @Override
+        public boolean ok(User user) {
+            Integer id = (Integer) user.getOpaqueUser();
+            return id.equals(2);
+        }
+
+        @Override
+        public String checkIdentifier() {
+            return "UserTwo";
+        }
+    }
+
+    public static class UserThreeCheck extends UserCheck {
+        @Override
+        public boolean ok(User user) {
+            Integer id = (Integer) user.getOpaqueUser();
+            return id.equals(3);
+        }
+
+        @Override
+        public String checkIdentifier() {
+            return "UserTwo";
+        }
+    }
+}

--- a/elide-core/src/test/java/example/UserIdChecks.java
+++ b/elide-core/src/test/java/example/UserIdChecks.java
@@ -48,7 +48,20 @@ public class UserIdChecks {
 
         @Override
         public String checkIdentifier() {
-            return "UserTwo";
+            return "UserThree";
+        }
+    }
+
+    public static class UserFourCheck extends UserCheck {
+        @Override
+        public boolean ok(User user) {
+            Integer id = (Integer) user.getOpaqueUser();
+            return id.equals(4);
+        }
+
+        @Override
+        public String checkIdentifier() {
+            return "UserFour";
         }
     }
 }

--- a/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
@@ -27,6 +27,7 @@ public class CreateButNoUpdate {
     public Long id;
     public String textValue;
 
+    @CreatePermission(expression = "deny all")
     @UpdatePermission(expression = "deny all")
     public String cannotModify = "unmodified";
 

--- a/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
@@ -22,13 +22,12 @@ import javax.persistence.Id;
 @Entity
 @CreatePermission(expression = "allow all")
 @ReadPermission(expression = "allow all")
-@UpdatePermission(expression = "updateOnCreate OR deny all")
+@UpdatePermission(expression = "deny all")
 public class CreateButNoUpdate {
     public Long id;
     public String textValue;
 
     @CreatePermission(expression = "deny all")
-    @UpdatePermission(expression = "deny all")
     public String cannotModify = "unmodified";
 
     @Id


### PR DESCRIPTION
This PR is an update to a previous PR https://github.com/yahoo/elide/pull/544
It was closed as I tried to rename the branch

The changes include the following:
1. Changed PersistenceResource and ActivePermissionExecutor to support the change
2. Added tests in for the same, with some refactoring as we couldn't add more tests to PersistenceResourceTests

