### PR TITLE
Update PersistentResourceFetcher.java

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.0.1
+**Fixes**
+ * Change `PersistentResourceFetcher` constructor visibility to public in order to allow this class instantiation outside of the elide-graphql.
+
 ## 4.0.0
 
 See: 4.0-beta-5

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -50,7 +50,7 @@ import static com.yahoo.elide.graphql.ModelBuilder.ARGUMENT_OPERATION;
 public class PersistentResourceFetcher implements DataFetcher {
     private final ElideSettings settings;
 
-    PersistentResourceFetcher(ElideSettings settings) {
+    public PersistentResourceFetcher(ElideSettings settings) {
         this.settings = settings;
     }
 


### PR DESCRIPTION
Change class constructor visibility to public to avoide Kotlin compilation error: `Kotlin: Cannot access '<init>': it is public/*package*/` while using this class. This should fix #621.