### PR TITLE
Fix null filter expression issue.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
  * Ignore provided-- but null-- operation names and variables in GraphQL requests.
  * Add additional logging around exception handling.
  * Don't swallow generic Exception in Elide. Log it and bubble it up to caller.
+ * Fix a bug where null filter expressions were possible if no filter was passed in by the user, but permission filters existed.
 
 **Features**
  * Handle ConstraintViolationException's by extracting the first constraint validation failure.

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -312,7 +312,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         Optional<FilterExpression> permissionFilter = getPermissionFilterExpression(loadClass, requestScope);
         if (permissionFilter.isPresent()) {
-            filterExpression = new AndFilterExpression(filterExpression, permissionFilter.get());
+            if (filterExpression != null) {
+                filterExpression = new AndFilterExpression(filterExpression, permissionFilter.get());
+            } else {
+                filterExpression = permissionFilter.get();
+            }
         }
 
         Set<PersistentResource> existingResources = filter(ReadPermission.class,


### PR DESCRIPTION
This PR fixes an issue where it's possible that a `null` `FilterExpression` is constructed. Namely, if no filter is passed in by the user and a permission filter exists, we end up creating the following filter expression:

```java
new AndFilterExpression(null, permissionFilter);
```

When this goes to evaluate, we try to operate on the `null` value causing an NPE. Rather than making the permission execution state machine null-safe, I have opted to make the change here. Namely, because security is a rather important component to our project, I would rather have hard crashes from developer mistakes rather than silent failures or-- worse-- invalid successes.