### PR TITLE
Add fetch joins for to-one relationships to improve HQL performance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,9 +5,12 @@
  * Fixed #640
  * Log runtime exception as error
 
+**Features**
+ * Added "fetch joins" for to-one relationships to improve HQL performance and limit N+1 queries.
+
 ## 4.2.0
 **Features**
-Upgraded hibernate 5 datastore to latest version (5.2.15)
+ * Upgraded hibernate 5 datastore to latest version (5.2.15)
 
 **Fixes**
  * Fixed bug where create-time pre-security hooks were running before any values were set.
@@ -83,8 +86,8 @@ See: 4.0-beta-5
    checked for newly created objects.
  * The semantics of `SharePermission` have changed.  `SharePermission` can no longer have an expression defined.  It either denies permission
    or exactly matches `ReadPermission`.
- * RSQL queries that compare strings are now case-insensitive. There is not currently a way to make 
-   case sensitive RSQL queries, however the RSQL spec does not provide this either. 
+ * RSQL queries that compare strings are now case-insensitive. There is not currently a way to make
+   case sensitive RSQL queries, however the RSQL spec does not provide this either.
    Fixes #387
 
 **Fixes**
@@ -102,9 +105,9 @@ See: 4.0-beta-5
  * Rollback relationship handling change.
  * Handle ForbiddenAccess only for denied Include, instead of filtering to empty set.
 
-## 3.1.4       
-**Fixes**      
- * Instead of ForbiddenAccess for denied Include, filter to empty set.     
+## 3.1.4
+**Fixes**
+ * Instead of ForbiddenAccess for denied Include, filter to empty set.
  * Generate error when parsing permission expression fails.
 
 ## 3.1.3
@@ -126,7 +129,7 @@ See: 4.0-beta-5
 
 ## 3.1.0
 **Fixes**
- * Use Entity name when Include is empty.  Cleanup Predicate. 
+ * Use Entity name when Include is empty.  Cleanup Predicate.
 
 ## 3.0.17
 **Features**
@@ -140,19 +143,19 @@ Cleanup equals code style
 
 ## 3.0.15
 **Fixes**
- * Use inverse relation type when updating. 
- 
+ * Use inverse relation type when updating.
+
 ## 3.0.14
 **Fixes**
  * Properly handle incorrect relationship field name in Patch request instead of `Entity is null`
  * Properly handle invalid filtering input in HQL filtering
  * Properly handle NOT in filterexpressionchecks
  * Fix parameter order in commit permission check
- 
+
 ## 3.0.13
 **Fixes**
  * Fixing regression in deferred permissions for updates
- 
+
 ## 3.0.12
 **Misc**
  * Cleanup hibernate stores to not care about multi edit transactions
@@ -229,8 +232,8 @@ Cleanup equals code style
 ## 3.0.0
 **Features**
 * Promoted `DefaultOpaqueUserFunction` to be a top-level class
-* Promoted `Elide.Builder` to be a top-level class `ElideSettingsBuilder` 
-* Revised datastore interface 
+* Promoted `Elide.Builder` to be a top-level class `ElideSettingsBuilder`
+* Revised datastore interface
     * Removed hibernate-isms
     * Made key-value persistence easier to support
 * Revised lifecycle hook model

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidAttributeException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/InvalidAttributeException.java
@@ -13,7 +13,7 @@ import com.yahoo.elide.core.HttpStatus;
  */
 public class InvalidAttributeException extends HttpStatusException {
     public InvalidAttributeException(String attributeName, String type, Throwable cause) {
-        super(HttpStatus.SC_NOT_FOUND, "Unknown attribute '" + attributeName + "' in " + "'" + type + "'", cause, null);
+        super(HttpStatus.SC_NOT_FOUND, "Unknown attribute '" + attributeName + "' in '" + type + "'", cause, null);
     }
 
     public InvalidAttributeException(String attributeName, String type) {

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -1347,8 +1347,8 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         left.setId(1);
         Right right = new Right();
         right.setId(1);
-        left.noUpdateOne2One = right;
-        right.noUpdateOne2One = left;
+        left.setNoUpdateOne2One(right);
+        right.setNoUpdateOne2One(left);
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
         User goodUser = new User(1);
@@ -1365,8 +1365,8 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         left.setId(1);
         Right right = new Right();
         right.setId(1);
-        left.noUpdateOne2One = right;
-        right.noUpdateOne2One = left;
+        left.setNoUpdateOne2One(right);
+        right.setNoUpdateOne2One(left);
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
         User goodUser = new User(1);
@@ -1385,9 +1385,9 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         right1.setId(1);
         Right right2 = new Right();
         right2.setId(2);
-        left.noInverseUpdate = Sets.newHashSet(right1, right2);
-        right1.noUpdate = Sets.newHashSet(left);
-        right2.noUpdate = Sets.newHashSet(left);
+        left.setNoInverseUpdate(Sets.newHashSet(right1, right2));
+        right1.setNoUpdate(Sets.newHashSet(left));
+        right2.setNoUpdate(Sets.newHashSet(left));
 
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
@@ -1405,14 +1405,14 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         left.setId(1);
         NoDeleteEntity noDelete = new NoDeleteEntity();
         noDelete.setId(1);
-        left.noDeleteOne2One = noDelete;
+        left.setNoDeleteOne2One(noDelete);
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
         User goodUser = new User(1);
         RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings, false);
         PersistentResource<Left> leftResource = new PersistentResource<>(left, null, "1", goodScope);
         Assert.assertTrue(leftResource.clearRelation("noDeleteOne2One"));
-        Assert.assertNull(leftResource.getObject().noDeleteOne2One);
+        Assert.assertNull(leftResource.getObject().getNoDeleteOne2One());
 
     }
 
@@ -1599,8 +1599,8 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         Right right = new Right();
         right.setId(2);
 
-        left.fieldLevelDelete = Sets.newHashSet(right);
-        right.allowDeleteAtFieldLevel = Sets.newHashSet(left);
+        left.setFieldLevelDelete(Sets.newHashSet(right));
+        right.setAllowDeleteAtFieldLevel(Sets.newHashSet(left));
 
         //Bad User triggers the delete permission failure
         User badUser = new User(-1);
@@ -1609,7 +1609,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         PersistentResource<Left> leftResource = new PersistentResource<>(left, null, badScope.getUUIDFor(left), badScope);
 
         Assert.assertTrue(leftResource.clearRelation("fieldLevelDelete"));
-        Assert.assertEquals(leftResource.getObject().fieldLevelDelete.size(), 0);
+        Assert.assertEquals(leftResource.getObject().getFieldLevelDelete().size(), 0);
     }
 
 
@@ -1619,8 +1619,8 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         left.setId(1);
         Right right = new Right();
 
-        left.noInverseUpdate = Sets.newHashSet(right);
-        right.noUpdate = Sets.newHashSet(left);
+        left.setNoInverseUpdate(Sets.newHashSet(right));
+        right.setNoUpdate(Sets.newHashSet(left));
 
         List<Resource> empty = new ArrayList<>();
         Relationship ids = new Relationship(null, new Data<>(empty));

--- a/elide-core/src/test/java/example/Author.java
+++ b/elide-core/src/test/java/example/Author.java
@@ -39,7 +39,7 @@ public class Author {
         FREELANCE
     }
 
-    private long id;
+    private Long id;
     private String name;
     private Collection<Book> books = new ArrayList<>();
     private AuthorType type;
@@ -49,11 +49,11 @@ public class Author {
     private Address homeAddress;
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(long id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/elide-core/src/test/java/example/Author.java
+++ b/elide-core/src/test/java/example/Author.java
@@ -39,7 +39,7 @@ public class Author {
         FREELANCE
     }
 
-    private Long id;
+    private long id;
     private String name;
     private Collection<Book> books = new ArrayList<>();
     private AuthorType type;
@@ -49,11 +49,11 @@ public class Author {
     private Address homeAddress;
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(long id) {
         this.id = id;
     }
 

--- a/elide-core/src/test/java/example/Left.java
+++ b/elide-core/src/test/java/example/Left.java
@@ -21,7 +21,6 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import java.util.Set;
 
-
 @Include(rootLevel = true, type = "left") // optional here because class has this name
 @Entity
 @Table(name = "xleft")  // left is SQL keyword
@@ -31,6 +30,10 @@ public class Left {
     private long id;
     private Set<Right> one2many;
     private Right one2one;
+    private NoDeleteEntity noDeleteOne2One;
+    private Set<Right> fieldLevelDelete;
+    private Right noUpdateOne2One;
+    private Set<Right> noInverseUpdate;
 
     @OneToOne(
             optional = false,
@@ -75,25 +78,48 @@ public class Left {
             targetEntity = Right.class,
             mappedBy = "noUpdateOne2One"
     )
-    public Right noUpdateOne2One;
+    public Right getNoUpdateOne2One() {
+        return noUpdateOne2One;
+    }
+
+    public void setNoUpdateOne2One(Right noUpdateOne2One) {
+        this.noUpdateOne2One = noUpdateOne2One;
+    }
 
     @ManyToMany(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Right.class,
             mappedBy = "noUpdate"
     )
-    public Set<Right> noInverseUpdate;
+    public Set<Right> getNoInverseUpdate() {
+        return noInverseUpdate;
+    }
+
+    public void setNoInverseUpdate(Set<Right> noInverseUpdate) {
+        this.noInverseUpdate = noInverseUpdate;
+    }
 
     @OneToOne(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = NoDeleteEntity.class
+
     )
-    public NoDeleteEntity noDeleteOne2One;
+    public NoDeleteEntity getNoDeleteOne2One() {
+        return noDeleteOne2One;
+    }
+
+    public void setNoDeleteOne2One(NoDeleteEntity noDeleteOne2One) {
+        this.noDeleteOne2One = noDeleteOne2One;
+    }
 
     @ManyToMany(
-        cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-        targetEntity = Right.class,
-        mappedBy = "allowDeleteAtFieldLevel"
+        cascade = { CascadeType.PERSIST, CascadeType.MERGE }
     )
-    public Set<Right> fieldLevelDelete;
+    public Set<Right> getFieldLevelDelete() {
+        return fieldLevelDelete;
+    }
+
+    public void setFieldLevelDelete(Set<Right> fieldLevelDelete) {
+        this.fieldLevelDelete = fieldLevelDelete;
+    }
 }

--- a/elide-core/src/test/java/example/Right.java
+++ b/elide-core/src/test/java/example/Right.java
@@ -32,6 +32,9 @@ public class Right {
     private long id;
     private Left many2one;
     private Left one2one;
+    private Set<Left> allowDeleteAtFieldLevel;
+    private Left noUpdateOne2One;
+    private Set<Left> noUpdate;
 
     @OneToOne(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
@@ -73,19 +76,36 @@ public class Right {
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Left.class
     )
-    public Left noUpdateOne2One;
+    public Left getNoUpdateOne2One() {
+        return noUpdateOne2One;
+    }
+
+    public void setNoUpdateOne2One(Left noUpdateOne2One) {
+        this.noUpdateOne2One = noUpdateOne2One;
+    }
 
     @UpdatePermission(expression = "deny all")
     @ManyToMany(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Left.class
     )
-    public Set<Left> noUpdate;
+    public Set<Left> getNoUpdate() {
+        return noUpdate;
+    }
+
+    public void setNoUpdate(Set<Left> noUpdate) {
+        this.noUpdate = noUpdate;
+    }
 
     @ManyToMany(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-            targetEntity = Left.class
+            cascade = { CascadeType.PERSIST, CascadeType.MERGE }
     )
     @UpdatePermission(expression = "allow all")
-    public Set<Left> allowDeleteAtFieldLevel;
+    public Set<Left> getAllowDeleteAtFieldLevel() {
+        return allowDeleteAtFieldLevel;
+    }
+
+    public void setAllowDeleteAtFieldLevel(Set<Left> allowDeleteAtFieldLevel) {
+        this.allowDeleteAtFieldLevel = allowDeleteAtFieldLevel;
+    }
 }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/Session.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/Session.java
@@ -5,12 +5,9 @@
  */
 package com.yahoo.elide.core.hibernate;
 
-import java.util.Collection;
-
 /**
  * Interface that represents a Hibernate session but has no dependencies on a specific version of Hibernate.
  */
 public interface Session {
     public Query createQuery(String queryText);
-    public Query createFilter(Collection collection, String queryText);
 }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -182,6 +182,12 @@ public abstract class AbstractHQLQueryBuilder {
         return joinClause.toString();
     }
 
+    /**
+     * Builds a JOIN clause that eagerly fetches to-one relationships that Hibernate needs to hydrate.
+     * @param entityClass The entity class that is being queried in the HQL query.
+     * @param alias The HQL alias for the entity class.
+     * @return The JOIN clause that can be added to the FROM clause.
+     */
     protected String extractToOneMergeJoins(Class<?> entityClass, String alias) {
         List<String> relationshipNames = dictionary.getRelationships(entityClass);
         StringBuilder joinString = new StringBuilder("");
@@ -200,7 +206,7 @@ public abstract class AbstractHQLQueryBuilder {
                 joinString.append(alias);
                 joinString.append(PERIOD);
                 joinString.append(relationshipName);
-                joinString.append(" ");
+                joinString.append(SPACE);
             }
         }
         return joinString.toString();

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -26,6 +26,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.persistence.OneToOne;
+
 /**
  * Abstract class used to construct HQL queries.
  */
@@ -182,10 +184,16 @@ public abstract class AbstractHQLQueryBuilder {
 
     protected String extractToOneMergeJoins(Class<?> entityClass, String alias) {
         List<String> relationshipNames = dictionary.getRelationships(entityClass);
-        StringBuffer joinString = new StringBuffer("");
+        StringBuilder joinString = new StringBuilder("");
         for (String relationshipName : relationshipNames) {
             RelationshipType type = dictionary.getRelationshipType(entityClass, relationshipName);
             if (type.isToOne() && !type.isComputed()) {
+                // fetch only OneToOne with mappedBy
+                OneToOne oneToOne = dictionary.getAttributeOrRelationAnnotation(
+                        entityClass, OneToOne.class, relationshipName);
+                if (oneToOne == null || oneToOne.mappedBy().isEmpty()) {
+                    continue;
+                }
                 joinString.append(LEFT);
                 joinString.append(JOIN);
                 joinString.append(FETCH);

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.core.hibernate.hql;
 
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.RelationshipType;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.PredicateExtractionVisitor;
@@ -42,6 +43,7 @@ public abstract class AbstractHQLQueryBuilder {
     protected static final String FROM = " FROM ";
     protected static final String JOIN = " JOIN ";
     protected static final String LEFT = " LEFT";
+    protected static final String FETCH = " FETCH ";
     protected static final String SELECT = "SELECT ";
     protected static final String AS = " AS ";
 
@@ -176,6 +178,24 @@ public abstract class AbstractHQLQueryBuilder {
         }
 
         return joinClause.toString();
+    }
+
+    protected String extractToOneMergeJoins(Class<?> entityClass, String alias) {
+        List<String> relationshipNames = dictionary.getRelationships(entityClass);
+        StringBuffer joinString = new StringBuffer("");
+        for (String relationshipName : relationshipNames) {
+            RelationshipType type = dictionary.getRelationshipType(entityClass, relationshipName);
+            if (type.isToOne() && !type.isComputed()) {
+                joinString.append(LEFT);
+                joinString.append(JOIN);
+                joinString.append(FETCH);
+                joinString.append(alias);
+                joinString.append(PERIOD);
+                joinString.append(relationshipName);
+                joinString.append(" ");
+            }
+        }
+        return joinString.toString();
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -200,9 +200,7 @@ public abstract class AbstractHQLQueryBuilder {
                 if (oneToOne == null || oneToOne.mappedBy().isEmpty()) {
                     continue;
                 }
-                joinString.append(LEFT);
-                joinString.append(JOIN);
-                joinString.append(FETCH);
+                joinString.append(" LEFT JOIN FETCH ");
                 joinString.append(alias);
                 joinString.append(PERIOD);
                 joinString.append(relationshipName);

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
@@ -47,7 +47,8 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
             String filterClause = new HQLFilterOperation().apply(filterExpression.get(), USE_ALIAS);
 
             //Build the JOIN clause
-            String joinClause =  getJoinClauseFromFilters(filterExpression.get());
+            String joinClause =  getJoinClauseFromFilters(filterExpression.get())
+                    + extractToOneMergeJoins(entityClass, entityAlias);
 
             query = session.createQuery(
                     SELECT
@@ -73,6 +74,8 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                     + entityName
                     + AS
                     + entityAlias
+                    + SPACE
+                    + extractToOneMergeJoins(entityClass, entityAlias)
                     + SPACE
                     + getSortClause(sorting, entityClass, USE_ALIAS));
         }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -43,7 +43,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
         }
 
         String childAlias = FilterPredicate.getTypeAlias(relationship.getChildType());
-        String parentAlias = FilterPredicate.getTypeAlias(relationship.getParentType()) + "_fetch";
+        String parentAlias = FilterPredicate.getTypeAlias(relationship.getParentType()) + "__fetch";
         String parentName = relationship.getParentType().getCanonicalName();
         String relationshipName = relationship.getRelationshipName();
 

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -52,7 +52,8 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
             Collection<FilterPredicate> predicates = fe.accept(extractor);
             String filterClause = new HQLFilterOperation().apply(fe, USE_ALIAS);
 
-            String joinClause =  getJoinClauseFromFilters(filterExpression.get());
+            String joinClause =  getJoinClauseFromFilters(filterExpression.get())
+                    + extractToOneMergeJoins(relationship.getChildType(), childAlias);
 
             //SELECT parent_children from Parent parent JOIN parent.children parent_children
             Query q = session.createQuery(SELECT
@@ -77,6 +78,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                             + parentName + SPACE + parentAlias
                             + JOIN
                             + parentAlias + PERIOD + relationshipName + SPACE + childAlias
+                            + extractToOneMergeJoins(relationship.getChildType(), childAlias)
                             + " WHERE " + parentAlias + PERIOD + "id=" + dictionary.getId(relationship.getParent())
                             + getSortClause(sorting, relationship.getChildType(), USE_ALIAS)
         ));

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -43,7 +43,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
         }
 
         String childAlias = FilterPredicate.getTypeAlias(relationship.getChildType());
-        String parentAlias = FilterPredicate.getTypeAlias(relationship.getParentType()) + "_FOOBAR";
+        String parentAlias = FilterPredicate.getTypeAlias(relationship.getParentType()) + "_fetch";
         String parentName = relationship.getParentType().getCanonicalName();
         String relationshipName = relationship.getRelationshipName();
 
@@ -65,7 +65,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                             + joinClause
                             + SPACE
                             + filterClause
-                            + " AND " + parentAlias + PERIOD + "id=" + dictionary.getId(relationship.getParent())
+                            + " AND " + parentAlias + "=:" + parentAlias
                             + SPACE
                             + getSortClause(sorting, relationship.getChildType(), USE_ALIAS)
             );
@@ -79,9 +79,11 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                             + JOIN
                             + parentAlias + PERIOD + relationshipName + SPACE + childAlias
                             + extractToOneMergeJoins(relationship.getChildType(), childAlias)
-                            + " WHERE " + parentAlias + PERIOD + "id=" + dictionary.getId(relationship.getParent())
+                            + " WHERE " + parentAlias + "=:" + parentAlias
                             + getSortClause(sorting, relationship.getChildType(), USE_ALIAS)
         ));
+
+        query.setParameter(parentAlias, relationship.getParent());
 
         addPaginationToQuery(query);
         return query;

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
@@ -20,6 +20,7 @@ import example.Author;
 import example.Book;
 import example.Chapter;
 import example.Publisher;
+import example.Left;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -54,6 +55,7 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Chapter.class);
         dictionary.bindEntity(Publisher.class);
+        dictionary.bindEntity(Left.class);
     }
 
 
@@ -95,6 +97,14 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
         String expected = " LEFT JOIN example_Author.books example_Author_books  "
                 + "LEFT JOIN example_Author_books.chapters example_Book_chapters   "
                 + "LEFT JOIN example_Author_books.publisher example_Book_publisher  ";
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testFetchJoinClause() {
+        String actual = extractToOneMergeJoins(Left.class, "right_alias");
+
+        String expected = " LEFT JOIN  FETCH right_alias.noUpdateOne2One  LEFT JOIN  FETCH right_alias.one2one ";
         Assert.assertEquals(actual, expected);
     }
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
@@ -104,7 +104,7 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
     public void testFetchJoinClause() {
         String actual = extractToOneMergeJoins(Left.class, "right_alias");
 
-        String expected = " LEFT JOIN  FETCH right_alias.noUpdateOne2One  LEFT JOIN  FETCH right_alias.one2one ";
+        String expected = " LEFT JOIN FETCH right_alias.noUpdateOne2One  LEFT JOIN FETCH right_alias.one2one ";
         Assert.assertEquals(actual, expected);
     }
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -33,9 +33,6 @@ public class RootCollectionFetchQueryBuilderTest {
     private static final String BOOKS = "books";
     private static final String PUBLISHER = "publisher";
 
-    private final Class<? extends Book> bookProxyClass = new Book() {
-    }.getClass();
-
     @BeforeClass
     public void initialize() {
         dictionary = new EntityDictionary(new HashMap<>());
@@ -48,7 +45,7 @@ public class RootCollectionFetchQueryBuilderTest {
     @Test
     public void testRootFetch() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
-                bookProxyClass, dictionary, new TestSessionWrapper());
+                Book.class, dictionary, new TestSessionWrapper());
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
 
@@ -127,7 +124,7 @@ public class RootCollectionFetchQueryBuilderTest {
     @Test
     public void testRootFetchWithSortingAndFilters() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
-                bookProxyClass, dictionary, new TestSessionWrapper());
+                Book.class, dictionary, new TestSessionWrapper());
 
         Map<String, Sorting.SortOrder> sorting = new HashMap<>();
         sorting.put(TITLE, Sorting.SortOrder.asc);

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -45,7 +45,7 @@ public class RootCollectionFetchQueryBuilderTest {
         dictionary.bindEntity(Chapter.class);
     }
 
-    @Test
+    //@Test
     public void testRootFetch() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
                 bookProxyClass, dictionary, new TestSessionWrapper());
@@ -58,7 +58,7 @@ public class RootCollectionFetchQueryBuilderTest {
         Assert.assertEquals(actual, expected);
     }
 
-    @Test
+    //@Test
     public void testRootFetchWithSorting() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
                 Book.class, dictionary, new TestSessionWrapper());
@@ -124,7 +124,7 @@ public class RootCollectionFetchQueryBuilderTest {
         Assert.assertEquals(actual, expected);
     }
 
-    @Test
+    //@Test
     public void testRootFetchWithSortingAndFilters() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
                 bookProxyClass, dictionary, new TestSessionWrapper());

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -45,20 +45,20 @@ public class RootCollectionFetchQueryBuilderTest {
         dictionary.bindEntity(Chapter.class);
     }
 
-    //@Test
+    @Test
     public void testRootFetch() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
                 bookProxyClass, dictionary, new TestSessionWrapper());
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
 
-        String expected = "SELECT example_Book FROM example.Book AS example_Book ";
+        String expected = "SELECT example_Book FROM example.Book AS example_Book  ";
         String actual = query.getQueryText();
 
         Assert.assertEquals(actual, expected);
     }
 
-    //@Test
+    @Test
     public void testRootFetchWithSorting() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
                 Book.class, dictionary, new TestSessionWrapper());
@@ -70,7 +70,7 @@ public class RootCollectionFetchQueryBuilderTest {
                 .withPossibleSorting(Optional.of(new Sorting(sorting)))
                 .build();
 
-        String expected = "SELECT example_Book FROM example.Book AS example_Book  order by example_Book.title asc";
+        String expected = "SELECT example_Book FROM example.Book AS example_Book   order by example_Book.title asc";
         String actual = query.getQueryText();
 
         Assert.assertEquals(actual, expected);
@@ -124,7 +124,7 @@ public class RootCollectionFetchQueryBuilderTest {
         Assert.assertEquals(actual, expected);
     }
 
-    //@Test
+    @Test
     public void testRootFetchWithSortingAndFilters() {
         RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
                 bookProxyClass, dictionary, new TestSessionWrapper());

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
@@ -35,9 +35,6 @@ public class RootCollectionPageTotalsQueryBuilderTest {
     private static final String BOOKS = "books";
     private static final String PUBLISHER = "publisher";
 
-    private final Class<? extends Book> bookProxyClass = new Book() {
-    }.getClass();
-
     @BeforeClass
     public void initialize() {
         dictionary = new EntityDictionary(new HashMap<>());
@@ -50,7 +47,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
     @Test
     public void testRootFetch() {
         RootCollectionPageTotalsQueryBuilder builder = new RootCollectionPageTotalsQueryBuilder(
-                bookProxyClass, dictionary, new TestSessionWrapper());
+                Book.class, dictionary, new TestSessionWrapper());
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
 
@@ -66,7 +63,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testRootFetchWithSorting() {
         RootCollectionPageTotalsQueryBuilder builder = new RootCollectionPageTotalsQueryBuilder(
-                bookProxyClass, dictionary, new TestSessionWrapper());
+                Book.class, dictionary, new TestSessionWrapper());
 
         Sorting sorting = mock(Sorting.class);
 
@@ -78,7 +75,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
         Pagination pagination = mock(Pagination.class);
 
         RootCollectionPageTotalsQueryBuilder builder = new RootCollectionPageTotalsQueryBuilder(
-                bookProxyClass, dictionary, new TestSessionWrapper());
+                Book.class, dictionary, new TestSessionWrapper());
 
         builder.withPossiblePagination(Optional.of(pagination));
     }

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -35,11 +35,6 @@ public class SubCollectionFetchQueryBuilderTest {
     private static final String PUBLISHER = "publisher";
     private static final String PUB1 = "Pub1";
 
-    public static class BookProxy extends Book {
-    }
-
-    private final Class<? extends Book> bookProxyClass = BookProxy.class;
-
     @BeforeClass
     public void initialize() {
         dictionary = new EntityDictionary(new HashMap<>());

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -72,7 +72,7 @@ public class SubCollectionFetchQueryBuilderTest {
         Assert.assertNull(query);
     }
 
-    //@Test
+    @Test
     public void testSubCollectionFetchWithSorting() {
         Author author = new Author();
         author.setId(1L);
@@ -97,13 +97,15 @@ public class SubCollectionFetchQueryBuilderTest {
                 .withPossibleSorting(Optional.of(new Sorting(sorting)))
                 .build();
 
-        String expected = " order by title asc";
+        String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
+                + "JOIN example_Author__fetch.books example_Book "
+                + "WHERE example_Author__fetch=:example_Author__fetch order by example_Book.title asc";
         String actual = query.getQueryText();
 
         Assert.assertEquals(actual, expected);
     }
 
-    //@Test
+    @Test
     public void testSubCollectionFetchWithJoinFilter() {
         Author author = new Author();
         author.setId(1L);
@@ -135,14 +137,17 @@ public class SubCollectionFetchQueryBuilderTest {
                 .withPossibleFilterExpression(Optional.of(publisherNamePredicate))
                 .build();
 
-        String expected = "WHERE books.publisher.name IN (:books_publisher_name_XXX) ";
+        String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
+                + "JOIN example_Author__fetch.books example_Book "
+                + "LEFT JOIN example_Book.publisher example_Book_publisher  "
+                + "WHERE example_Book_publisher.name IN (:books_publisher_name_XXX) AND example_Author__fetch=:example_Author__fetch ";
         String actual = query.getQueryText();
-        actual = actual.replaceFirst(":books_publisher_name_\\w+", ":books_publisher_name_XXX");
+        actual = actual.replaceFirst(":publisher_name_\\w+_\\w+", ":books_publisher_name_XXX");
 
         Assert.assertEquals(actual, expected);
     }
 
-    //@Test
+    @Test
     public void testSubCollectionFetchWithSortingAndFilters() {
         Author author = new Author();
         author.setId(1L);
@@ -178,7 +183,11 @@ public class SubCollectionFetchQueryBuilderTest {
                 .withPossibleSorting(Optional.of(new Sorting(sorting)))
                 .build();
 
-        String expected = "WHERE publisher.name IN (:publisher_name_XXX)  order by title asc";
+        String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
+                + "JOIN example_Author__fetch.books example_Book "
+                + "LEFT JOIN example_Book.publisher example_Book_publisher  "
+                + "WHERE example_Book_publisher.name IN (:publisher_name_XXX) AND example_Author__fetch=:example_Author__fetch  order by example_Book.title asc";
+
         String actual = query.getQueryText();
         actual = actual.replaceFirst(":publisher_name_\\w+", ":publisher_name_XXX");
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -35,8 +35,10 @@ public class SubCollectionFetchQueryBuilderTest {
     private static final String PUBLISHER = "publisher";
     private static final String PUB1 = "Pub1";
 
-    private final Class<? extends Book> bookProxyClass = new Book() {
-    }.getClass();
+    public static class BookProxy extends Book {
+    }
+
+    private final Class<? extends Book> bookProxyClass = BookProxy.class;
 
     @BeforeClass
     public void initialize() {
@@ -57,7 +59,7 @@ public class SubCollectionFetchQueryBuilderTest {
 
         RelationshipImpl relationship = new RelationshipImpl(
                 Author.class,
-                bookProxyClass,
+                Book.class,
                 BOOKS,
                 author,
                 Arrays.asList(book));
@@ -70,7 +72,7 @@ public class SubCollectionFetchQueryBuilderTest {
         Assert.assertNull(query);
     }
 
-    @Test
+    //@Test
     public void testSubCollectionFetchWithSorting() {
         Author author = new Author();
         author.setId(1L);
@@ -80,7 +82,7 @@ public class SubCollectionFetchQueryBuilderTest {
 
         RelationshipImpl relationship = new RelationshipImpl(
                 Author.class,
-                bookProxyClass,
+                Book.class,
                 BOOKS,
                 author,
                 Arrays.asList(book));
@@ -101,7 +103,7 @@ public class SubCollectionFetchQueryBuilderTest {
         Assert.assertEquals(actual, expected);
     }
 
-    @Test
+    //@Test
     public void testSubCollectionFetchWithJoinFilter() {
         Author author = new Author();
         author.setId(1L);
@@ -111,14 +113,13 @@ public class SubCollectionFetchQueryBuilderTest {
 
         RelationshipImpl relationship = new RelationshipImpl(
                 Author.class,
-                bookProxyClass,
+                Book.class,
                 BOOKS,
                 author,
                 Arrays.asList(book)
         );
 
         List<Path.PathElement>  publisherNamePath = Arrays.asList(
-                new Path.PathElement(Author.class, Book.class, BOOKS),
                 new Path.PathElement(Book.class, Publisher.class, PUBLISHER),
                 new Path.PathElement(Publisher.class, String.class, NAME)
         );
@@ -141,7 +142,7 @@ public class SubCollectionFetchQueryBuilderTest {
         Assert.assertEquals(actual, expected);
     }
 
-    @Test
+    //@Test
     public void testSubCollectionFetchWithSortingAndFilters() {
         Author author = new Author();
         author.setId(1L);
@@ -151,7 +152,7 @@ public class SubCollectionFetchQueryBuilderTest {
 
         RelationshipImpl relationship = new RelationshipImpl(
                 Author.class,
-                bookProxyClass,
+                Book.class,
                 BOOKS,
                 author,
                 Arrays.asList(book)

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/TestSessionWrapper.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/TestSessionWrapper.java
@@ -8,16 +8,9 @@ package com.yahoo.elide.datastores.hibernate.hql;
 import com.yahoo.elide.core.hibernate.Query;
 import com.yahoo.elide.core.hibernate.Session;
 
-import java.util.Collection;
-
 public class TestSessionWrapper implements Session {
     @Override
     public Query createQuery(String queryText) {
-        return new TestQueryWrapper(queryText);
-    }
-
-    @Override
-    public Query createFilter(Collection collection, String queryText) {
         return new TestQueryWrapper(queryText);
     }
 }

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/porting/SessionWrapper.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/porting/SessionWrapper.java
@@ -9,8 +9,6 @@ import com.yahoo.elide.core.hibernate.Query;
 import com.yahoo.elide.core.hibernate.Session;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collection;
-
 /**
  * Wraps a Hibernate 3 Session allowing most data store logic
  * to not directly depend on a specific version of Hibernate.
@@ -28,12 +26,6 @@ public class SessionWrapper implements Session {
     public Query createQuery(String queryText) {
         logQuery(queryText);
         return new QueryWrapper(session.createQuery(queryText));
-    }
-
-    @Override
-    public Query createFilter(Collection collection, String queryText) {
-        logQuery(queryText);
-        return new QueryWrapper(session.createFilter(collection, queryText));
     }
 
     private static void logQuery(String queryText) {

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/porting/SessionWrapper.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/porting/SessionWrapper.java
@@ -10,8 +10,6 @@ import com.yahoo.elide.core.hibernate.Session;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collection;
-
 /**
  * Wraps a Hibernate 5 Session allowing most data store logic
  * to not directly depend on a specific version of Hibernate.
@@ -30,12 +28,6 @@ public class SessionWrapper implements Session {
     public Query createQuery(String queryText) {
         logQuery(queryText);
         return new QueryWrapper(session.createQuery(queryText));
-    }
-
-    @Override
-    public Query createFilter(Collection collection, String queryText) {
-        logQuery(queryText);
-        return new QueryWrapper(session.createFilter(collection, queryText));
     }
 
     private static void logQuery(String queryText) {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -161,7 +161,7 @@ public class AnyPolymorphismIT extends AbstractApiResourceInitializer {
                 .given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
-                .get("/property" + "/" + id)
+                .get("/property/" + id)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.SC_OK)

--- a/elide-integration-tests/src/test/java/example/Left.java
+++ b/elide-integration-tests/src/test/java/example/Left.java
@@ -35,6 +35,10 @@ public class Left {
     private long id;
     private Set<Right> one2many;
     private Right one2one;
+    private NoDeleteEntity noDeleteOne2One;
+    private Set<Right> noInverseDelete;
+    private Right noUpdateOne2One;
+    private Set<Right> noInverseUpdate;
 
     @OneToOne(
             optional = false,
@@ -74,6 +78,7 @@ public class Left {
         return id;
     }
 
+
     @UpdatePermission(expression = "deny all")
     @OneToOne(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
@@ -81,26 +86,48 @@ public class Left {
             mappedBy = "noUpdateOne2One",
             fetch = FetchType.LAZY
     )
-    public Right noUpdateOne2One;
+    public Right getNoUpdateOne2One() {
+        return noUpdateOne2One;
+    }
+
+    public void setNoUpdateOne2One(Right noUpdateOne2One) {
+        this.noUpdateOne2One = noUpdateOne2One;
+    }
 
     @ManyToMany(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Right.class,
             mappedBy = "noUpdate"
     )
-    public Set<Right> noInverseUpdate;
+    public Set<Right> getNoInverseUpdate() {
+        return noInverseUpdate;
+    }
+
+    public void setNoInverseUpdate(Set<Right> noInverseUpdate) {
+        this.noInverseUpdate = noInverseUpdate;
+    }
 
     @OneToOne(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = NoDeleteEntity.class,
             fetch = FetchType.LAZY
     )
-    public NoDeleteEntity noDeleteOne2One;
+    public NoDeleteEntity getNoDeleteOne2One() {
+        return noDeleteOne2One;
+    }
+
+    public void setNoDeleteOne2One(NoDeleteEntity noDeleteOne2One) {
+        this.noDeleteOne2One = noDeleteOne2One;
+    }
 
     @ManyToMany(
-        cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-        targetEntity = Right.class,
-        mappedBy = "allowDeleteAtFieldLevel"
+        cascade = { CascadeType.PERSIST, CascadeType.MERGE }
     )
-    public Set<Right> noInverseDelete;
+    public Set<Right> getNoInverseDelete() {
+        return noInverseDelete;
+    }
+
+    public void setNoInverseDelete(Set<Right> noInverseDelete) {
+        this.noInverseDelete = noInverseDelete;
+    }
 }

--- a/elide-integration-tests/src/test/java/example/Right.java
+++ b/elide-integration-tests/src/test/java/example/Right.java
@@ -33,11 +33,54 @@ public class Right {
     private long id;
     private Left many2one;
     private Left one2one;
+    private Left noUpdateOne2One;
+    private Set<Left> noUpdate;
+    private Set<Left> noDelete;
+
+    @UpdatePermission(expression = "deny all")
+    @OneToOne(
+            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+            targetEntity = Left.class,
+            fetch = FetchType.LAZY
+    )
+    public Left getNoUpdateOne2One() {
+        return noUpdateOne2One;
+    }
+
+    public void setNoUpdateOne2One(Left noUpdateOne2One) {
+        this.noUpdateOne2One = noUpdateOne2One;
+    }
+
+    @UpdatePermission(expression = "deny all")
+    @ManyToMany(
+            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+            targetEntity = Left.class
+    )
+    public Set<Left> getNoUpdate() {
+        return noUpdate;
+    }
+
+    public void setNoUpdate(Set<Left> noUpdate) {
+        this.noUpdate = noUpdate;
+    }
+
+    @ManyToMany(
+            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
+            targetEntity = Left.class
+    )
+    public Set<Left> getNoDelete() {
+        return noDelete;
+    }
+
+    public void setNoDelete(Set<Left> noDelete) {
+        this.noDelete = noDelete;
+    }
 
     @OneToOne(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Left.class,
             fetch = FetchType.LAZY
+
     )
     public Left getOne2one() {
         return one2one;
@@ -69,25 +112,4 @@ public class Right {
     public long getId() {
         return id;
     }
-
-    @UpdatePermission(expression = "deny all")
-    @OneToOne(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-            targetEntity = Left.class,
-            fetch = FetchType.LAZY
-    )
-    public Left noUpdateOne2One;
-
-    @UpdatePermission(expression = "deny all")
-    @ManyToMany(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-            targetEntity = Left.class
-    )
-    public Set<Left> noUpdate;
-
-    @ManyToMany(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
-            targetEntity = Left.class
-    )
-    public Set<Left> noDelete;
 }

--- a/elide-integration-tests/src/test/java/example/SpecialRead.java
+++ b/elide-integration-tests/src/test/java/example/SpecialRead.java
@@ -30,8 +30,16 @@ public class SpecialRead {
 
     public String value;
 
+    private Child child;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    public Child child;
+    public Child getChild() {
+        return child;
+    }
+
+    public void setChild(Child child) {
+        this.child = child;
+    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
Hibernate will lazily fetch to-one relationships leading to N+1 problem during hydration.  This PR should help mitigate.