### PR TITLE
Add support for custom error objects

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Next
 **Features**
  * Add `CustomErrorException` and `ErrorObjects` to support custom error objects
+ * Allow user to configure to return error objects
 
 ## 4.2.2
 **Fixes**

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Next
+**Features**
+ * Add `CustomErrorException` and `ErrorObjects` to support custom error objects
+
 ## 4.2.2
 **Fixes**
  * Resolve hibernate proxy class for relationship

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -35,4 +35,5 @@ public class ElideSettings {
     @Getter private final int defaultPageSize;
     @Getter private final boolean useFilterExpressions;
     @Getter private final int updateStatusCode;
+    @Getter private final boolean returnErrorObjects;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -41,6 +41,7 @@ public class ElideSettingsBuilder {
     private int defaultPageSize = Pagination.DEFAULT_PAGE_LIMIT;
     private boolean useFilterExpressions;
     private int updateStatusCode;
+    private boolean returnErrorObjects;
 
     /**
      * A new builder used to generate Elide instances. Instantiates an {@link EntityDictionary} without
@@ -77,7 +78,8 @@ public class ElideSettingsBuilder {
                 defaultMaxPageSize,
                 defaultPageSize,
                 useFilterExpressions,
-                updateStatusCode);
+                updateStatusCode,
+                returnErrorObjects);
     }
 
     public ElideSettingsBuilder withAuditLogger(AuditLogger auditLogger) {
@@ -154,6 +156,11 @@ public class ElideSettingsBuilder {
 
     public ElideSettingsBuilder withUseFilterExpressions(boolean useFilterExpressions) {
         this.useFilterExpressions = useFilterExpressions;
+        return this;
+    }
+
+    public ElideSettingsBuilder withReturnErrorObjects(boolean returnErrorObjects) {
+        this.returnErrorObjects = returnErrorObjects;
         return this;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/ErrorObjects.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/ErrorObjects.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  * Error Objects, see http://jsonapi.org/format/#error-objects. <br><br>
  * Builder example: <br>
  * <pre><code>
- *   ErrorObjects errorObjects = ErrorObjects.create()
+ *   ErrorObjects errorObjects = ErrorObjects.builder()
  *       .addError()
  *           .withDetail("first error message")
  *       .addError()
@@ -32,91 +32,65 @@ public class ErrorObjects {
         this.errors = Objects.requireNonNull(errors, "errors must not be null");
     }
 
-    public static ErrorObjectsBuilder create() {
-        return new ErrorObjectsBuilder(new ErrorObjects(new ArrayList<>()));
+    public static ErrorObjectsBuilder builder() {
+        return new ErrorObjectsBuilder();
     }
 
     /**
      * ErrorObjectsBuilder.
      */
     public static class ErrorObjectsBuilder {
-
-        private final ErrorObjects container;
         private final List<Map<String, Object>> errors;
+        private Map<String, Object> currentError;
 
-        ErrorObjectsBuilder(ErrorObjects container) {
-            this.container = container;
-            this.errors = container.getErrors();
+        ErrorObjectsBuilder() {
+            this.errors = new ArrayList<>();
         }
 
-        public ErrorObjectBuilder addError() {
-            Map<String, Object> errorObject = new HashMap<>();
-            errors.add(errorObject);
-            return new ErrorObjectBuilder(this, errorObject);
+        public ErrorObjectsBuilder withId(String id) {
+            return with("id", id);
+        }
+
+        public ErrorObjectsBuilder withStatus(String status) {
+            return with("status", status);
+        }
+
+        public ErrorObjectsBuilder withCode(String code) {
+            return with("code", code);
+        }
+
+        public ErrorObjectsBuilder withTitle(String title) {
+            return with("title", title);
+        }
+
+        public ErrorObjectsBuilder withDetail(String detail) {
+            return with("detail", detail);
+        }
+
+        public ErrorObjectsBuilder with(String key, Object value) {
+            currentError.put(key, value);
+            return this;
+        }
+
+        public ErrorObjectsBuilder addError() {
+            validateCurrentError();
+            Map<String, Object> error = new HashMap<>();
+            errors.add(error);
+            currentError = error;
+            return this;
         }
 
         public ErrorObjects build() {
             if (errors.isEmpty()) {
-                throw new IllegalArgumentException("at least one error object");
+                throw new IllegalArgumentException("At least one error is required");
             }
-            return container;
+            validateCurrentError();
+            return new ErrorObjects(errors);
         }
 
-        /**
-         * ErrorObjectBuilder.
-         */
-        public static class ErrorObjectBuilder {
-
-            private ErrorObjectsBuilder rootBuilder;
-            private Map<String, Object> errorObject;
-
-            ErrorObjectBuilder(ErrorObjectsBuilder rootBuilder, Map<String, Object> errorObject) {
-                this.rootBuilder = rootBuilder;
-                this.errorObject = errorObject;
-            }
-
-            public ErrorObjectBuilder withId(String id) {
-                errorObject.put("id", id);
-                return this;
-            }
-
-            public ErrorObjectBuilder withStatus(String status) {
-                errorObject.put("status", status);
-                return this;
-            }
-
-            public ErrorObjectBuilder withCode(String code) {
-                errorObject.put("code", code);
-                return this;
-            }
-
-            public ErrorObjectBuilder withTitle(String title) {
-                errorObject.put("title", title);
-                return this;
-            }
-
-            public ErrorObjectBuilder withDetail(String detail) {
-                errorObject.put("detail", detail);
-                return this;
-            }
-
-            public ErrorObjectBuilder put(String key, Object value) {
-                errorObject.put(key, value);
-                return this;
-            }
-
-            public ErrorObjectBuilder addError() {
-                if (errorObject.isEmpty()) {
-                    throw new IllegalArgumentException("empty error object is not allow");
-                }
-                return rootBuilder.addError();
-            }
-
-            public ErrorObjects build() {
-                if (errorObject.isEmpty()) {
-                    throw new IllegalArgumentException("empty error object is not allow");
-                }
-                return rootBuilder.build();
+        private void validateCurrentError() throws IllegalArgumentException {
+            if (currentError != null && currentError.isEmpty()) {
+                throw new IllegalArgumentException("Error must contain at least one key-value pair");
             }
         }
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/ErrorObjects.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/ErrorObjects.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Error Objects, see http://jsonapi.org/format/#error-objects. <br><br>
+ * Builder example: <br>
+ * <pre><code>
+ *   ErrorObjects errorObjects = ErrorObjects.create()
+ *       .addError()
+ *           .withDetail("first error message")
+ *       .addError()
+ *           .withDetail("second error message")
+ *       .build();
+ * </code></pre>
+ */
+public class ErrorObjects {
+    @Getter private final List<Map<String, Object>> errors;
+
+    public ErrorObjects(List<Map<String, Object>> errors) {
+        this.errors = Objects.requireNonNull(errors, "errors must not be null");
+    }
+
+    public static ErrorObjectsBuilder create() {
+        return new ErrorObjectsBuilder(new ErrorObjects(new ArrayList<>()));
+    }
+
+    /**
+     * ErrorObjectsBuilder.
+     */
+    public static class ErrorObjectsBuilder {
+
+        private final ErrorObjects container;
+        private final List<Map<String, Object>> errors;
+
+        ErrorObjectsBuilder(ErrorObjects container) {
+            this.container = container;
+            this.errors = container.getErrors();
+        }
+
+        public ErrorObjectBuilder addError() {
+            Map<String, Object> errorObject = new HashMap<>();
+            errors.add(errorObject);
+            return new ErrorObjectBuilder(this, errorObject);
+        }
+
+        public ErrorObjects build() {
+            if (errors.isEmpty()) {
+                throw new IllegalArgumentException("at least one error object");
+            }
+            return container;
+        }
+
+        /**
+         * ErrorObjectBuilder.
+         */
+        public static class ErrorObjectBuilder {
+
+            private ErrorObjectsBuilder rootBuilder;
+            private Map<String, Object> errorObject;
+
+            ErrorObjectBuilder(ErrorObjectsBuilder rootBuilder, Map<String, Object> errorObject) {
+                this.rootBuilder = rootBuilder;
+                this.errorObject = errorObject;
+            }
+
+            public ErrorObjectBuilder withId(String id) {
+                errorObject.put("id", id);
+                return this;
+            }
+
+            public ErrorObjectBuilder withStatus(String status) {
+                errorObject.put("status", status);
+                return this;
+            }
+
+            public ErrorObjectBuilder withCode(String code) {
+                errorObject.put("code", code);
+                return this;
+            }
+
+            public ErrorObjectBuilder withTitle(String title) {
+                errorObject.put("title", title);
+                return this;
+            }
+
+            public ErrorObjectBuilder withDetail(String detail) {
+                errorObject.put("detail", detail);
+                return this;
+            }
+
+            public ErrorObjectBuilder put(String key, Object value) {
+                errorObject.put(key, value);
+                return this;
+            }
+
+            public ErrorObjectBuilder addError() {
+                if (errorObject.isEmpty()) {
+                    throw new IllegalArgumentException("empty error object is not allow");
+                }
+                return rootBuilder.addError();
+            }
+
+            public ErrorObjects build() {
+                if (errorObject.isEmpty()) {
+                    throw new IllegalArgumentException("empty error object is not allow");
+                }
+                return rootBuilder.build();
+            }
+        }
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/CustomErrorException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/CustomErrorException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.exceptions;
+
+
+import com.yahoo.elide.core.ErrorObjects;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Objects;
+
+/**
+ * Define your business exception extend this.
+ */
+public class CustomErrorException extends HttpStatusException {
+    private static final long serialVersionUID = 1L;
+
+    private final ErrorObjects errorObjects;
+
+    /**
+     * constructor.
+     * @param status http status
+     * @param message exception message
+     * @param errorObjects custom error objects, not {@code null}
+     */
+    public CustomErrorException(int status, String message, ErrorObjects errorObjects) {
+        this(status, message, null, errorObjects);
+    }
+
+    /**
+     * constructor.
+     * @param status http status
+     * @param message exception message
+     * @param cause the cause
+     * @param errorObjects custom error objects, not {@code null}
+     */
+    public CustomErrorException(int status, String message, Throwable cause, ErrorObjects errorObjects) {
+        super(status, message, cause, null);
+        this.errorObjects = Objects.requireNonNull(errorObjects, "errorObjects must not be null");
+    }
+
+    @Override
+    public Pair<Integer, JsonNode> getErrorResponse() {
+        return buildCustomResponse();
+    }
+
+    @Override
+    public Pair<Integer, JsonNode> getVerboseErrorResponse() {
+        return buildCustomResponse();
+    }
+
+    private Pair<Integer, JsonNode> buildCustomResponse() {
+        JsonNode responseBody = OBJECT_MAPPER.convertValue(errorObjects, JsonNode.class);
+        return Pair.of(getStatus(), responseBody);
+    }
+}
+

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/CustomErrorException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/CustomErrorException.java
@@ -5,11 +5,8 @@
  */
 package com.yahoo.elide.core.exceptions;
 
-
-import com.yahoo.elide.core.ErrorObjects;
-
 import com.fasterxml.jackson.databind.JsonNode;
-
+import com.yahoo.elide.core.ErrorObjects;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Objects;
@@ -59,4 +56,3 @@ public class CustomErrorException extends HttpStatusException {
         return Pair.of(getStatus(), responseBody);
     }
 }
-

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorObjectsTests/ErrorObjectsIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorObjectsTests/ErrorObjectsIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.errorObjectsTests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.restassured.RestAssured;
+import com.yahoo.elide.initialization.AbstractIntegrationTestInitializer;
+import com.yahoo.elide.initialization.ErrorObjectsIntegrationTestApplicationResourceConfig;
+import org.apache.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.MediaType;
+
+import java.io.IOException;
+
+public class ErrorObjectsIT extends AbstractIntegrationTestInitializer {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
+
+    public ErrorObjectsIT() {
+        super(ErrorObjectsIntegrationTestApplicationResourceConfig.class);
+    }
+
+    @Test
+    public void testJsonAPIErrorObjects() throws IOException {
+        String request = "{ \"data\": { \"type\": \"nocreate\", \"id\": \"1\" } }";
+
+        JsonNode errors = objectMapper.readTree(
+                RestAssured
+                        .given()
+                        .contentType(JSONAPI_CONTENT_TYPE)
+                        .accept(JSONAPI_CONTENT_TYPE)
+                        .body(request)
+                        .post("/nocreate")
+                        .then()
+                        .statusCode(HttpStatus.SC_FORBIDDEN)
+                        .extract().body().asString());
+
+        for (JsonNode errorNode : errors.get("errors")) {
+            Assert.assertTrue(errorNode.isObject(), "expected error should be object");
+            Assert.assertTrue(errorNode.has("detail"), "JsonAPI error should have 'detail'");
+        }
+    }
+
+    @Test
+    public void testGraphQLErrorObjects() throws IOException {
+        String request = "mutation { nocreate(op: UPSERT, data:{id:\"1\"}) { edges { node { id } } } }";
+
+        JsonNode errors = objectMapper.readTree(
+                RestAssured
+                        .given()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .body(request)
+                        .post("/graphQL")
+                        .then()
+                        .statusCode(HttpStatus.SC_FORBIDDEN)
+                        .extract().body().asString());
+
+        for (JsonNode errorNode : errors.get("errors")) {
+            Assert.assertTrue(errorNode.isObject(), "expected error should be object");
+            Assert.assertTrue(errorNode.has("message"), "GraphQL error should have 'message'");
+        }
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/ErrorObjectsIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/ErrorObjectsIntegrationTestApplicationResourceConfig.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.initialization;
+
+import com.yahoo.elide.audit.TestAuditLogger;
+import org.glassfish.jersey.server.ResourceConfig;
+
+/**
+ * Resource configuration for error objects integration tests.
+ */
+public class ErrorObjectsIntegrationTestApplicationResourceConfig extends ResourceConfig {
+    public ErrorObjectsIntegrationTestApplicationResourceConfig() {
+        register(new ErrorObjectsTestBinder(new TestAuditLogger()));
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/ErrorObjectsTestBinder.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/ErrorObjectsTestBinder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.initialization;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.audit.AuditLogger;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.DefaultFilterDialect;
+import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.resources.DefaultOpaqueUserFunction;
+import example.TestCheckMappings;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import java.util.Arrays;
+
+/**
+ * Typical-use test binder for integration test resource configs.
+ */
+public class ErrorObjectsTestBinder extends AbstractBinder {
+    private final AuditLogger auditLogger;
+
+    public ErrorObjectsTestBinder(final AuditLogger auditLogger) {
+        this.auditLogger = auditLogger;
+    }
+
+    @Override
+    protected void configure() {
+        // Elide instance
+        bindFactory(new Factory<Elide>() {
+            @Override
+            public Elide provide() {
+                EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
+                DefaultFilterDialect defaultFilterStrategy = new DefaultFilterDialect(dictionary);
+                RSQLFilterDialect rsqlFilterStrategy = new RSQLFilterDialect(dictionary);
+
+                MultipleFilterDialect multipleFilterStrategy = new MultipleFilterDialect(
+                        Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy),
+                        Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy)
+                );
+
+                return new Elide(new ElideSettingsBuilder(AbstractIntegrationTestInitializer.getDatabaseManager())
+                        .withAuditLogger(auditLogger)
+                        .withJoinFilterDialect(multipleFilterStrategy)
+                        .withSubqueryFilterDialect(multipleFilterStrategy)
+                        .withEntityDictionary(dictionary)
+                        .withReturnErrorObjects(true)
+                        .build());
+            }
+
+            @Override
+            public void dispose(Elide elide) {
+                // do nothing
+            }
+        }).to(Elide.class).named("elide");
+
+        // User function
+        bindFactory(new Factory<DefaultOpaqueUserFunction>() {
+            private final Integer user = 1;
+
+            @Override
+            public DefaultOpaqueUserFunction provide() {
+                return v -> user;
+            }
+
+            @Override
+            public void dispose(DefaultOpaqueUserFunction defaultOpaqueUserFunction) {
+                // do nothing
+            }
+        }).to(DefaultOpaqueUserFunction.class).named("elideUserExtractionFunction");
+    }
+}


### PR DESCRIPTION
- Add `CustomErrorException` extend the `HttpStatusException`
- Add `ErrorObjects` to help build error objects

For example, people build a `ErrorObjects` and provides it to the `CustomErrorException` (or its subclass) and throw it in the lifecycle trigger funtions. Then the error in the response is what they want.

Is this a valid use case ?