### PR TITLE
Update elide standalone to support GraphQL.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 
 **Features**
  * Handle ConstraintViolationException's by extracting the first constraint validation failure.
+ * Include GraphQL in Elide standalone by default with ability to remove it via dependency management.
 
 ## 4.0-beta-3
 **Fixes**

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>elide-datastore-hibernate5</artifactId>
             <version>4.0-beta-4</version>
         </dependency>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-graphql</artifactId>
+            <version>4.0-beta-2</version>
+        </dependency>
 
         <!-- MySQL Driver -->
         <dependency>

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
@@ -78,11 +78,21 @@ public class ElideStandalone {
 
         context.setAttribute(ELIDE_STANDALONE_SETTINGS_ATTR, elideStandaloneSettings);
 
-        ServletHolder jerseyServlet = context.addServlet(ServletContainer.class,
-                elideStandaloneSettings.getJsonApiPathSpec());
-        jerseyServlet.setInitOrder(0);
-        jerseyServlet.setInitParameter("jersey.config.server.provider.packages", "com.yahoo.elide.resources");
-        jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
+        if (elideStandaloneSettings.enableJSONAPI()) {
+            ServletHolder jerseyServlet = context.addServlet(ServletContainer.class,
+                    elideStandaloneSettings.getJsonApiPathSpec());
+            jerseyServlet.setInitOrder(0);
+            jerseyServlet.setInitParameter("jersey.config.server.provider.packages", "com.yahoo.elide.resources");
+            jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
+        }
+
+        if (elideStandaloneSettings.enableGraphQL()) {
+            ServletHolder jerseyServlet = context.addServlet(ServletContainer.class,
+                    elideStandaloneSettings.getGraphQLApiPathSepc());
+            jerseyServlet.setInitOrder(0);
+            jerseyServlet.setInitParameter("jersey.config.server.provider.packages", "com.yahoo.elide.graphql");
+            jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
+        }
 
         try {
             jettyServer.start();

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -108,6 +108,33 @@ public interface ElideStandaloneSettings {
     }
 
     /**
+     * API root path specification for the GraphQL endpoint. Namely, this is the root uri for GraphQL.
+     *
+     * @return Default: /graphql/api/v1
+     */
+    default String getGraphQLApiPathSepc() {
+        return "/graphql/api/v1";
+    }
+
+    /**
+     * Enable the JSONAPI endpoint. If false, the endpoint will be disabled.
+     *
+     * @return Default: True
+     */
+    default boolean enableJSONAPI() {
+        return true;
+    }
+
+    /**
+     * Enable the GraphQL endpoint. If false, the endpoint will be disabled.
+     *
+     * @return Default: True
+     */
+    default boolean enableGraphQL() {
+        return true;
+    }
+
+    /**
      * JAX-RS filters to register with the web service.
      *
      * @return Default: Empty


### PR DESCRIPTION
This allows developers to enable GraphQL without any friction. If they don't want GraphQL included in their project, there is only one step:

_In their ElideStandaloneSettings_
```java
boolean enableGraphQL() {
    return false;
}
```

That being said, this approach still will include the Elide graphql code. If they don't want any trace of GraphQL in their project, it's easy to exclude in their dependency management by simply excluding the `com.yahoo.elide:elide-graphql` transitive dependency that is brought in by `elide-standalone`.