### PR TITLE
Use SecurityContext as default User object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.3.0
+**Features**
+ * Use SecurityContext as default User object
+
 ## 4.2.14
 **Features**
  * Added [Codahale InstrumentedFilter](https://metrics.dropwizard.io/3.1.0/manual/servlet/) & corresponding metrics, threads, admin servlets as a setting option for Elide Standalone.

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2019, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -38,11 +38,13 @@ public class JsonApiEndpoint {
     protected final Elide elide;
     protected final Function<SecurityContext, Object> getUser;
 
+    private static final DefaultOpaqueUserFunction DEFAULT_GET_USER = securityContext -> securityContext;
+
     @Inject
     public JsonApiEndpoint(@Named("elide") Elide elide,
                            @Named("elideUserExtractionFunction") DefaultOpaqueUserFunction getUser) {
         this.elide = elide;
-        this.getUser = getUser == null ? v -> null : getUser;
+        this.getUser = getUser == null ? DEFAULT_GET_USER : getUser;
     }
 
     /**

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, Yahoo Inc.
+ * Copyright 2019, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -68,6 +68,7 @@ public class GraphQLEndpoint {
     private static final String OPERATION_NAME = "operationName";
     private static final String VARIABLES = "variables";
     private static final String MUTATION = "mutation";
+    private static final DefaultOpaqueUserFunction DEFAULT_GET_USER = securityContext -> securityContext;
 
     @Inject
     public GraphQLEndpoint(
@@ -76,7 +77,7 @@ public class GraphQLEndpoint {
         log.error("Started ~~");
         this.elide = elide;
         this.elideSettings = elide.getElideSettings();
-        this.getUser = getUser;
+        this.getUser = getUser == null ? DEFAULT_GET_USER : getUser;
         PersistentResourceFetcher fetcher = new PersistentResourceFetcher(elide.getElideSettings());
         ModelBuilder builder = new ModelBuilder(elide.getElideSettings().getDictionary(), fetcher);
         this.api = new GraphQL(builder.build());


### PR DESCRIPTION
This PR sets the request's [SecurityContext](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/core/SecurityContext.html) as the DefaultOpaqueUser in the case a `elideUserExtractionFunction` is not provided.

This could simplify Elide configuration since the [SecurityContext](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/core/SecurityContext.html) or the [Principal](https://docs.oracle.com/javase/8/docs/api/java/security/Principal.html) inside the [SecurityContext](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/core/SecurityContext.html) is what developers would naturally want to use when writing their permission checks.

