### PR TITLE
Restore hibernate flush mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ## 4.4.2
 **Fixes**
  * Fix error in lookupEntityClass and add test
+ * Restore Flush mechanism for Hibernate but allow for customization.
 
 ## 4.4.1
 **Features**

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -343,11 +343,10 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
 
             // Make sure value is comparable and perform comparison
             if (leftCompare instanceof Comparable) {
-                int result = ((Comparable<Object>) leftCompare).compareTo(rightCompare);
                 if (order == Sorting.SortOrder.asc) {
-                    return result;
+                    return ((Comparable<Object>) leftCompare).compareTo(rightCompare);
                 }
-                return -result;
+                return ((Comparable<Object>) rightCompare).compareTo(leftCompare);
             }
 
             throw new IllegalStateException("Trying to comparing non-comparable types!");


### PR DESCRIPTION
The change to force a flush before commit does not work for some of our Hibernate 3 beans.

This change makes the flush mechanism configurable while defaulting to the prior functionality.