### PR TITLE
Hold weak references to class loaders.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@
  * Add support for asterisk life cycle hooks (hooks that invoke for all fields in a model).
 
 **Fixes**
- * Add support for multiple classloaders when using CoerceUtils.
+ * Add support for multiple classloaders when using CoerceUtils ([Issue #689](https://github.com/yahoo/elide/issues/689))
  * Issue#691
  * Issue#644
 


### PR DESCRIPTION
Updates the multiple classloader implementation to hold a `WeakReference<ClassLoader>` instead of a direct reference to `ClassLoader`.

@wcekan does this look better?