### PR TITLE
Replace jcabi-mysql-maven-plugin with H2 for testing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 4.2.14
+**Features**
+ * replaced jcabi-mysql-maven-plugin with H2 for testing
+
 ## 4.2.13
 **Features**
  * Add FilterPredicate sub-classes for each operation type

--- a/elide-contrib/elide-swagger/pom.xml
+++ b/elide-contrib/elide-swagger/pom.xml
@@ -77,6 +77,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
             <scope>provided</scope>
        </dependency>
        <dependency>

--- a/elide-contrib/pom.xml
+++ b/elide-contrib/pom.xml
@@ -77,18 +77,6 @@
                             </configuration>
                         </execution>
                         <execution>
-                            <id>reserve-network-port-pre-integration-test</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>reserve-network-port</goal>
-                            </goals>
-                            <configuration>
-                                <portNames>
-                                    <portName>mysql.port</portName>
-                                </portNames>
-                            </configuration>
-                        </execution>
-                        <execution>
                             <id>reserve-network-port-process-test-classes</id>
                             <phase>process-test-classes</phase>
                             <goals>
@@ -108,7 +96,6 @@
                     <version>2.19</version>
                     <configuration>
                         <systemPropertyVariables>
-                            <mysql.port>${mysql.port}</mysql.port>
                             <restassured.port>${restassured.port}</restassured.port>
                             <dataStoreSupplier>${dataStoreSupplier}</dataStoreSupplier>
                         </systemPropertyVariables>

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -14,6 +14,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
@@ -46,7 +49,6 @@ import example.Editor;
 import example.Publisher;
 import example.TestCheckMappings;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -259,7 +261,7 @@ public class LifeCycleTest {
         PersistentResource resource = PersistentResource.createObject(null, Book.class, scope, Optional.of("uuid"));
         resource.setValueChecked("title", "should not affect calls since this is create!");
         resource.setValueChecked("genre", "boring books");
-        Assert.assertNotNull(resource);
+        assertNotNull(resource);
         verify(book, never()).onCreateBook(scope);
         verify(book, never()).checkPermission(scope);
 
@@ -580,9 +582,9 @@ public class LifeCycleTest {
         scope.runQueuedPreCommitTriggers();
         scope.runQueuedPostCommitTriggers();
 
-        Assert.assertTrue(book.readPreSecurityInvoked);
-        Assert.assertTrue(book.readPreCommitInvoked);
-        Assert.assertTrue(book.readPostCommitInvoked);
+        assertTrue(book.readPreSecurityInvoked);
+        assertTrue(book.readPreCommitInvoked);
+        assertTrue(book.readPostCommitInvoked);
     }
 
     /**
@@ -640,9 +642,9 @@ public class LifeCycleTest {
         scope.runQueuedPreCommitTriggers();
         scope.runQueuedPostCommitTriggers();
 
-        Assert.assertTrue(book.updatePreSecurityInvoked);
-        Assert.assertTrue(book.updatePreCommitInvoked);
-        Assert.assertTrue(book.updatePostCommitInvoked);
+        assertTrue(book.updatePreSecurityInvoked);
+        assertTrue(book.updatePreCommitInvoked);
+        assertTrue(book.updatePostCommitInvoked);
     }
 
     /**
@@ -701,9 +703,9 @@ public class LifeCycleTest {
         scope.runQueuedPreSecurityTriggers();
         scope.runQueuedPostCommitTriggers();
 
-        Assert.assertTrue(book.createPreCommitInvoked);
-        Assert.assertTrue(book.createPostCommitInvoked);
-        Assert.assertTrue(book.createPreCommitInvoked);
+        assertTrue(book.createPreCommitInvoked);
+        assertTrue(book.createPostCommitInvoked);
+        assertTrue(book.createPreCommitInvoked);
     }
 
     /**
@@ -762,9 +764,9 @@ public class LifeCycleTest {
         scope.runQueuedPreCommitTriggers();
         scope.runQueuedPostCommitTriggers();
 
-        Assert.assertTrue(book.deletePreSecurityInvoked);
-        Assert.assertTrue(book.deletePreCommitInvoked);
-        Assert.assertTrue(book.deletePostCommitInvoked);
+        assertTrue(book.deletePreSecurityInvoked);
+        assertTrue(book.deletePreCommitInvoked);
+        assertTrue(book.deletePostCommitInvoked);
     }
 
     /**
@@ -793,7 +795,7 @@ public class LifeCycleTest {
         Publisher publisher = (Publisher) publisherResource.getObject();
 
         /* Only the creat hooks should be triggered */
-        Assert.assertFalse(publisher.isUpdateHookInvoked());
+        assertFalse(publisher.isUpdateHookInvoked());
 
         scope = new RequestScope(null, null, tx, new User(1), null, getElideSettings(null, store.getDictionary(), MOCK_AUDIT_LOGGER), false);
 
@@ -804,7 +806,7 @@ public class LifeCycleTest {
         scope.runQueuedPreCommitTriggers();
 
         publisher = (Publisher) publisherResource.getObject();
-        Assert.assertTrue(publisher.isUpdateHookInvoked());
+        assertTrue(publisher.isUpdateHookInvoked());
     }
 
     /**
@@ -834,7 +836,7 @@ public class LifeCycleTest {
         Publisher publisher = (Publisher) publisherResource.getObject();
 
         /* Only the creat hooks should be triggered */
-        Assert.assertFalse(publisher.isUpdateHookInvoked());
+        assertFalse(publisher.isUpdateHookInvoked());
 
         scope = new RequestScope(null, null, tx, new User(1), null, getElideSettings(null, store.getDictionary(), MOCK_AUDIT_LOGGER), false);
 
@@ -845,7 +847,7 @@ public class LifeCycleTest {
         scope.runQueuedPreCommitTriggers();
 
         publisher = (Publisher) publisherResource.getObject();
-        Assert.assertTrue(publisher.isUpdateHookInvoked());
+        assertTrue(publisher.isUpdateHookInvoked());
     }
 
     private Elide getElide(DataStore dataStore, EntityDictionary dictionary, AuditLogger auditLogger) {

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -127,8 +127,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -155,10 +155,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.jcabi</groupId>
-                <artifactId>jcabi-mysql-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/datastores/hibernate3/HibernateDataStoreSupplier.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/datastores/hibernate3/HibernateDataStoreSupplier.java
@@ -45,9 +45,8 @@ public class HibernateDataStoreSupplier implements Supplier<DataStore> {
 
         SessionFactory sessionFactory = configuration.configure("hibernate.cfg.xml")
                 .setProperty(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread")
-                .setProperty(Environment.URL, "jdbc:mysql://localhost:"
-                                + System.getProperty("mysql.port", "3306")
-                                + "/root?serverTimezone=UTC")
+                .setProperty(Environment.DIALECT, "org.hibernate.dialect.H2Dialect")
+                .setProperty(Environment.URL, "jdbc:h2:~/root;IGNORECASE=TRUE")
                 .setProperty(Environment.USER, "root")
                 .setProperty(Environment.PASS, "root")
                 .buildSessionFactory();

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/datastores/hibernate3/HibernateDataStoreSupplier.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/datastores/hibernate3/HibernateDataStoreSupplier.java
@@ -46,7 +46,7 @@ public class HibernateDataStoreSupplier implements Supplier<DataStore> {
         SessionFactory sessionFactory = configuration.configure("hibernate.cfg.xml")
                 .setProperty(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread")
                 .setProperty(Environment.DIALECT, "org.hibernate.dialect.H2Dialect")
-                .setProperty(Environment.URL, "jdbc:h2:~/root;IGNORECASE=TRUE")
+                .setProperty(Environment.URL, "jdbc:h2:mem:root;IGNORECASE=TRUE")
                 .setProperty(Environment.USER, "root")
                 .setProperty(Environment.PASS, "root")
                 .buildSessionFactory();

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -145,11 +145,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
             <scope>test</scope>
@@ -173,10 +168,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.jcabi</groupId>
-                <artifactId>jcabi-mysql-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateDataStoreSupplier.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateDataStoreSupplier.java
@@ -42,9 +42,8 @@ public class HibernateDataStoreSupplier implements Supplier<DataStore> {
                 new StandardServiceRegistryBuilder()
                         .configure("hibernate.cfg.xml")
                         .applySetting(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread")
-                        .applySetting(Environment.URL, "jdbc:mysql://localhost:"
-                                + System.getProperty("mysql.port", "3306")
-                                + "/root?serverTimezone=UTC")
+                        .applySetting(Environment.DIALECT, "org.hibernate.dialect.H2Dialect")
+                        .applySetting(Environment.URL, "jdbc:h2:~/root;IGNORECASE=TRUE")
                         .applySetting(Environment.USER, "root")
                         .applySetting(Environment.PASS, "root")
                         .build());

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateDataStoreSupplier.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateDataStoreSupplier.java
@@ -43,7 +43,7 @@ public class HibernateDataStoreSupplier implements Supplier<DataStore> {
                         .configure("hibernate.cfg.xml")
                         .applySetting(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread")
                         .applySetting(Environment.DIALECT, "org.hibernate.dialect.H2Dialect")
-                        .applySetting(Environment.URL, "jdbc:h2:~/root;IGNORECASE=TRUE")
+                        .applySetting(Environment.URL, "jdbc:h2:mem:root;IGNORECASE=TRUE")
                         .applySetting(Environment.USER, "root")
                         .applySetting(Environment.PASS, "root")
                         .build());

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreSupplier.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreSupplier.java
@@ -37,7 +37,7 @@ import javax.persistence.Persistence;
  * Supplier of Hibernate 5 Data Store.
  */
 public class HibernateEntityManagerDataStoreSupplier implements Supplier<DataStore> {
-    private static final String JDBC = "jdbc:h2:~/root;IGNORECASE=TRUE";
+    private static final String JDBC = "jdbc:h2:mem:root;IGNORECASE=TRUE";
     private static final String ROOT = "root";
 
     @Override

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreSupplier.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreSupplier.java
@@ -37,10 +37,7 @@ import javax.persistence.Persistence;
  * Supplier of Hibernate 5 Data Store.
  */
 public class HibernateEntityManagerDataStoreSupplier implements Supplier<DataStore> {
-    private static final String JDBC_PREFIX = "jdbc:mysql://localhost:";
-    private static final String JDBC_SUFFIX = "/root?serverTimezone=UTC";
-    private static final String MYSQL_PORT_PROPERTY = "mysql.port";
-    private static final String MYSQL_PORT = "3306";
+    private static final String JDBC = "jdbc:h2:~/root;IGNORECASE=TRUE";
     private static final String ROOT = "root";
 
     @Override
@@ -59,12 +56,11 @@ public class HibernateEntityManagerDataStoreSupplier implements Supplier<DataSto
             throw new IllegalStateException(e);
         }
 
-        options.put("javax.persistence.jdbc.driver", "com.mysql.jdbc.Driver");
-        options.put("javax.persistence.jdbc.url", JDBC_PREFIX
-                                + System.getProperty(MYSQL_PORT_PROPERTY, MYSQL_PORT)
-                                + JDBC_SUFFIX);
+        options.put("javax.persistence.jdbc.driver", "org.h2.Driver");
+        options.put("javax.persistence.jdbc.url", JDBC);
         options.put("javax.persistence.jdbc.user", ROOT);
         options.put("javax.persistence.jdbc.password", ROOT);
+        options.put("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
         options.put(AvailableSettings.LOADED_CLASSES, bindClasses);
 
         EntityManagerFactory emf = Persistence.createEntityManagerFactory("elide-tests", options);
@@ -75,11 +71,10 @@ public class HibernateEntityManagerDataStoreSupplier implements Supplier<DataSto
                 new StandardServiceRegistryBuilder()
                         .configure("hibernate.cfg.xml")
                         .applySetting(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread")
-                        .applySetting(Environment.URL, JDBC_PREFIX
-                                + System.getProperty(MYSQL_PORT_PROPERTY, MYSQL_PORT)
-                                + JDBC_SUFFIX)
+                        .applySetting(Environment.URL, JDBC)
                         .applySetting(Environment.USER, ROOT)
                         .applySetting(Environment.PASS, ROOT)
+                        .applySetting(Environment.DIALECT, "org.hibernate.dialect.H2Dialect")
                         .build());
 
         try {

--- a/elide-datastore/elide-datastore-multiplex/pom.xml
+++ b/elide-datastore/elide-datastore-multiplex/pom.xml
@@ -63,11 +63,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- For proper serialization in elide-core -->
         <dependency>
@@ -143,10 +138,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.jcabi</groupId>
-                <artifactId>jcabi-mysql-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableStoreSupplier.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableStoreSupplier.java
@@ -31,11 +31,10 @@ public class BridgeableStoreSupplier implements Supplier<DataStore> {
                 new StandardServiceRegistryBuilder()
                         .configure("hibernate.cfg.xml")
                         .applySetting(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread")
-                        .applySetting(Environment.URL, "jdbc:mysql://localhost:"
-                                + System.getProperty("mysql.port", "3306")
-                                + "/root?serverTimezone=UTC")
+                        .applySetting(Environment.URL, "jdbc:h2:~/root;IGNORECASE=TRUE")
                         .applySetting(Environment.USER, "root")
                         .applySetting(Environment.PASS, "root")
+                        .applySetting(Environment.DIALECT, "org.hibernate.dialect.H2Dialect")
                         .build());
 
         metadataSources.addAnnotatedClass(HibernateUser.class);

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableStoreSupplier.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableStoreSupplier.java
@@ -31,7 +31,7 @@ public class BridgeableStoreSupplier implements Supplier<DataStore> {
                 new StandardServiceRegistryBuilder()
                         .configure("hibernate.cfg.xml")
                         .applySetting(Environment.CURRENT_SESSION_CONTEXT_CLASS, "thread")
-                        .applySetting(Environment.URL, "jdbc:h2:~/root;IGNORECASE=TRUE")
+                        .applySetting(Environment.URL, "jdbc:h2:mem:root;IGNORECASE=TRUE")
                         .applySetting(Environment.USER, "root")
                         .applySetting(Environment.PASS, "root")
                         .applySetting(Environment.DIALECT, "org.hibernate.dialect.H2Dialect")

--- a/elide-datastore/pom.xml
+++ b/elide-datastore/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>logback-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <pluginManagement>
@@ -110,18 +115,6 @@
                             </configuration>
                         </execution>
                         <execution>
-                            <id>reserve-network-port-pre-integration-test</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>reserve-network-port</goal>
-                            </goals>
-                            <configuration>
-                                <portNames>
-                                    <portName>mysql.port</portName>
-                                </portNames>
-                            </configuration>
-                        </execution>
-                        <execution>
                             <id>reserve-network-port-process-test-classes</id>
                             <phase>process-test-classes</phase>
                             <goals>
@@ -137,58 +130,10 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
-                    <executions>
-                        <execution>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>unpack</goal>
-                            </goals>
-                            <configuration>
-                                <artifactItems>
-                                    <artifactItem>
-                                        <groupId>com.jcabi</groupId>
-                                        <artifactId>mysql-dist</artifactId>
-                                        <version>5.5.34</version>
-                                        <classifier>${mysql.classifier}</classifier>
-                                        <type>zip</type>
-                                        <overWrite>false</overWrite>
-                                        <outputDirectory>${project.build.directory}/mysql-dist</outputDirectory>
-                                    </artifactItem>
-                                </artifactItems>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>com.jcabi</groupId>
-                    <artifactId>jcabi-mysql-maven-plugin</artifactId>
-                    <!-- Above 0.7 breaks on Windows OS: jcabi/jcabi-mysql-maven-plugin#39 -->
-                    <version>0.7</version>
-                    <executions>
-                        <execution>
-                            <id>mysql-test</id>
-                            <goals>
-                                <goal>classify</goal>
-                                <goal>start</goal>
-                                <goal>stop</goal>
-                            </goals>
-                            <configuration>
-                                <port>${mysql.port}</port>
-                                <data>${mysql.data.directory}</data>
-                                <socket>${java.io.tmpdir}/elide.sock</socket>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.19.1</version>
                     <configuration>
                         <systemPropertyVariables>
-                            <mysql.port>${mysql.port}</mysql.port>
                             <restassured.port>${restassured.port}</restassured.port>
                             <dataStoreSupplier>${dataStoreSupplier}</dataStoreSupplier>
                         </systemPropertyVariables>

--- a/elide-example/elide-blog-example-resteasy/pom.xml
+++ b/elide-example/elide-blog-example-resteasy/pom.xml
@@ -96,6 +96,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
         </dependency>
 
         <!-- Testing -->

--- a/elide-example/elide-blog-example/pom.xml
+++ b/elide-example/elide-blog-example/pom.xml
@@ -106,6 +106,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
         </dependency>
 
         <!-- Testing -->

--- a/elide-example/elide-hibernate3-mysql-example/pom.xml
+++ b/elide-example/elide-hibernate3-mysql-example/pom.xml
@@ -88,6 +88,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
         </dependency>
     </dependencies>
 

--- a/elide-integration-tests/pom.xml
+++ b/elide-integration-tests/pom.xml
@@ -53,8 +53,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -1333,8 +1333,8 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
         Assert.assertEquals(errors.size(), 1);
 
         String error = errors.get(0).asText();
-        String expected = "TransactionException: Duplicate entry 'duplicate' for key 'name'";
-        Assert.assertTrue(error.equals(expected), "Error does not equal with '" + expected + "'");
+        String expected = "TransactionException: Unique index or primary key violation:";
+        Assert.assertTrue(error.startsWith(expected), "Error does not start with '" + expected + "' but found " + error);
     }
 
     @Test(priority = 29)

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.yahoo.elide.Elide;
@@ -50,7 +51,6 @@ import example.TestCheckMappings;
 import example.User;
 
 import org.apache.http.HttpStatus;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -1329,12 +1329,12 @@ public class ResourceIT extends AbstractIntegrationTestInitializer {
             .asString());
 
         JsonNode errors = result.get("errors");
-        Assert.assertNotNull(errors);
-        Assert.assertEquals(errors.size(), 1);
+        assertNotNull(errors);
+        assertEquals(errors.size(), 1);
 
         String error = errors.get(0).asText();
         String expected = "TransactionException: Unique index or primary key violation:";
-        Assert.assertTrue(error.startsWith(expected), "Error does not start with '" + expected + "' but found " + error);
+        assertTrue(error.startsWith(expected), "Error does not start with '" + expected + "' but found " + error);
     }
 
     @Test(priority = 29)

--- a/elide-integration-tests/src/test/java/example/Book.java
+++ b/elide-integration-tests/src/test/java/example/Book.java
@@ -120,8 +120,8 @@ public class Book extends BaseId {
         this.authors = authors;
     }
 
-    // Case sensitive collation for MySQL:
-    @Column(columnDefinition = "varchar(255) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL")
+    // Case sensitive collation for H2
+    @Column(columnDefinition = "VARCHAR_CASESENSITIVE(255) DEFAULT NULL")
     public String getEditorName() {
         return editorName;
     }

--- a/elide-integration-tests/src/test/resources/hibernate.cfg.xml
+++ b/elide-integration-tests/src/test/resources/hibernate.cfg.xml
@@ -13,10 +13,9 @@
     <session-factory>
         <!-- local connection properties -->
         <!-- this is what we normally use -->
-        <property name="hibernate.connection.driver_class">com.mysql.cj.jdbc.Driver</property>
-        <!-- dialect for Mysql -->
-        <property name="dialect">org.hibernate.dialect.MySQL5InnoDBDialect</property>
-
+        <property name="hibernate.connection.driver_class">org.h2.Driver</property>
+        <!-- dialect for H2 -->
+        <property name="dialect">org.hibernate.dialect.H2Dialect</property>
         <property name="hibernate.jdbc.batch_size">50</property>
         <property name="hibernate.jdbc.fetch_size">50</property>
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>1.4.197</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>2.2.26</version>
@@ -192,7 +198,7 @@
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
-                <version>2.4.7</version>
+                <version>2.4.15</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Replacing a deprecated `jcabi-mysql-maven-plugin` with H2 for database testing.