### PR TITLE
Delay OnCreatePreSecurity until fields are populated.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 **Fixes**
  * Root collection loads now push down security filter predicates.
  * Avoid throwing exceptions that must be handled by the containing application, instead throw exceptions that will be handled directly within Elide.
+ * Restore OnCreatePreSecurity lifecycle hook to occur after fields are populated.
 
 ## 4.0-beta-1
 **Features**

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.CreatePermission;
@@ -1513,12 +1514,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                     method.invoke(obj);
                 }
             } catch (ReflectiveOperationException e) {
-                if (e.getCause() instanceof RuntimeException) {
-                    throw (RuntimeException) e.getCause();
-                }
-                if (e.getCause() instanceof Error) {
-                    throw (Error) e.getCause();
-                }
+                Throwables.propagateIfPossible(e.getCause());
                 throw new IllegalArgumentException(e);
             }
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -11,7 +11,6 @@ import com.google.common.collect.Sets;
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
-import com.yahoo.elide.annotation.OnCreatePreSecurity;
 import com.yahoo.elide.annotation.OnDeletePreSecurity;
 import com.yahoo.elide.annotation.OnReadPreSecurity;
 import com.yahoo.elide.annotation.OnUpdatePreSecurity;
@@ -136,7 +135,6 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         // Keep track of new resources for non shareable resources
         requestScope.getNewPersistentResources().add(newResource);
-        newResource.runTriggers(OnCreatePreSecurity.class, "");
         checkPermission(CreatePermission.class, newResource);
 
         newResource.auditClass(Audit.Action.CREATE, new ChangeSpec(newResource, null, null, newResource.getObject()));
@@ -1517,6 +1515,9 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             } catch (ReflectiveOperationException e) {
                 if (e.getCause() instanceof RuntimeException) {
                     throw (RuntimeException) e.getCause();
+                }
+                if (e.getCause() instanceof Error) {
+                    throw (Error) e.getCause();
                 }
                 throw new IllegalArgumentException(e);
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -418,6 +418,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
 
         switch (crudAction) {
             case CREATE:
+                queueTrigger.accept(OnCreatePreSecurity.class);
                 queueTrigger.accept(OnCreatePreCommit.class);
                 queueTrigger.accept(OnCreatePostCommit.class);
                 break;

--- a/elide-core/src/test/java/example/Book.java
+++ b/elide-core/src/test/java/example/Book.java
@@ -6,6 +6,8 @@
 package example;
 
 import com.yahoo.elide.annotation.Audit;
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.OnCreatePostCommit;
 import com.yahoo.elide.annotation.OnCreatePreCommit;
@@ -20,10 +22,11 @@ import com.yahoo.elide.annotation.OnUpdatePostCommit;
 import com.yahoo.elide.annotation.OnUpdatePreCommit;
 import com.yahoo.elide.annotation.OnUpdatePreSecurity;
 import com.yahoo.elide.annotation.SharePermission;
+import com.yahoo.elide.annotation.UpdatePermission;
+import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.RequestScope;
+import com.yahoo.elide.security.checks.OperationCheck;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -32,10 +35,17 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+
 /**
  * Model for books.
  */
 @Entity
+@CreatePermission(expression = "Book operation check")
+@UpdatePermission(expression = "Book operation check")
+@DeletePermission(expression = "Book operation check")
 @SharePermission
 @Table(name = "book")
 @Include(rootLevel = true)
@@ -44,6 +54,15 @@ import javax.persistence.Table;
         logStatement = "{0}",
         logExpressions = {"${book.title}"})
 public class Book {
+    static public class BookOperationCheck extends OperationCheck<Book> {
+        @Override
+        public boolean ok(Book book, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            // trigger method for testing
+            book.checkPermission(requestScope);
+            return true;
+        }
+    }
+
     private long id;
     private String title;
     private String genre;
@@ -119,6 +138,10 @@ public class Book {
     @OnCreatePreSecurity
     public void onCreateBook(RequestScope requestScope) {
         // book entity created
+    }
+
+    public void checkPermission(RequestScope requestScope) {
+        // performs create permission check
     }
 
     @OnDeletePreSecurity

--- a/elide-core/src/test/java/example/TestCheckMappings.java
+++ b/elide-core/src/test/java/example/TestCheckMappings.java
@@ -44,6 +44,7 @@ public class TestCheckMappings {
                     put("Principal is user two", UserIdChecks.UserTwoCheck.class);
                     put("Principal is user three", UserIdChecks.UserThreeCheck.class);
                     put("Principal is user four", UserIdChecks.UserFourCheck.class);
+                    put("Book operation check", Book.BookOperationCheck.class);
                 }
             };
 


### PR DESCRIPTION
Restored lifecycle hook for create pre-security to occur after fields are populated.

Expanded test as well.