### PR TITLE
Enforce Elide import order with checkstyle.

### DIFF
--- a/checkstyle-style.xml
+++ b/checkstyle-style.xml
@@ -22,6 +22,16 @@
       <property name="allowClassImports" value="false"/>
       <property name="allowStaticMemberImports" value="false"/>
     </module>
+    <module name="CustomImportOrder">
+      <metadata name="net.sf.eclipsecs.core.comment" value="Not enough groups to handle unusual Elide import order.  Used special formatting for thirdPartyPackageRegExp to leave java and javax to the end."/>
+      <property name="severity" value="error"/>
+      <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
+      <property name="specialImportsRegExp" value="^(com\.yahoo)\."/>
+      <property name="standardPackageRegExp" value="^(com|example|org)\."/>
+      <property name="thirdPartyPackageRegExp" value="^([^j]|j[^a]|ja[^v]|java[^x.]).*"/>
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="false"/>
+    </module>
     <module name="FileContentsHolder"/>
     <module name="ConstantName">
       <metadata name="net.sf.eclipsecs.core.comment" value="Constants (static finals) must be uppercase letters/digits/underscore."/>

--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/Audits.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/Audits.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.annotation;
 
-
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/ResourceIdentifier.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/ResourceIdentifier.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.jsonapi.models;
 
-
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.ForbiddenAccessException;

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/GetVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/GetVisitor.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.parsers;
 
-
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.generated.parsers.CoreParser.QueryContext;
 

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/FilterExpressionCheckEvaluationVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/FilterExpressionCheckEvaluationVisitor.java
@@ -6,7 +6,6 @@
 
 package com.yahoo.elide.parsers.expression;
 
-
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/NotExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/NotExpression.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.security.permissions.expressions;
 
-
 import static com.yahoo.elide.security.permissions.ExpressionResult.DEFERRED;
 import static com.yahoo.elide.security.permissions.ExpressionResult.FAIL;
 import static com.yahoo.elide.security.permissions.ExpressionResult.PASS;


### PR DESCRIPTION
Configured CheckStyle `CustomImportOrder` to handle the unusual Elide import order.

See [elide-intellij-codestyle.xml](https://github.com/yahoo/elide/blob/master/elide-intellij-codestyle.xml)