### PR TITLE
Updated when pre-security hooks run for create.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.2.0
+**Fixes**
+ * Fixed bug where create-time pre-security hooks were running before any values were set.
+
 ## 4.1.0
 **Fixes**
  * Performance enhancements including caching the `Class.getSimpleName`.

--- a/elide-annotations/pom.xml
+++ b/elide-annotations/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/elide-contrib/elide-swagger/pom.xml
+++ b/elide-contrib/elide-swagger/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>elide-contrib-parent-pom</artifactId>
         <groupId>com.yahoo.elide</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -42,14 +42,14 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
     	    <artifactId>elide-core</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Test -->
         <dependency>
             <groupId>com.yahoo.elide</groupId>
     	    <artifactId>elide-integration-tests</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/elide-contrib/pom.xml
+++ b/elide-contrib/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>elide-parent-pom</artifactId>
         <groupId>com.yahoo.elide</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>com.yahoo.elide</groupId>
                 <artifactId>elide-core</artifactId>
-                <version>4.1.1-SNAPSHOT</version>
+                <version>4.2.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1337,8 +1337,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         if (!isNewlyCreated) {
             runTriggers(OnUpdatePreSecurity.class, CLASS_NO_FIELD);
             runTriggers(OnUpdatePreSecurity.class, fieldName, Optional.of(spec));
-            checkFieldAwareDeferPermissions(UpdatePermission.class, fieldName, newValue, existingValue);
         }
+
+        // TODO: Need to refactor this logic. For creates this is properly converted in the executor. This logic
+        // should be explicitly encapsulated here, not there.
+        checkFieldAwareDeferPermissions(UpdatePermission.class, fieldName, newValue, existingValue);
 
         setValue(fieldName, newValue);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -11,7 +11,6 @@ import com.google.common.collect.Sets;
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
-import com.yahoo.elide.annotation.OnCreatePreSecurity;
 import com.yahoo.elide.annotation.OnDeletePreSecurity;
 import com.yahoo.elide.annotation.OnReadPreSecurity;
 import com.yahoo.elide.annotation.OnUpdatePreSecurity;
@@ -1335,12 +1334,12 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         ChangeSpec spec = new ChangeSpec(this, fieldName, existingValue, newValue);
         boolean isNewlyCreated = requestScope.getNewPersistentResources().contains(this);
 
-        Class<? extends Annotation> annotationClass = (isNewlyCreated)
-                ? OnCreatePreSecurity.class  : OnUpdatePreSecurity.class;
+        if (!isNewlyCreated) {
+            runTriggers(OnUpdatePreSecurity.class, CLASS_NO_FIELD);
+            runTriggers(OnUpdatePreSecurity.class, fieldName, Optional.of(spec));
+            checkFieldAwareDeferPermissions(UpdatePermission.class, fieldName, newValue, existingValue);
+        }
 
-        runTriggers(annotationClass, CLASS_NO_FIELD);
-        runTriggers(annotationClass, fieldName, Optional.of(spec));
-        checkFieldAwareDeferPermissions(UpdatePermission.class, fieldName, newValue, existingValue);
         setValue(fieldName, newValue);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -233,7 +233,7 @@ public class LifeCycleTest {
         RequestScope scope = new RequestScope(null, null, tx, new User(1), null, getElideSettings(null, dictionary, MOCK_AUDIT_LOGGER),
                 false);
         PersistentResource resource = PersistentResource.createObject(null, Book.class, scope, Optional.of("uuid"));
-        resource.setValue("title", "should not affect calls since this is create!");
+        resource.setValueChecked("title", "should not affect calls since this is create!");
         Assert.assertNotNull(resource);
         verify(book, never()).onCreateBook(scope);
         verify(book, never()).checkPermission(scope);
@@ -253,14 +253,14 @@ public class LifeCycleTest {
         verify(book, never()).checkPermission(scope);
 
         scope.getPermissionExecutor().executeCommitChecks();
-        verify(book, times(1)).checkPermission(scope);
+        verify(book, times(2)).checkPermission(scope);
 
         scope.runQueuedPostCommitTriggers();
         verify(book, times(1)).postCreateBook(scope);
         verify(book, never()).postDeleteBook(scope);
         verify(book, never()).postUpdateTitle(scope);
         verify(book, times(1)).postRead(scope);
-        verify(book, times(1)).checkPermission(scope);
+        verify(book, times(2)).checkPermission(scope);
     }
 
     @Test

--- a/elide-datastore/elide-datastore-hibernate/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-integration-tests</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -52,19 +52,19 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-integration-tests</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -51,19 +51,19 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-integration-tests</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
     	</dependency>

--- a/elide-datastore/elide-datastore-inmemorydb/pom.xml
+++ b/elide-datastore/elide-datastore-inmemorydb/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-integration-tests</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/elide-datastore/elide-datastore-multiplex/pom.xml
+++ b/elide-datastore/elide-datastore-multiplex/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -47,19 +47,19 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-inmemorydb</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate5</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-integration-tests</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/elide-datastore/elide-datastore-noop/pom.xml
+++ b/elide-datastore/elide-datastore-noop/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/elide-datastore/pom.xml
+++ b/elide-datastore/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -57,7 +57,7 @@
             <dependency>
                 <groupId>com.yahoo.elide</groupId>
                 <artifactId>elide-core</artifactId>
-                <version>4.1.1-SNAPSHOT</version>
+                <version>4.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>

--- a/elide-example/elide-blog-example-resteasy/pom.xml
+++ b/elide-example/elide-blog-example-resteasy/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-example-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate5</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Jetty -->

--- a/elide-example/elide-blog-example/pom.xml
+++ b/elide-example/elide-blog-example/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-example-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -29,12 +29,12 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate5</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Jetty -->

--- a/elide-example/elide-hibernate3-mysql-example/pom.xml
+++ b/elide-example/elide-hibernate3-mysql-example/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-example-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate3</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Jetty -->

--- a/elide-example/pom.xml
+++ b/elide-example/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>com.yahoo.elide</groupId>
                 <artifactId>elide-core</artifactId>
-                <version>4.1.1-SNAPSHOT</version>
+                <version>4.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>

--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/elide-integration-tests/pom.xml
+++ b/elide-integration-tests/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -29,12 +29,12 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-graphql</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <!-- Additional dependencies -->
         <dependency>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.yahoo.elide</groupId>
     <artifactId>elide-standalone</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Elide Standalone</name>
     <description>Elide Standalone Application</description>
@@ -16,7 +16,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-parent-pom</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.2.0-SNAPSHOT</version>
     </parent>
 
     <licenses>
@@ -62,12 +62,12 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-hibernate5</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-graphql</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.2.0-SNAPSHOT</version>
         </dependency>
 
         <!-- MySQL Driver -->

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.yahoo.elide</groupId>
     <artifactId>elide-parent-pom</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Elide: Parent Pom</name>
     <description>Parent pom for Elide project</description>
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>com.yahoo.elide</groupId>
                 <artifactId>elide-annotations</artifactId>
-                <version>4.1.1-SNAPSHOT</version>
+                <version>4.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
This changes when pre-security hooks run for commit-time checks. In general:

`OnCreatePreSecurity` actually runs before the security check is run but _after_ the values on the object are set. Since create checks are all deferred to commit-time to look at the final state of the object, this allows the `PreSecurity` hooks to be useful for creates. If we don't do this, the object is totally empty at time of `PreSecurity`.