### PR TITLE
Flush once for patch extension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 4.4.1
+**Fixes**
+ * Flush once for patch extension
+
 ## 4.4.0
 **Features**
  * Issue#763 Support for filtering & sorting on computed attributes
@@ -8,12 +12,11 @@
  * Throw proper exception on invalid PersistentResource where id=null
  * Issue#744 Elide returns wrong date parsing format in 400 error for non-default DateFormats
  * Enable RSQL filter dialect by default (in addition to the default filter dialect).
- * Flush once for patch extension
 
 ## 4.3.3
 **Fixes**
  * Issue#744 Better error handling for mismatched method in Lifecycle and additional test
- * Upgraded puppycrawl.tools (checkstyle) dependency to address CVE-2019-9658 
+ * Upgraded puppycrawl.tools (checkstyle) dependency to address CVE-2019-9658
  * Issue#766 Outdated MySQL driver in elide-standalone and examples
 
 ## 4.3.2

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
  * Throw proper exception on invalid PersistentResource where id=null
  * Issue#744 Elide returns wrong date parsing format in 400 error for non-default DateFormats
  * Enable RSQL filter dialect by default (in addition to the default filter dialect).
+ * Flush once for patch extension
 
 ## 4.3.3
 **Fixes**

--- a/elide-contrib/elide-test-helpers/pom.xml
+++ b/elide-contrib/elide-test-helpers/pom.xml
@@ -62,18 +62,18 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-	    </plugin>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-   	    </plugin>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-	    </plugin>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-failsafe-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -186,14 +186,7 @@ public interface DataStoreTransaction extends Closeable {
             Optional<Sorting> sorting,
             Optional<Pagination> pagination,
             RequestScope scope) {
-        RequestScope requestScope;
-        try {
-            requestScope = scope;
-        } catch (ClassCastException e) {
-            throw new ClassCastException("Fail trying to cast requestscope");
-        }
-
-        return PersistentResource.getValue(entity, relationName, requestScope);
+        return PersistentResource.getValue(entity, relationName, scope);
     }
 
 
@@ -244,15 +237,7 @@ public interface DataStoreTransaction extends Closeable {
     default Object getAttribute(Object entity,
                                 String attributeName,
                                 RequestScope scope) {
-        RequestScope requestScope;
-        try {
-            requestScope = scope;
-        } catch (ClassCastException e) {
-            throw new ClassCastException("Fail trying to cast requestscope");
-        }
-
-        Object val = PersistentResource.getValue(entity, attributeName, requestScope);
-        return val;
+        return PersistentResource.getValue(entity, attributeName, scope);
 
     }
 

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -158,6 +158,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <forkMode>once</forkMode>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -86,7 +86,9 @@ public class HibernateTransaction implements DataStoreTransaction {
             deferredTasks.forEach(Runnable::run);
             deferredTasks.clear();
             FlushMode flushMode = session.getFlushMode();
-            if (flushMode != FlushMode.COMMIT && flushMode != FlushMode.MANUAL && flushMode != FlushMode.NEVER) {
+            // flush once for patch extension
+            if (requestScope != null && !requestScope.isMutatingMultipleEntities()
+                && flushMode != FlushMode.MANUAL && flushMode != FlushMode.NEVER) {
                 session.flush();
             }
         } catch (HibernateException e) {

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -205,6 +205,7 @@
                     <forkMode>once</forkMode>
                     <reuseForks>false</reuseForks>
                     <trimStackTrace>false</trimStackTrace>
+                    <failIfNoTests>true</failIfNoTests>
                 </configuration>
             </plugin>
             <plugin>

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -90,7 +90,8 @@ public class HibernateTransaction implements DataStoreTransaction {
             deferredTasks.forEach(Runnable::run);
             deferredTasks.clear();
             FlushMode flushMode = session.getHibernateFlushMode();
-            if (flushMode != FlushMode.COMMIT && flushMode != FlushMode.MANUAL) {
+            // flush once for patch extension
+            if (requestScope != null && !requestScope.isMutatingMultipleEntities() && flushMode != FlushMode.MANUAL) {
                 session.flush();
             }
         } catch (PersistenceException e) {

--- a/elide-datastore/elide-datastore-jpa/pom.xml
+++ b/elide-datastore/elide-datastore-jpa/pom.xml
@@ -184,6 +184,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <forkMode>once</forkMode>
+                    <failIfNoTests>true</failIfNoTests>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/elide-datastore/elide-datastore-multiplex/pom.xml
+++ b/elide-datastore/elide-datastore-multiplex/pom.xml
@@ -152,6 +152,7 @@
                     <excludes>
                         <exclude>com.yahoo.elide.tests.*</exclude>
                     </excludes>
+                    <failIfNoTests>true</failIfNoTests>
                 </configuration>
             </plugin>
             <plugin>

--- a/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/GenerateIT.groovy
+++ b/elide-integration-tests/src/test/groovy/com/yahoo/elide/tests/GenerateIT.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.tests
+import static com.jayway.restassured.RestAssured.given
+import static org.testng.Assert.assertFalse
+import static org.testng.Assert.assertTrue
+
+import com.yahoo.elide.core.HttpStatus
+import com.yahoo.elide.initialization.AbstractIntegrationTestInitializer
+
+import org.testng.annotations.Test
+/**
+ * Tests for UserType
+ */
+class GenerateIT extends AbstractIntegrationTestInitializer {
+
+    @Test(priority = 1)
+    public void testGeneratePost() {
+
+        String body = """
+        {
+            "data": {
+                "id": 1,
+                "type": "generate",
+                "attributes": {
+                }
+            }
+        }
+        """
+
+        String resp = given()
+            .contentType("application/vnd.api+json")
+            .accept("application/vnd.api+json")
+            .body(body)
+            .post("/generate")
+            .then()
+            .statusCode(HttpStatus.SC_CREATED)
+            .extract().body().asString()
+
+        assertTrue(resp.contains("created"), "Generated field is missing\n" + resp)
+        assertFalse(resp.contains(":null"), "Generated field is null\n" + resp)
+    }
+}

--- a/elide-integration-tests/src/test/java/example/Generate.java
+++ b/elide-integration-tests/src/test/java/example/Generate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
+
+import lombok.Setter;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+@Entity
+@Include(rootLevel = true)
+public class Generate {
+    @Setter
+    private long id;
+
+    @Setter
+    private Date created;
+
+    @Id
+    public long getId() {
+        return id;
+    }
+
+    @Generated(GenerationTime.INSERT)
+    @Column(updatable = false, insertable = false, columnDefinition = "timestamp default current_timestamp")
+    @Temporal(TemporalType.TIMESTAMP)
+    public Date getCreated() {
+        return created;
+    }
+}


### PR DESCRIPTION
Flush is required before serialization to properly populate `@Generated` fields.