### PR TITLE
Remapped catch blocks for HibernateException to PersistenceException

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,13 @@
 # Change Log
+
+## 4.2.1
+**Fixes**
+Fixed #640
+
 ## 4.2.0
 **Features**
 Upgraded hibernate 5 datastore to latest version (5.2.15)
 
-## 4.2.0
 **Fixes**
  * Fixed bug where create-time pre-security hooks were running before any values were set.
 

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateSessionFactoryStore.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateSessionFactoryStore.java
@@ -8,10 +8,11 @@ package com.yahoo.elide.datastores.hibernate5;
 import com.google.common.base.Preconditions;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.exceptions.TransactionException;
-import org.hibernate.HibernateException;
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+
+import javax.persistence.PersistenceException;
 
 /**
  * Implementation for HibernateStore supporting SessionFactory.
@@ -36,7 +37,7 @@ public class HibernateSessionFactoryStore extends AbstractHibernateStore {
             Preconditions.checkNotNull(session);
             Preconditions.checkArgument(session.isConnected());
             return session;
-        } catch (HibernateException e) {
+        } catch (PersistenceException e) {
             throw new TransactionException(e);
         }
     }

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -27,13 +27,13 @@ import com.yahoo.elide.datastores.hibernate5.porting.SessionWrapper;
 import com.yahoo.elide.security.User;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.FlushMode;
-import org.hibernate.HibernateException;
 import org.hibernate.ObjectNotFoundException;
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
 import org.hibernate.collection.internal.AbstractPersistentCollection;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
+import javax.persistence.PersistenceException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
@@ -86,7 +86,7 @@ public class HibernateTransaction implements DataStoreTransaction {
             if (flushMode != FlushMode.COMMIT && flushMode != FlushMode.MANUAL) {
                 session.flush();
             }
-        } catch (HibernateException e) {
+        } catch (PersistenceException e) {
             log.error("Caught hibernate exception during flush", e);
             throw new TransactionException(e);
         }
@@ -97,7 +97,7 @@ public class HibernateTransaction implements DataStoreTransaction {
         try {
             this.flush(scope);
             this.session.getTransaction().commit();
-        } catch (HibernateException e) {
+        } catch (PersistenceException e) {
             throw new TransactionException(e);
         }
     }


### PR DESCRIPTION
Hibernate 5.2 changes HibernateException to now extend PersistenceException:
https://github.com/hibernate/hibernate-orm/wiki/Migration-Guide---5.2

Fixes #640