### PR TITLE
Filter getRelation call to single entity in-memory.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,12 @@
 # Change Log
 
-## 4.0-beta-4
-**Features**
- * ChangeSpec is now passed to OnUpdate life cycle hooks (allowing the hooks to see the before & after change to a given field).
-
 ## 4.0-beta-3
 **Fixes**
  * Updated MIT attribution for portions of MutableGraphQLInputObjectType
+ * getRelation (single) call filters in-memory to avoid collision on multiple objects being created in the same transaction.
+
+**Features**
+ * ChangeSpec is now passed to OnUpdate life cycle hooks (allowing the hooks to see the before & after change to a given field).
 
 ## 4.0-beta-2
 **Fixes**

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -790,7 +790,14 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
       if (resources.isEmpty()) {
             return null;
       }
-      return resources.iterator().next();
+      // If this is an in-memory object (i.e. UUID being created within tx), datastore may not be able to filter.
+      // If we get multiple results back, make sure we find the right id first.
+      for (PersistentResource resource : resources) {
+          if (resource.matchesId(id)) {
+              return resource;
+          }
+      }
+      return null;
     }
 
     /**

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -782,6 +782,26 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         Assert.assertEquals(((Child) results.iterator().next().getObject()).getName(), "paul john");
     }
 
+    @Test
+    public void testGetSingleRelationInMemory() {
+        // Ensure we don't break when we try to get a specific relationship in memory (i.e. not yet pushed to datastore)
+        Parent parent = newParent(1);
+        Child child1 = newChild(1, "paul john");
+        Child child2 = newChild(2, "john buzzard");
+        Child child3 = newChild(3, "chris smith");
+        parent.setChildren(Sets.newHashSet(child1, child2, child3));
+
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        when(tx.getRelation(eq(tx), any(), any(), any(), any(), any(), any())).thenReturn(Sets.newHashSet(child1, child2, child3));
+
+        PersistentResource<Parent> parentResource = new PersistentResource<>(parent, null, "1", goodUserScope);
+
+        PersistentResource childResource = parentResource.getRelation("children", "2");
+
+        Assert.assertEquals(childResource.getId(), "2");
+        Assert.assertEquals(((Child) childResource.getObject()).getName(), "john buzzard");
+    }
+
     @Test(expectedExceptions = ForbiddenAccessException.class)
     public void testGetRelationForbiddenByEntity() {
         NoReadEntity noread = new NoReadEntity();


### PR DESCRIPTION
This is required so we don't have collision errors when trying to traverse through newly created objects that belong to the same collection within a single transaction.

Example:

```
Create: /apps/1/players/abc
Create: /apps/1/players/def
Add: /apps/1/players/def/skills
```

In this example we are creating 2 new players in a game and adding skills to player `def`. Without this change, there is no way to guarantee we won't collide and try to add these skills to `abc`.

This seems to be a regression in Elide 4. I have the corresponding test addition to Elide 3 here: https://github.com/yahoo/elide/pull/597