### PR TITLE
Handle forbidden include

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ## 3.2.0
 **Fixes**
  * Rollback relationship handling change.
+ * Handle ForbiddenAccess only for denied Include, instead of filtering to empty set.
 
 ## 3.1.4       
 **Fixes**      

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.generated.parsers.ExpressionParser;
 import com.yahoo.elide.security.checks.Check;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
@@ -143,6 +144,7 @@ public class EntityPermissions implements CheckInstantiator {
             }
         });
         ExpressionParser parser = new ExpressionParser(new CommonTokenStream(lexer));
+        parser.setErrorHandler(new BailErrorStrategy());
         lexer.reset();
         return parser.start();
     }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.jsonapi.document.processors;
 
 import com.google.common.collect.Lists;
 import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -77,7 +78,14 @@ public class IncludedProcessor implements DocumentProcessor {
         //Pop off a relation of relation path
         String relation = relationPath.remove(0);
 
-        rec.getRelationCheckedFiltered(relation).forEach(resource -> {
+        Set<PersistentResource> collection;
+        try {
+            collection = rec.getRelationCheckedFiltered(relation);
+        } catch (ForbiddenAccessException e) {
+            return;
+        }
+
+        collection.forEach(resource -> {
             jsonApiDocument.addIncluded(resource.toResource());
 
             //If more relations left in the path, process a level deeper

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -13,12 +13,12 @@ import com.yahoo.elide.security.User;
 import com.yahoo.elide.security.checks.Check;
 import example.Author;
 import example.Book;
+import example.TestCheckMappings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -52,7 +52,7 @@ public class LifeCycleTest {
     }
 
     LifeCycleTest() {
-        dictionary = new TestEntityDictionary(new HashMap<>());
+        dictionary = new TestEntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Author.class);
     }

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.jsonapi.document.processors;
 
 import com.google.common.collect.Sets;
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.audit.TestAuditLogger;
 import com.yahoo.elide.core.DataStoreTransaction;
@@ -16,6 +17,7 @@ import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Resource;
 import com.yahoo.elide.security.User;
 import example.Child;
+import example.FunWithPermissions;
 import example.Parent;
 import example.TestCheckMappings;
 import org.mockito.Answers;
@@ -25,6 +27,7 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -49,6 +52,8 @@ public class IncludedProcessorTest {
     private PersistentResource<Child> childRecord3;
     private PersistentResource<Child> childRecord4;
 
+    private PersistentResource<FunWithPermissions> funWithPermissionsRecord;
+
     @BeforeMethod
     public void setUp() throws Exception {
         includedProcessor = new IncludedProcessor();
@@ -56,14 +61,22 @@ public class IncludedProcessorTest {
         EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(Child.class);
         dictionary.bindEntity(Parent.class);
+        dictionary.bindEntity(FunWithPermissions.class);
+
+        ElideSettings elideSettings = new ElideSettingsBuilder(null)
+                .withAuditLogger(new TestAuditLogger())
+                .withEntityDictionary(dictionary)
+                .build();
 
         RequestScope goodUserScope = new RequestScope(null,
                 new JsonApiDocument(), mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS),
                 new User(1), null,
-                new ElideSettingsBuilder(null)
-                        .withAuditLogger(new TestAuditLogger())
-                        .withEntityDictionary(dictionary)
-                        .build());
+                elideSettings);
+
+        RequestScope badUserScope = new RequestScope(null,
+                new JsonApiDocument(), mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS),
+                new User(-1), null,
+                elideSettings);
 
         //Create objects
         Parent parent1 = newParent(1);
@@ -74,6 +87,8 @@ public class IncludedProcessorTest {
         Child child2 = newChild(3);
         Child child3 = newChild(4);
         Child child4 = newChild(5);
+
+        FunWithPermissions funWithPermissions = newFunWithPermissions(1);
 
         //Form relationships
         parent1.setSpouses(new HashSet<>(Collections.singletonList(parent2)));
@@ -94,6 +109,8 @@ public class IncludedProcessorTest {
         childRecord2  = new PersistentResource<>(child2, null, goodUserScope.getUUIDFor(child2), goodUserScope);
         childRecord3  = new PersistentResource<>(child3, null, goodUserScope.getUUIDFor(child3), goodUserScope);
         childRecord4  = new PersistentResource<>(child4, null, goodUserScope.getUUIDFor(child4), goodUserScope);
+
+        funWithPermissionsRecord = new PersistentResource<>(funWithPermissions, null, goodUserScope.getUUIDFor(funWithPermissions), badUserScope);
     }
 
     @Test
@@ -184,6 +201,18 @@ public class IncludedProcessorTest {
     }
 
     @Test
+    public void testIncludeForbiddenRelationship() {
+        JsonApiDocument jsonApiDocument = new JsonApiDocument();
+
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        queryParams.put(INCLUDE, Collections.singletonList("relation1"));
+        includedProcessor.execute(jsonApiDocument, funWithPermissionsRecord, Optional.of(queryParams));
+
+        Assert.assertNull(jsonApiDocument.getIncluded(),
+                "Included Processor included forbidden relationship");
+    }
+
+    @Test
     public void testNoQueryParams() throws Exception {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
         includedProcessor.execute(jsonApiDocument, parentRecord1, Optional.empty());
@@ -218,5 +247,12 @@ public class IncludedProcessorTest {
         child.setId(id);
         child.setParents(new HashSet<>());
         return child;
+    }
+
+    private FunWithPermissions newFunWithPermissions(int id) {
+        FunWithPermissions funWithPermissions = new FunWithPermissions();
+        funWithPermissions.setId(id);
+        funWithPermissions.setRelation1(new HashSet<>());
+        return funWithPermissions;
     }
 }


### PR DESCRIPTION
Limits the ForbiddenAccess handling to IncludeProcessor instead of returning empty set from getRelationship.