### PR TITLE
Ignore null operation names.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.0-beta-4
+**Fixes**
+ * Ignore provided-- but null-- operation names and variables in GraphQL requests.
+
 ## 4.0-beta-3
 **Fixes**
  * Updated MIT attribution for portions of MutableGraphQLInputObjectType

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -95,12 +95,12 @@ public class GraphQLEndpoint {
             String query = jsonDocument.get(QUERY).asText();
 
             String operationName = null;
-            if (jsonDocument.has(OPERATION_NAME)) {
+            if (jsonDocument.has(OPERATION_NAME) && !jsonDocument.get(OPERATION_NAME).isNull()) {
                 operationName = jsonDocument.get(OPERATION_NAME).asText();
             }
 
             ExecutionResult result;
-            if (jsonDocument.has(VARIABLES)) {
+            if (jsonDocument.has(VARIABLES) && !jsonDocument.get(VARIABLES).isNull()) {
                 Map<String, Object> variables = mapper.convertValue(jsonDocument.get(VARIABLES), Map.class);
                 result = api.execute(query, operationName, requestScope, variables);
             } else {


### PR DESCRIPTION
Currently we don't really have support for operation names-- this may ultimately become a feature in the future. However, clients such as apollo send this with a `null` value by default. We should treat a null value properly in our system.