### PR TITLE
Predicates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 4.2.14
+**Features**
+ * Add FilterPredicate sub-classes for each operation type
+ 
 ## 4.2.13
 **Fixes**
  * Upgrade jackson databind to 2.9.8

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,8 @@
 # Change Log
-## 4.2.14
+## 4.2.13
 **Features**
  * Add FilterPredicate sub-classes for each operation type
- 
-## 4.2.13
+
 **Fixes**
  * Upgrade jackson databind to 2.9.8
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -21,8 +21,7 @@ import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 import com.yahoo.elide.core.exceptions.InvalidObjectIdentifierException;
 import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
-import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.InMemoryFilterVisitor;
@@ -887,13 +886,12 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                 .collect(Collectors.toList());
 
         /* construct a new SQL like filter expression, eg: book.id IN [1,2] */
-        FilterExpression idFilter = new FilterPredicate(
+        FilterExpression idFilter = new InPredicate(
                 new Path.PathElement(
                         entityType,
                         idType,
                         idField),
-                Operator.IN,
-                new ArrayList<>(coercedIds));
+                coercedIds);
 
         return idFilter;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryTransaction.java
@@ -10,8 +10,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
-import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.InMemoryFilterVisitor;
@@ -25,7 +24,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -186,10 +184,9 @@ public class InMemoryTransaction implements DataStoreTransaction {
                              Optional<FilterExpression> filterExpression, RequestScope scope) {
         Class idType = dictionary.getIdType(entityClass);
         String idField = dictionary.getIdFieldName(entityClass);
-        FilterExpression idFilter = new FilterPredicate(
+        FilterExpression idFilter = new InPredicate(
                 new Path.PathElement(entityClass, idType, idField),
-                Operator.IN,
-                Arrays.asList(id)
+                id
         );
         FilterExpression joinedFilterExpression = filterExpression
                 .map(fe -> (FilterExpression) new AndFilterExpression(idFilter, fe))

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/FalsePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/FalsePredicate.java
@@ -20,6 +20,6 @@ public class FalsePredicate extends FilterPredicate {
     }
 
     public FalsePredicate(PathElement pathElement) {
-        super(pathElement, Operator.FALSE, Collections.emptyList());
+        this(new Path(Collections.singletonList(pathElement)));
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/FalsePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/FalsePredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * False Predicate class.
+ */
+public class FalsePredicate extends FilterPredicate {
+
+    public FalsePredicate(Path path) {
+        super(path, Operator.FALSE, Collections.emptyList());
+    }
+
+    public FalsePredicate(PathElement pathElement) {
+        super(pathElement, Operator.FALSE, Collections.emptyList());
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/GEPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/GEPredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * GE Predicate class.
+ */
+public class GEPredicate extends FilterPredicate {
+
+    public GEPredicate(Path path, Object value) {
+        super(path, Operator.GE, Collections.singletonList(value));
+    }
+
+    public GEPredicate(PathElement pathElement, Object value) {
+        super(pathElement, Operator.GE, Collections.singletonList(value));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/GEPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/GEPredicate.java
@@ -20,6 +20,6 @@ public class GEPredicate extends FilterPredicate {
     }
 
     public GEPredicate(PathElement pathElement, Object value) {
-        super(pathElement, Operator.GE, Collections.singletonList(value));
+        this(new Path(Collections.singletonList(pathElement)), value);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/GTPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/GTPredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * GT Predicate class.
+ */
+public class GTPredicate extends FilterPredicate {
+
+    public GTPredicate(Path path, Object value) {
+        super(path, Operator.GT, Collections.singletonList(value));
+    }
+
+    public GTPredicate(PathElement pathElement, Object value) {
+        super(pathElement, Operator.GT, Collections.singletonList(value));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/GTPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/GTPredicate.java
@@ -20,6 +20,6 @@ public class GTPredicate extends FilterPredicate {
     }
 
     public GTPredicate(PathElement pathElement, Object value) {
-        super(pathElement, Operator.GT, Collections.singletonList(value));
+        this(new Path(Collections.singletonList(pathElement)), value);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InInsensitivePredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class InInsensitivePredicate extends FilterPredicate {
     }
 
     public InInsensitivePredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.IN_INSENSITIVE, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InInsensitivePredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * IN Insensitive Predicate class.
+ */
+public class InInsensitivePredicate extends FilterPredicate {
+
+    public InInsensitivePredicate(Path path, List<Object> values) {
+        super(path, Operator.IN_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> InInsensitivePredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public InInsensitivePredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.IN_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> InInsensitivePredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * IN Predicate class.
+ */
+public class InPredicate extends FilterPredicate {
+
+    public InPredicate(Path path, List<Object> values) {
+        super(path, Operator.IN, values);
+    }
+
+    @SafeVarargs
+    public <T> InPredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public InPredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.IN, values);
+    }
+
+    @SafeVarargs
+    public <T> InPredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InPredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class InPredicate extends FilterPredicate {
     }
 
     public InPredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.IN, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixInsensitivePredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * INFIX Insensitive Predicate class.
+ */
+public class InfixInsensitivePredicate extends FilterPredicate {
+
+    public InfixInsensitivePredicate(Path path, List<Object> values) {
+        super(path, Operator.INFIX_CASE_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> InfixInsensitivePredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public InfixInsensitivePredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.INFIX_CASE_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> InfixInsensitivePredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixInsensitivePredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class InfixInsensitivePredicate extends FilterPredicate {
     }
 
     public InfixInsensitivePredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.INFIX_CASE_INSENSITIVE, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixPredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class InfixPredicate extends FilterPredicate {
     }
 
     public InfixPredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.INFIX, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/InfixPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * INFIX Predicate class.
+ */
+public class InfixPredicate extends FilterPredicate {
+
+    public InfixPredicate(Path path, List<Object> values) {
+        super(path, Operator.INFIX, values);
+    }
+
+    @SafeVarargs
+    public <T> InfixPredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public InfixPredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.INFIX, values);
+    }
+
+    @SafeVarargs
+    public <T> InfixPredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/IsNullPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/IsNullPredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * ISNULL Predicate class.
+ */
+public class IsNullPredicate extends FilterPredicate {
+
+    public IsNullPredicate(Path path) {
+        super(path, Operator.ISNULL, Collections.emptyList());
+    }
+
+    public IsNullPredicate(PathElement pathElement) {
+        super(pathElement, Operator.ISNULL, Collections.emptyList());
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/IsNullPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/IsNullPredicate.java
@@ -20,6 +20,6 @@ public class IsNullPredicate extends FilterPredicate {
     }
 
     public IsNullPredicate(PathElement pathElement) {
-        super(pathElement, Operator.ISNULL, Collections.emptyList());
+        this(new Path(Collections.singletonList(pathElement)));
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/LEPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/LEPredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * LE Predicate class.
+ */
+public class LEPredicate extends FilterPredicate {
+
+    public LEPredicate(Path path, Object value) {
+        super(path, Operator.LE, Collections.singletonList(value));
+    }
+
+    public LEPredicate(PathElement pathElement, Object value) {
+        super(pathElement, Operator.LE, Collections.singletonList(value));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/LEPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/LEPredicate.java
@@ -20,6 +20,6 @@ public class LEPredicate extends FilterPredicate {
     }
 
     public LEPredicate(PathElement pathElement, Object value) {
-        super(pathElement, Operator.LE, Collections.singletonList(value));
+        this(new Path(Collections.singletonList(pathElement)), value);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/LTPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/LTPredicate.java
@@ -20,6 +20,6 @@ public class LTPredicate extends FilterPredicate {
     }
 
     public LTPredicate(PathElement pathElement, Object value) {
-        super(pathElement, Operator.LT, Collections.singletonList(value));
+        this(new Path(Collections.singletonList(pathElement)), value);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/LTPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/LTPredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * LT Predicate class.
+ */
+public class LTPredicate extends FilterPredicate {
+
+    public LTPredicate(Path path, Object value) {
+        super(path, Operator.LT, Collections.singletonList(value));
+    }
+
+    public LTPredicate(PathElement pathElement, Object value) {
+        super(pathElement, Operator.LT, Collections.singletonList(value));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInInsensitivePredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * NOT Insensitive Predicate class.
+ */
+public class NotInInsensitivePredicate extends FilterPredicate {
+
+    public NotInInsensitivePredicate(Path path, List<Object> values) {
+        super(path, Operator.NOT_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> NotInInsensitivePredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public NotInInsensitivePredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.NOT_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> NotInInsensitivePredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInInsensitivePredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class NotInInsensitivePredicate extends FilterPredicate {
     }
 
     public NotInInsensitivePredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.NOT_INSENSITIVE, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInPredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class NotInPredicate extends FilterPredicate {
     }
 
     public NotInPredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.NOT, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotInPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Not In Predicate class.
+ */
+public class NotInPredicate extends FilterPredicate {
+
+    public NotInPredicate(Path path, List<Object> values) {
+        super(path, Operator.NOT, values);
+    }
+
+    @SafeVarargs
+    public <T> NotInPredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public NotInPredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.NOT, values);
+    }
+
+    @SafeVarargs
+    public <T> NotInPredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotNullPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotNullPredicate.java
@@ -20,6 +20,6 @@ public class NotNullPredicate extends FilterPredicate {
     }
 
     public NotNullPredicate(PathElement pathElement) {
-        super(pathElement, Operator.NOTNULL, Collections.emptyList());
+        this(new Path(Collections.singletonList(pathElement)));
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotNullPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotNullPredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * Not NUL Predicate class.
+ */
+public class NotNullPredicate extends FilterPredicate {
+
+    public NotNullPredicate(Path path) {
+        super(path, Operator.NOTNULL, Collections.emptyList());
+    }
+
+    public NotNullPredicate(PathElement pathElement) {
+        super(pathElement, Operator.NOTNULL, Collections.emptyList());
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixInsensitivePredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class PostfixInsensitivePredicate extends FilterPredicate {
     }
 
     public PostfixInsensitivePredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.POSTFIX_CASE_INSENSITIVE, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixInsensitivePredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * POSTFIX Predicate class.
+ */
+public class PostfixInsensitivePredicate extends FilterPredicate {
+
+    public PostfixInsensitivePredicate(Path path, List<Object> values) {
+        super(path, Operator.POSTFIX_CASE_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> PostfixInsensitivePredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public PostfixInsensitivePredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.POSTFIX_CASE_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> PostfixInsensitivePredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixPredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class PostfixPredicate extends FilterPredicate {
     }
 
     public PostfixPredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.POSTFIX, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PostfixPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * POSTFIX Predicate class.
+ */
+public class PostfixPredicate extends FilterPredicate {
+
+    public PostfixPredicate(Path path, List<Object> values) {
+        super(path, Operator.POSTFIX, values);
+    }
+
+    @SafeVarargs
+    public <T> PostfixPredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public PostfixPredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.POSTFIX, values);
+    }
+
+    @SafeVarargs
+    public <T> PostfixPredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixInsensitivePredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class PrefixInsensitivePredicate extends FilterPredicate {
     }
 
     public PrefixInsensitivePredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.PREFIX_CASE_INSENSITIVE, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixInsensitivePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixInsensitivePredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * PREFIX Predicate class.
+ */
+public class PrefixInsensitivePredicate extends FilterPredicate {
+
+    public PrefixInsensitivePredicate(Path path, List<Object> values) {
+        super(path, Operator.PREFIX_CASE_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> PrefixInsensitivePredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public PrefixInsensitivePredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.PREFIX_CASE_INSENSITIVE, values);
+    }
+
+    @SafeVarargs
+    public <T> PrefixInsensitivePredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * PREFIX Predicate class.
+ */
+public class PrefixPredicate extends FilterPredicate {
+
+    public PrefixPredicate(Path path, List<Object> values) {
+        super(path, Operator.PREFIX, values);
+    }
+
+    @SafeVarargs
+    public <T> PrefixPredicate(Path path, T... a) {
+        this(path, Arrays.asList(a));
+    }
+
+    public PrefixPredicate(PathElement pathElement, List<Object> values) {
+        super(pathElement, Operator.PREFIX, values);
+    }
+
+    @SafeVarargs
+    public <T> PrefixPredicate(PathElement pathElement, T... a) {
+        this(pathElement, Arrays.asList(a));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/PrefixPredicate.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,7 +27,7 @@ public class PrefixPredicate extends FilterPredicate {
     }
 
     public PrefixPredicate(PathElement pathElement, List<Object> values) {
-        super(pathElement, Operator.PREFIX, values);
+        this(new Path(Collections.singletonList(pathElement)), values);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/TruePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/TruePredicate.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+
+import java.util.Collections;
+
+/**
+ * TRUE Predicate class.
+ */
+public class TruePredicate extends FilterPredicate {
+
+    public TruePredicate(Path path) {
+        super(path, Operator.TRUE, Collections.emptyList());
+    }
+
+    public TruePredicate(PathElement pathElement) {
+        super(pathElement, Operator.TRUE, Collections.emptyList());
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/TruePredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/TruePredicate.java
@@ -20,6 +20,6 @@ public class TruePredicate extends FilterPredicate {
     }
 
     public TruePredicate(PathElement pathElement) {
-        super(pathElement, Operator.TRUE, Collections.emptyList());
+        this(new Path(Collections.singletonList(pathElement)));
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -9,6 +9,9 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.FilterPredicate;
+import com.yahoo.elide.core.filter.InPredicate;
+import com.yahoo.elide.core.filter.IsNullPredicate;
+import com.yahoo.elide.core.filter.NotNullPredicate;
 import com.yahoo.elide.core.filter.Operator;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -320,7 +323,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
                 return new FilterPredicate(path, caseSensitivityStrategy.mapOperator(Operator.IN), values);
             }
 
-            return new FilterPredicate(path, Operator.IN, values);
+            return new InPredicate(path, values);
         }
 
         /**
@@ -333,14 +336,11 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
         private FilterExpression buildIsNullOperator(Path path, List<String> arguments) {
             String arg = arguments.get(0);
             try {
-                Operator elideOP;
                 boolean wantsNull = CoerceUtil.coerce(arg, boolean.class);
                 if (wantsNull) {
-                    elideOP = Operator.ISNULL;
-                } else {
-                    elideOP = Operator.NOTNULL;
+                    return new IsNullPredicate(path);
                 }
-                return new FilterPredicate(path, elideOP, Collections.emptyList());
+                return new NotNullPredicate(path);
             } catch (InvalidValueException ignored) {
                 throw new RSQLParseException(String.format("Invalid value for operator =isnull= '%s'", arg));
             }

--- a/elide-core/src/test/groovy/com/yahoo/elide/core/filter/FilterPredicateTest.groovy
+++ b/elide-core/src/test/groovy/com/yahoo/elide/core/filter/FilterPredicateTest.groovy
@@ -5,6 +5,9 @@
  */
 package com.yahoo.elide.core.filter
 
+import static org.mockito.Mockito.mock
+import static org.mockito.Mockito.when
+
 import com.yahoo.elide.core.EntityDictionary
 import com.yahoo.elide.core.RelationshipType
 import com.yahoo.elide.core.exceptions.InvalidPredicateException
@@ -22,9 +25,6 @@ import org.testng.annotations.Test
 
 import javax.ws.rs.core.MultivaluedHashMap
 import javax.ws.rs.core.MultivaluedMap
-
-import static org.mockito.Mockito.mock
-import static org.mockito.Mockito.when
 /**
  * Predicate test class.
  */

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/ExpressionScopingVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/ExpressionScopingVisitorTest.java
@@ -8,7 +8,7 @@ package com.yahoo.elide.core.filter.expression;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.Path.PathElement;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 
 import example.Author;
 import example.Book;
@@ -18,7 +18,6 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -36,12 +35,12 @@ public class ExpressionScopingVisitorTest {
                 new PathElement(Book.class, Author.class, "authors"),
                 new PathElement(Author.class, String.class, NAME)
         ));
-        FilterPredicate p1 = new FilterPredicate(p1Path, Operator.IN, Arrays.asList("foo", "bar"));
+        FilterPredicate p1 = new InPredicate(p1Path, "foo", "bar");
 
-        FilterPredicate p2 = new FilterPredicate(new PathElement(Book.class, String.class, NAME), Operator.IN, Collections.singletonList("blah"));
-        FilterPredicate p3 = new FilterPredicate(new PathElement(Book.class, String.class, GENRE), Operator.IN, Collections.singletonList(SCIFI));
+        FilterPredicate p2 = new InPredicate(new PathElement(Book.class, String.class, NAME), "blah");
+        FilterPredicate p3 = new InPredicate(new PathElement(Book.class, String.class, GENRE), SCIFI);
         //P4 is a duplicate of P3
-        FilterPredicate p4 = new FilterPredicate(new PathElement(Book.class, String.class, GENRE), Operator.IN, Collections.singletonList(SCIFI));
+        FilterPredicate p4 = new InPredicate(new PathElement(Book.class, String.class, GENRE), SCIFI);
 
         OrFilterExpression or = new OrFilterExpression(p2, p3);
         AndFilterExpression and1 = new AndFilterExpression(or, p1);

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/FilterPredicateExtractionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/FilterPredicateExtractionVisitorTest.java
@@ -7,7 +7,7 @@ package com.yahoo.elide.core.filter.expression;
 
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 
 import com.google.common.collect.Sets;
 
@@ -32,23 +32,23 @@ public class FilterPredicateExtractionVisitorTest {
                 new Path.PathElement(Book.class, Author.class, "authors"),
                 new Path.PathElement(Author.class, String.class, "name")
         ));
-        FilterPredicate p1 = new FilterPredicate(p1Path, Operator.IN, Arrays.asList("foo", "bar"));
+        FilterPredicate p1 = new InPredicate(p1Path, "foo", "bar");
 
         Path p2Path = new Path(Arrays.asList(
                 new Path.PathElement(Book.class, String.class, "name")
         ));
-        FilterPredicate p2 = new FilterPredicate(p2Path, Operator.IN, Arrays.asList("blah"));
+        FilterPredicate p2 = new InPredicate(p2Path, "blah");
 
         Path p3Path = new Path(Arrays.asList(
                 new Path.PathElement(Book.class, String.class, "genre")
         ));
-        FilterPredicate p3 = new FilterPredicate(p3Path, Operator.IN, Arrays.asList("scifi"));
+        FilterPredicate p3 = new InPredicate(p3Path, "scifi");
 
         //P4 is a duplicate of P3
         Path p4Path = new Path(Arrays.asList(
                 new Path.PathElement(Book.class, String.class, "genre")
         ));
-        FilterPredicate p4 = new FilterPredicate(p4Path, Operator.IN, Arrays.asList("scifi"));
+        FilterPredicate p4 = new InPredicate(p4Path, "scifi");
 
         OrFilterExpression or = new OrFilterExpression(p2, p3);
         AndFilterExpression and1 = new AndFilterExpression(or, p1);

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterVisitorTest.java
@@ -13,14 +13,19 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.FalsePredicate;
 import com.yahoo.elide.core.filter.GEPredicate;
 import com.yahoo.elide.core.filter.GTPredicate;
+import com.yahoo.elide.core.filter.InInsensitivePredicate;
 import com.yahoo.elide.core.filter.InPredicate;
+import com.yahoo.elide.core.filter.InfixInsensitivePredicate;
 import com.yahoo.elide.core.filter.InfixPredicate;
 import com.yahoo.elide.core.filter.IsNullPredicate;
 import com.yahoo.elide.core.filter.LEPredicate;
 import com.yahoo.elide.core.filter.LTPredicate;
+import com.yahoo.elide.core.filter.NotInInsensitivePredicate;
 import com.yahoo.elide.core.filter.NotInPredicate;
 import com.yahoo.elide.core.filter.NotNullPredicate;
+import com.yahoo.elide.core.filter.PostfixInsensitivePredicate;
 import com.yahoo.elide.core.filter.PostfixPredicate;
+import com.yahoo.elide.core.filter.PrefixInsensitivePredicate;
 import com.yahoo.elide.core.filter.PrefixPredicate;
 import com.yahoo.elide.core.filter.TruePredicate;
 
@@ -33,6 +38,7 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -86,6 +92,14 @@ public class InMemoryFilterVisitorTest {
         fn = expression.accept(visitor);
         Assert.assertTrue(fn.test(author));
         expression = new NotInPredicate(authorIdElement, 1L);
+        fn = expression.accept(visitor);
+        Assert.assertFalse(fn.test(author));
+
+        // Test exact match insensitive
+        expression = new InInsensitivePredicate(authorNameElement, author.getName().toUpperCase(Locale.ENGLISH));
+        fn = expression.accept(visitor);
+        Assert.assertTrue(fn.test(author));
+        expression = new NotInInsensitivePredicate(authorNameElement, author.getName().toUpperCase(Locale.ENGLISH));
         fn = expression.accept(visitor);
         Assert.assertFalse(fn.test(author));
 
@@ -190,6 +204,18 @@ public class InMemoryFilterVisitorTest {
         expression = new PostfixPredicate(authorNameElement, "test");
         fn = expression.accept(visitor);
         Assert.assertFalse(fn.test(author));
+
+        // When prefix, infix, postfix are correctly matched if case-insensitive
+        expression = new PrefixInsensitivePredicate(authorNameElement, "author");
+        fn = expression.accept(visitor);
+        Assert.assertTrue(fn.test(author));
+        expression = new InfixInsensitivePredicate(authorNameElement, "for");
+        fn = expression.accept(visitor);
+        Assert.assertTrue(fn.test(author));
+        expression = new PostfixInsensitivePredicate(authorNameElement, "test");
+        fn = expression.accept(visitor);
+        Assert.assertTrue(fn.test(author));
+
 
         // When prefix, infix, postfix are not matched
         expression = new PrefixPredicate(authorNameElement, "error");

--- a/elide-core/src/test/java/example/Editor.java
+++ b/elide-core/src/test/java/example/Editor.java
@@ -14,13 +14,12 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.NotNullPredicate;
 import com.yahoo.elide.security.FilterExpressionCheck;
 
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Collections;
 import java.util.UUID;
 
 import javax.persistence.Entity;
@@ -81,7 +80,7 @@ public class Editor {
         @Override
         public FilterPredicate getFilterExpression(Class entityClass, com.yahoo.elide.security.RequestScope requestScope) {
             Path path = super.getFieldPath(entityClass, requestScope, "getEditor", "editor");
-            return new FilterPredicate(path, Operator.NOTNULL, Collections.emptyList());
+            return new NotNullPredicate(path);
         }
     }
 }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
@@ -9,7 +9,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path.PathElement;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.HQLFilterOperation;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.ExpressionScopingVisitor;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -22,7 +22,6 @@ import com.yahoo.elide.utils.coerce.CoerceUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 
 /**
@@ -72,8 +71,7 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
         String idField = dictionary.getIdFieldName(parentType);
 
         //Construct a predicate that selects an individual element of the relationship's parent (Author.id = 3).
-        FilterPredicate idExpression = new FilterPredicate(
-                new PathElement(parentType, idType, idField), Operator.IN, Collections.singletonList(idVal));
+        FilterPredicate idExpression = new InPredicate(new PathElement(parentType, idType, idField), idVal);
 
         Collection<FilterPredicate> predicates = new ArrayList<>();
         String joinClause = "";

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/HQLFilterOperationTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/HQLFilterOperationTest.java
@@ -39,18 +39,17 @@ public class HQLFilterOperationTest {
                 new Path.PathElement(Book.class, Author.class, "authors"),
                 new Path.PathElement(Author.class, String.class, "name")
         );
-        FilterPredicate p1 = new FilterPredicate(new Path(p1Path),
-                Operator.IN, Arrays.asList("foo", "bar"));
+        FilterPredicate p1 = new InPredicate(new Path(p1Path), "foo", "bar");
 
         List<Path.PathElement> p2Path = Arrays.asList(
                 new Path.PathElement(Book.class, String.class, "name")
         );
-        FilterPredicate p2 = new FilterPredicate(new Path(p2Path), Operator.IN, Arrays.asList("blah"));
+        FilterPredicate p2 = new InPredicate(new Path(p2Path), "blah");
 
         List<Path.PathElement> p3Path = Arrays.asList(
                 new Path.PathElement(Book.class, String.class, "genre")
         );
-        FilterPredicate p3 = new FilterPredicate(new Path(p3Path), Operator.IN, Arrays.asList("scifi"));
+        FilterPredicate p3 = new InPredicate(new Path(p3Path), "scifi");
 
         OrFilterExpression or = new OrFilterExpression(p2, p3);
         AndFilterExpression and = new AndFilterExpression(or, p1);

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
@@ -16,7 +16,8 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
+import com.yahoo.elide.core.filter.InfixPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.hibernate.Query;
@@ -74,13 +75,13 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
                 new Path.PathElement(Chapter.class, String.class, TITLE)
         );
 
-        FilterPredicate titlePredicate = new FilterPredicate(
+        FilterPredicate titlePredicate = new InPredicate(
                 new Path(chapterTitlePath),
-                Operator.IN, Arrays.asList(ABC, DEF));
+                ABC, DEF);
 
-        FilterPredicate titlePredicateDuplicate = new FilterPredicate(
+        FilterPredicate titlePredicateDuplicate = new InPredicate(
                 new Path(chapterTitlePath),
-                Operator.IN, Arrays.asList(ABC, DEF));
+                ABC, DEF);
 
         List<Path.PathElement>  publisherNamePath = Arrays.asList(
                 new Path.PathElement(Author.class, Book.class, BOOKS),
@@ -88,9 +89,9 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
                 new Path.PathElement(Publisher.class, String.class, NAME)
         );
 
-        FilterPredicate publisherNamePredicate = new FilterPredicate(
+        FilterPredicate publisherNamePredicate = new InPredicate(
                 new Path(publisherNamePath),
-                Operator.IN, Arrays.asList("Pub1"));
+                "Pub1");
 
         OrFilterExpression orExpression = new OrFilterExpression(titlePredicate, publisherNamePredicate);
         AndFilterExpression andExpression = new AndFilterExpression(orExpression, titlePredicateDuplicate);
@@ -158,13 +159,13 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
         Path.PathElement idPath = new Path.PathElement(Book.class, Chapter.class, "id");
 
         Query query = mock(Query.class);
-        FilterPredicate predicate = new FilterPredicate(idPath, Operator.IN, Arrays.asList(ABC, DEF));
+        FilterPredicate predicate = new InPredicate(idPath, ABC, DEF);
         supplyFilterQueryParameters(query, Arrays.asList(predicate));
 
         verify(query, times(2)).setParameter(anyString(), any());
 
         query = mock(Query.class);
-        predicate = new FilterPredicate(idPath, Operator.INFIX, Arrays.asList(ABC));
+        predicate = new InfixPredicate(idPath, ABC);
         supplyFilterQueryParameters(query, Arrays.asList(predicate));
 
         verify(query, times(1)).setParameter(anyString(), any());

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -8,7 +8,7 @@ package com.yahoo.elide.datastores.hibernate.hql;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.hibernate.hql.RootCollectionFetchQueryBuilder;
 import com.yahoo.elide.core.sort.Sorting;
@@ -84,9 +84,9 @@ public class RootCollectionFetchQueryBuilderTest {
                 new Path.PathElement(Chapter.class, String.class, TITLE)
         );
 
-        FilterPredicate titlePredicate = new FilterPredicate(
+        FilterPredicate titlePredicate = new InPredicate(
                 new Path(chapterTitlePath),
-                Operator.IN, Arrays.asList("ABC", "DEF"));
+                "ABC", "DEF");
 
         List<Path.PathElement>  publisherNamePath = Arrays.asList(
                 new Path.PathElement(Author.class, Book.class, BOOKS),
@@ -94,8 +94,8 @@ public class RootCollectionFetchQueryBuilderTest {
                 new Path.PathElement(Publisher.class, String.class, "name")
         );
 
-        FilterPredicate publisherNamePredicate = new FilterPredicate(
-                new Path(publisherNamePath), Operator.IN, Arrays.asList("Pub1"));
+        FilterPredicate publisherNamePredicate = new InPredicate(
+                new Path(publisherNamePath), "Pub1");
 
         OrFilterExpression expression = new OrFilterExpression(titlePredicate, publisherNamePredicate);
 
@@ -133,7 +133,7 @@ public class RootCollectionFetchQueryBuilderTest {
 
         Path.PathElement idPath = new Path.PathElement(Book.class, Chapter.class, "id");
 
-        FilterPredicate idPredicate = new FilterPredicate(idPath, Operator.IN, Arrays.asList(1));
+        FilterPredicate idPredicate = new InPredicate(idPath, 1);
 
 
         TestQueryWrapper query = (TestQueryWrapper) builder

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.mock;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.hibernate.hql.RootCollectionPageTotalsQueryBuilder;
 import com.yahoo.elide.core.pagination.Pagination;
@@ -90,9 +90,9 @@ public class RootCollectionPageTotalsQueryBuilderTest {
                 new Path.PathElement(Chapter.class, String.class, TITLE)
         );
 
-        FilterPredicate titlePredicate = new FilterPredicate(
+        FilterPredicate titlePredicate = new InPredicate(
                 new Path(chapterTitlePath),
-                Operator.IN, Arrays.asList("ABC", "DEF"));
+                "ABC", "DEF");
 
         List<Path.PathElement>  publisherNamePath = Arrays.asList(
                 new Path.PathElement(Author.class, Book.class, BOOKS),
@@ -100,8 +100,8 @@ public class RootCollectionPageTotalsQueryBuilderTest {
                 new Path.PathElement(Publisher.class, String.class, "name")
         );
 
-        FilterPredicate publisherNamePredicate = new FilterPredicate(
-                new Path(publisherNamePath), Operator.IN, Arrays.asList("Pub1"));
+        FilterPredicate publisherNamePredicate = new InPredicate(
+                new Path(publisherNamePath), "Pub1");
 
         OrFilterExpression expression = new OrFilterExpression(titlePredicate, publisherNamePredicate);
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -8,7 +8,7 @@ package com.yahoo.elide.datastores.hibernate.hql;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.hibernate.hql.RelationshipImpl;
 import com.yahoo.elide.core.hibernate.hql.SubCollectionFetchQueryBuilder;
 import com.yahoo.elide.core.sort.Sorting;
@@ -123,9 +123,9 @@ public class SubCollectionFetchQueryBuilderTest {
                 new Path.PathElement(Publisher.class, String.class, NAME)
         );
 
-        FilterPredicate publisherNamePredicate = new FilterPredicate(
+        FilterPredicate publisherNamePredicate = new InPredicate(
                 new Path(publisherNamePath),
-                Operator.IN, Arrays.asList(PUB1));
+                PUB1);
 
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship, dictionary, new TestSessionWrapper());
@@ -165,9 +165,9 @@ public class SubCollectionFetchQueryBuilderTest {
                 new Path.PathElement(Publisher.class, String.class, NAME)
         );
 
-        FilterPredicate publisherNamePredicate = new FilterPredicate(
+        FilterPredicate publisherNamePredicate = new InPredicate(
                 new Path(publisherNamePath),
-                Operator.IN, Arrays.asList(PUB1));
+                PUB1);
 
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship, dictionary, new TestSessionWrapper());

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionPageTotalsQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionPageTotalsQueryBuilderTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.mock;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.hibernate.hql.AbstractHQLQueryBuilder;
 import com.yahoo.elide.core.hibernate.hql.RelationshipImpl;
 import com.yahoo.elide.core.hibernate.hql.SubCollectionPageTotalsQueryBuilder;
@@ -123,9 +123,9 @@ public class SubCollectionPageTotalsQueryBuilderTest {
                 new Path.PathElement(Publisher.class, String.class, "name")
         );
 
-        FilterPredicate publisherNamePredicate = new FilterPredicate(
+        FilterPredicate publisherNamePredicate = new InPredicate(
                 new Path(publisherNamePath),
-                Operator.IN, Arrays.asList("Pub1"));
+                "Pub1");
 
         SubCollectionPageTotalsQueryBuilder builder = new SubCollectionPageTotalsQueryBuilder(
                 relationship, dictionary, new TestSessionWrapper());

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -10,8 +10,9 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.TransactionException;
+import com.yahoo.elide.core.filter.FalsePredicate;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.hibernate.hql.AbstractHQLQueryBuilder;
@@ -38,7 +39,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -133,9 +133,9 @@ public class HibernateTransaction implements DataStoreTransaction {
             FilterPredicate idExpression;
             Path.PathElement idPath = new Path.PathElement(entityClass, idType, idField);
             if (id != null) {
-                idExpression = new FilterPredicate(idPath, Operator.IN, Collections.singletonList(id));
+                idExpression = new InPredicate(idPath, id);
             } else {
-                idExpression = new FilterPredicate(idPath, Operator.FALSE, Collections.emptyList());
+                idExpression = new FalsePredicate(idPath);
             }
 
             FilterExpression joinedExpression = filterExpression

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -10,8 +10,9 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.TransactionException;
+import com.yahoo.elide.core.filter.FalsePredicate;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.hibernate.hql.AbstractHQLQueryBuilder;
@@ -38,7 +39,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 
@@ -133,9 +133,9 @@ public class HibernateTransaction implements DataStoreTransaction {
             FilterPredicate idExpression;
             Path.PathElement idPath = new Path.PathElement(entityClass, idType, idField);
             if (id != null) {
-                idExpression = new FilterPredicate(idPath, Operator.IN, Collections.singletonList(id));
+                idExpression = new InPredicate(idPath, id);
             } else {
-                idExpression = new FilterPredicate(idPath, Operator.FALSE, Collections.emptyList());
+                idExpression = new FalsePredicate(idPath);
             }
 
             FilterExpression joinedExpression = filterExpression

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableRedisStore.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableRedisStore.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.FilterPredicate;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.Operator;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -34,7 +35,6 @@ import redis.clients.jedis.Jedis;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -152,10 +152,9 @@ public class BridgeableRedisStore implements DataStore {
                             Optional.empty(),
                             scope);
                 } else if ("redisActions".equals(relationName)) {
-                    FilterExpression updatedExpression = new FilterPredicate(
+                    FilterExpression updatedExpression = new InPredicate(
                             new Path.PathElement(entityClass, String.class, "user_id"),
-                            Operator.IN,
-                            Collections.singletonList(String.valueOf(((HibernateUser) parent).getId()))
+                            String.valueOf(((HibernateUser) parent).getId())
                     );
 
                     return muxTx.loadObject(entityClass,
@@ -173,10 +172,9 @@ public class BridgeableRedisStore implements DataStore {
             if (parent.getClass().equals(HibernateUser.class) && "redisActions".equals(relationName)) {
                 EntityDictionary dictionary = scope.getDictionary();
                 Class<?> entityClass = dictionary.getParameterizedType(parent, relationName);
-                FilterExpression filterExpression = new FilterPredicate(
+                FilterExpression filterExpression = new InPredicate(
                         new Path.PathElement(entityClass, String.class, "user_id"),
-                        Operator.IN,
-                        Collections.singletonList(String.valueOf(((HibernateUser) parent).getId()))
+                        String.valueOf(((HibernateUser) parent).getId())
                 );
                 return muxTx.loadObjects(entityClass,
                         Optional.of(filterExpression),

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLTest.java
@@ -7,8 +7,6 @@
 package com.yahoo.elide.graphql;
 
 import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.security.checks.Check;
-
 import example.Address;
 import example.Author;
 import example.Book;
@@ -28,7 +26,7 @@ public class GraphQLTest {
 
     @BeforeClass
     public void init() {
-        Map<String, Class<? extends Check>> checks = new HashMap<>();
+        Map checks = new HashMap<>();
         checks.put("allow all", com.yahoo.elide.security.checks.prefab.Role.ALL.class);
 
         dictionary = new EntityDictionary(checks);

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLTest.java
@@ -7,6 +7,8 @@
 package com.yahoo.elide.graphql;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.security.checks.Check;
+
 import example.Address;
 import example.Author;
 import example.Book;
@@ -26,7 +28,7 @@ public class GraphQLTest {
 
     @BeforeClass
     public void init() {
-        Map checks = new HashMap<>();
+        Map<String, Class<? extends Check>> checks = new HashMap<>();
         checks.put("allow all", com.yahoo.elide.security.checks.prefab.Role.ALL.class);
 
         dictionary = new EntityDictionary(checks);

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -24,7 +24,9 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.InfixPredicate;
+import com.yahoo.elide.core.filter.PostfixPredicate;
+import com.yahoo.elide.core.filter.PrefixPredicate;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.initialization.AbstractIntegrationTestInitializer;
 import com.yahoo.elide.jsonapi.models.Data;
@@ -54,7 +56,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1920,9 +1921,9 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
         Path.PathElement pathToTitle = new Path.PathElement(Book.class, String.class, "title");
 
         return new Object[][]{
-                {new FilterPredicate(pathToTitle, Operator.INFIX, Arrays.asList("with%perce")), 1},
-                {new FilterPredicate(pathToTitle, Operator.PREFIX, Arrays.asList("titlewith%perce")), 1},
-                {new FilterPredicate(pathToTitle, Operator.POSTFIX, Arrays.asList("with%percentage")), 1}
+                {new InfixPredicate(pathToTitle, "with%perce"), 1},
+                {new PrefixPredicate(pathToTitle, "titlewith%perce"), 1},
+                {new PostfixPredicate(pathToTitle, "with%percentage"), 1}
         };
     }
 

--- a/elide-integration-tests/src/test/java/example/Child.java
+++ b/elide-integration-tests/src/test/java/example/Child.java
@@ -13,8 +13,7 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.core.Path;
-import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.NotNullPredicate;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.FilterExpressionCheck;
@@ -22,7 +21,6 @@ import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.CommitCheck;
 import com.yahoo.elide.security.checks.OperationCheck;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -143,8 +141,7 @@ public class Child extends BaseId {
     static public class InitCheckFilter extends FilterExpressionCheck<Child> {
         @Override
         public FilterExpression getFilterExpression(Class<?> entityClass, RequestScope requestScope) {
-            return new FilterPredicate(new Path.PathElement(Child.class, Long.class, "id"), Operator.NOTNULL,
-                    Collections.emptyList());
+            return new NotNullPredicate(new Path.PathElement(Child.class, Long.class, "id"));
         }
     }
 

--- a/elide-integration-tests/src/test/java/example/Editor.java
+++ b/elide-integration-tests/src/test/java/example/Editor.java
@@ -14,13 +14,12 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
-import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.NotNullPredicate;
 import com.yahoo.elide.security.FilterExpressionCheck;
 
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Collections;
 import java.util.UUID;
 
 import javax.persistence.Entity;
@@ -81,7 +80,7 @@ public class Editor {
         @Override
         public FilterPredicate getFilterExpression(Class entityClass, com.yahoo.elide.security.RequestScope requestScope) {
             Path path = super.getFieldPath(entityClass, requestScope, "getEditor", "editor");
-            return new FilterPredicate(path, Operator.NOTNULL, Collections.emptyList());
+            return new NotNullPredicate(path);
         }
     }
 }


### PR DESCRIPTION
Created all the `XXPredicate` helper classes for each `Operation` type to make Filter expression checks cleaner to build, and provide type checking.