### PR TITLE
Fix NPE in path expansion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 3.1.4
+**Fixes**
+ * Fix NPE in filter path expansion
+
 ## 3.1.3
  * Add support for @Any relationships through a @MappedInterface
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -333,6 +333,9 @@ public enum Operator {
                 continue;
             }
             val = PersistentResource.getValue(val, field, requestScope);
+            if (val == null) {
+                break;
+            }
         }
         return val;
     }


### PR DESCRIPTION
If filter path had a null value, the next get could NPE.
For example, `chapter.book.publisher` when chapter.book is null.