### PR TITLE
Add elide-test-helpers

### DIFF
--- a/checkstyle-style.xml
+++ b/checkstyle-style.xml
@@ -18,6 +18,7 @@
   <property name="severity" value="warning"/>
   <module name="TreeWalker">
     <module name="AvoidStarImport">
+      <property name="excludes" value="com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL"/>
       <metadata name="net.sf.eclipsecs.core.comment" value="Removes wildcard imports."/>
       <property name="allowClassImports" value="false"/>
       <property name="allowStaticMemberImports" value="false"/>

--- a/elide-contrib/elide-test-helpers/README.md
+++ b/elide-contrib/elide-test-helpers/README.md
@@ -1,0 +1,61 @@
+# Elide Test Helpers
+
+A set of helpers for testing Elide web services
+
+## Installation
+```xml
+<dependency>
+  <groupId>com.yahoo.elide</groupId>
+  <artifactId>elide-test-helpers</artifactId>
+  <version>${elide.verison}</version>
+  <scope>test</scope>
+</dependency>
+```
+
+## Usage
+
+The `JsonApiDSL` can be used to build JSON:API documents in a typesafe way.
+
+```java
+package com.yahoo.elideinstnace.integration
+
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.*;
+
+public class ReviewTest {
+  @Test
+  public void createReview() {
+
+    given().
+    contentType("application/vnd.api+json").
+    body(
+      data(
+        resource(
+          type("review"),
+          attributes(
+            attr("title", "My Awesome Review")
+          ),
+          relationships(
+          	relation("author",
+              linkage(
+                type("author"), 
+                id("1")
+              )
+            )
+          )
+        )
+      ).toJSON()
+    ).
+    when().
+      post("/reviews/").
+    then().
+      statusCode(HttpStatus.SC_CREATED).
+      body(
+        "data.id", equalTo("22"),
+      );
+  }
+}

--- a/elide-contrib/elide-test-helpers/pom.xml
+++ b/elide-contrib/elide-test-helpers/pom.xml
@@ -1,0 +1,92 @@
+<!--
+  ~ Copyright 2019, Yahoo Inc.
+  ~ Licensed under the Apache License, Version 2.0
+  ~ See LICENSE file in project root for terms.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>elide-test-helpers</artifactId>
+    <packaging>jar</packaging>
+    <name>Elide Test Helpers</name>
+    <description>Test Helpers for Elide</description>
+    <url>https://github.com/yahoo/elide</url>
+    <parent>
+        <artifactId>elide-contrib-parent-pom</artifactId>
+        <groupId>com.yahoo.elide</groupId>
+        <version>4.2.15-SNAPSHOT</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Yahoo Inc.</name>
+            <url>https://github.com/yahoo</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <developerConnection>scm:git:ssh://git@github.com/yahoo/elide.git</developerConnection>
+        <url>https://github.com/yahoo/elide.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+	    </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+   	    </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+	    </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi;
+
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Attribute;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Attributes;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Data;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Id;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relation;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relationships;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Resource;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.ResourceLinkage;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Type;
+
+/**
+ * Adds helper functions for creating Json API style data.
+ * <p>
+ * Example:
+ * data(
+ * resource(
+ * type("users"),
+ * id("the-user-id")
+ * )
+ * )
+ * <p>
+ * Creates Json in the form:
+ * "data": {
+ * "type": "user",
+ * "id":   "the-user-id"
+ * }
+ */
+public class JsonApiDSL {
+
+    /**
+     * Data data.
+     *
+     * @param resources the resources
+     * @return data
+     */
+    public static Data data(Resource... resources) {
+        return new Data(resources);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type          the type
+     * @param id            the id
+     * @param attributes    the attributes
+     * @param relationships the relationships
+     * @return the resource
+     */
+    public static Resource resource(Type type, Id id, Attributes attributes, Relationships relationships) {
+        return new Resource(id, type, attributes, relationships);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type       the type
+     * @param id         the id
+     * @param attributes the attributes
+     * @return the resource
+     */
+    public static Resource resource(Type type, Id id, Attributes attributes) {
+        return new Resource(id, type, attributes, null);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type the type
+     * @param id   the id
+     * @return the resource
+     */
+    public static Resource resource(Type type, Id id) {
+        return new Resource(id, type, null, null);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type       the type
+     * @param attributes the attributes
+     * @return the resource
+     */
+    public static Resource resource(Type type, Attributes attributes) {
+        return new Resource(id(null), type, attributes, null);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type          the type
+     * @param attributes    the attributes
+     * @param relationships the relationships
+     * @return the resource
+     */
+    public static Resource resource(Type type, Attributes attributes, Relationships relationships) {
+        return new Resource(id(null), type, attributes, relationships);
+    }
+
+    /**
+     * Type type.
+     *
+     * @param value the value
+     * @return the type
+     */
+    public static Type type(String value) {
+        return new Type(value);
+    }
+
+    /**
+     * Id id.
+     *
+     * @param id the id
+     * @return the id
+     */
+    public static Id id(Object id) {
+        return new Id(id);
+    }
+
+    /**
+     * Attributes attributes.
+     *
+     * @param attrs the attrs
+     * @return the attributes
+     */
+    public static Attributes attributes(Attribute... attrs) {
+        return new Attributes(attrs);
+    }
+
+    /**
+     * Attr attribute.
+     *
+     * @param key   the key
+     * @param value the value
+     * @return the attribute
+     */
+    public static Attribute attr(String key, Object value) {
+        return new Attribute(key, value);
+    }
+
+    /**
+     * Relationships relationships.
+     *
+     * @param relationships the relationships
+     * @return the relationships
+     */
+    public static Relationships relationships(Relation... relationships) {
+        return new Relationships(relationships);
+    }
+
+    /**
+     * Relation relation.
+     *
+     * @param field           the field
+     * @param resourceLinkage the resource linkage
+     * @return the relation
+     */
+    public static Relation relation(String field, ResourceLinkage... resourceLinkage) {
+        return new Relation(field, resourceLinkage);
+    }
+
+    /**
+     * Linkage resource linkage.
+     *
+     * @param type the type
+     * @param id   the id
+     * @return the resource linkage
+     */
+    public static ResourceLinkage linkage(Type type, Id id) {
+        return new ResourceLinkage(id, type);
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Attribute.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Attribute.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * The type Attribute.
+ */
+@AllArgsConstructor
+public class Attribute {
+    /**
+     * The Key.
+     */
+    final String key;
+    /**
+     * The Value.
+     */
+    final Object value;
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Attributes.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Attributes.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import java.util.LinkedHashMap;
+
+/**
+ * The type Attributes.
+ */
+public class Attributes extends LinkedHashMap {
+
+    /**
+     * Instantiates a new Attributes.
+     *
+     * @param attributes the attributes
+     */
+    public Attributes(Attribute... attributes) {
+        for (Attribute attribute : attributes) {
+            this.put(attribute.key, attribute.value);
+        }
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Data.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Data.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import com.google.gson.Gson;
+
+import java.util.LinkedHashMap;
+
+/**
+ * The type Data.
+ */
+public class Data extends LinkedHashMap<String, Object> {
+    static private final Gson GSON_INSTANCE = new Gson();
+
+    /**
+     * Instantiates a new Data.
+     *
+     * @param resources the resources
+     */
+    public Data(Resource... resources) {
+        // PATCH method does not work on an array of resources, hence sending it as a single element
+        if (resources.length == 1) {
+            this.put("data", resources[0]);
+        }
+        else {
+            this.put("data", resources);
+        }
+    }
+
+    /**
+     * To json string.
+     *
+     * @return the string
+     */
+    public String toJSON() {
+        return GSON_INSTANCE.toJson(this);
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Id.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Id.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * The type Id.
+ */
+@AllArgsConstructor
+public class Id {
+    /**
+     * The Value.
+     */
+    final Object value;
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+/**
+ * The type Relation.
+ */
+public class Relation {
+
+    /**
+     * The Field.
+     */
+    final String field;
+    /**
+     * The Resource linkages.
+     */
+    final ResourceLinkage[] resourceLinkages;
+
+    /**
+     * Instantiates a new Relation.
+     *
+     * @param field            the field
+     * @param resourceLinkages the resource linkages
+     */
+    public Relation(String field, ResourceLinkage... resourceLinkages) {
+        this.field = field;
+        this.resourceLinkages = resourceLinkages;
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relationships.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relationships.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The type Relationships.
+ */
+public class Relationships extends LinkedHashMap<String, Map> {
+
+    /**
+     * Instantiates a new Relationships.
+     *
+     * @param relations the relations
+     */
+    public Relationships(Relation... relations) {
+        for (Relation relation : relations) {
+            Map<String, ResourceLinkage[]> data = new LinkedHashMap<>();
+            data.put("data", relation.resourceLinkages);
+            this.put(relation.field, data);
+        }
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Resource.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Resource.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+/**
+ * Holds a Resource.
+ */
+public class Resource extends ResourceLinkage {
+
+    /**
+     * Instantiates a new Resource.
+     *
+     * @param id            the id
+     * @param type          the type
+     * @param attributes    the attributes
+     * @param relationships the relationships
+     */
+    public Resource(Id id, Type type, Attributes attributes, Relationships relationships) {
+        super(id, type);
+        this.put("attributes", attributes);
+        this.put("relationships", relationships);
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/ResourceLinkage.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/ResourceLinkage.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import java.util.LinkedHashMap;
+
+/**
+ * The type Resource linkage.
+ */
+public class ResourceLinkage extends LinkedHashMap<String, Object> {
+    /**
+     * Instantiates a new Resource linkage.
+     *
+     * @param id   the id
+     * @param type the type
+     */
+    public ResourceLinkage(Id id, Type type) {
+       this.put("id", id.value);
+       this.put("type", type.value);
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Type.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Type.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * The type Type.
+ */
+@AllArgsConstructor
+public class Type {
+    /**
+     * The Value.
+     */
+    final String value;
+}

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi;
+
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.*;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class JsonApiDSLTest {
+
+    @Test
+    public void verifyBasicRequest() {
+        String expected = "{\"data\":{\"id\":1,\"type\":\"blog\"}}";
+
+        String actual = data(
+                resource(
+                        type("blog"),
+                        id(1)
+                )
+        ).toJSON();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void verifyRequestWithAttributes() {
+        String expected = "{\"data\":{\"id\":\"1\",\"type\":\"blog\",\""
+                + "attributes\":{\"title\":\"Why You Should use Elide\",\"date\":\"2019-01-01\"}}}";
+
+        String actual = data(
+                resource(
+                        type("blog"),
+                        id("1"),
+                        attributes(
+                                attr("title", "Why You Should use Elide"),
+                                attr("date", "2019-01-01")
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void verifyRequestWithOneToOneRelationship() {
+        String expected = "{\"data\":{\"id\":\"1\",\"type\":\"blog\","
+                + "\"attributes\":{\"title\":\"title\"},"
+                + "\"relationships\":{\"author\":{\"data\":[{\"id\":\"1\",\"type\":\"author\"}]}}}}";
+
+        String actual = data(
+                resource(
+                        type("blog"),
+                        id("1"),
+                        attributes(
+                                attr("title", "title")
+                        ),
+                        relationships(
+                                relation("author",
+                                        linkage(type("author"), id("1"))
+                                )
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void verifyRequestWithOneToManyRelationship() {
+        String expected = "{\"data\":{\"id\":\"1\",\"type\":\"blog\","
+                + "\"attributes\":{\"title\":\"title\"},"
+                + "\"relationships\":{\"comments\":{"
+                + "\"data\":[{\"id\":\"1\",\"type\":\"comment\"},{\"id\":\"2\",\"type\":\"comment\"}]}}}}";
+
+        String actual = data(
+                resource(
+                        type("blog"),
+                        id("1"),
+                        attributes(
+                                attr("title", "title")
+                        ),
+                        relationships(
+                              relation("comments",
+                                      linkage(type("comment"), id("1")),
+                                      linkage(type("comment"), id("2"))
+                              )
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void verifyRequestWithManyRelationships() {
+        String expected = "{\"data\":{\"id\":\"1\",\"type\":\"blog\","
+                + "\"attributes\":{\"title\":\"title\"},"
+                + "\"relationships\":{"
+                + "\"author\":{\"data\":[{\"id\":\"1\",\"type\":\"author\"}]},"
+                + "\"comments\":{\"data\":[{\"id\":\"2\",\"type\":\"comment\"}]}}}}";
+
+        String actual = data(
+                resource(
+                        type("blog"),
+                        id("1"),
+                        attributes(
+                                attr("title", "title")
+                        ),
+                        relationships(
+                                relation("author",
+                                        linkage(type("author"), id("1"))
+                                ),
+                                relation("comments",
+                                        linkage(type("comment"), id("2"))
+                                )
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(actual, expected);
+    }
+}

--- a/elide-contrib/pom.xml
+++ b/elide-contrib/pom.xml
@@ -45,6 +45,7 @@
 
     <modules>
         <module>elide-swagger</module>
+        <module>elide-test-helpers</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
- Creates new elide-test-helpers module
- Add README
- Adds DSL for creating json:api documents
- Allows wild card import for JsonApiDSL class