### PR TITLE
Handle Forbidden for Include

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Change Log
 ## 3.1.4
 **Fixes**
- * properly handle ForbiddenAccess for Include
+ * Instead of ForbiddenAccess for denied Include, filter to empty set.
 
 ## 3.1.3
  * Add support for @Any relationships through a @MappedInterface

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 3.1.4
+**Fixes**
+ * properly handle ForbiddenAccess for Include
+
 ## 3.1.3
  * Add support for @Any relationships through a @MappedInterface
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ## 3.1.4
 **Fixes**
  * Instead of ForbiddenAccess for denied Include, filter to empty set.
+ * Generate error when parsing permission expression fails.
 
 ## 3.1.3
  * Add support for @Any relationships through a @MappedInterface

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.generated.parsers.ExpressionParser;
 import com.yahoo.elide.security.checks.Check;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
@@ -143,6 +144,7 @@ public class EntityPermissions implements CheckInstantiator {
             }
         });
         ExpressionParser parser = new ExpressionParser(new CommonTokenStream(lexer));
+        parser.setErrorHandler(new BailErrorStrategy());
         lexer.reset();
         return parser.start();
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -952,7 +952,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             throw new InvalidAttributeException(relationName, type);
         }
 
-        checkFieldAwareDeferPermissions(ReadPermission.class, relationName, null, null);
+        try {
+            checkFieldAwareDeferPermissions(ReadPermission.class, relationName, null, null);
+        } catch (ForbiddenAccessException e) {
+            return false;
+        }
 
         return !shouldSkipCollection(
                 dictionary.getParameterizedType(obj, relationName),

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -13,12 +13,12 @@ import com.yahoo.elide.security.User;
 import com.yahoo.elide.security.checks.Check;
 import example.Author;
 import example.Book;
+import example.TestCheckMappings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -52,7 +52,7 @@ public class LifeCycleTest {
     }
 
     LifeCycleTest() {
-        dictionary = new TestEntityDictionary(new HashMap<>());
+        dictionary = new TestEntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Author.class);
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -800,21 +800,21 @@ public class PersistentResourceTest extends PersistentResource {
         Assert.assertEquals(((Child) results.iterator().next().getObject()).getName(), "paul john");
     }
 
-    @Test(expectedExceptions = ForbiddenAccessException.class)
+    @Test
     public void testGetRelationForbiddenByEntity() {
         NoReadEntity noread = new NoReadEntity();
 
         PersistentResource<NoReadEntity> noreadResource = new PersistentResource<>(noread, null, "3", goodUserScope);
-        noreadResource.getRelationCheckedFiltered("child");
+        Assert.assertEquals(noreadResource.getRelationCheckedFiltered("child").size(), 0);
     }
 
-    @Test(expectedExceptions = ForbiddenAccessException.class)
+    @Test
     public void testGetRelationForbiddenByField() {
         FunWithPermissions fun = new FunWithPermissions();
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", badUserScope);
 
-        funResource.getRelationCheckedFiltered("relation1");
+        Assert.assertEquals(funResource.getRelationCheckedFiltered("relation1").size(), 0);
     }
 
     @Test
@@ -835,13 +835,13 @@ public class PersistentResourceTest extends PersistentResource {
         fcResource.getAttribute("public1");
     }
 
-    @Test(expectedExceptions = ForbiddenAccessException.class)
+    @Test
     public void testGetRelationForbiddenByEntity2() {
         FirstClassFields firstClassFields = new FirstClassFields();
 
         PersistentResource<FirstClassFields> fcResource = new PersistentResource<>(firstClassFields, null, "3", badUserScope);
 
-        fcResource.getRelationCheckedFiltered("private2");
+        Assert.assertEquals(fcResource.getRelationCheckedFiltered("private2").size(), 0);
     }
 
     @Test(expectedExceptions = ForbiddenAccessException.class)


### PR DESCRIPTION
Uncaught exception caused Include to fail when not allowed.

By returning empty set, all the other allowed fields are returned instead of having to guess which are visible.