### PR TITLE
Add support for multiple classloaders for CoerceUtil.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.2.7
+**Fixes**
+ * Add support for multiple classloaders when using CoerceUtils.
+
 ## 4.2.6
 **Fixes**
  * Fix NPE serializing Dates


### PR DESCRIPTION
Addresses issues with: https://github.com/yahoo/elide/issues/689

In summary, `BeanUtilsBean#getInstance` [returns a pseudo-singleton](https://commons.apache.org/proper/commons-beanutils/apidocs/org/apache/commons/beanutils/BeanUtilsBean.html#getInstance--). Namely, it's based on the `Thread.currentThread().getContextClassLoader()`.

This PR sets up CoerceUtil for each new classloader as necessary.