### PR TITLE
Fix #696 Introduce CaseSensitivityStrategy for string comparison

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.2.8
+**Fixes**
+ * Issue#696
+
 ## 4.2.7
 **Features**
  * Add support for asterisk life cycle hooks (hooks that invoke for all fields in a model).

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/CaseSensitivityStrategy.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/CaseSensitivityStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter.dialect;
+
+import com.yahoo.elide.core.filter.Operator;
+
+/**
+ * Defines the behavior how string comparisons should be compared regarding case sensitivity.
+ */
+public interface CaseSensitivityStrategy {
+    /**
+     * Maps a general case operator to an operator respecting case sensitivity behavior.
+     *
+     * @param baseOperator the general case operator (case sensitivity not considered)
+     * @return comparison operator (case sensitivity considered)
+     */
+    Operator mapOperator(Operator baseOperator);
+
+    /**
+     * The default Elide strategy which implements the FIQL standard.
+     * Uses lowercase string comparisons.
+     * (@see <a href="https://tools.ietf.org/html/draft-nottingham-atompub-fiql-00#section-3.2.2.1">
+     * FIQL specification</a>)
+     */
+    public class FIQLCompliant implements CaseSensitivityStrategy {
+        public Operator mapOperator(Operator operator) {
+            switch (operator) {
+                case IN:
+                    return Operator.IN_INSENSITIVE;
+                case NOT:
+                    return Operator.NOT_INSENSITIVE;
+                case INFIX:
+                    return Operator.INFIX_CASE_INSENSITIVE;
+                case PREFIX:
+                    return Operator.PREFIX_CASE_INSENSITIVE;
+                case POSTFIX:
+                    return Operator.POSTFIX_CASE_INSENSITIVE;
+                default:
+                    return operator;
+            }
+        }
+    }
+
+    /**
+     * The strategy delegates the decision case sensitivity for string comparison to the
+     * underlying database column collation definition.
+     * <p>
+     * This strategy can be used if the underlying database has performance issues due to
+     * missing functional index functionality (i.e. MySQL).
+     */
+    public class UseColumnCollation implements CaseSensitivityStrategy {
+        public Operator mapOperator(Operator operator) {
+            return operator;
+        }
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -19,7 +19,13 @@ import com.yahoo.elide.parsers.JsonApiParser;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 import cz.jirutka.rsql.parser.RSQLParser;
 import cz.jirutka.rsql.parser.RSQLParserException;
-import cz.jirutka.rsql.parser.ast.*;
+import cz.jirutka.rsql.parser.ast.AndNode;
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+import cz.jirutka.rsql.parser.ast.Node;
+import cz.jirutka.rsql.parser.ast.OrNode;
+import cz.jirutka.rsql.parser.ast.RSQLOperators;
+import cz.jirutka.rsql.parser.ast.RSQLVisitor;
 
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.*;

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -22,8 +22,8 @@ import java.util.Map;
  * Tests RSQLFilterDialect
  */
 public class RSQLFilterDialectTest {
+    private RSQLFilterDialect dialect;
 
-    RSQLFilterDialect dialect;
     @BeforeTest
     public void init() {
         EntityDictionary dictionary = new EntityDictionary(Collections.EMPTY_MAP);

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
@@ -22,8 +22,8 @@ import java.util.Map;
  * Tests RSQLFilterDialect
  */
 public class RSQLFilterDialectWithColumnCollationStrategyTest {
+    private RSQLFilterDialect dialect;
 
-    RSQLFilterDialect dialect;
     @BeforeTest
     public void init() {
         EntityDictionary dictionary = new EntityDictionary(Collections.EMPTY_MAP);

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter.dialect;
+
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import example.Author;
+import example.Book;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Tests RSQLFilterDialect
+ */
+public class RSQLFilterDialectWithColumnCollationStrategyTest {
+
+    RSQLFilterDialect dialect;
+    @BeforeTest
+    public void init() {
+        EntityDictionary dictionary = new EntityDictionary(Collections.EMPTY_MAP);
+
+        dictionary.bindEntity(Author.class);
+        dictionary.bindEntity(Book.class);
+        dialect = new RSQLFilterDialect(dictionary, new CaseSensitivityStrategy.UseColumnCollation());
+    }
+
+    @Test
+    public void testTypedExpressionParsing() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter[book]",
+                "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
+        );
+
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
+
+        Assert.assertEquals(expressionMap.size(), 1);
+        Assert.assertEquals(expressionMap.get("book").toString(),
+                "((book.title INFIX [foo] AND NOT (book.title PREFIX [bar])) "
+                        + "AND (book.genre IN [sci-fi, action] OR book.publishDate GT [123]))"
+        );
+    }
+
+    @Test
+    public void testGlobalExpressionParsing() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title==*foo*;authors.name==Hemingway"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "(book.title INFIX [foo] AND book.authors.name IN [Hemingway])"
+        );
+    }
+
+    @Test
+    public void testEqualOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title==Hemingway"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "book.title IN [Hemingway]"
+        );
+    }
+
+    @Test
+    public void testNotEqualOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title!=Hemingway"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "NOT (book.title IN [Hemingway])"
+        );
+    }
+
+    @Test
+    public void testInOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=in=Hemingway"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "book.title IN [Hemingway]"
+        );
+    }
+
+    @Test
+    public void testOutOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=out=Hemingway"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "NOT (book.title IN [Hemingway])"
+        );
+    }
+
+    @Test
+    public void testNumericComparisonOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "(publishDate=gt=5,publishDate=ge=5,publishDate=lt=10,publishDate=le=10);"
+                        + "(publishDate>5,publishDate>=5,publishDate<10,publishDate<=10)"
+
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "((((book.publishDate GT [5] OR book.publishDate GE [5]) OR book.publishDate LT [10]) OR book.publishDate LE [10]) "
+                        + "AND "
+                        + "(((book.publishDate GT [5] OR book.publishDate GE [5]) OR book.publishDate LT [10]) OR book.publishDate LE [10]))"
+        );
+    }
+
+    @Test
+    public void testSubstringOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title==*Hemingway*,title==*Hemingway,title==Hemingway*"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "((book.title INFIX [Hemingway] OR book.title POSTFIX [Hemingway]) OR book.title PREFIX [Hemingway])"
+        );
+    }
+
+    @Test
+    public void testExpressionGrouping() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title==foo;(title==bar;title==baz)"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "(book.title IN [foo] AND (book.title IN [bar] AND book.title IN [baz]))"
+        );
+    }
+
+    @Test
+    public void testIsnullOperatorBool() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=isnull=true"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "book.title ISNULL []"
+        );
+    }
+
+    @Test
+    public void testIsnullOperatorInt() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=isnull=1"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "book.title ISNULL []"
+        );
+    }
+
+    @Test
+    public void testNotnullOperatorBool() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=isnull=false"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "book.title NOTNULL []"
+        );
+    }
+
+    @Test
+    public void testNotnullOperatorInt() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=isnull=0"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "book.title NOTNULL []"
+        );
+    }
+}


### PR DESCRIPTION
Following our discussion in #696 I implemented an additional configuration to the RSQLDialect.
I am not totally sure whether this is the correct place for a "global configuration", but this would suit the requirements in our project without changing the default Elide behavior.

Any feedback is welcome.