### PR TITLE
Add equals and hash for test models

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
    did not correctly handle newly created/deleted objects.
  * Fixed broken graphql link in README.md
  * Fixed elide standalone instructions.
+ * Fixed hashcode and equals for some test models
 
 ## 4.2.2
 **Fixes**

--- a/elide-core/src/test/java/example/NoUpdateEntity.java
+++ b/elide-core/src/test/java/example/NoUpdateEntity.java
@@ -29,6 +29,7 @@ public class NoUpdateEntity {
     public long getId() {
         return id;
     }
+
     public void setId(long id) {
         this.id = id;
     }

--- a/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/ShareableIT.groovy
+++ b/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/ShareableIT.groovy
@@ -24,7 +24,7 @@ class ShareableIT extends AbstractIntegrationTestInitializer {
     public void setUp() {
         DataStoreTransaction tx = dataStore.beginTransaction();
         Left left = new Left();
-        tx.save(left, null);
+        tx.createObject(left, null);
         tx.commit(null);
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AccessIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AccessIT.java
@@ -32,7 +32,7 @@ public class AccessIT extends AbstractIntegrationTestInitializer {
         Parent parent = new Parent();
         parent.setChildren(new HashSet<>());
         parent.setSpouses(new HashSet<>());
-        tx.save(parent, null);
+        tx.createObject(parent, null);
         tx.commit(null);
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/EmbeddedIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/EmbeddedIT.java
@@ -36,7 +36,7 @@ public class EmbeddedIT extends AbstractIntegrationTestInitializer {
         Embedded embedded = new Embedded(); // id 1
         embedded.setSegmentIds(ImmutableSet.of(3L, 4L, 5L));
 
-        tx.save(embedded, null);
+        tx.createObject(embedded, null);
 
         Left left = new Left();
         Right right = new Right();
@@ -44,8 +44,8 @@ public class EmbeddedIT extends AbstractIntegrationTestInitializer {
         left.setOne2one(right);
         right.setOne2one(left);
 
-        tx.save(left, null);
-        tx.save(right, null);
+        tx.createObject(left, null);
+        tx.createObject(right, null);
 
         tx.commit(null);
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -82,8 +82,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
         parent.setSpouses(Sets.newHashSet());
         child.setParents(Sets.newHashSet(parent));
 
-        tx.save(parent, null);
-        tx.save(child, null);
+        tx.createObject(parent, null);
+        tx.createObject(child, null);
 
         // Single tests
         Parent p1 = new Parent(); // id 2
@@ -108,9 +108,9 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
 
         p1.setChildren(childrenSet1);
 
-        tx.save(p1, null);
-        tx.save(c1, null);
-        tx.save(c2, null);
+        tx.createObject(p1, null);
+        tx.createObject(c1, null);
+        tx.createObject(c2, null);
 
         // List tests
         Parent p2 = new Parent(); // id 3
@@ -132,37 +132,37 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
         p3.setSpouses(Sets.newHashSet());
         p3.setChildren(Sets.newHashSet());
 
-        tx.save(p2, null);
-        tx.save(p3, null);
-        tx.save(c3, null);
-        tx.save(c4, null);
+        tx.createObject(p2, null);
+        tx.createObject(p3, null);
+        tx.createObject(c3, null);
+        tx.createObject(c4, null);
 
         Book bookWithPercentage = new Book();
         bookWithPercentage.setTitle("titlewith%percentage");
         Book bookWithoutPercentage = new Book();
         bookWithoutPercentage.setTitle("titlewithoutpercentage");
 
-        tx.save(bookWithPercentage, null);
-        tx.save(bookWithoutPercentage, null);
+        tx.createObject(bookWithPercentage, null);
+        tx.createObject(bookWithoutPercentage, null);
 
         FunWithPermissions fun = new FunWithPermissions();
-        tx.save(fun, null);
+        tx.createObject(fun, null);
 
         User user = new User(); //ID 1
         user.setPassword("god");
-        tx.save(user, null);
+        tx.createObject(user, null);
 
         Invoice invoice = new Invoice();
         invoice.setId(1);
         LineItem item = new LineItem();
         invoice.setItems(Sets.newHashSet(item));
         item.setInvoice(invoice);
-        tx.save(invoice, null);
-        tx.save(item, null);
+        tx.createObject(invoice, null);
+        tx.createObject(item, null);
 
         ExceptionThrowingBean etb = new ExceptionThrowingBean();
         etb.setId(1L);
-        tx.save(etb, null);
+        tx.createObject(etb, null);
 
         tx.commit(null);
     }

--- a/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/AnotherFilterExpressionCheckObj.java
@@ -16,9 +16,6 @@ import com.yahoo.elide.security.FilterExpressionCheck;
 import com.yahoo.elide.security.RequestScope;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
@@ -33,8 +30,7 @@ import java.util.List;
 @Table(name = "anotherFilterExpressionCheckObj")
 @ReadPermission(expression = "checkActsLikeFilter")
 @Include(rootLevel = true)
-public class AnotherFilterExpressionCheckObj {
-    private long id;
+public class AnotherFilterExpressionCheckObj extends BaseId {
     private String anotherName;
     private long createDate = 0;
 
@@ -63,16 +59,6 @@ public class AnotherFilterExpressionCheckObj {
 
     public void setCreateDate(long createDate) {
         this.createDate = createDate;
-    }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
     }
 
     public static FilterPredicate createFilterPredicate() {

--- a/elide-integration-tests/src/test/java/example/AssignedIdLong.java
+++ b/elide-integration-tests/src/test/java/example/AssignedIdLong.java
@@ -37,4 +37,20 @@ public class AssignedIdLong {
     public void setValue(int value) {
         this.value = value;
     }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof AssignedIdLong)) {
+            return false;
+        }
+
+        AssignedIdLong other = (AssignedIdLong) obj;
+
+        return id == other.id;
+    }
 }

--- a/elide-integration-tests/src/test/java/example/AssignedIdString.java
+++ b/elide-integration-tests/src/test/java/example/AssignedIdString.java
@@ -37,4 +37,31 @@ public class AssignedIdString {
     public void setValue(int value) {
         this.value = value;
     }
+
+    @Override
+    public int hashCode() {
+        if (id == null) {
+            return super.hashCode();
+        }
+        return id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (id == null) {
+            return super.equals(obj);
+        }
+
+        if (obj == null || !(obj instanceof AssignedIdString)) {
+            return false;
+        }
+
+        AssignedIdString other = (AssignedIdString) obj;
+
+        if (other.id == null) {
+            return (id == other.id);
+        }
+
+        return id.equals(other.id);
+    }
 }

--- a/elide-integration-tests/src/test/java/example/AssignedIdString.java
+++ b/elide-integration-tests/src/test/java/example/AssignedIdString.java
@@ -59,7 +59,7 @@ public class AssignedIdString {
         AssignedIdString other = (AssignedIdString) obj;
 
         if (other.id == null) {
-            return (id == other.id);
+            return false;
         }
 
         return id.equals(other.id);

--- a/elide-integration-tests/src/test/java/example/AuditEntity.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntity.java
@@ -14,9 +14,6 @@ import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import java.util.List;
@@ -31,21 +28,10 @@ import java.util.List;
 @DeletePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
 @SharePermission
-public class AuditEntity {
-    private Long id;
+public class AuditEntity extends BaseId {
     private AuditEntity otherEntity;
     private String value;
     private List<AuditEntityInverse> inverses;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     @OneToOne
     @Audit(action = Audit.Action.UPDATE,

--- a/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
@@ -14,9 +14,6 @@ import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import java.util.List;
 
@@ -27,19 +24,8 @@ import java.util.List;
 @UpdatePermission(expression = "allow all")
 @DeletePermission(expression = "allow all")
 @SharePermission
-public class AuditEntityInverse {
-    private Long id;
+public class AuditEntityInverse extends BaseId {
     private List<AuditEntity> entities;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     @ManyToMany
     @Audit(action = Audit.Action.UPDATE,

--- a/elide-integration-tests/src/test/java/example/Author.java
+++ b/elide-integration-tests/src/test/java/example/Author.java
@@ -11,9 +11,6 @@ import com.yahoo.elide.annotation.Paginate;
 import com.yahoo.elide.annotation.SharePermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
@@ -31,19 +28,9 @@ import java.util.Collection;
         operation = 10,
         logStatement = "{0}",
         logExpressions = {"${author.name}"})
-public class Author {
-    private long id;
+public class Author extends BaseId {
     private String name;
     private Collection<Book> books = new ArrayList<>();
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;

--- a/elide-integration-tests/src/test/java/example/BaseId.java
+++ b/elide-integration-tests/src/test/java/example/BaseId.java
@@ -5,22 +5,49 @@
  */
 package example;
 
+import com.yahoo.elide.annotation.Exclude;
+
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
+import java.util.UUID;
 
 @MappedSuperclass
 public abstract class BaseId {
-    private long id;
+    protected long id;
+    protected String naturalKey = UUID.randomUUID().toString();
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     public long getId() {
         return id;
     }
 
     public void setId(long id) {
         this.id = id;
+    }
+
+    @Exclude
+    public String getNaturalKey() {
+        return naturalKey;
+    }
+
+    public void setNaturalKey(String naturalKey) {
+        this.naturalKey = naturalKey;
+    }
+
+    @Override
+    public int hashCode() {
+        return naturalKey.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof BaseId)) {
+            return false;
+        }
+
+        return ((BaseId) obj).naturalKey.equals(naturalKey);
     }
 }

--- a/elide-integration-tests/src/test/java/example/Book.java
+++ b/elide-integration-tests/src/test/java/example/Book.java
@@ -13,9 +13,6 @@ import org.hibernate.annotations.Formula;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -37,8 +34,7 @@ import java.util.Collection;
         operation = 10,
         logStatement = "{0}",
         logExpressions = {"${book.title}"})
-public class Book {
-    private long id;
+public class Book extends BaseId {
     private String title;
     private String genre;
     private String language;
@@ -47,15 +43,6 @@ public class Book {
     private Collection<Chapter> chapters = new ArrayList<>();
     private String editorName;
     private Publisher publisher;
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;

--- a/elide-integration-tests/src/test/java/example/Chapter.java
+++ b/elide-integration-tests/src/test/java/example/Chapter.java
@@ -12,24 +12,10 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true, type = "chapter")
 @SharePermission
-public class Chapter {
-    private Long id;
+public class Chapter extends BaseId {
     @Getter @Setter private String title;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 }

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -5,7 +5,6 @@
  */
 package example;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.CreatePermission;
@@ -23,13 +22,9 @@ import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.CommitCheck;
 import com.yahoo.elide.security.checks.OperationCheck;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
@@ -54,30 +49,15 @@ import java.util.Set;
        operation = 0,
        logStatement = "CREATE Child {0} Parent {1}",
        logExpressions = {"${child.id}", "${parent.id}"})
-public class Child {
-    @JsonIgnore
-
-    private long id;
+public class Child extends BaseId {
     private Set<Parent> parents;
-
 
     private String name;
 
     private Set<Child> friends;
     private Child noReadAccess;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
     @ManyToMany(
-            cascade = {CascadeType.PERSIST, CascadeType.MERGE},
             mappedBy = "children",
             targetEntity = Parent.class
         )

--- a/elide-integration-tests/src/test/java/example/Container.java
+++ b/elide-integration-tests/src/test/java/example/Container.java
@@ -8,9 +8,6 @@ package example;
 import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.Collection;
@@ -21,20 +18,9 @@ import java.util.Collection;
 @Entity
 @Table(name = "container")
 @Include(rootLevel = true, type = "container")
-public class Container {
-    private long id;
+public class Container extends BaseId {
     private Collection<Unshareable> unshareables;
     private Collection<Shareable> shareables;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     @OneToMany(mappedBy = "container")
     public Collection<Unshareable> getUnshareables() {

--- a/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
@@ -11,9 +11,6 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 /**
  * A model intended to be ONLY created and read, but never updated.
@@ -23,20 +20,9 @@ import javax.persistence.Id;
 @CreatePermission(expression = "allow all")
 @ReadPermission(expression = "allow all")
 @UpdatePermission(expression = "deny all")
-public class CreateButNoUpdate {
-    public Long id;
+public class CreateButNoUpdate extends BaseId {
     public String textValue;
 
     @CreatePermission(expression = "deny all")
     public String cannotModify = "unmodified";
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 }

--- a/elide-integration-tests/src/test/java/example/Embedded.java
+++ b/elide-integration-tests/src/test/java/example/Embedded.java
@@ -5,37 +5,20 @@
  */
 package example;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yahoo.elide.annotation.Include;
 
 import java.util.Set;
 
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-
 
 /**
  * Embedded test bean.
  */
 @Include(rootLevel = true)
 @Entity
-public class Embedded {
-    @JsonIgnore
-    private long id;
+public class Embedded extends BaseId {
     private Set<Long> segmentIds;
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
 
     @ElementCollection
     public Set<Long> getSegmentIds() {

--- a/elide-integration-tests/src/test/java/example/EntityWithPaginateCountableFalse.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithPaginateCountableFalse.java
@@ -11,23 +11,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true)
 @Paginate(countable = false)
-public class EntityWithPaginateCountableFalse {
-    @Setter
-    private Long id;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId () {
-        return id;
-    }
-
+public class EntityWithPaginateCountableFalse extends BaseId {
     @Getter
     @Setter
     private String name;

--- a/elide-integration-tests/src/test/java/example/EntityWithPaginateDefaultLimit.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithPaginateDefaultLimit.java
@@ -11,23 +11,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true)
 @Paginate(defaultLimit = 5)
-public class EntityWithPaginateDefaultLimit {
-    @Setter
-    private Long id;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId () {
-        return id;
-    }
-
+public class EntityWithPaginateDefaultLimit extends BaseId {
     @Getter
     @Setter
     private String name;

--- a/elide-integration-tests/src/test/java/example/EntityWithPaginateMaxLimit.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithPaginateMaxLimit.java
@@ -11,23 +11,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @Entity
 @Include(rootLevel = true)
 @Paginate(maxLimit = 10)
-public class EntityWithPaginateMaxLimit {
-    @Setter
-    private Long id;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId () {
-        return id;
-    }
-
+public class EntityWithPaginateMaxLimit extends BaseId {
     @Getter
     @Setter
     private String name;

--- a/elide-integration-tests/src/test/java/example/EntityWithoutPaginate.java
+++ b/elide-integration-tests/src/test/java/example/EntityWithoutPaginate.java
@@ -10,25 +10,13 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 /**
  * Entity that does not have the Paginate annotation that modifies pagination behavior.
  */
 @Entity
 @Include(rootLevel = true)
-public class EntityWithoutPaginate {
-    @Setter
-    private Long id;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId () {
-        return id;
-    }
-
+public class EntityWithoutPaginate extends BaseId {
     @Getter
     @Setter
     private String name;

--- a/elide-integration-tests/src/test/java/example/ExceptionThrowingBean.java
+++ b/elide-integration-tests/src/test/java/example/ExceptionThrowingBean.java
@@ -37,4 +37,20 @@ public class ExceptionThrowingBean {
     public void setBadValue(String unused) {
         // Do nothing
     }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof LineItem)) {
+            return false;
+        }
+
+        ExceptionThrowingBean other = (ExceptionThrowingBean) obj;
+
+        return id == other.id;
+    }
 }

--- a/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
+++ b/elide-integration-tests/src/test/java/example/FilterExpressionCheckObj.java
@@ -15,9 +15,6 @@ import com.yahoo.elide.security.FilterExpressionCheck;
 import com.yahoo.elide.security.RequestScope;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
@@ -32,21 +29,10 @@ import java.util.List;
 @Include(rootLevel = true)
 @SharePermission
 @ReadPermission(expression = "checkLE OR deny all")  //ReadPermission for object id <= 2
-public class FilterExpressionCheckObj {
-    private long id;
+public class FilterExpressionCheckObj extends BaseId {
     private String name;
 
     private Collection<AnotherFilterExpressionCheckObj> listOfAnotherObjs = new ArrayList<>();
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     //This field only display for id == User.id (which is 1 in IT)
     @ReadPermission(expression = "checkRestrictUser")

--- a/elide-integration-tests/src/test/java/example/FunWithPermissions.java
+++ b/elide-integration-tests/src/test/java/example/FunWithPermissions.java
@@ -5,7 +5,6 @@
  */
 package example;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
@@ -17,9 +16,6 @@ import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
@@ -36,9 +32,7 @@ import javax.persistence.Table;
 // Hibernate
 @Entity
 @Table(name = "fun")
-public class FunWithPermissions {
-    @JsonIgnore
-    private long id;
+public class FunWithPermissions extends BaseId {
     private String field1;
     private String field2;
 
@@ -70,16 +64,6 @@ public class FunWithPermissions {
 
     public void setRelation3(Child relation3) {
         this.relation3 = relation3;
-    }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
     }
 
     @ReadPermission(expression = "deny all")

--- a/elide-integration-tests/src/test/java/example/Invoice.java
+++ b/elide-integration-tests/src/test/java/example/Invoice.java
@@ -28,12 +28,28 @@ public class Invoice {
         this.id = id;
     }
 
-    @OneToMany(cascade = { CascadeType.ALL} , mappedBy = "invoice", targetEntity = LineItem.class)
+    @OneToMany(cascade = { CascadeType.DETACH, CascadeType.REMOVE } , mappedBy = "invoice", targetEntity = LineItem.class)
     public Set<LineItem> getItems() {
         return items;
     }
 
     public void setItems(Set<LineItem> items) {
         this.items = items;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof Invoice)) {
+            return false;
+        }
+
+        Invoice other = (Invoice) obj;
+
+        return id == other.id;
     }
 }

--- a/elide-integration-tests/src/test/java/example/Left.java
+++ b/elide-integration-tests/src/test/java/example/Left.java
@@ -97,7 +97,7 @@ public class Left extends BaseId {
         this.noDeleteOne2One = noDeleteOne2One;
     }
 
-    @ManyToMany()
+    @ManyToMany
     public Set<Right> getNoInverseDelete() {
         return noInverseDelete;
     }

--- a/elide-integration-tests/src/test/java/example/Left.java
+++ b/elide-integration-tests/src/test/java/example/Left.java
@@ -5,19 +5,14 @@
  */
 package example;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import java.util.Set;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
@@ -30,9 +25,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "xleft")  // left is SQL keyword
 @DeletePermission(expression = "negativeIntegerUser")
-public class Left {
-    @JsonIgnore
-    private long id;
+public class Left extends BaseId {
     private Set<Right> one2many;
     private Right one2one;
     private NoDeleteEntity noDeleteOne2One;
@@ -42,7 +35,6 @@ public class Left {
 
     @OneToOne(
             optional = false,
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Right.class,
             mappedBy = "one2one",
             fetch = FetchType.LAZY
@@ -55,16 +47,11 @@ public class Left {
         this.one2one = one2one;
     }
 
-    public void setId(long id) {
-        this.id = id;
-    }
-
     public void setOne2many(Set<Right> one2many) {
         this.one2many = one2many;
     }
 
     @OneToMany(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Right.class,
             mappedBy = "many2one"
     )
@@ -72,16 +59,8 @@ public class Left {
         return one2many;
     }
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-
     @UpdatePermission(expression = "deny all")
     @OneToOne(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Right.class,
             mappedBy = "noUpdateOne2One",
             fetch = FetchType.LAZY
@@ -95,7 +74,6 @@ public class Left {
     }
 
     @ManyToMany(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Right.class,
             mappedBy = "noUpdate"
     )
@@ -108,7 +86,6 @@ public class Left {
     }
 
     @OneToOne(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = NoDeleteEntity.class,
             fetch = FetchType.LAZY
     )
@@ -120,9 +97,7 @@ public class Left {
         this.noDeleteOne2One = noDeleteOne2One;
     }
 
-    @ManyToMany(
-        cascade = { CascadeType.PERSIST, CascadeType.MERGE }
-    )
+    @ManyToMany()
     public Set<Right> getNoInverseDelete() {
         return noInverseDelete;
     }

--- a/elide-integration-tests/src/test/java/example/LineItem.java
+++ b/elide-integration-tests/src/test/java/example/LineItem.java
@@ -35,4 +35,20 @@ public class LineItem {
     public void setInvoice(Invoice invoice) {
         this.invoice = invoice;
     }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof LineItem)) {
+            return false;
+        }
+
+        LineItem other = (LineItem) obj;
+
+        return id == other.id;
+    }
 }

--- a/elide-integration-tests/src/test/java/example/MapColorShape.java
+++ b/elide-integration-tests/src/test/java/example/MapColorShape.java
@@ -11,9 +11,6 @@ import com.yahoo.elide.annotation.SharePermission;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.Table;
 import java.util.LinkedHashMap;
@@ -26,19 +23,8 @@ import java.util.Map;
 @Table(name = "color_shape")
 @Include(rootLevel = true)
 @SharePermission
-public class MapColorShape {
-    private long id;
+public class MapColorShape extends BaseId {
     private Map<Color, Shape> colorShapeMap = new LinkedHashMap<>();
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     @ElementCollection
     @MapKeyColumn(name = "color")

--- a/elide-integration-tests/src/test/java/example/NoCommitEntity.java
+++ b/elide-integration-tests/src/test/java/example/NoCommitEntity.java
@@ -13,8 +13,6 @@ import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.CommitCheck;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 import javax.persistence.Table;
 
 import java.util.Optional;
@@ -28,22 +26,11 @@ import java.util.Optional;
 // Hibernate
 @Entity
 @Table(name = "nocommit")
-public class NoCommitEntity {
+public class NoCommitEntity extends BaseId {
     static public class NoCommitCheck<T> extends CommitCheck<T> {
         @Override
         public boolean ok(T record, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
             return false;
         }
-    }
-
-    private long id;
-
-    @Id @GeneratedValue
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
     }
 }

--- a/elide-integration-tests/src/test/java/example/NoCreateEntity.java
+++ b/elide-integration-tests/src/test/java/example/NoCreateEntity.java
@@ -9,8 +9,6 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 import javax.persistence.Table;
 
 /**
@@ -21,14 +19,5 @@ import javax.persistence.Table;
 // Hibernate
 @Entity
 @Table(name = "nocreate")
-public class NoCreateEntity {
-    private long id;
-
-    @Id @GeneratedValue
-    public long getId() {
-        return id;
-    }
-    public void setId(long id) {
-        this.id = id;
-    }
+public class NoCreateEntity extends BaseId {
 }

--- a/elide-integration-tests/src/test/java/example/NoDeleteEntity.java
+++ b/elide-integration-tests/src/test/java/example/NoDeleteEntity.java
@@ -9,8 +9,6 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 import javax.persistence.Table;
 
 /**
@@ -21,14 +19,5 @@ import javax.persistence.Table;
 // Hibernate
 @Entity
 @Table(name = "nodelete")
-public class NoDeleteEntity {
-    private long id;
-
-    @Id @GeneratedValue
-    public long getId() {
-        return id;
-    }
-    public void setId(long id) {
-        this.id = id;
-    }
+public class NoDeleteEntity extends BaseId {
 }

--- a/elide-integration-tests/src/test/java/example/NoReadEntity.java
+++ b/elide-integration-tests/src/test/java/example/NoReadEntity.java
@@ -10,8 +10,6 @@ import com.yahoo.elide.annotation.ReadPermission;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -23,18 +21,9 @@ import javax.persistence.Table;
 // Hibernate
 @Entity
 @Table(name = "noread")
-public class NoReadEntity {
-    private long id;
+public class NoReadEntity extends BaseId {
     public String field;
 
     @OneToOne(fetch = FetchType.LAZY)
     public Child child;
-
-    @Id @GeneratedValue
-    public long getId() {
-        return id;
-    }
-    public void setId(long id) {
-        this.id = id;
-    }
 }

--- a/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
+++ b/elide-integration-tests/src/test/java/example/NoShareBiDirectional.java
@@ -10,26 +10,13 @@ import com.yahoo.elide.annotation.SharePermission;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
 @Entity
 @Include(rootLevel = true, type = "noShareBid")
 @SharePermission(sharable = false)
-public class NoShareBiDirectional {
-    private Long id;
+public class NoShareBiDirectional extends BaseId {
     private NoShareBiDirectional other;
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     @OneToOne(fetch = FetchType.LAZY)
     public NoShareBiDirectional getOther() {

--- a/elide-integration-tests/src/test/java/example/NoUpdateEntity.java
+++ b/elide-integration-tests/src/test/java/example/NoUpdateEntity.java
@@ -9,8 +9,6 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.Set;
@@ -23,17 +21,7 @@ import java.util.Set;
 // Hibernate
 @Entity
 @Table(name = "noupdate")
-public class NoUpdateEntity {
-    private long id;
-
+public class NoUpdateEntity extends BaseId {
     @OneToMany()
     public Set<Child> children;
-
-    @Id @GeneratedValue
-    public long getId() {
-        return id;
-    }
-    public void setId(long id) {
-        this.id = id;
-    }
 }

--- a/elide-integration-tests/src/test/java/example/NotIncludedResource.java
+++ b/elide-integration-tests/src/test/java/example/NotIncludedResource.java
@@ -10,27 +10,13 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @ReadPermission(expression = "allow all")
 @CreatePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
 @Entity
-public class NotIncludedResource {
-    private Long id;
+public class NotIncludedResource extends BaseId {
     private String someParams;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getSomeParams() {
         return someParams;

--- a/elide-integration-tests/src/test/java/example/OneToOneNonRoot.java
+++ b/elide-integration-tests/src/test/java/example/OneToOneNonRoot.java
@@ -12,9 +12,6 @@ import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 
@@ -23,22 +20,10 @@ import javax.persistence.PrimaryKeyJoinColumn;
 @CreatePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
 @Entity
-public class OneToOneNonRoot {
-    private Long id;
-
+public class OneToOneNonRoot extends BaseId {
     private String test;
 
     private OneToOneRoot root;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTest() {
         return test;

--- a/elide-integration-tests/src/test/java/example/OneToOneRoot.java
+++ b/elide-integration-tests/src/test/java/example/OneToOneRoot.java
@@ -12,9 +12,6 @@ import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
 @Include(rootLevel = true)
@@ -22,22 +19,10 @@ import javax.persistence.OneToOne;
 @CreatePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
 @Entity
-public class OneToOneRoot {
-    private Long id;
-
+public class OneToOneRoot extends BaseId {
     private String name;
 
     private OneToOneNonRoot otherObject;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;

--- a/elide-integration-tests/src/test/java/example/Parent.java
+++ b/elide-integration-tests/src/test/java/example/Parent.java
@@ -18,7 +18,6 @@ import com.yahoo.elide.security.checks.CommitCheck;
 import com.yahoo.elide.security.checks.OperationCheck;
 import lombok.ToString;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -56,8 +55,7 @@ public class Parent extends BaseId {
     @UpdatePermission(expression = "allow all OR deny all")
     // Hibernate
     @ManyToMany(
-            targetEntity = Child.class,
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE }
+            targetEntity = Child.class
     )
     @JoinTable(
             name = "Parent_Child",

--- a/elide-integration-tests/src/test/java/example/Publisher.java
+++ b/elide-integration-tests/src/test/java/example/Publisher.java
@@ -8,26 +8,14 @@ package example;
 import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
 
 /**
  * Publisher for book/author example.
  */
 @Entity
 @Include
-public class Publisher {
-    private long id;
+public class Publisher extends BaseId {
     private String name;
-
-    @Id @GeneratedValue
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;

--- a/elide-integration-tests/src/test/java/example/ResourceWithInvalidRelationship.java
+++ b/elide-integration-tests/src/test/java/example/ResourceWithInvalidRelationship.java
@@ -11,9 +11,6 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
 @Include(rootLevel = true)
@@ -21,22 +18,10 @@ import javax.persistence.OneToOne;
 @CreatePermission(expression = "allow all")
 @UpdatePermission(expression = "allow all")
 @Entity
-public class ResourceWithInvalidRelationship {
-    private Long id;
-
+public class ResourceWithInvalidRelationship extends BaseId {
     private String name;
 
     private NotIncludedResource notIncludedResource;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;

--- a/elide-integration-tests/src/test/java/example/Right.java
+++ b/elide-integration-tests/src/test/java/example/Right.java
@@ -5,7 +5,6 @@
  */
 package example;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 
@@ -14,9 +13,6 @@ import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
@@ -28,9 +24,7 @@ import javax.persistence.Table;
 @Include(rootLevel = true, type = "right") // optional here because class has this name
 @Entity
 @Table(name = "xright")     // right is SQL keyword
-public class Right {
-    @JsonIgnore
-    private long id;
+public class Right extends BaseId {
     private Left many2one;
     private Left one2one;
     private Left noUpdateOne2One;
@@ -39,7 +33,6 @@ public class Right {
 
     @UpdatePermission(expression = "deny all")
     @OneToOne(
-            cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Left.class,
             fetch = FetchType.LAZY
     )
@@ -101,15 +94,5 @@ public class Right {
     )
     public Left getMany2one() {
         return many2one;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
     }
 }

--- a/elide-integration-tests/src/test/java/example/Shareable.java
+++ b/elide-integration-tests/src/test/java/example/Shareable.java
@@ -10,9 +10,6 @@ import com.yahoo.elide.annotation.SharePermission;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -23,19 +20,8 @@ import javax.persistence.Table;
 @SharePermission
 @Table(name = "shareable")
 @Include(rootLevel = true, type = "shareable")
-public class Shareable {
-    private long id;
+public class Shareable extends BaseId {
     private Container container;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     @ManyToOne(fetch = FetchType.LAZY)
     public Container getContainer() {

--- a/elide-integration-tests/src/test/java/example/SpecialRead.java
+++ b/elide-integration-tests/src/test/java/example/SpecialRead.java
@@ -15,9 +15,6 @@ import com.yahoo.elide.security.checks.OperationCheck;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import java.util.Optional;
 
@@ -25,9 +22,7 @@ import java.util.Optional;
 @Include(rootLevel = true, type = "specialread")
 @ReadPermission(expression = "specialValue")
 @UpdatePermission(expression = "updateOnCreate")
-public class SpecialRead {
-    public Long id;
-
+public class SpecialRead extends BaseId {
     public String value;
 
     private Child child;
@@ -39,16 +34,6 @@ public class SpecialRead {
 
     public void setChild(Child child) {
         this.child = child;
-    }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public static class SpecialValue extends OperationCheck<SpecialRead> {

--- a/elide-integration-tests/src/test/java/example/Unshareable.java
+++ b/elide-integration-tests/src/test/java/example/Unshareable.java
@@ -9,9 +9,6 @@ import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -21,19 +18,8 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "unshareable")
 @Include(rootLevel = true, type = "unshareable")
-public class Unshareable {
-    private long id;
+public class Unshareable extends BaseId {
     private Container container;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
 
     @ManyToOne(fetch = FetchType.LAZY)
     public Container getContainer() {

--- a/elide-integration-tests/src/test/java/example/User.java
+++ b/elide-integration-tests/src/test/java/example/User.java
@@ -5,7 +5,6 @@
  */
 package example;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
@@ -14,9 +13,6 @@ import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.OperationCheck;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.Transient;
 
 import java.util.Optional;
@@ -27,10 +23,7 @@ import java.util.Optional;
  */
 @Entity
 @Include(rootLevel = true)
-public class User {
-    @JsonIgnore
-    private long id;
-
+public class User extends BaseId {
     private int role;
 
     private String reversedPassword;
@@ -68,16 +61,6 @@ public class User {
      */
     public void setReversedPassword(String reversedPassword) {
         this.reversedPassword = reversedPassword;
-    }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
     }
 
     @UpdatePermission(expression = "adminRoleCheck OR updateOnCreate")

--- a/elide-integration-tests/src/test/java/example/YetAnotherPermission.java
+++ b/elide-integration-tests/src/test/java/example/YetAnotherPermission.java
@@ -10,28 +10,14 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 
 @CreatePermission(expression = "allow all")
 @ReadPermission(expression = "deny all")
 @Include(rootLevel = true)
 @Entity
-public class YetAnotherPermission {
-    private Long id;
+public class YetAnotherPermission extends BaseId {
     private String hiddenName;
     private String youShouldBeAbleToRead;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getHiddenName() {
         return hiddenName;


### PR DESCRIPTION
Subset of integration test models did not correctly implement hashcode and equals. 

Also switched out initialization code to use tx.createObject instead of tx.save (consistent with how Elide initializes).