### PR TITLE
Fix exception handling.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 **Fixes**
  * Ignore provided-- but null-- operation names and variables in GraphQL requests.
  * Add additional logging around exception handling.
+ * Don't swallow generic Exception in Elide. Log it and bubble it up to caller.
+
+**Features**
+ * Handle ConstraintViolationException's by extracting the first constraint validation failure.
 
 ## 4.0-beta-3
 **Fixes**

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -101,6 +101,13 @@
             <version>2.1.0</version>
         </dependency>
 
+        <!-- JSR 303 Validation -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.0.Final</version>
+        </dependency>
+
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidConstraintException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidConstraintException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.exceptions;
+import com.yahoo.elide.core.HttpStatus;
+
+/**
+ * Invalid constraint exception. Message is exactly what is provided in the constructor.
+ *
+ * {@link com.yahoo.elide.core.HttpStatus#SC_BAD_REQUEST invalid}
+ */
+public class InvalidConstraintException extends HttpStatusException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidConstraintException(String message) {
+        super(HttpStatus.SC_BAD_REQUEST, message);
+    }
+
+    @Override
+    public String toString() {
+        String message = getMessage();
+
+        if (message == null) {
+            return getClass().getSimpleName();
+        }
+
+        return message;
+    }
+}


### PR DESCRIPTION
This PR tweaks how we perform exception handling. Namely, we log generic `Exception`s but no longer swallow them. This allows the caller to make decisions on how to handle Exceptions which we do not support.

Moreover, I added support for handling the `ConstraintViolationException` thrown for JSR303 failures.