### PR TITLE
Fix pom.xml so github stops complaining about bogus security alerts

### DIFF
--- a/elide-contrib/elide-swagger/pom.xml
+++ b/elide-contrib/elide-swagger/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${version.jackson}</version>
             <scope>provided</scope>
        </dependency>
        <dependency>

--- a/elide-example/elide-blog-example/pom.xml
+++ b/elide-example/elide-blog-example/pom.xml
@@ -110,7 +110,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${version.jackson}</version>
         </dependency>
 
         <!-- Testing -->

--- a/elide-example/elide-hibernate3-mysql-example/pom.xml
+++ b/elide-example/elide-hibernate3-mysql-example/pom.xml
@@ -96,7 +96,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${version.jackson}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION

## Description
For some reason, github security alerts don't handle sub-modules that have version dependencies (where the version is defined in a parent pom).

![Screen Shot 2019-07-08 at 5 28 14 PM](https://user-images.githubusercontent.com/6979393/60846724-f5619680-a1a5-11e9-8887-45758329ee4b.png)

## Motivation and Context
So we stop getting bogus alerts.

## How Has This Been Tested?
The build passes.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
