### PR TITLE
#801 RSQL filter on customized id field

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -69,6 +69,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 
+import static com.yahoo.elide.core.EntityDictionary.REGULAR_ID_NAME;
+
 /**
  * Entity Dictionary maps JSON API Entity beans to/from Entity type names.
  *
@@ -327,7 +329,7 @@ public class EntityBinding {
         String fieldName = getFieldName(fieldOrMethod);
         Class<?> fieldType = getFieldType(entityClass, fieldOrMethod);
 
-        if (fieldName == null || "id".equals(fieldName) || "class".equals(fieldName)
+        if (fieldName == null || REGULAR_ID_NAME.equals(fieldName) || "class".equals(fieldName)
                 || OBJ_METHODS.contains(fieldOrMethod)) {
             return; // Reserved
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.REGULAR_ID_NAME;
+
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.ComputedRelationship;
 import com.yahoo.elide.annotation.Exclude;
@@ -68,8 +70,6 @@ import javax.persistence.MapsId;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
-
-import static com.yahoo.elide.core.EntityDictionary.REGULAR_ID_NAME;
 
 /**
  * Entity Dictionary maps JSON API Entity beans to/from Entity type names.

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -74,7 +74,7 @@ public class EntityDictionary {
     protected final BiMap<String, Class<? extends Check>> checkNames;
     protected final Injector injector;
 
-    private final static String REGULAR_ID_NAME = "id";
+    public final static String REGULAR_ID_NAME = "id";
     private final static ConcurrentHashMap<Class, String> SIMPLE_NAMES = new ConcurrentHashMap<>();
 
     /**
@@ -609,7 +609,6 @@ public class EntityDictionary {
      * <pre>
      * {@code
      * public class Address {
-     *
      *     {@literal @}Id
      *     private Long id
      *
@@ -631,7 +630,6 @@ public class EntityDictionary {
      * <pre>
      * {@code
      * public class Address {
-     *
      *     {@literal @}Id
      *     private Long surrogateKey
      *
@@ -651,10 +649,10 @@ public class EntityDictionary {
      * }
      * </pre>
      * JSON-API spec does not allow "id" as non-ID field name. If, therefore, there is a non-ID field called "id",
-     * callling this method has undefined behavior
+     * calling this method has undefined behavior
      *
      * @param entityClass Entity class
-     * @param identifier  Field to lookup type
+     * @param identifier  Identifier/Field to lookup type
      * @return Type of entity
      */
     public Class<?> getType(Class<?> entityClass, String identifier) {
@@ -692,7 +690,7 @@ public class EntityDictionary {
      * Retrieve the parameterized type for the given field.
      *
      * @param entityClass the entity class
-     * @param identifier  the identifier
+     * @param identifier  the identifier/field name
      * @param paramIndex  the index of the parameterization
      * @return Entity type for field otherwise null.
      */

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -44,6 +44,8 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.core.MultivaluedMap;
 
+import static com.yahoo.elide.core.EntityDictionary.REGULAR_ID_NAME;
+
 /**
  * FilterDialect which implements support for RSQL filter dialect.
  */
@@ -204,6 +206,12 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
             Class entityType = rootEntityType;
 
             for (String associationName : associationNames) {
+                // if the association name is "id", replaced it with real id field name
+                // id field name can be "id" or other string, but non-id field can't have name "id".
+                if (associationName.equals(REGULAR_ID_NAME)) {
+                    associationName = dictionary.getIdFieldName(entityType);
+                }
+
                 String typeName = dictionary.getJsonAliasFor(entityType);
                 Class fieldType = dictionary.getParameterizedType(entityType, associationName);
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.core.filter.dialect;
 
+import static com.yahoo.elide.core.EntityDictionary.REGULAR_ID_NAME;
+
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
@@ -43,8 +45,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.MultivaluedMap;
-
-import static com.yahoo.elide.core.EntityDictionary.REGULAR_ID_NAME;
 
 /**
  * FilterDialect which implements support for RSQL filter dialect.

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -11,6 +11,8 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import example.Author;
 import example.Book;
 
+import example.Job;
+import example.StringId;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -36,6 +38,8 @@ public class RSQLFilterDialectTest {
 
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Book.class);
+        dictionary.bindEntity(StringId.class);
+        dictionary.bindEntity(Job.class);
         dialect = new RSQLFilterDialect(dictionary);
     }
 
@@ -266,6 +270,38 @@ public class RSQLFilterDialectTest {
         Assert.assertEquals(
                 visitor.visit(comparisonNode, Author.class).toString(),
                 "author.id INFIX_CASE_INSENSITIVE [20]"
+        );
+    }
+
+    @Test
+    public void testFilterOnCustomizedLongIdField() throws ParseException {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "id==1"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/job", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "job.jobId IN [1]"
+        );
+    }
+
+    @Test
+    public void testFilterOnCustomizedStringIdField() throws ParseException {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "id==*identifier*"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/stringForId", queryParams);
+
+        Assert.assertEquals(expression.toString(),
+                "stringId.surrogateKey INFIX_CASE_INSENSITIVE [identifier]"
         );
     }
 }


### PR DESCRIPTION
Resolves https://github.com/yahoo/elide/issues/801

## Description
Update RSQL filter to use real id field when the entity is using customized id field.

## Motivation and Context
Previous, filtering on **id** field would fail if the id field for an entity is using a customized id field name. As **id** is a reserved field name only for id field, when filtering on **id**, the filter should be applied to the bound id field.

## How Has This Been Tested?
Use Job.class and StringId.class for testing customized id field, reference: https://github.com/yahoo/elide/pull/809

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
