### PR TITLE
Add additional logging around caught exceptions.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 3.2.1
+**Fixes**
+ * Add additional logging around exception handling.
+
 ## 3.2.0
 **Features**
  * Updated interface to beta standalone application. Plans to finalize this before Elide 4.0 release.

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -232,18 +232,23 @@ public class Elide {
             return buildErrorResponse(e, isVerbose);
 
         } catch (JsonPatchExtensionException e) {
+            log.debug("JSON patch extension exception caught", e);
             return buildResponse(e.getResponse());
 
         } catch (HttpStatusException e) {
+            log.debug("Caught HTTP status exception", e);
             return buildErrorResponse(e, isVerbose);
 
         } catch (IOException e) {
+            log.error("IO Exception uncaught by Elide", e);
             return buildErrorResponse(new TransactionException(e), isVerbose);
 
         } catch (ParseCancellationException e) {
+            log.error("Parse cancellation exception uncaught by Elide", e);
             return buildErrorResponse(new InvalidURLException(e), isVerbose);
 
         } catch (Exception e) {
+            log.error("Generic exception uncaught by Elide", e);
             return buildErrorResponse(new InternalServerErrorException(e), isVerbose);
 
         } catch (Error e) {


### PR DESCRIPTION
This adds additional logging around our exception handling. `debug` for "expected" exceptions and `error` for response codes which are more likely to be server-related issues.