### PR TITLE
Add default jpa query batching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 **Features**
 * Issue#812 Add support for BigDecimal field in GraphQL. 
+* Elide standalone now includes a Hikari connection pool & Hibernate batch fetching by default
 
 ## 4.4.3
 **Features**

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -91,6 +91,12 @@
             <version>${hibernate5.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-hikaricp</artifactId>
+            <version>${hibernate5.version}</version>
+        </dependency>
+
         <!-- MySQL Driver -->
         <dependency>
             <groupId>mysql</groupId>

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
@@ -32,7 +32,16 @@ public class Util {
             options.put("hibernate.current_session_context_class", "thread");
             options.put("hibernate.jdbc.use_scrollable_resultset", "true");
 
-            //TODO - Maybe configure Hikari or C3PO as a best practice
+            // Collection Proxy & JDBC Batching
+            options.put("hibernate.jdbc.batch_size", "50");
+            options.put("hibernate.jdbc.fetch_size", "50");
+            options.put("hibernate.default_batch_fetch_size", "100");
+
+            // Hikari Connection Pool Settings
+            options.putIfAbsent("hibernate.connection.provider_class", "com.zaxxer.hikari.hibernate.HikariConnectionProvider");
+            options.putIfAbsent("hibernate.hikari.connectionTimeout", "20000");
+            options.putIfAbsent("hibernate.hikari.maximumPoolSize", "30");
+            options.putIfAbsent("hibernate.hikari.idleTimeout", "30000");
 
             options.put("javax.persistence.jdbc.driver", "com.mysql.jdbc.Driver");
             options.put("javax.persistence.jdbc.url", "jdbc:mysql://localhost/elide?serverTimezone=UTC");


### PR DESCRIPTION

## Description
Elide Standalone should have sane defaults for:
- Hibernate batch fetching
- A JDBC connection pool

## Motivation and Context

Out of the box, Elide standalone does not leverage any basic features that improve performance.  Given that Elide standalone is an opinionated instance, it should enable these best practices.

## How Has This Been Tested?

Manually tested with Elide Standalone.  Verified the connection pool settings took effect.

## Screenshots (if appropriate):
N/A
