### PR TITLE
Correctly flushing the transaction between two GraphQL root document …

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## What Is Elide?
 
-[Elide](http://elide.io/) provides opinionated APIs for web & mobile applications.  Elide is a Java library that lets you set up a [GraphQL](graphql.org) or [JSON API](http://jsonapi.org) web service with minimal effort starting from 
+[Elide](http://elide.io/) provides opinionated APIs for web & mobile applications.  Elide is a Java library that lets you set up a [GraphQL](http://graphql.org) or [JSON API](http://jsonapi.org) web service with minimal effort starting from 
 a [JPA annotated data model](https://en.wikipedia.org/wiki/Java_Persistence_API).    
 
 ### Security Comes Standard

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@
  * Allow user to configure to return error objects
  * Update `ElideStandalone` to allow users to programmatically manipulate the `ServletContextHandler`.
 
+**Fixes**
+ * Fixed bug in GraphQL when multiple root documents are present in the same payload.  The flush between the documents
+   did not correctly handle newly created/deleted objects.
+ * Fixed broken graphql link in README.md
+
 ## 4.2.2
 **Fixes**
  * Resolve hibernate proxy class for relationship

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/Environment.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/Environment.java
@@ -57,9 +57,7 @@ public class Environment {
 
         if (isRoot()) {
             // Flush (but don't commit) between root queries
-            requestScope.getDirtyResources().forEach(
-                    resource -> requestScope.getTransaction().save(resource.getObject(), requestScope)
-            );
+            requestScope.saveOrCreateObjects();
             requestScope.getTransaction().flush(requestScope);
         }
 


### PR DESCRIPTION
…fetches in the same request

I found this testing the JpaDataStore (GraphQLIT).