### PR TITLE
Switch to open jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
   language: java
   sudo: false
   jdk:
-    - oraclejdk8
+    - openjdk8
   addons:
     apt:
       packages:

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 4.4.5
 **Fixes**
  * Issue 801
+ * Switched to Open JDK 8
  
 ## 4.4.4
 **Fixes**


### PR DESCRIPTION

## Description
Travis Builds are failing with Oracle JDK8.  This PR changes to use Open JDK.

## Motivation and Context
Switch to Open JDK (get away from Oracle).

## How Has This Been Tested?
This PR build.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
