### PR TITLE
Issue691

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 ## 4.2.7
 **Fixes**
  * Add support for multiple classloaders when using CoerceUtils.
+ * Issue#691
+ * Issue#644
+
+**Features**
+ * Both JPA Field (new) and Property (4.2.6 and earlier) Access are now supported.
 
 ## 4.2.6
 **Fixes**

--- a/elide-contrib/elide-swagger/pom.xml
+++ b/elide-contrib/elide-swagger/pom.xml
@@ -70,8 +70,8 @@
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
-            <artifactId>persistence-api</artifactId>
-            <version>1.0.2</version>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -68,8 +68,8 @@
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
-            <artifactId>persistence-api</artifactId>
-            <version>1.0.2</version>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -116,8 +116,6 @@ public class EntityBinding {
         jsonApiType = type;
         entityName = name;
 
-        accessType = AccessType.PROPERTY;
-
         // Map id's, attributes, and relationships
         List<AccessibleObject> fieldOrMethodList = new ArrayList<>();
         fieldOrMethodList.addAll(Arrays.asList(cls.getDeclaredFields())
@@ -130,6 +128,7 @@ public class EntityBinding {
             accessType = AccessType.FIELD;
 
 
+            /* Add all public methods that are computed */
             fieldOrMethodList.addAll(Arrays.asList(cls.getMethods())
                     .stream()
                     .filter((method) -> !Modifier.isStatic(method.getModifiers()))
@@ -137,8 +136,18 @@ public class EntityBinding {
                             || method.isAnnotationPresent(ComputedRelationship.class))
                     .collect(Collectors.toList()));
         } else {
+            /* Preserve the behavior of Elide 4.2.6 and earlier */
+            accessType = AccessType.PROPERTY;
+
             fieldOrMethodList.clear();
 
+            /* Add all public fields */
+            fieldOrMethodList.addAll(Arrays.asList(cls.getFields())
+                .stream()
+                .filter((field) -> ! Modifier.isStatic(field.getModifiers()))
+                .collect(Collectors.toList()));
+
+            /* Add all public methods */
             fieldOrMethodList.addAll(Arrays.asList(cls.getMethods())
                     .stream()
                     .filter((method) -> !Modifier.isStatic(method.getModifiers()))

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -119,25 +119,22 @@ public class EntityBinding {
         entityName = name;
 
         // Map id's, attributes, and relationships
-        List<AccessibleObject> fieldOrMethodList = new ArrayList<>();
-
-        fieldOrMethodList.addAll(
-                getInstanceMembers(cls.getDeclaredFields(), (field) -> ! ((Field) field).isSynthetic()));
+        List<AccessibleObject> fieldOrMethodList = new ArrayList<>(
+                getInstanceMembers(cls.getDeclaredFields(), (field) -> !((Field) field).isSynthetic())
+        );
 
         if (fieldOrMethodList.stream().anyMatch(field -> field.isAnnotationPresent(Id.class))) {
             accessType = AccessType.FIELD;
 
-
             /* Add all public methods that are computed */
-            fieldOrMethodList.addAll(getInstanceMembers(cls.getMethods())
-                    .stream()
-                    .filter((method) -> method.isAnnotationPresent(ComputedAttribute.class)
-                            || method.isAnnotationPresent(ComputedRelationship.class))
-                    .collect(Collectors.toList()));
+            fieldOrMethodList.addAll(
+                    getInstanceMembers(cls.getMethods(),
+                            (method) -> method.isAnnotationPresent(ComputedAttribute.class)
+                                    || method.isAnnotationPresent(ComputedRelationship.class))
+            );
 
             //Elide needs to manipulate private fields that are exposed.
             fieldOrMethodList.forEach(field -> field.setAccessible(true));
-
         } else {
             /* Preserve the behavior of Elide 4.2.6 and earlier */
             accessType = AccessType.PROPERTY;

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -135,6 +135,10 @@ public class EntityBinding {
                     .filter((method) -> method.isAnnotationPresent(ComputedAttribute.class)
                             || method.isAnnotationPresent(ComputedRelationship.class))
                     .collect(Collectors.toList()));
+
+            //Elide needs to manipulate private fields that are exposed.
+            fieldOrMethodList.forEach(field -> field.setAccessible(true));
+
         } else {
             /* Preserve the behavior of Elide 4.2.6 and earlier */
             accessType = AccessType.PROPERTY;
@@ -153,9 +157,6 @@ public class EntityBinding {
                     .filter((method) -> !Modifier.isStatic(method.getModifiers()))
                     .collect(Collectors.toList()));
         }
-
-        //Elide needs to manipulate private fields that are exposed.
-        fieldOrMethodList.forEach(field -> field.setAccessible(true));
 
         bindEntityFields(cls, type, fieldOrMethodList);
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -145,6 +145,9 @@ public class EntityBinding {
                     .collect(Collectors.toList()));
         }
 
+        //Elide needs to manipulate private fields that are exposed.
+        fieldOrMethodList.forEach(field -> field.setAccessible(true));
+
         bindEntityFields(cls, type, fieldOrMethodList);
 
         attributes = dequeToList(attributesDeque);

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.persistence.AccessType;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -363,6 +364,15 @@ public class EntityDictionary {
      */
     public String getIdFieldName(Class<?> entityClass) {
         return getEntityBinding(entityClass).getIdFieldName();
+    }
+
+    /**
+     * Returns whether the entire entity uses Field or Property level access.
+     * @param entityClass Entity Class
+     * @return The JPA Access Type
+     */
+    public AccessType getAccessType(Class<?> entityClass) {
+        return getEntityBinding(entityClass).getAccessType();
     }
 
     /**

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -86,7 +86,8 @@ public class EntityDictionaryTest extends EntityDictionary {
         @Entity
         @Include
         class Foo {
-            public int bar;
+            @Id
+            private int bar;
         }
 
         Initializer<Foo> initializer = mock(Initializer.class);

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.core;
 
+import static org.mockito.Mockito.mock;
+
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
@@ -26,11 +28,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import javax.persistence.AccessType;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Transient;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
@@ -39,7 +36,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.mockito.Mockito.mock;
+import javax.persistence.AccessType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Transient;
 
 public class EntityDictionaryTest extends EntityDictionary {
 
@@ -289,7 +290,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         Assert.assertEquals(getIdType(StringId.class), String.class,
                 "getIdType returns the type of the ID field of the given class");
 
-        Assert.assertEquals(getIdType(NoId.class), null,
+        Assert.assertNull(getIdType(NoId.class),
                 "getIdType returns null if ID field is missing");
 
         Assert.assertEquals(getIdType(Friend.class), long.class,
@@ -308,8 +309,15 @@ public class EntityDictionaryTest extends EntityDictionary {
         Assert.assertEquals(getType(FieldAnnotations.class, "privateField"), Boolean.class,
             "getType returns the type of attribute when Column annotation is on a getter");
 
-        Assert.assertEquals(getType(FieldAnnotations.class, "missingField"), null,
-            "getId returns null if attribute is missing");
+        Assert.assertNull(getType(FieldAnnotations.class, "missingField"),
+                "getId returns null if attribute is missing"
+        );
+
+        Assert.assertEquals(getType(FieldAnnotations.class, "parent"), FieldAnnotations.class,
+                "getType return the type of a private field relationship");
+
+        Assert.assertEquals(getType(FieldAnnotations.class, "children"), Set.class,
+                "getType return the type of a private field relationship");
 
         Assert.assertEquals(getType(Parent.class, "children"), Set.class,
             "getType returns the type of relationship fields");

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -87,6 +87,8 @@ public class EntityDictionaryTest extends EntityDictionary {
         @Include
         class Foo {
             @Id
+            private long id;
+
             private int bar;
         }
 
@@ -213,7 +215,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         Assert.assertEquals(getType(FieldAnnotations.class, "id"), Long.class,
             "getType returns the type of the ID field of the given class");
 
-        Assert.assertEquals(getType(FieldAnnotations.class, "publicField"), long.class,
+        Assert.assertEquals(getType(FieldAnnotations.class, "publicField"), null,
             "getType returns the type of attribute when Column annotation is on a field");
 
         Assert.assertEquals(getType(FieldAnnotations.class, "privateField"), Boolean.class,

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -215,7 +215,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         Assert.assertEquals(getType(FieldAnnotations.class, "id"), Long.class,
             "getType returns the type of the ID field of the given class");
 
-        Assert.assertEquals(getType(FieldAnnotations.class, "publicField"), null,
+        Assert.assertEquals(getType(FieldAnnotations.class, "publicField"), long.class,
             "getType returns the type of attribute when Column annotation is on a field");
 
         Assert.assertEquals(getType(FieldAnnotations.class, "privateField"), Boolean.class,

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -310,7 +310,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     public void testGetRelationships() {
         FunWithPermissions fun = new FunWithPermissions();
         fun.setRelation1(Sets.newHashSet());
-        fun.relation2 = Sets.newHashSet();
+        fun.setRelation2(Sets.newHashSet());
         fun.setRelation3(null);
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
@@ -346,10 +346,10 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     @Test
     public void testGetAttributes() {
         FunWithPermissions fun = new FunWithPermissions();
-        fun.field3 = "Foobar";
+        fun.setField3("Foobar");
         fun.setField1("blah");
         fun.setField2(null);
-        fun.field4 = "bar";
+        fun.setField4("bar");
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
@@ -420,7 +420,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     @Test
     public void testGetValue() throws Exception {
         FunWithPermissions fun = new FunWithPermissions();
-        fun.field3 = "testValue";
+        fun.setField3("testValue");
         String result;
         result = (String) getValue(fun, "field3",  getRequestScope());
         Assert.assertEquals(result, "testValue", "getValue should set the appropriate value in the resource");
@@ -471,7 +471,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         FunWithPermissions fun = new FunWithPermissions();
         this.obj = fun;
         setValue("field3", "testValue");
-        Assert.assertEquals(fun.field3, "testValue", "setValue should set the appropriate value in the resource");
+        Assert.assertEquals(fun.getField3(), "testValue", "setValue should set the appropriate value in the resource");
 
         setValue("field1", "testValue2");
         Assert.assertEquals(fun.getField1(), "testValue2", "setValue should set the appropriate value in the resource");
@@ -689,7 +689,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     public void testGetAttributeSuccess() {
         FunWithPermissions fun = new FunWithPermissions();
         fun.setField2("blah");
-        fun.field3 = null;
+        fun.setField3(null);
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "1", goodUserScope);
 
@@ -733,7 +733,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         Child child1 = newChild(1);
         Child child2 = newChild(2);
         Child child3 = newChild(3);
-        fun.relation2 = Sets.newHashSet(child1, child2, child3);
+        fun.setRelation2(Sets.newHashSet(child1, child2, child3));
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
@@ -748,7 +748,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         Child child1 = newChild(1);
         Child child2 = newChild(-2);
         Child child3 = newChild(3);
-        fun.relation2 = Sets.newHashSet(child1, child2, child3);
+        fun.setRelation2(Sets.newHashSet(child1, child2, child3));
 
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodUserScope);
 
@@ -871,7 +871,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         Child child1 = newChild(1);
         Child child2 = newChild(2);
         Child child3 = newChild(3);
-        fun.relation2 = Sets.newHashSet(child1, child2, child3);
+        fun.setRelation2(Sets.newHashSet(child1, child2, child3));
 
         User goodUser = new User(1);
 
@@ -893,7 +893,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         Child child1 = newChild(1);
         Child child2 = newChild(2);
         Child child3 = newChild(3);
-        fun.relation2 = Sets.newHashSet(child1, child2, child3);
+        fun.setRelation2(Sets.newHashSet(child1, child2, child3));
 
         User goodUser = new User(1);
 
@@ -1052,7 +1052,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         NoUpdateEntity noUpdate = new NoUpdateEntity();
         noUpdate.setId(1);
         Child child = newChild(2);
-        noUpdate.children = Sets.newHashSet();
+        noUpdate.setChildren(Sets.newHashSet());
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);
         User goodUser = new User(1);

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/CanPaginateVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/CanPaginateVisitorTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import javax.persistence.Entity;
+import javax.persistence.Id;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -82,7 +83,9 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
-            public String title;
+            @Id
+            private long id;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -99,7 +102,9 @@ public class CanPaginateVisitorTest {
         @Include
         @ReadPermission(expression = "In Memory Check")
         class Book {
-            public String title;
+            @Id
+            private long id;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -115,7 +120,9 @@ public class CanPaginateVisitorTest {
         @Include
         @ReadPermission(expression = "False User Check")
         class Book {
-            public String title;
+            @Id
+            private long id;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -130,8 +137,11 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression = "Filter Expression Check")
-            public String title;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -146,9 +156,12 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression =
                     "(Filter Expression Check AND False User Check) OR (Filter Expression Check OR NOT False User Check)")
-            public String title;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -163,8 +176,11 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression = "False User Check OR In Memory Check")
-            public String title;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -179,8 +195,11 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression = "True User Check OR In Memory Check")
-            public String title;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -195,8 +214,11 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression = "False User Check AND In Memory Check")
-            public String title;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -211,8 +233,11 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression = "True User Check AND In Memory Check")
-            public String title;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -227,8 +252,11 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression = "NOT In Memory Check")
-            public String title;
+            private String title;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -243,11 +271,14 @@ public class CanPaginateVisitorTest {
         @Entity
         @Include
         class Book {
+            @Id
+            private long id;
+
             @ReadPermission(expression = "Filter Expression Check")
-            public String title;
+            private String title;
 
             @ReadPermission(expression = "In Memory Check")
-            public Date publicationDate;
+            private Date publicationDate;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -263,11 +294,14 @@ public class CanPaginateVisitorTest {
         @Include
         @ReadPermission(expression = "In Memory Check")
         class Book {
-            @ReadPermission(expression = "Filter Expression Check")
-            public String title;
+            @Id
+            private long id;
 
             @ReadPermission(expression = "Filter Expression Check")
-            public Date publicationDate;
+            private String title;
+
+            @ReadPermission(expression = "Filter Expression Check")
+            private Date publicationDate;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);
@@ -283,13 +317,16 @@ public class CanPaginateVisitorTest {
         @Include
         @ReadPermission(expression = "In Memory Check")
         class Book {
-            @ReadPermission(expression = "Filter Expression Check")
-            public String title;
+            @Id
+            private long id;
 
             @ReadPermission(expression = "Filter Expression Check")
-            public Date publicationDate;
+            private String title;
 
-            public boolean outOfPrint;
+            @ReadPermission(expression = "Filter Expression Check")
+            private Date publicationDate;
+
+            private boolean outOfPrint;
         }
 
         EntityDictionary dictionary = new EntityDictionary(checkMappings);

--- a/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.persistence.Entity;
+import javax.persistence.Id;
 
 public class PermissionExpressionBuilderTest {
 
@@ -86,8 +87,10 @@ public class PermissionExpressionBuilderTest {
         @Include
         @UpdatePermission(expression = "user has no access")
         class Model {
+            @Id
+            private long id;
             @UpdatePermission(expression = "user has all access OR user has no access")
-            public int foo;
+            private int foo;
         }
 
         dictionary.bindEntity(Model.class);
@@ -102,8 +105,8 @@ public class PermissionExpressionBuilderTest {
                 changes);
 
         Assert.assertEquals(expression.toString(),
-                "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null} WITH CHANGES ChangeSpec { "
-                        + "resource=PersistentResource{type=model, id=null}, field=foo, original=1, modified=2} "
+                "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=0} WITH CHANGES ChangeSpec { "
+                        + "resource=PersistentResource{type=model, id=0}, field=foo, original=1, modified=2} "
                         + "FOR EXPRESSION [FIELD(((user has all access "
                         + "\u001B[34mWAS UNEVALUATED\u001B[m)) OR ((user has no access "
                         + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");
@@ -111,8 +114,8 @@ public class PermissionExpressionBuilderTest {
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
         Assert.assertEquals(expression.toString(),
-                "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null} WITH CHANGES ChangeSpec { "
-                        + "resource=PersistentResource{type=model, id=null}, field=foo, original=1, modified=2} "
+                "UPDATE PERMISSION WAS INVOKED ON PersistentResource{type=model, id=0} WITH CHANGES ChangeSpec { "
+                        + "resource=PersistentResource{type=model, id=0}, field=foo, original=1, modified=2} "
                         + "FOR EXPRESSION [FIELD(((user has all access "
                         + "\u001B[32mPASSED\u001B[m)) OR ((user has no access "
                         + "\u001B[34mWAS UNEVALUATED\u001B[m)))]");

--- a/elide-core/src/test/java/example/Author.java
+++ b/elide-core/src/test/java/example/Author.java
@@ -6,6 +6,7 @@
 package example;
 
 import com.yahoo.elide.annotation.Audit;
+import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.SharePermission;
 
@@ -14,6 +15,7 @@ import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -39,46 +41,38 @@ public class Author {
         FREELANCE
     }
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter @Setter
     private Long id;
-    private String name;
-    private Collection<Book> books = new ArrayList<>();
-    private AuthorType type;
 
+    @Exclude
+    private String naturalKey = UUID.randomUUID().toString();
+
+    @Override
+    public int hashCode() {
+        return naturalKey.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof Author)) {
+            return false;
+        }
+
+        return ((Author) obj).naturalKey.equals(naturalKey);
+    }
+
+    @Getter @Setter
+    private String name;
+
+    @ManyToMany(mappedBy = "authors")
+    @Getter @Setter
+    private Collection<Book> books = new ArrayList<>();
+
+    @Getter @Setter
+    private AuthorType type;
 
     @Getter @Setter
     private Address homeAddress;
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public AuthorType getType() {
-        return type;
-    }
-
-    public void setType(AuthorType type) {
-        this.type = type;
-    }
-
-    @ManyToMany(mappedBy = "authors")
-    public Collection<Book> getBooks() {
-        return books;
-    }
-
-    public void setBooks(Collection<Book> books) {
-        this.books = books;
-    }
 }

--- a/elide-core/src/test/java/example/FieldAnnotations.java
+++ b/elide-core/src/test/java/example/FieldAnnotations.java
@@ -7,14 +7,19 @@ package example;
 
 import com.yahoo.elide.annotation.Include;
 
+import java.util.Set;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 @Include(rootLevel = true, type = "stringId")
 @Entity
 public class FieldAnnotations {
 
+    @Id
     private Long id;
 
     @Column
@@ -22,7 +27,12 @@ public class FieldAnnotations {
 
     private Boolean privateField;
 
-    @Id
+    @OneToMany(mappedBy = "parent")
+    private Set<FieldAnnotations> children;
+
+    @ManyToOne
+    private FieldAnnotations parent;
+
     public Long getId() {
         return id;
     }

--- a/elide-core/src/test/java/example/FunWithPermissions.java
+++ b/elide-core/src/test/java/example/FunWithPermissions.java
@@ -38,24 +38,42 @@ public class FunWithPermissions {
     private long id;
     private String field1;
     private String field2;
+    private String field3;
+    private String field4;
+    private Set<Child> relation1;
+    private Set<Child> relation2;
+    private Child relation3;
 
     @ReadPermission(expression = "negativeIntegerUser")
-    public String field3;
+    public String getField3() {
+        return field3;
+    }
+
+    public void setField3(String field3) {
+        this.field3 = field3;
+    }
 
     @UpdatePermission(expression = "negativeIntegerUser")
-    public String field4;
+    public String getField4() {
+        return field4;
+    }
 
-    private Set<Child> relation1;
+    public void setField4(String field4) {
+        this.field4 = field4;
+    }
+
+    public void setRelation2(Set<Child> relation2) {
+        this.relation2 = relation2;
+    }
 
     @ReadPermission(expression = "negativeIntegerUser")
     @OneToMany(
             targetEntity = Child.class,
             cascade = { CascadeType.PERSIST, CascadeType.MERGE }
     )
-    public Set<Child> relation2;
-
-
-    private Child relation3;
+    public Set<Child> getRelation2() {
+        return relation2;
+    }
 
     @ReadPermission(expression = "negativeIntegerUser")
     @UpdatePermission(expression = "negativeIntegerUser")
@@ -154,18 +172,50 @@ public class FunWithPermissions {
     }
 
     /* Verifies a chain of checks where all can succeed */
-    @ReadPermission(expression = "allow all OR negativeIntegerUser")
-    public String field5;
 
-    /* Verifies a chain of checks where the first can fail or all succeed */
+    private String field5;
+
+    @ReadPermission(expression = "allow all OR negativeIntegerUser")
+    public String getField5() {
+        return field5;
+    }
+
+    public void setField5(String field5) {
+        this.field5 = field5;
+    }
+
+    private String field6;
+
     @ReadPermission(expression = "negativeIntegerUser AND allow all")
-    public String field6;
+    public String getField6() {
+        return field6;
+    }
+
+    public void setField6(String field6) {
+        this.field6 = field6;
+    }
+
+    private String field7;
 
     /* Verifies a chain of checks where the last can fail. */
     @ReadPermission(expression = "allow all AND deny all")
-    public String field7;
+    public String getField7() {
+        return field7;
+    }
+
+    public void setField7(String field7) {
+        this.field7 = field7;
+    }
+
+    private String field8;
 
     /* Verifies a chain of checks where all can fail or the last can succeed. */
     @ReadPermission(expression = "deny all OR negativeIntegerUser")
-    public String field8;
+    public String getField8() {
+        return field8;
+    }
+
+    public void setField8(String field8) {
+        this.field8 = field8;
+    }
 }

--- a/elide-core/src/test/java/example/NoReadEntity.java
+++ b/elide-core/src/test/java/example/NoReadEntity.java
@@ -7,6 +7,7 @@ package example;
 
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
+import lombok.Data;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -18,18 +19,13 @@ import javax.persistence.Table;
 // Hibernate
 @Entity
 @Table(name = "noread")
+@Data
 public class NoReadEntity {
+    @Id
     private long id;
-    public String field;
+
+    private String field;
 
     @OneToOne
-    public Child child;
-
-    @Id
-    public long getId() {
-        return id;
-    }
-    public void setId(long id) {
-        this.id = id;
-    }
+    private Child child;
 }

--- a/elide-core/src/test/java/example/NoUpdateEntity.java
+++ b/elide-core/src/test/java/example/NoUpdateEntity.java
@@ -7,6 +7,7 @@ package example;
 
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import lombok.Data;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -19,18 +20,11 @@ import java.util.Set;
 // Hibernate
 @Entity
 @Table(name = "noupdate")
+@Data
 public class NoUpdateEntity {
+    @Id
     private long id;
 
     @OneToMany()
-    public Set<Child> children;
-
-    @Id
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
+    private Set<Child> children;
 }

--- a/elide-datastore/elide-datastore-hibernate/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate/pom.xml
@@ -71,8 +71,8 @@
 
         <dependency>
             <groupId>javax.persistence</groupId>
-            <artifactId>persistence-api</artifactId>
-            <version>1.0.2</version>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/elide-datastore/elide-datastore-multiplex/pom.xml
+++ b/elide-datastore/elide-datastore-multiplex/pom.xml
@@ -78,8 +78,8 @@
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
-            <artifactId>persistence-api</artifactId>
-            <version>1.0.2</version>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/elide-datastore/elide-datastore-noop/pom.xml
+++ b/elide-datastore/elide-datastore-noop/pom.xml
@@ -55,8 +55,8 @@
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
-            <artifactId>persistence-api</artifactId>
-            <version>1.0.2</version>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -86,8 +86,8 @@
         </dependency>
         <dependency>
             <groupId>javax.persistence</groupId>
-            <artifactId>persistence-api</artifactId>
-            <version>1.0.2</version>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-integration-tests/src/test/java/example/Author.java
+++ b/elide-integration-tests/src/test/java/example/Author.java
@@ -6,15 +6,22 @@
 package example;
 
 import com.yahoo.elide.annotation.Audit;
+import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.Paginate;
 import com.yahoo.elide.annotation.SharePermission;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * Model for authors.
@@ -28,24 +35,35 @@ import java.util.Collection;
         operation = 10,
         logStatement = "{0}",
         logExpressions = {"${author.name}"})
-public class Author extends BaseId {
+public class Author {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    @Setter
+    private Long id;
+
+    @Exclude
+    private String naturalKey = UUID.randomUUID().toString();
+
+    @Override
+    public int hashCode() {
+        return naturalKey.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof Author)) {
+            return false;
+        }
+
+        return ((Author) obj).naturalKey.equals(naturalKey);
+    }
+
+    @Getter @Setter
     private String name;
-    private Collection<Book> books = new ArrayList<>();
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
 
     @ManyToMany(mappedBy = "authors")
-    public Collection<Book> getBooks() {
-        return books;
-    }
-
-    public void setBooks(Collection<Book> books) {
-        this.books = books;
-    }
+    @Getter @Setter
+    private Collection<Book> books = new ArrayList<>();
 }

--- a/elide-integration-tests/src/test/java/example/Chapter.java
+++ b/elide-integration-tests/src/test/java/example/Chapter.java
@@ -39,11 +39,11 @@ public class Chapter {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof BaseId)) {
+        if (obj == null || !(obj instanceof Chapter)) {
             return false;
         }
 
-        return ((BaseId) obj).naturalKey.equals(naturalKey);
+        return ((Chapter) obj).naturalKey.equals(naturalKey);
     }
 
     @Getter @Setter private String title;

--- a/elide-integration-tests/src/test/java/example/Chapter.java
+++ b/elide-integration-tests/src/test/java/example/Chapter.java
@@ -5,6 +5,7 @@
  */
 package example;
 
+import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.SharePermission;
 
@@ -12,10 +13,38 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.util.UUID;
 
 @Entity
 @Include(rootLevel = true, type = "chapter")
 @SharePermission
-public class Chapter extends BaseId {
+/**
+ * This class tests using JPA Field based access.
+ */
+public class Chapter {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Exclude
+    private String naturalKey = UUID.randomUUID().toString();
+
+    @Override
+    public int hashCode() {
+        return naturalKey.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof BaseId)) {
+            return false;
+        }
+
+        return ((BaseId) obj).naturalKey.equals(naturalKey);
+    }
+
     @Getter @Setter private String title;
 }

--- a/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
@@ -21,8 +21,24 @@ import javax.persistence.Entity;
 @ReadPermission(expression = "allow all")
 @UpdatePermission(expression = "deny all")
 public class CreateButNoUpdate extends BaseId {
-    public String textValue;
+    private String textValue;
+
+    private String cannotModify = "unmodified";
 
     @CreatePermission(expression = "deny all")
-    public String cannotModify = "unmodified";
+    public String getCannotModify() {
+        return cannotModify;
+    }
+
+    public void setCannotModify(String cannotModify) {
+        this.cannotModify = cannotModify;
+    }
+
+    public void setTextValue(String textValue) {
+        this.textValue = textValue;
+    }
+
+    public String getTextValue() {
+        return textValue;
+    }
 }

--- a/elide-integration-tests/src/test/java/example/FunWithPermissions.java
+++ b/elide-integration-tests/src/test/java/example/FunWithPermissions.java
@@ -35,24 +35,42 @@ import javax.persistence.Table;
 public class FunWithPermissions extends BaseId {
     private String field1;
     private String field2;
+    private String field3;
+    private String field4;
+    private Set<Child> relation1;
+    private Set<Child> relation2;
+    private Child relation3;
 
     @ReadPermission(expression = "negativeIntegerUser")
-    public String field3;
+    public String getField3() {
+        return field3;
+    }
+
+    public void setField3(String field3) {
+        this.field3 = field3;
+    }
 
     @UpdatePermission(expression = "negativeIntegerUser")
-    public String field4;
+    public String getField4() {
+        return field4;
+    }
 
-    private Set<Child> relation1;
+    public void setField4(String field4) {
+        this.field4 = field4;
+    }
+
+    public void setRelation2(Set<Child> relation2) {
+        this.relation2 = relation2;
+    }
 
     @ReadPermission(expression = "negativeIntegerUser")
     @OneToMany(
             targetEntity = Child.class,
             cascade = { CascadeType.PERSIST, CascadeType.MERGE }
     )
-    public Set<Child> relation2;
-
-
-    private Child relation3;
+    public Set<Child> getRelation2() {
+        return relation2;
+    }
 
     @ReadPermission(expression = "negativeIntegerUser")
     @UpdatePermission(expression = "negativeIntegerUser")
@@ -98,19 +116,49 @@ public class FunWithPermissions extends BaseId {
         this.relation1 = relation;
     }
 
-    /* Verifies a chain of checks where all can succeed */
-    @ReadPermission(expression = "allow all OR negativeIntegerUser")
-    public String field5;
+    private String field5;
 
-    /* Verifies a chain of checks where the first can fail or all succeed */
+    @ReadPermission(expression = "allow all OR negativeIntegerUser")
+    public String getField5() {
+        return field5;
+    }
+
+    public void setField5(String field5) {
+        this.field5 = field5;
+    }
+
+    private String field6;
+
     @ReadPermission(expression = "negativeIntegerUser AND allow all")
-    public String field6;
+    public String getField6() {
+        return field6;
+    }
+
+    public void setField6(String field6) {
+        this.field6 = field6;
+    }
+
+    private String field7;
 
     /* Verifies a chain of checks where the last can fail. */
     @ReadPermission(expression = "allow all AND deny all")
-    public String field7;
+    public String getField7() {
+        return field7;
+    }
+
+    public void setField7(String field7) {
+        this.field7 = field7;
+    }
+
+    private String field8;
 
     /* Verifies a chain of checks where all can fail or the last can succeed. */
     @ReadPermission(expression = "deny all OR negativeIntegerUser")
-    public String field8;
+    public String getField8() {
+        return field8;
+    }
+
+    public void setField8(String field8) {
+        this.field8 = field8;
+    }
 }

--- a/elide-integration-tests/src/test/java/example/SpecialRead.java
+++ b/elide-integration-tests/src/test/java/example/SpecialRead.java
@@ -23,9 +23,16 @@ import java.util.Optional;
 @ReadPermission(expression = "specialValue")
 @UpdatePermission(expression = "updateOnCreate")
 public class SpecialRead extends BaseId {
-    public String value;
-
+    private String value;
     private Child child;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
 
     @ManyToOne(fetch = FetchType.LAZY)
     public Child getChild() {


### PR DESCRIPTION
For entities which annotate the primary key getter (JPA property) with @Id, the behavior should be identical to 4.2.6 and earlier.

For entities which annotate the primary key field (JPA field) with @Id, Elide will only expose fields and computed attributes/relationships (which can be properties).

Also updated the dependency on Elide to JPA 2.2.

Fixes #691 and #644 