### PR TITLE
Allow ORM to generate SQL when possible (to avoid N+1)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 4.4.3
+**Features**
+ * When fetching a collection, if there are no filters, sorting, or client specified pagination, the ORM backed data stores will return the proxy object rather than construct a HQL query.  This allows the ORM the opportunity to generate SQL to avoid the N+1 problem.
+
 ## 4.4.2
 **Fixes**
  * Fix error in lookupEntityClass and add test

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -445,6 +445,14 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
                 || filteredInMemory
                 || sortedInMemory) {
             return Pair.of(Optional.empty(), pagination);
+
+        /*
+         * For default pagination, we let the store do its work, but we also let the store ignore pagination
+         * by also performing in memory.  This allows the ORM the opportunity to manage its own SQL query generation
+         * to avoid N+1.
+         */
+        } else if (pagination.isPresent() && pagination.get().isDefaultInstance()) {
+            return Pair.of(pagination, pagination);
         } else {
             return Pair.of(pagination, Optional.empty());
         }

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -196,6 +196,17 @@ public class HibernateTransaction implements DataStoreTransaction {
         if (val instanceof Collection) {
             Collection filteredVal = (Collection) val;
             if (filteredVal instanceof AbstractPersistentCollection) {
+
+                /*
+                 * If there is no filtering or sorting required in the data store, and the pagination is default,
+                 * return the proxy and let Hibernate manage the SQL generation.
+                 */
+                if (! filterExpression.isPresent() && ! sorting.isPresent()) {
+                    if (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance())) {
+                        return val;
+                    }
+                }
+
                 Class<?> relationClass = dictionary.getParameterizedType(entity, relationName);
 
                 RelationshipImpl relationship = new RelationshipImpl(

--- a/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/main/java/com/yahoo/elide/datastores/hibernate3/HibernateTransaction.java
@@ -201,10 +201,9 @@ public class HibernateTransaction implements DataStoreTransaction {
                  * If there is no filtering or sorting required in the data store, and the pagination is default,
                  * return the proxy and let Hibernate manage the SQL generation.
                  */
-                if (! filterExpression.isPresent() && ! sorting.isPresent()) {
-                    if (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance())) {
-                        return val;
-                    }
+                if (! filterExpression.isPresent() && ! sorting.isPresent()
+                    && (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance()))) {
+                    return val;
                 }
 
                 Class<?> relationClass = dictionary.getParameterizedType(entity, relationName);

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -207,10 +207,9 @@ public class HibernateTransaction implements DataStoreTransaction {
                  * If there is no filtering or sorting required in the data store, and the pagination is default,
                  * return the proxy and let Hibernate manage the SQL generation.
                  */
-                if (! filterExpression.isPresent() && ! sorting.isPresent()) {
-                    if (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance())) {
-                        return val;
-                    }
+                if (! filterExpression.isPresent() && ! sorting.isPresent()
+                    && (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance()))) {
+                    return val;
                 }
 
                 Class<?> relationClass = dictionary.getParameterizedType(entity, relationName);

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateTransaction.java
@@ -202,6 +202,17 @@ public class HibernateTransaction implements DataStoreTransaction {
         if (val instanceof Collection) {
             Collection filteredVal = (Collection) val;
             if (filteredVal instanceof AbstractPersistentCollection) {
+
+                /*
+                 * If there is no filtering or sorting required in the data store, and the pagination is default,
+                 * return the proxy and let Hibernate manage the SQL generation.
+                 */
+                if (! filterExpression.isPresent() && ! sorting.isPresent()) {
+                    if (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance())) {
+                        return val;
+                    }
+                }
+
                 Class<?> relationClass = dictionary.getParameterizedType(entity, relationName);
 
                 RelationshipImpl relationship = new RelationshipImpl(

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
@@ -215,6 +215,17 @@ public abstract class AbstractJpaTransaction implements JpaTransaction {
         if (val instanceof Collection) {
             Collection<?> filteredVal = (Collection<?>) val;
             if (IS_PERSISTENT_COLLECTION.test(filteredVal)) {
+
+                /*
+                 * If there is no filtering or sorting required in the data store, and the pagination is default,
+                 * return the proxy and let the ORM manage the SQL generation.
+                 */
+                if (! filterExpression.isPresent() && ! sorting.isPresent()) {
+                    if (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance())) {
+                        return val;
+                    }
+                }
+
                 Class<?> relationClass = dictionary.getParameterizedType(entity, relationName);
 
                 RelationshipImpl relationship = new RelationshipImpl(

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
@@ -220,10 +220,9 @@ public abstract class AbstractJpaTransaction implements JpaTransaction {
                  * If there is no filtering or sorting required in the data store, and the pagination is default,
                  * return the proxy and let the ORM manage the SQL generation.
                  */
-                if (! filterExpression.isPresent() && ! sorting.isPresent()) {
-                    if (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance())) {
-                        return val;
-                    }
+                if (! filterExpression.isPresent() && ! sorting.isPresent()
+                    && (! pagination.isPresent() || (pagination.isPresent() && pagination.get().isDefaultInstance()))) {
+                    return val;
                 }
 
                 Class<?> relationClass = dictionary.getParameterizedType(entity, relationName);


### PR DESCRIPTION
When fetching a collection, if there are no filters, sorting, or client specified pagination, the ORM backed data stores will *now* return the proxy object rather than construct a JPQL query.  This allows the ORM the opportunity to generate SQL to avoid the N+1 problem.

Note: JPQL can only avoid the N+1 problem by prefetching toOne relationships through joins.  Other ORM provided solutions are not supported in JPQL.  Prefetching toMany relationships through joins is not tenable for large collections.