### PR TITLE
loadObject should return unique result

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Change Log
+<<<<<<< HEAD
 
 ## 5.0.9
 **Fixes**
@@ -963,6 +964,11 @@ Because Elide 5 is a major release, we took time to reorganize the module & pack
  * Enable support for JPA @MapsId annotation on relationships so that client doesn't have
    to provide a dummy ID to make entity creation work.
  * Cache all calls to getEntityBinding
+=======
+## 4.4.1
+**Fixes**
+  * Default DataStore loadOject should return only a unique result
+>>>>>>> 815cbecf4... loadObject should return unique result
 
 ## 4.4.0
 **Features**

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,4 @@
 # Change Log
-<<<<<<< HEAD
 
 ## 5.0.9
 **Fixes**
@@ -964,11 +963,6 @@ Because Elide 5 is a major release, we took time to reorganize the module & pack
  * Enable support for JPA @MapsId annotation on relationships so that client doesn't have
    to provide a dummy ID to make entity creation work.
  * Cache all calls to getEntityBinding
-=======
-## 4.4.1
-**Fixes**
-  * Default DataStore loadOject should return only a unique result
->>>>>>> 815cbecf4... loadObject should return unique result
 
 ## 4.4.0
 **Features**

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
@@ -143,7 +143,10 @@ public interface DataStoreTransaction extends Closeable {
 
         Iterator<T> it = results == null ? null : results.iterator();
         if (it != null && it.hasNext()) {
-            return it.next();
+            Object obj = it.next();
+            if (!it.hasNext()) {
+              return obj;
+            }
         }
         return null;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.exceptions.InvalidObjectIdentifierException;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.predicates.InPredicate;
@@ -143,10 +144,13 @@ public interface DataStoreTransaction extends Closeable {
 
         Iterator<T> it = results == null ? null : results.iterator();
         if (it != null && it.hasNext()) {
-            Object obj = it.next();
+            T obj = it.next();
             if (!it.hasNext()) {
               return obj;
             }
+
+            //Multiple objects with the same ID.
+            throw new InvalidObjectIdentifierException(id.toString(), dictionary.getJsonAliasFor(entityClass));
         }
         return null;
     }


### PR DESCRIPTION
If the default datastore `loadObject` fails to filter to a single result, do not return any.

Currently the first element of the collection would erroneously be returned.