### PR TITLE
Ignore non-entity types in hibernate class metadata (elide 3.x)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,9 @@
 # Change Log
+
+## 3.2.2
+**Fixes**
+ * Ignore non-entity types if present in the hibernate class metadata in the hibernate stores. This can legitimately occur when tools like envers are used.
+
 ## 3.2.1
 **Fixes**
  * Add additional logging around exception handling.

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -40,6 +40,7 @@
 
     <properties>
         <dataStoreSupplier>com.yahoo.elide.datastores.hibernate3.HibernateDataStoreSupplier</dataStoreSupplier>
+        <hibernate3.version>3.6.10.Final</hibernate3.version>
     </properties>
 
     <dependencies>
@@ -77,7 +78,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>3.6.10.Final</version>
+            <version>${hibernate3.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>xml-apis</artifactId>
@@ -133,6 +134,14 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Envers testing -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers</artifactId>
+            <version>${hibernate3.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/example/Person.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/example/Person.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
+import org.hibernate.envers.Audited;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,6 +18,7 @@ import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true)
+@Audited // Ensure envers does not cause any problems
 public class Person {
     @Setter
     private long id;

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -154,6 +154,14 @@
             <artifactId>jetty-webapp</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Envers testing -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers</artifactId>
+            <version>${hibernate5.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateStore.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateStore.java
@@ -107,7 +107,21 @@ public class HibernateStore implements DataStore {
     public void populateEntityDictionary(EntityDictionary dictionary) {
         /* bind all entities */
         for (ClassMetadata meta : sessionFactory.getAllClassMetadata().values()) {
-            dictionary.bindEntity(meta.getMappedClass());
+            try {
+                Class mappedClass = meta.getMappedClass();
+
+                // Ignore this result. We are just checking to see if it throws an exception meaning that
+                // provided class was _not_ an entity.
+                dictionary.lookupEntityClass(mappedClass);
+
+                // Bind if successful
+                dictionary.bindEntity(meta.getMappedClass());
+            } catch (IllegalArgumentException e)  {
+                // Ignore this entity
+                // Turns out that hibernate may include non-entity types in this list when using things
+                // like envers. Since they are not entities, we do not want to bind them into the entity
+                // dictionary
+            }
         }
     }
 

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/example/Person.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/example/Person.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
+import org.hibernate.envers.Audited;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,6 +18,7 @@ import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true)
+@Audited // Ensure envers does not cause any issues
 public class Person {
     @Setter
     private long id;

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/datastore/InjectionAwareHibernateStore.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/datastore/InjectionAwareHibernateStore.java
@@ -47,8 +47,18 @@ public class InjectionAwareHibernateStore extends HibernateStore {
             /* bind all entities to injector */
             metadata.forEach(meta -> {
                 // Ensure they receive proper injection:
-                dictionary.bindInitializer(injector::inject, meta.getMappedClass());
-                log.debug("Elide bound entity: {}", meta.getEntityName());
+                // Since tools like envers can insert non-entities into our metadata, make sure
+                // we ignore non-entities:
+                try {
+                    // This is only used to catch an exception. If non-entity is passed, then an exception is thrown
+                    dictionary.lookupEntityClass(meta.getMappedClass());
+                    // If we have gotten this far, we can happily bind the entity
+                    dictionary.bindInitializer(injector::inject, meta.getMappedClass());
+                    log.debug("Elide bound entity: {}", meta.getEntityName());
+                } catch (IllegalArgumentException e) {
+                    // Ignore this non-entity
+                    log.debug("Elide ignoring non-entity found in hibernate metadata: {}", meta.getEntityName());
+                }
             });
         } else {
             log.info("No injector found, not binding one to entities.");


### PR DESCRIPTION
This is a proposed fix for https://github.com/yahoo/elide/issues/611. In short, with tools like envers hibernate can legitimately store non-entity types in its class metadata. As a result, we do not want to bind these objects in Elide. This allows us to first check if the class we're trying to bind is an entity. If it's not, we simply ignore the class otherwise we proceed as usual.

This is the fix for Elide 3.