### PR TITLE
Add license info to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,7 @@ Resolves #<issue number> (if appropriate)
 <!--- see how your change affects other areas of the code, etc. -->
 
 ## Screenshots (if appropriate):
+
+
+## License
+I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.


### PR DESCRIPTION

## Description

VZM is moving away from using the CLA checker. We can remove the CLA checker if we add the license clause to the PR template

## Motivation and Context

This also will allow `dependabot-preview` to make PRs

## How Has This Been Tested?
n/a

## Screenshots (if appropriate):
n/a