### PR TITLE
Add support for JPA @MapsId annotation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
  * Throw proper exception on invalid PersistentResource where id=null
  * Issue#744 Elide returns wrong date parsing format in 400 error for non-default DateFormats
  * Enable RSQL filter dialect by default (in addition to the default filter dialect).
+ * Enable support for JPA @MapsId annotation on relationships so that client doesn't have
+   to provide a dummy ID to make entity creation work.
 
 ## 4.3.3
 **Fixes**

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -60,9 +60,11 @@ import java.util.stream.Stream;
 import javax.persistence.AccessType;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
@@ -82,6 +84,8 @@ public class EntityBinding {
     public final Class<?> entityClass;
     public final String jsonApiType;
     public final String entityName;
+    @Getter
+    public boolean idGenerated;
     @Getter
     private AccessibleObject idField;
     @Getter
@@ -127,6 +131,7 @@ public class EntityBinding {
         entityClass = null;
         inheritedTypes = null;
         entityPermissions = EntityPermissions.EMPTY_PERMISSIONS;
+        idGenerated = false;
     }
 
     public EntityBinding(EntityDictionary dictionary, Class<?> cls, String type, String name) {
@@ -293,6 +298,9 @@ public class EntityBinding {
         if (idField != null && !fieldOrMethod.equals(idField)) {
             throw new DuplicateMappingException(type + " " + cls.getName() + ":" + fieldName);
         }
+        if (fieldOrMethod.isAnnotationPresent(GeneratedValue.class)) {
+            idGenerated = true;
+        }
     }
 
     /**
@@ -344,6 +352,10 @@ public class EntityBinding {
         boolean toOne = fieldOrMethod.isAnnotationPresent(ToOne.class);
         boolean toMany = fieldOrMethod.isAnnotationPresent(ToMany.class);
         boolean computedRelationship = fieldOrMethod.isAnnotationPresent(ComputedRelationship.class);
+
+        if (fieldOrMethod.isAnnotationPresent(MapsId.class)) {
+            idGenerated = true;
+        }
 
         RelationshipType type;
         String mappedBy = "";

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1893,7 +1893,8 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         //If id field is not a `@GeneratedValue` or mapped via a `@MapsId` attribute
         //then persist the provided id
-        if (!(persistentResource.isIdGenerated() || persistentResource.isIdMapped())) {
+        //if (!(persistentResource.isIdGenerated() || persistentResource.isIdMapped())) {
+        if (!persistentResource.isIdGenerated()) {
             if (id != null && !id.isEmpty()) {
                 persistentResource.setId(id);
             } else {

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -69,8 +69,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import javax.persistence.GeneratedValue;
-import javax.persistence.MapsId;
 import javax.ws.rs.WebApplicationException;
 
 /**
@@ -753,38 +751,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @return Boolean
      */
     public boolean isIdGenerated() {
-        return getIdAnnotations().stream().anyMatch(a -> a.annotationType().equals(GeneratedValue.class));
+        return dictionary.getEntityBinding(
+            getObject().getClass()
+        ).isIdGenerated();
     }
 
-    /**
-     * Indicates if the ID is mapped to another entity or not.
-     *
-     * @return Boolean
-     */
-    public boolean isIdMapped() {
-        final Class<?> cls = getObject().getClass();
-        for (final AccessibleObject obj : dictionary.getEntityBinding(cls).getAllFields()) {
-            if (
-                dictionary.getAttributeOrRelationAnnotation(
-                    cls,
-                    MapsId.class,
-                    EntityBinding.getFieldName(obj)
-                ) != null
-            ) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns annotations applied to the ID field.
-     *
-     * @return Collection of Annotations
-     */
-    private Collection<Annotation> getIdAnnotations() {
-        return dictionary.getIdAnnotations(getObject());
-    }
 
     /**
      * Gets UUID.
@@ -1893,7 +1864,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         //If id field is not a `@GeneratedValue` or mapped via a `@MapsId` attribute
         //then persist the provided id
-       if (!(persistentResource.isIdGenerated() || persistentResource.isIdMapped())) {
+       if (!persistentResource.isIdGenerated()) {
             if (id != null && !id.isEmpty()) {
                 persistentResource.setId(id);
             } else {

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1893,8 +1893,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         //If id field is not a `@GeneratedValue` or mapped via a `@MapsId` attribute
         //then persist the provided id
-        //if (!(persistentResource.isIdGenerated() || persistentResource.isIdMapped())) {
-        if (!persistentResource.isIdGenerated()) {
+       if (!(persistentResource.isIdGenerated() || persistentResource.isIdMapped())) {
             if (id != null && !id.isEmpty()) {
                 persistentResource.setId(id);
             } else {

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
@@ -6,6 +6,8 @@
 package com.yahoo.elide.core;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import org.mockito.Mock;
 import org.testng.annotations.BeforeTest;
@@ -18,8 +20,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 public class EntityBindingTest {
     private EntityBinding entityBinding;
@@ -80,21 +80,21 @@ public class EntityBindingTest {
     private class ChildClass extends ParentClass {
         String childField;
     }
-    
+
     private class GeneratedValueClass {
         @Id
         @GeneratedValue
         String id;
     }
 
-    private class MapsIdClass extends ParentClass{
+    private class MapsIdClass extends ParentClass {
         @OneToOne
         @MapsId
-        ParentClass parent;
+        private ParentClass parent;
     }
 
     private class BadMapsIdClass extends ParentClass {
         @MapsId
-        ParentClass parent;
+        private ParentClass parent;
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
@@ -67,7 +67,7 @@ public class EntityBindingTest {
     @Test
     public void testIdGeneratedFalseWhenBadMapsId() throws Exception {
         final EntityBinding eb = new EntityBinding(entityDictionary, BadMapsIdClass.class, "test", "testBinding");
-        assertFalse(entityBinding.isIdGenerated());
+        assertFalse(eb.isIdGenerated());
     }
 
     private class ParentClass {

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
@@ -14,7 +14,12 @@ import org.testng.annotations.Test;
 import java.lang.reflect.AccessibleObject;
 import java.util.List;
 
+import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class EntityBindingTest {
     private EntityBinding entityBinding;
@@ -42,6 +47,29 @@ public class EntityBindingTest {
         assertEquals(idField, ParentClass.class.getDeclaredField("parentField"));
     }
 
+    @Test
+    public void testIdGeneratedFalseWhenNoAnnotations() throws Exception {
+        assertFalse(entityBinding.isIdGenerated());
+    }
+
+    @Test
+    public void testIdGeneratedTrueWhenGenerateValue() throws Exception {
+        final EntityBinding eb = new EntityBinding(entityDictionary, GeneratedValueClass.class, "test", "testBinding");
+        assertTrue(eb.isIdGenerated());
+    }
+
+    @Test
+    public void testIdGeneratedTrueWhenMapsId() throws Exception {
+        final EntityBinding eb = new EntityBinding(entityDictionary, MapsIdClass.class, "test", "testBinding");
+        assertTrue(eb.isIdGenerated());
+    }
+
+    @Test
+    public void testIdGeneratedFalseWhenBadMapsId() throws Exception {
+        final EntityBinding eb = new EntityBinding(entityDictionary, BadMapsIdClass.class, "test", "testBinding");
+        assertFalse(entityBinding.isIdGenerated());
+    }
+
     private class ParentClass {
         @Id
         String parentField;
@@ -51,5 +79,22 @@ public class EntityBindingTest {
 
     private class ChildClass extends ParentClass {
         String childField;
+    }
+    
+    private class GeneratedValueClass {
+        @Id
+        @GeneratedValue
+        String id;
+    }
+
+    private class MapsIdClass extends ParentClass{
+        @OneToOne
+        @MapsId
+        ParentClass parent;
+    }
+
+    private class BadMapsIdClass extends ParentClass {
+        @MapsId
+        ParentClass parent;
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
@@ -90,11 +90,11 @@ public class EntityBindingTest {
     private class MapsIdClass extends ParentClass {
         @OneToOne
         @MapsId
-        private ParentClass parent;
+        public ParentClass parent;
     }
 
     private class BadMapsIdClass extends ParentClass {
         @MapsId
-        private ParentClass parent;
+        public ParentClass parent;
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -48,6 +48,7 @@ import example.ComputedBean;
 import example.FirstClassFields;
 import example.FunWithPermissions;
 import example.Invoice;
+import example.Job;
 import example.Left;
 import example.LineItem;
 import example.MapColorShape;
@@ -1658,6 +1659,27 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
 
         Assert.assertEquals(created.getObject(), parent,
                 "The create function should return the requested parent object"
+        );
+    }
+
+    @Test()
+    public void testCreateMappedIdObjectSuccess() {
+        final Job job = new Job();
+        job.setId(123);
+        job.setTitle("day job");
+        job.setParent(newParent(1));
+
+        final DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        when(tx.createNewObject(Job.class)).thenReturn(job);
+
+        final RequestScope goodScope = new RequestScope(null, null, tx, new User(1), null, elideSettings, false);
+        System.out.println("HELLO WORLD1");
+        final PersistentResource<Job> created = PersistentResource.createObject(null, Job.class, goodScope, Optional.empty());
+        System.out.println("HELLO WORLD2");
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+
+        Assert.assertEquals("day job", created.getObject().getTitle(),
+                "The create function should return the requested job object"
         );
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -114,6 +114,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         dictionary.bindEntity(Child.class);
         dictionary.bindEntity(Parent.class);
         dictionary.bindEntity(FunWithPermissions.class);
+        dictionary.bindEntity(Job.class);
         dictionary.bindEntity(Left.class);
         dictionary.bindEntity(Right.class);
         dictionary.bindEntity(NoReadEntity.class);
@@ -1665,7 +1666,6 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     @Test()
     public void testCreateMappedIdObjectSuccess() {
         final Job job = new Job();
-        job.setId(123);
         job.setTitle("day job");
         job.setParent(newParent(1));
 
@@ -1673,13 +1673,34 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         when(tx.createNewObject(Job.class)).thenReturn(job);
 
         final RequestScope goodScope = new RequestScope(null, null, tx, new User(1), null, elideSettings, false);
-        System.out.println("HELLO WORLD1");
         final PersistentResource<Job> created = PersistentResource.createObject(null, Job.class, goodScope, Optional.empty());
-        System.out.println("HELLO WORLD2");
         created.getRequestScope().getPermissionExecutor().executeCommitChecks();
 
-        Assert.assertEquals("day job", created.getObject().getTitle(),
+        Assert.assertEquals(created.getObject().getTitle(), "day job",
                 "The create function should return the requested job object"
+        );
+        Assert.assertEquals(created.getObject().getId(), null,
+                "The create function should not override the ID"
+        );
+    }
+    @Test()
+    public void testCreateMappedIdObjectIgnoredSpecifiedId() {
+        final Job job = new Job();
+        job.setTitle("day job");
+        job.setParent(newParent(1));
+
+        final DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        when(tx.createNewObject(Job.class)).thenReturn(job);
+
+        final RequestScope goodScope = new RequestScope(null, null, tx, new User(1), null, elideSettings, false);
+        final PersistentResource<Job> created = PersistentResource.createObject(null, Job.class, goodScope, Optional.of("1234"));
+        created.getRequestScope().getPermissionExecutor().executeCommitChecks();
+
+        Assert.assertEquals(created.getObject().getTitle(), "day job",
+                "The create function should return the requested job object"
+        );
+        Assert.assertEquals(created.getObject().getId(), null,
+                "The create function should not override the ID"
         );
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -1673,7 +1673,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         when(tx.createNewObject(Job.class)).thenReturn(job);
 
         final RequestScope goodScope = new RequestScope(null, null, tx, new User(1), null, elideSettings, false);
-        final PersistentResource<Job> created = PersistentResource.createObject(null, Job.class, goodScope, Optional.empty());
+        PersistentResource<Job> created = PersistentResource.createObject(null, Job.class, goodScope, Optional.empty());
         created.getRequestScope().getPermissionExecutor().executeCommitChecks();
 
         Assert.assertEquals(created.getObject().getTitle(), "day job",
@@ -1682,18 +1682,8 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         Assert.assertEquals(created.getObject().getId(), null,
                 "The create function should not override the ID"
         );
-    }
-    @Test()
-    public void testCreateMappedIdObjectIgnoredSpecifiedId() {
-        final Job job = new Job();
-        job.setTitle("day job");
-        job.setParent(newParent(1));
 
-        final DataStoreTransaction tx = mock(DataStoreTransaction.class);
-        when(tx.createNewObject(Job.class)).thenReturn(job);
-
-        final RequestScope goodScope = new RequestScope(null, null, tx, new User(1), null, elideSettings, false);
-        final PersistentResource<Job> created = PersistentResource.createObject(null, Job.class, goodScope, Optional.of("1234"));
+        created = PersistentResource.createObject(null, Job.class, goodScope, Optional.of("1234"));
         created.getRequestScope().getPermissionExecutor().executeCommitChecks();
 
         Assert.assertEquals(created.getObject().getTitle(), "day job",

--- a/elide-core/src/test/java/example/Job.java
+++ b/elide-core/src/test/java/example/Job.java
@@ -18,7 +18,7 @@ import javax.persistence.Table;
 
 /**
  * Model to represent a Parent's Job.
- * 
+ *
  * Used to test/demonstrate the use of {@literal @MapsId} annotation.
  */
 @Entity
@@ -29,7 +29,7 @@ public class Job {
     @Id
     @Getter
     private Long id;
-    
+
     @Getter @Setter
     private String title;
 

--- a/elide-core/src/test/java/example/Job.java
+++ b/elide-core/src/test/java/example/Job.java
@@ -11,23 +11,30 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.Entity;
+import javax.persistence.Id;
 import javax.persistence.MapsId;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 /**
- * Model for ghostwriters.
+ * Model to represent a Parent's Job.
+ * 
+ * Used to test/demonstrate the use of {@literal @MapsId} annotation.
  */
 @Entity
 @Table(name = "job")
 @Include(rootLevel = true, type = "job")
-public class Job extends BaseId {
+public class Job {
+
+    @Id
+    @Getter
+    private Long id;
+    
+    @Getter @Setter
+    private String title;
 
     @OneToOne
     @MapsId
     @Getter @Setter
     private Parent parent;
-
-    @Getter @Setter
-    private String title;
 }

--- a/elide-core/src/test/java/example/Job.java
+++ b/elide-core/src/test/java/example/Job.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.MapsId;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+/**
+ * Model for ghostwriters.
+ */
+@Entity
+@Table(name = "job")
+@Include(rootLevel = true, type = "job")
+public class Job extends BaseId {
+
+    @OneToOne
+    @MapsId
+    @Getter @Setter
+    private Parent parent;
+
+    @Getter @Setter
+    private String title;
+}


### PR DESCRIPTION
If you have a JPA model where one entity has an ID which is dictated by the value in another entity (mapped via the JPA `@MapsId` annotation) then ELIDE needs to not force a creating POST request to contain an ID.
e.g.[https://www.concretepage.com/hibernate/example-mapsid-hibernate](https://www.concretepage.com/hibernate/example-mapsid-hibernate)

This PR adds support for the `@MapsId` annotation in entities. Without this you are unable to create such a dependent entity using ELIDE (unless you provide a dummy ID which gets discarded, and which is an incorrect use of JSON:API)