### PR TITLE
Add graphql support for BigDecimal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 4.4.5
+**Features**
+* Issue#812 Add support for BigDecimal field in GraphQL. 
+
 ## 4.4.4
 **Fixes**
  * When requesting an ID field whose name is not 'id', an error happens: `No such association id for type xxx`. When the requested field name equals 'id', Elide has been fixed to look for the field with the annotation @Id rather than looking by field name.

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,11 @@
 # Change Log
-## 4.4.5
-**Features**
-* Issue#812 Add support for BigDecimal field in GraphQL. 
 
 ## 4.4.4
 **Fixes**
  * When requesting an ID field whose name is not 'id', an error happens: `No such association id for type xxx`. When the requested field name equals 'id', Elide has been fixed to look for the field with the annotation @Id rather than looking by field name.
+
+**Features**
+* Issue#812 Add support for BigDecimal field in GraphQL. 
 
 ## 4.4.3
 **Features**

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -27,6 +27,7 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
 import lombok.extern.slf4j.Slf4j;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -75,6 +76,8 @@ public class GraphQLConversionUtils {
             return Scalars.GraphQLString;
         } else if (Date.class.isAssignableFrom(clazz)) {
             return GraphQLScalars.GRAPHQL_DATE_TYPE;
+        } else if (clazz.equals(BigDecimal.class)) {
+            return Scalars.GraphQLBigDecimal;
         }
 
         return null;

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -59,6 +59,7 @@ public class ModelBuilderTest {
     private static final String PUBLISH_DATE = "publishDate";
     private static final String GENRE = "genre";
     private static final String LANGUAGE = "language";
+    private static final String WEIGHT_LBS = "weightLbs";
 
     // TODO: We need more tests. I've updated the models to contain all of the situations below, but we should _esnure_
     // the generated result is exactly correct:
@@ -148,6 +149,7 @@ public class ModelBuilderTest {
         Assert.assertTrue(bookType.getFieldDefinition(GENRE).getType().equals(Scalars.GraphQLString));
         Assert.assertTrue(bookType.getFieldDefinition(LANGUAGE).getType().equals(Scalars.GraphQLString));
         Assert.assertTrue(bookType.getFieldDefinition(PUBLISH_DATE).getType().equals(Scalars.GraphQLLong));
+        Assert.assertTrue(bookType.getFieldDefinition(WEIGHT_LBS).getType().equals(Scalars.GraphQLBigDecimal));
 
         GraphQLObjectType addressType = (GraphQLObjectType) authorType.getFieldDefinition("homeAddress").getType();
         Assert.assertTrue(addressType.getFieldDefinition("street1").getType().equals(Scalars.GraphQLString));

--- a/elide-graphql/src/test/java/example/Book.java
+++ b/elide-graphql/src/test/java/example/Book.java
@@ -22,6 +22,7 @@ import com.yahoo.elide.annotation.OnUpdatePreSecurity;
 import com.yahoo.elide.annotation.SharePermission;
 import com.yahoo.elide.security.RequestScope;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -61,6 +62,7 @@ public class Book {
     private Author.AuthorType authorTypeAtTimeOfPublication;
     private Set<PublicationFormat> publicationFormats = new HashSet<>();
     private Set<Preview> previews = new HashSet<>();
+    private BigDecimal weightLbs;
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     public long getId() {
@@ -101,6 +103,14 @@ public class Book {
 
     public long getPublishDate() {
         return this.publishDate;
+    }
+
+    public void setWeightLbs(BigDecimal weight) {
+        this.weightLbs = weight;
+    }
+
+    public BigDecimal getWeightLbs() {
+        return this.weightLbs;
     }
 
     @ManyToMany


### PR DESCRIPTION
Resolves https://github.com/yahoo/elide/issues/812

## Description
This change adds support for BigDecimal in the GraphQL API by mapping it to the GraphQLBigDecimal class.

## Motivation and Context
This change allows models with BigDecimal fields to be properly converted to GraphQLBigDecimal, when using the GraphQL API. Currently, BigDecimal gets converted to an Object type instead of a Scalar.

## How Has This Been Tested?
- Added BigDecimal field `weightLbs` to the Book model in `elide-graphql/src/test/java/example/Book.java`.
- Added assertion to ModelBuilderTest to assert that `weightLbs` on the Book model gets converted to a GraphQLBigDecimal class.