### PR TITLE
Add hook for servlet context handler.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 **Features**
  * Add `CustomErrorException` and `ErrorObjects` to support custom error objects
  * Allow user to configure to return error objects
+ * Update `ElideStandalone` to allow users to programmatically manipulate the `ServletContextHandler`.
 
 ## 4.2.2
 **Fixes**

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
@@ -94,6 +94,8 @@ public class ElideStandalone {
             jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
         }
 
+        elideStandaloneSettings.updateServletContextHandler(context);
+
         try {
             jettyServer.start();
             log.info("Jetty started!");

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.resources.DefaultOpaqueUserFunction;
 import com.yahoo.elide.security.checks.Check;
 import com.yahoo.elide.standalone.Util;
 import com.yahoo.elide.standalone.datastore.InjectionAwareHibernateStore;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ResourceConfig;
 
@@ -163,5 +164,14 @@ public interface ElideStandaloneSettings {
      */
     default String getHibernate5ConfigPath() {
         return "./settings/hibernate.cfg.xml";
+    }
+
+    /**
+     * A hook to directly modify the jetty servlet context handler as necessary.
+     *
+     * @param servletContextHandler ServletContextHandler in use by Elide standalone.
+     */
+    default void updateServletContextHandler(ServletContextHandler servletContextHandler) {
+        // Do nothing
     }
 }


### PR DESCRIPTION
This PR adds support to manipulate the Jetty `ServletContextHandler` directly through a new `ElideStandaloneSettings` feature.