### PR TITLE
Add support for encoding of error responses

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 ## 4.4.6
 **Features**
  * Issue #815.  Added the ability to customize the JPQL generation for a filter operator globally or for a specific entity attribute.
+ * Issue #871. Add ElideSettings property `encodeErrorResponses`, which when enabled will encode error messages to be safe for HTML. This works for both JSONAPI and GraphQL endpoints, with verbose errors or error object settings enabled/disabled.
+ * HttpStatusException class now supports the following additional functions: `getErrorResponse(boolean encodeResponse)` and `getVerboseErrorResponse(boolean encodeResponse)`
+ * Add `GraphQLErrorSerializer` and `ExecutionResultSerializer` which are added to the `ObjectMapper` provided by the ElideSettings. These are used to parse the GraphQL results, instead of using `ExecutionResult#toSpecification`.
 
 **Fixes**
  * Run vulnerability check during build.  Updated dependencies to fix CVE-2018-1000632, CVE-2017-15708, CVE-2019-10247

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -144,6 +144,12 @@
             <version>0.9.11</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+            <version>1.2.2</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -40,4 +40,5 @@ public class ElideSettings {
     @Getter private final int updateStatusCode;
     @Getter private final boolean returnErrorObjects;
     @Getter private final Map<Class, Serde> serdes;
+    @Getter private final boolean encodeErrorResponses;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -50,6 +50,7 @@ public class ElideSettingsBuilder {
     private boolean useFilterExpressions;
     private int updateStatusCode;
     private boolean returnErrorObjects;
+    private boolean encodeErrorResponses;
 
     /**
      * A new builder used to generate Elide instances. Instantiates an {@link EntityDictionary} without
@@ -94,7 +95,8 @@ public class ElideSettingsBuilder {
                 useFilterExpressions,
                 updateStatusCode,
                 returnErrorObjects,
-                serdes);
+                serdes,
+                encodeErrorResponses);
     }
 
     public ElideSettingsBuilder withAuditLogger(AuditLogger auditLogger) {
@@ -192,6 +194,11 @@ public class ElideSettingsBuilder {
 
     public ElideSettingsBuilder withReturnErrorObjects(boolean returnErrorObjects) {
         this.returnErrorObjects = returnErrorObjects;
+        return this;
+    }
+
+    public ElideSettingsBuilder withEncodeErrorResponses(boolean encodeErrorResponses) {
+        this.encodeErrorResponses = encodeErrorResponses;
         return this;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/CustomErrorException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/CustomErrorException.java
@@ -44,16 +44,17 @@ public class CustomErrorException extends HttpStatusException {
     }
 
     @Override
-    public Pair<Integer, JsonNode> getErrorResponse() {
+    public Pair<Integer, JsonNode> getErrorResponse(boolean encodeResponse) {
         return buildCustomResponse();
     }
 
     @Override
-    public Pair<Integer, JsonNode> getVerboseErrorResponse() {
+    public Pair<Integer, JsonNode> getVerboseErrorResponse(boolean encodeResponse) {
         return buildCustomResponse();
     }
 
     private Pair<Integer, JsonNode> buildCustomResponse() {
+        // TODO: should support for encoding custom responses be added?
         JsonNode responseBody = OBJECT_MAPPER.convertValue(errorObjects, JsonNode.class);
         return Pair.of(getStatus(), responseBody);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.owasp.encoder.Encode;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,16 +52,46 @@ public abstract class HttpStatusException extends RuntimeException {
                 : null;
     }
 
+    /**
+     * Get a response detailing the error that occurred.
+     * @return Pair containing status code and a JsonNode containing error details
+     */
     public Pair<Integer, JsonNode> getErrorResponse() {
+        return getErrorResponse(false);
+    }
+
+    /**
+     * Get a response detailing the error that occurred.
+     * Optionally, encode the error message to be safe for HTML.
+     * @param encodeResponse true if the message should be encoded for html
+     * @return Pair containing status code and a JsonNode containing error details
+     */
+    public Pair<Integer, JsonNode> getErrorResponse(boolean encodeResponse) {
+        String message = encodeResponse ? Encode.forHtml(toString()) : toString();
         Map<String, List<String>> errors = Collections.singletonMap(
-                "errors", Collections.singletonList(toString())
+                "errors", Collections.singletonList(message)
         );
         return buildResponse(errors);
     }
 
+    /**
+     * Get a verbose response detailing the error that occurred.
+     * @return Pair containing status code and a JsonNode containing error details
+     */
     public Pair<Integer, JsonNode> getVerboseErrorResponse() {
+        return getVerboseErrorResponse(false);
+    }
+
+    /**
+     * Get a verbose response detailing the error that occurred.
+     * Optionally, encode the error message to be safe for HTML.
+     * @param encodeResponse true if the message should be encoded for html
+     * @return Pair containing status code and a JsonNode containing error details
+     */
+    public Pair<Integer, JsonNode> getVerboseErrorResponse(boolean encodeResponse) {
+        String message = encodeResponse ? Encode.forHtml(getVerboseMessage()) : getVerboseMessage();
         Map<String, List<String>> errors = Collections.singletonMap(
-                "errors", Collections.singletonList(getVerboseMessage())
+                "errors", Collections.singletonList(message)
         );
         return buildResponse(errors);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/JsonPatchExtensionException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/JsonPatchExtensionException.java
@@ -41,7 +41,6 @@ public class JsonPatchExtensionException extends HttpStatusException {
 
     @Override
     public Pair<Integer, JsonNode> getErrorResponse(boolean encodeResponse) {
-        // TODO: encode response
         if (!encodeResponse) {
             return response;
         }
@@ -56,7 +55,6 @@ public class JsonPatchExtensionException extends HttpStatusException {
 
     @Override
     public Pair<Integer, JsonNode> getVerboseErrorResponse(boolean encodeResponse) {
-        // TODO: encode response
         if (!encodeResponse) {
             return response;
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/JsonPatchExtensionException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/JsonPatchExtensionException.java
@@ -6,8 +6,14 @@
 package com.yahoo.elide.core.exceptions;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.owasp.encoder.Encode;
 
 /**
  * Exception describing error caused from Json Patch Extension request.
@@ -21,7 +27,7 @@ public class JsonPatchExtensionException extends HttpStatusException {
     }
 
     /**
-     * @deprecated use {@link #getErrorResponse()}
+     * @deprecated use {@link #getErrorResponse(boolean encodeResponse)}
      */
     @Deprecated
     public Pair<Integer, JsonNode> getResponse() {
@@ -30,11 +36,50 @@ public class JsonPatchExtensionException extends HttpStatusException {
 
     @Override
     public Pair<Integer, JsonNode> getErrorResponse() {
-        return response;
+        return getErrorResponse(false);
+    }
+
+    @Override
+    public Pair<Integer, JsonNode> getErrorResponse(boolean encodeResponse) {
+        // TODO: encode response
+        if (!encodeResponse) {
+            return response;
+        }
+
+        return encodeResponse();
     }
 
     @Override
     public Pair<Integer, JsonNode> getVerboseErrorResponse() {
-        return response;
+        return getVerboseErrorResponse(false);
+    }
+
+    @Override
+    public Pair<Integer, JsonNode> getVerboseErrorResponse(boolean encodeResponse) {
+        // TODO: encode response
+        if (!encodeResponse) {
+            return response;
+        }
+
+        return encodeResponse();
+    }
+
+    private Pair<Integer, JsonNode> encodeResponse() {
+        // response is final, so construct a new response with encoded values
+        ArrayNode encodedArray = JsonNodeFactory.instance.arrayNode();
+        ArrayNode errors = (ArrayNode) response.getRight().get("errors");
+        for (JsonNode node : errors) {
+            ObjectNode objectNode = (ObjectNode) node;
+
+            TextNode text = (TextNode) objectNode.get("detail");
+            IntNode status = (IntNode) objectNode.get("status");
+
+            ObjectNode encodedObjectNode = JsonNodeFactory.instance.objectNode();
+            TextNode encodedTextNode = JsonNodeFactory.instance.textNode(Encode.forHtml(text.asText()));
+            encodedObjectNode.set("detail", encodedTextNode);
+            encodedObjectNode.set("status", status);
+            encodedArray.add(encodedObjectNode);
+        }
+        return Pair.of(response.getLeft(), encodedArray);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/exceptions/HttpStatusExceptionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/exceptions/HttpStatusExceptionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.exceptions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.function.Supplier;
+
+public class HttpStatusExceptionTest {
+
+    @Test
+    public void testGetResponse() {
+        // result should not be encoded
+        String expected = "{\"errors\":[\": test<script>encoding\"]}";
+        HttpStatusException exception =  new HttpStatusException(500, "test<script>encoding") { };
+        Pair<Integer, JsonNode> res = exception.getErrorResponse();
+        Assert.assertEquals(res.getRight().toString(), expected);
+    }
+
+    @Test
+    public void testGetVerboseResponse() {
+        // result should not be encoded
+        String expected = "{\"errors\":[\": test<script>encoding\"]}";
+        HttpStatusException exception =  new HttpStatusException(500, "test<script>encoding") { };
+        Pair<Integer, JsonNode> res = exception.getVerboseErrorResponse();
+        Assert.assertEquals(res.getRight().toString(), expected);
+    }
+
+    @Test
+    public void testGetEncodedResponse() {
+        String expected = "{\"errors\":[\": test&lt;script&gt;encoding\"]}";
+        HttpStatusException exception =  new HttpStatusException(500, "test<script>encoding") { };
+        Pair<Integer, JsonNode> res = exception.getErrorResponse(true);
+        Assert.assertEquals(res.getRight().toString(), expected);
+    }
+
+    @Test
+    public void testGetEncodedVerboseResponse() {
+        String expected = "{\"errors\":[\": test&lt;script&gt;encoding\"]}";
+        HttpStatusException exception = new HttpStatusException(500, "test<script>encoding") { };
+        Pair<Integer, JsonNode> res = exception.getVerboseErrorResponse(true);
+        Assert.assertEquals(res.getRight().toString(), expected);
+    }
+
+    @Test
+    public void testGetEncodedVerboseResponseWithSupplier() {
+        String expected = "{\"errors\":[\"a more verbose &lt;script&gt; encoding test\"]}";
+        Supplier<String> supplier = () -> "a more verbose <script> encoding test";
+        HttpStatusException exception = new HttpStatusException(500, "test<script>encoding",
+                new RuntimeException("runtime exception"), supplier) { };
+        Pair<Integer, JsonNode> res = exception.getVerboseErrorResponse(true);
+        Assert.assertEquals(res.getRight().toString(), expected);
+    }
+
+    @Test
+    public void testGetVerboseResponseWithSupplier() {
+        String expected = "{\"errors\":[\"a more verbose &lt;script&gt; encoding test\"]}";
+        Supplier<String> supplier = () -> "a more verbose <script> encoding test";
+        HttpStatusException exception = new HttpStatusException(500, "test<script>encoding",
+                new RuntimeException("runtime exception"), supplier) { };
+        Pair<Integer, JsonNode> res = exception.getVerboseErrorResponse(true);
+        Assert.assertEquals(res.getRight().toString(), expected);
+    }
+}

--- a/elide-datastore/pom.xml
+++ b/elide-datastore/pom.xml
@@ -142,6 +142,7 @@
                             <suiteXmlFile>${project.basedir}/../testng-audit.xml</suiteXmlFile>
                             <suiteXmlFile>${project.basedir}/../testng-fieldleveltest.xml</suiteXmlFile>
                             <suiteXmlFile>${project.basedir}/../testng-assignedIdLong.xml</suiteXmlFile>
+                            <suiteXmlFile>${project.basedir}/../testng-errorencoding.xml</suiteXmlFile>
                         </suiteXmlFiles>
                     </configuration>
                     <executions>

--- a/elide-datastore/testng-errorencoding.xml
+++ b/elide-datastore/testng-errorencoding.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019, Yahoo Inc.
+  ~ Licensed under the Apache License, Version 2.0
+  ~ See LICENSE file in project root for terms.
+  -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="Test Suite With Encoding">
+    <test name="com.yahoo.elide.errorEncodingTests">
+        <packages>
+            <package name="com.yahoo.elide.errorEncodingTests"/>
+        </packages>
+    </test>
+</suite>

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ExecutionResultSerializer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ExecutionResultSerializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Custom serializer used to generate response messages. Should closely mimic the
+ * {@link ExecutionResult#toSpecification()} function which specifies which fields should be present in the result of
+ * a GraphQL call. {@link GraphQLError} objects should be handed off to a {@link GraphQLErrorSerializer} to handle
+ * optional encoding of the error message.
+ */
+@Slf4j
+public class ExecutionResultSerializer extends StdSerializer<ExecutionResult> {
+    private final GraphQLErrorSerializer errorSerializer;
+
+    protected ExecutionResultSerializer(GraphQLErrorSerializer errorSerializer) {
+        super(ExecutionResult.class);
+        this.errorSerializer = errorSerializer;
+    }
+
+    @Override
+    public void serialize(ExecutionResult value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        // mimic the ExecutionResult.toSpecification response
+        gen.writeStartObject();
+        Map<String, Object> spec = value.toSpecification();
+        if (spec.containsKey("data")) {
+            gen.writeObjectField("data", spec.get("data"));
+        }
+
+        if (spec.containsKey("errors")) {
+            List<GraphQLError> errors = value.getErrors();
+            gen.writeArrayFieldStart("errors");
+            for (GraphQLError error : errors) {
+                // includes start object and end object
+                errorSerializer.serialize(error, gen, provider);
+            }
+            gen.writeEndArray();
+        }
+
+        if (spec.containsKey("extensions")) {
+            gen.writeObjectField("extensions", spec.get("extensions"));
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLErrorSerializer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLErrorSerializer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import org.owasp.encoder.Encode;
+
+import graphql.GraphQLError;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Custom serializer used to generate response messages from {@link GraphQLError} objects.
+ * Supports optional encoding of the error's message field, making it safe for display in HTML.
+ */
+public class GraphQLErrorSerializer extends StdSerializer<GraphQLError> {
+    private final boolean encodeErrors;
+
+    /**
+     * Construct a new GraphQLErrorSerializer, optionally with error encoding enabled.
+     * @param encodeErrors true if the message field should be encoded
+     */
+    protected GraphQLErrorSerializer(boolean encodeErrors) {
+        super(GraphQLError.class);
+        this.encodeErrors = encodeErrors;
+    }
+
+    protected GraphQLErrorSerializer() {
+        this(false);
+    }
+
+    @Override
+    public void serialize(GraphQLError value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        Map<String, Object> errorSpec = value.toSpecification();
+        gen.writeStartObject();
+
+        gen.writeStringField("message",
+                encodeErrors ? Encode.forHtml((String) errorSpec.get("message"))
+                        : (String) errorSpec.get("message"));
+
+        if (errorSpec.containsKey("locations")) {
+            gen.writeFieldName("locations");
+            gen.writeObject(errorSpec.get("locations"));
+        }
+
+        if (errorSpec.containsKey("path")) {
+            gen.writeFieldName("path");
+            gen.writeObject(errorSpec.get("path"));
+        }
+
+        if (errorSpec.containsKey("extensions")) {
+            gen.writeObject(errorSpec.get("extensions"));
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
 
 public class EncodedErrorObjectsIT extends AbstractIntegrationTestInitializer {
 
+    private static final String GRAPHQL_CONTENT_TYPE = "application/json";
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
     private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
             "application/vnd.api+json; ext=jsonpatch";
@@ -118,6 +119,34 @@ public class EncodedErrorObjectsIT extends AbstractIntegrationTestInitializer {
                 .body(request).post("/invoice")
                 .then()
                 .statusCode(HttpStatus.SC_LOCKED)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void graphQLMutationError() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLMutationError.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLMutationError.json");
+        given()
+                .contentType(GRAPHQL_CONTENT_TYPE)
+                .accept(GRAPHQL_CONTENT_TYPE)
+                .body(request)
+                .post("/graphQL")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void graphQLFetchError() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLFetchError.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLFetchError.json");
+        given()
+                .contentType(GRAPHQL_CONTENT_TYPE)
+                .accept(GRAPHQL_CONTENT_TYPE)
+                .body(request)
+                .post("/graphQL")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
                 .body(equalTo(expected));
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
@@ -9,25 +9,22 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.yahoo.elide.initialization.AbstractIntegrationTestInitializer;
-import com.yahoo.elide.initialization.EncodedErrorResponsesTestApplicationResourceConfig;
+import com.yahoo.elide.initialization.EncodedErrorObjectsTestApplicationResourceConfig;
 import com.yahoo.elide.utils.JsonParser;
 
 import org.apache.http.HttpStatus;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/**
- * Test class for checking encoding of error response messages.
- */
-public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer {
+public class EncodedErrorObjectsIT extends AbstractIntegrationTestInitializer {
 
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
     private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
             "application/vnd.api+json; ext=jsonpatch";
     private final JsonParser jsonParser = new JsonParser();
 
-    public EncodedErrorResponsesIT() {
-        super(EncodedErrorResponsesTestApplicationResourceConfig.class);
+    public EncodedErrorObjectsIT() {
+        super(EncodedErrorObjectsTestApplicationResourceConfig.class);
     }
 
     @BeforeClass
@@ -39,7 +36,7 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
     @Test
     public void invalidAttributeException() {
         String request = jsonParser.getJson("/EncodedErrorResponsesIT/InvalidAttributeException.req.json");
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidAttributeException.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/jsonPatchExtensionExceptionErrorObject.json");
         given()
                 .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
@@ -52,32 +49,32 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
 
     @Test
     public void invalidCollectionException() {
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidCollection.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidCollectionErrorObject.json");
         given().when().get("/unknown").then().statusCode(HttpStatus.SC_NOT_FOUND).body(equalTo(expected));
     }
 
     @Test
     public void invalidEntityBodyException() {
         String request = jsonParser.getJson("/EncodedErrorResponsesIT/invalidEntityBodyException.req.json");
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidEntityBodyException.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidEntityBodyExceptionErrorObject.json");
         given()
                 .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(request)
                 .patch("/parent")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body(equalTo(expected));
     }
 
     @Test
     public void invalidObjectIdentifierException() {
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidObjectIdentifierExecption.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidObjectIdentifierExceptionErrorObject.json");
         given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .get("/parent/100")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND)
                 .body(equalTo(expected));
     }
@@ -86,13 +83,13 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
     @Test
     public void invalidValueException() {
         String request = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueException.req.json");
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueException.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueExceptionErrorObject.json");
         given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .body(request)
                 .post("/invoice")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body(equalTo(expected));
     }
@@ -100,12 +97,12 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
     @Test
     public void jsonPatchExtensionException() {
         String request = jsonParser.getJson("/EncodedErrorResponsesIT/jsonPatchExtensionException.req.json");
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/jsonPatchExtensionException.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/jsonPatchExtensionExceptionErrorObject.json");
         given()
                 .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(request).patch()
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body(equalTo(expected));
     }
@@ -114,12 +111,12 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
     public void transactionException() {
         // intentionally forget the comma between type and id to force a transaction exception
         String request = "{\"data\": {\"type\": \"invoice\" \"id\": 100}}";
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/transactionException.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/transactionExceptionErrorObject.json");
         given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .body(request).post("/invoice")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_LOCKED)
                 .body(equalTo(expected));
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorResponsesIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorResponsesIT.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
  */
 public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer {
 
+    private static final String GRAPHQL_CONTENT_TYPE = "application/json";
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
     private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
             "application/vnd.api+json; ext=jsonpatch";
@@ -121,6 +122,34 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
                 .body(request).post("/invoice")
         .then()
                 .statusCode(HttpStatus.SC_LOCKED)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void graphQLMutationError() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLMutationError.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLMutationError.json");
+        given()
+                .contentType(GRAPHQL_CONTENT_TYPE)
+                .accept(GRAPHQL_CONTENT_TYPE)
+                .body(request)
+                .post("/graphQL")
+        .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void graphQLFetchError() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLFetchError.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLFetchError.json");
+        given()
+                .contentType(GRAPHQL_CONTENT_TYPE)
+                .accept(GRAPHQL_CONTENT_TYPE)
+                .body(request)
+                .post("/graphQL")
+        .then()
+                .statusCode(HttpStatus.SC_OK)
                 .body(equalTo(expected));
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorResponsesIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorResponsesIT.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.errorEncodingTests;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.initialization.AbstractIntegrationTestInitializer;
+import com.yahoo.elide.initialization.EncodedErrorResponsesTestApplicationResourceConfig;
+import com.yahoo.elide.utils.JsonParser;
+
+import com.google.common.collect.Sets;
+
+import example.Book;
+import example.Child;
+import example.ExceptionThrowingBean;
+import example.FunWithPermissions;
+import example.Invoice;
+import example.LineItem;
+import example.Parent;
+import example.User;
+
+import org.apache.http.HttpStatus;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Slf4j
+public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer {
+
+    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
+    private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
+            "application/vnd.api+json; ext=jsonpatch";
+    private final JsonParser jsonParser = new JsonParser();
+
+    public EncodedErrorResponsesIT() {
+        super(EncodedErrorResponsesTestApplicationResourceConfig.class);
+    }
+
+    @BeforeClass
+    public void setup() throws Exception {
+        DataStoreTransaction tx = dataStore.beginTransaction();
+
+        Parent parent = new Parent(); // id 1
+        Child child = new Child(); // id 1
+        parent.setChildren(Sets.newHashSet(child));
+        parent.setSpouses(Sets.newHashSet());
+        child.setParents(Sets.newHashSet(parent));
+
+        tx.createObject(parent, null);
+        tx.createObject(child, null);
+
+        // Single tests
+        Parent p1 = new Parent(); // id 2
+        p1.setFirstName("John");
+        p1.setSpouses(Sets.newHashSet());
+
+        Child c1 = new Child(); // id 2
+        c1.setName("Child-ID2");
+        c1.setParents(Sets.newHashSet(p1));
+
+        Child c2 = new Child(); // id 3
+        c2.setName("Child-ID3");
+        c2.setParents(Sets.newHashSet(p1));
+
+        Set<Child> friendSet = new HashSet<>();
+        friendSet.add(c2);
+        c1.setFriends(friendSet);
+
+        Set<Child> childrenSet1 = new HashSet<>();
+        childrenSet1.add(c1);
+        childrenSet1.add(c2);
+
+        p1.setChildren(childrenSet1);
+
+        // List tests
+        Parent p2 = new Parent(); // id 3
+        Parent p3 = new Parent();  // id 4
+        Child c3 = new Child(); // id 4
+        c3.setParents(Sets.newHashSet(p2));
+        Child c4 = new Child(); // id 5
+        c4.setParents(Sets.newHashSet(p2));
+        Set<Child> childrenSet2 = new HashSet<>();
+        childrenSet2.add(c3);
+        childrenSet2.add(c4);
+
+        p2.setChildren(childrenSet2);
+        p2.setFirstName("Link");
+
+        p3.setFirstName("Unknown");
+
+        p2.setSpouses(Sets.newHashSet());
+        p3.setSpouses(Sets.newHashSet());
+        p3.setChildren(Sets.newHashSet());
+
+        tx.createObject(c1, null);
+        tx.createObject(c2, null);
+        tx.createObject(c3, null);
+        tx.createObject(c4, null);
+
+        tx.createObject(p1, null);
+        tx.createObject(p2, null);
+        tx.createObject(p3, null);
+
+        Book bookWithPercentage = new Book();
+        bookWithPercentage.setTitle("titlewith%percentage");
+        Book bookWithoutPercentage = new Book();
+        bookWithoutPercentage.setTitle("titlewithoutpercentage");
+
+        tx.createObject(bookWithPercentage, null);
+        tx.createObject(bookWithoutPercentage, null);
+
+        FunWithPermissions fun = new FunWithPermissions();
+        tx.createObject(fun, null);
+
+        User user = new User(); //ID 1
+        user.setPassword("god");
+        tx.createObject(user, null);
+
+        Invoice invoice = new Invoice();
+        invoice.setId(1);
+        LineItem item = new LineItem();
+        invoice.setItems(Sets.newHashSet(item));
+        item.setInvoice(invoice);
+        tx.createObject(invoice, null);
+        tx.createObject(item, null);
+
+        ExceptionThrowingBean etb = new ExceptionThrowingBean();
+        etb.setId(1L);
+        tx.createObject(etb, null);
+
+        tx.commit(null);
+        tx.close();
+
+        tearDownServer();
+        setUpServer();
+    }
+
+    @Test
+    public void invalidAttributeException() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/InvalidAttributeException.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidAttributeException.json");
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .body(request)
+                .patch("/parent")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void invalidCollectionException() {
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidCollection.json");
+        given().when().get("/unknown").then().statusCode(HttpStatus.SC_NOT_FOUND).body(equalTo(expected));
+    }
+
+    @Test
+    public void invalidEntityBodyException() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/invalidEntityBodyException.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidEntityBodyException.json");
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .body(request)
+                .patch("/parent")
+        .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void invalidObjectIdentifierException() {
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidObjectIdentifierExecption.json");
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .get("/parent/100")
+        .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body(equalTo(expected));
+    }
+
+
+    @Test
+    public void invalidValueException() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueException.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueException.json");
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(request)
+                .post("/invoice")
+        .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void jsonPatchExtensionException() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/jsonPatchExtensionException.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/jsonPatchExtensionException.json");
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .body(request).patch()
+        .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void transactionException() {
+        // intentionally forget the comma between type and id to force a transaction exception
+        String request = "{\"data\": {\"type\": \"invoice\" \"id\": 100}}";
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/transactionException.json");
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(request).post("/invoice")
+        .then()
+                .statusCode(HttpStatus.SC_LOCKED)
+                .body(equalTo(expected));
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
  */
 public class VerboseEncodedErrorResponsesIT extends AbstractIntegrationTestInitializer {
 
+    private static final String GRAPHQL_CONTENT_TYPE = "application/json";
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
     private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
             "application/vnd.api+json; ext=jsonpatch";
@@ -123,6 +124,34 @@ public class VerboseEncodedErrorResponsesIT extends AbstractIntegrationTestIniti
                 .body(request).post("/invoice")
                 .then()
                 .statusCode(HttpStatus.SC_LOCKED)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void graphQLMutationError() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLMutationError.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLMutationError.json");
+        given()
+                .contentType(GRAPHQL_CONTENT_TYPE)
+                .accept(GRAPHQL_CONTENT_TYPE)
+                .body(request)
+                .post("/graphQL")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    public void graphQLFetchError() {
+        String request = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLFetchError.req.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/graphQLFetchError.json");
+        given()
+                .contentType(GRAPHQL_CONTENT_TYPE)
+                .accept(GRAPHQL_CONTENT_TYPE)
+                .body(request)
+                .post("/graphQL")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
                 .body(equalTo(expected));
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
@@ -9,7 +9,7 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.yahoo.elide.initialization.AbstractIntegrationTestInitializer;
-import com.yahoo.elide.initialization.EncodedErrorResponsesTestApplicationResourceConfig;
+import com.yahoo.elide.initialization.VerboseEncodedErrorResponsesTestApplicationResourceConfig;
 import com.yahoo.elide.utils.JsonParser;
 
 import org.apache.http.HttpStatus;
@@ -17,17 +17,19 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Test class for checking encoding of error response messages.
+ * Test class for checking encoding on verbose error messages.
+ * Note that many exceptions don't really differ very much/at all between verbose and non-verbose, so many
+ * of these tests are similar to {@link EncodedErrorResponsesIT}.
  */
-public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer {
+public class VerboseEncodedErrorResponsesIT extends AbstractIntegrationTestInitializer {
 
     private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
     private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
             "application/vnd.api+json; ext=jsonpatch";
     private final JsonParser jsonParser = new JsonParser();
 
-    public EncodedErrorResponsesIT() {
-        super(EncodedErrorResponsesTestApplicationResourceConfig.class);
+    public VerboseEncodedErrorResponsesIT() {
+        super(VerboseEncodedErrorResponsesTestApplicationResourceConfig.class);
     }
 
     @BeforeClass
@@ -65,7 +67,7 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
                 .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(request)
                 .patch("/parent")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body(equalTo(expected));
     }
@@ -77,7 +79,7 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .get("/parent/100")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND)
                 .body(equalTo(expected));
     }
@@ -86,13 +88,13 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
     @Test
     public void invalidValueException() {
         String request = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueException.req.json");
-        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueException.json");
+        String expected = jsonParser.getJson("/EncodedErrorResponsesIT/invalidValueExceptionVerbose.json");
         given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .body(request)
                 .post("/invoice")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body(equalTo(expected));
     }
@@ -105,7 +107,7 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
                 .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(request).patch()
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body(equalTo(expected));
     }
@@ -119,7 +121,7 @@ public class EncodedErrorResponsesIT extends AbstractIntegrationTestInitializer 
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .accept(JSONAPI_CONTENT_TYPE)
                 .body(request).post("/invoice")
-        .then()
+                .then()
                 .statusCode(HttpStatus.SC_LOCKED)
                 .body(equalTo(expected));
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorObjectsTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorObjectsTestApplicationResourceConfig.java
@@ -12,13 +12,10 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 import javax.inject.Inject;
 
-/**
- * Resource configuration for encoded error response integration tests.
- */
-public class EncodedErrorResponsesTestApplicationResourceConfig extends ResourceConfig {
+public class EncodedErrorObjectsTestApplicationResourceConfig extends ResourceConfig {
 
     @Inject
-    public EncodedErrorResponsesTestApplicationResourceConfig(ServiceLocator injector) {
-        register(new EncodedErrorResponsesTestBinder(new TestAuditLogger(), injector, false, false));
+    public EncodedErrorObjectsTestApplicationResourceConfig(ServiceLocator injector) {
+        register(new EncodedErrorResponsesTestBinder(new TestAuditLogger(), injector, false, true));
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorResponsesTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorResponsesTestApplicationResourceConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.initialization;
+
+import com.yahoo.elide.audit.TestAuditLogger;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.server.ResourceConfig;
+
+import javax.inject.Inject;
+
+/**
+ * Resource configuration for encoded error response integration tests.
+ */
+public class EncodedErrorResponsesTestApplicationResourceConfig extends ResourceConfig {
+
+    @Inject
+    public EncodedErrorResponsesTestApplicationResourceConfig(ServiceLocator injector) {
+        register(new EncodedErrorResponsesTestBinder(new TestAuditLogger(), injector));
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorResponsesTestBinder.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorResponsesTestBinder.java
@@ -16,6 +16,8 @@ import com.yahoo.elide.core.filter.dialect.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.resources.DefaultOpaqueUserFunction;
+import com.yahoo.elide.security.executors.ActivePermissionExecutor;
+import com.yahoo.elide.security.executors.VerbosePermissionExecutor;
 
 import example.TestCheckMappings;
 
@@ -35,10 +37,15 @@ import java.util.Arrays;
 public class EncodedErrorResponsesTestBinder extends AbstractBinder {
     private final AuditLogger auditLogger;
     private final ServiceLocator injector;
+    private final boolean verboseErrors;
+    private final boolean errorObjects;
 
-    public EncodedErrorResponsesTestBinder(final AuditLogger auditLogger, ServiceLocator injector) {
+    public EncodedErrorResponsesTestBinder(final AuditLogger auditLogger, ServiceLocator injector,
+                                           boolean verboseErrors, boolean errorObjects) {
         this.auditLogger = auditLogger;
         this.injector = injector;
+        this.verboseErrors = verboseErrors;
+        this.errorObjects = errorObjects;
     }
 
     @Override
@@ -62,6 +69,8 @@ public class EncodedErrorResponsesTestBinder extends AbstractBinder {
                         .withSubqueryFilterDialect(multipleFilterStrategy)
                         .withEntityDictionary(dictionary)
                         .withEncodeErrorResponses(true)
+                        .withReturnErrorObjects(errorObjects)
+                        .withPermissionExecutor(verboseErrors ? VerbosePermissionExecutor::new : ActivePermissionExecutor::new)
                         .build());
             }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorResponsesTestBinder.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/EncodedErrorResponsesTestBinder.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.initialization;
+
+import static com.yahoo.elide.initialization.AbstractIntegrationTestInitializer.getDatabaseManager;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.audit.AuditLogger;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.DefaultFilterDialect;
+import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.resources.DefaultOpaqueUserFunction;
+
+import example.TestCheckMappings;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+
+/**
+ * Binder for integration tests related to encoding error responses.
+ * Sets {@link ElideSettings#isEncodeErrorResponses()} to true.
+ */
+@Slf4j
+public class EncodedErrorResponsesTestBinder extends AbstractBinder {
+    private final AuditLogger auditLogger;
+    private final ServiceLocator injector;
+
+    public EncodedErrorResponsesTestBinder(final AuditLogger auditLogger, ServiceLocator injector) {
+        this.auditLogger = auditLogger;
+        this.injector = injector;
+    }
+
+    @Override
+    protected void configure() {
+        // Elide instance
+        bindFactory(new Factory<Elide>() {
+            @Override
+            public Elide provide() {
+                EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS, injector::inject);
+                DefaultFilterDialect defaultFilterStrategy = new DefaultFilterDialect(dictionary);
+                RSQLFilterDialect rsqlFilterStrategy = new RSQLFilterDialect(dictionary);
+
+                MultipleFilterDialect multipleFilterStrategy = new MultipleFilterDialect(
+                        Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy),
+                        Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy)
+                );
+
+                return new Elide(new ElideSettingsBuilder(getDatabaseManager())
+                        .withAuditLogger(auditLogger)
+                        .withJoinFilterDialect(multipleFilterStrategy)
+                        .withSubqueryFilterDialect(multipleFilterStrategy)
+                        .withEntityDictionary(dictionary)
+                        .withEncodeErrorResponses(true)
+                        .build());
+            }
+
+            @Override
+            public void dispose(Elide elide) {
+                // do nothing
+            }
+        }).to(Elide.class).named("elide");
+
+        // User function
+        bindFactory(new Factory<DefaultOpaqueUserFunction>() {
+            private final Integer user = 1;
+
+            @Override
+            public DefaultOpaqueUserFunction provide() {
+                return v -> user;
+            }
+
+            @Override
+            public void dispose(DefaultOpaqueUserFunction defaultOpaqueUserFunction) {
+                // do nothing
+            }
+        }).to(DefaultOpaqueUserFunction.class).named("elideUserExtractionFunction");
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/VerboseEncodedErrorResponsesTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/VerboseEncodedErrorResponsesTestApplicationResourceConfig.java
@@ -12,13 +12,10 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 import javax.inject.Inject;
 
-/**
- * Resource configuration for encoded error response integration tests.
- */
-public class EncodedErrorResponsesTestApplicationResourceConfig extends ResourceConfig {
+public class VerboseEncodedErrorResponsesTestApplicationResourceConfig extends ResourceConfig {
 
     @Inject
-    public EncodedErrorResponsesTestApplicationResourceConfig(ServiceLocator injector) {
-        register(new EncodedErrorResponsesTestBinder(new TestAuditLogger(), injector, false, false));
+    public VerboseEncodedErrorResponsesTestApplicationResourceConfig(ServiceLocator injector) {
+        register(new EncodedErrorResponsesTestBinder(new TestAuditLogger(), injector, true, false));
     }
 }

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/InvalidAttributeException.req.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/InvalidAttributeException.req.json
@@ -1,0 +1,13 @@
+[
+  {
+    "op":"add",
+    "path":"/-",
+    "value":{
+      "type":"parent",
+      "id":"nice",
+      "attributes":{
+        "badAttr":"no val"
+      }
+    }
+  }
+]

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLFetchError.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLFetchError.json
@@ -1,0 +1,10 @@
+{
+  "errors":[
+    {
+      "message":"Invalid Syntax",
+      "locations":[
+        {"line":1,"column":43}
+      ]
+    }
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLFetchError.req.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLFetchError.req.json
@@ -1,0 +1,3 @@
+{
+  "query": "{invoice(sort: \"<script>\"){edges{node{id}}}"
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLMutationError.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLMutationError.json
@@ -1,0 +1,12 @@
+{
+  "data":null,
+  "errors":[
+    {
+      "message":"Exception while fetching data (/invoice) : Invalid value: 6&lt;script&gt;alert(1)&lt;/script&gt;",
+      "locations":[
+        {"line":1,"column":11}
+      ],
+      "path":["invoice"]
+    }
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLMutationError.req.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/graphQLMutationError.req.json
@@ -1,0 +1,3 @@
+{
+  "query": "mutation {invoice(op: UPSERT, data:{id: \"6<script>alert(1)</script>\"}){edges{node{id}}}}"
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidAttributeException.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidAttributeException.json
@@ -1,0 +1,6 @@
+[
+  {
+    "detail": "Unknown attribute &#39;badAttr&#39; in &#39;parent&#39;",
+    "status": 404
+  }
+]

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidCollection.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidCollection.json
@@ -1,0 +1,1 @@
+{"errors":["InvalidCollectionException: Unknown collection &#39;unknown&#39;"]}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidCollectionErrorObject.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidCollectionErrorObject.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "detail":"InvalidCollectionException: Unknown collection &#39;unknown&#39;"
+    }
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidEntityBodyException.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidEntityBodyException.json
@@ -1,0 +1,5 @@
+{
+  "errors": [
+    "InvalidEntityBodyException: Bad Request Body&#39;[{&#34;op&#34;:&#34;add&#34;,&#34;path&#34;:&#34;/parent&#34;,&#34;value&#34;:{&#34;id&#34;:&#34;23&#34;,&#34;type&#34;:&#34;parent&#34;},&#34;relationships&#34;:{&#34;spouses&#34;:{}}}]&#39;"
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidEntityBodyException.req.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidEntityBodyException.req.json
@@ -1,0 +1,13 @@
+[
+  {
+    "op": "add",
+    "path": "/parent",
+    "value": {
+      "id": "23",
+      "type": "parent"
+    },
+    "relationships": {
+      "spouses": {}
+    }
+  }
+]

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidEntityBodyExceptionErrorObject.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidEntityBodyExceptionErrorObject.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "detail":"InvalidEntityBodyException: Bad Request Body&#39;[{&#34;op&#34;:&#34;add&#34;,&#34;path&#34;:&#34;/parent&#34;,&#34;value&#34;:{&#34;id&#34;:&#34;23&#34;,&#34;type&#34;:&#34;parent&#34;},&#34;relationships&#34;:{&#34;spouses&#34;:{}}}]&#39;"
+    }
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidObjectIdentifierExceptionErrorObject.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidObjectIdentifierExceptionErrorObject.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "detail":"InvalidObjectIdentifierException: Unknown identifier &#39;100&#39; for parent"
+    }
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidObjectIdentifierExecption.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidObjectIdentifierExecption.json
@@ -1,0 +1,5 @@
+{
+  "errors": [
+    "InvalidObjectIdentifierException: Unknown identifier &#39;100&#39; for parent"
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueException.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueException.json
@@ -1,0 +1,5 @@
+{
+  "errors": [
+    "InvalidValueException: Invalid value: a"
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueException.req.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueException.req.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "type": "invoice",
+    "id": "a"
+  }
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueExceptionErrorObject.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueExceptionErrorObject.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "detail":"InvalidValueException: Invalid value: a"
+    }
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueExceptionVerbose.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/invalidValueExceptionVerbose.json
@@ -1,0 +1,5 @@
+{
+    "errors": [
+      "Error converting from &#39;String&#39; to &#39;Long&#39; For input string: &#34;a&#34;"
+    ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/jsonPatchExtensionException.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/jsonPatchExtensionException.json
@@ -1,0 +1,6 @@
+[
+  {
+    "detail":"Bad Request Body&#39;Could not parse patch extension value: {&#34;id&#34;:&#34;6&#34;,&#34;type&#34;:&#34;parent&#34;,&#34;notARelationship&#34;:{}}&#39;",
+    "status":400
+  }
+]

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/jsonPatchExtensionException.req.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/jsonPatchExtensionException.req.json
@@ -1,0 +1,11 @@
+[
+  {
+    "op": "add",
+    "path": "/-",
+    "value": {
+      "id": "6",
+      "type": "parent",
+      "notARelationship": {}
+    }
+  }
+]

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/jsonPatchExtensionExceptionErrorObject.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/jsonPatchExtensionExceptionErrorObject.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "detail":"JsonPatchExtensionException"
+    }
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/transactionException.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/transactionException.json
@@ -1,0 +1,5 @@
+{
+  "errors": [
+    "TransactionException: Unexpected character (&#39;&#34;&#39; (code 34)): was expecting comma to separate Object entries\n at [Source: (String)&#34;{&#34;data&#34;: {&#34;type&#34;: &#34;invoice&#34; &#34;id&#34;: 100}}&#34;; line: 1, column: 30]"
+  ]
+}

--- a/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/transactionExceptionErrorObject.json
+++ b/elide-integration-tests/src/test/resources/EncodedErrorResponsesIT/transactionExceptionErrorObject.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "detail":"TransactionException: Unexpected character (&#39;&#34;&#39; (code 34)): was expecting comma to separate Object entries\n at [Source: (String)&#34;{&#34;data&#34;: {&#34;type&#34;: &#34;invoice&#34; &#34;id&#34;: 100}}&#34;; line: 1, column: 30]"
+    }
+  ]
+}


### PR DESCRIPTION
Related/Resolves #871 
Add optional support for encoding error response messages, which can be enabled through the setting `ElideSettings.encodeErrorResponses`.

This proposed implementation uses the owasp-java-encoder `Encode.forHtml(errorString)` to safely encode strings for display in HTML.

## Description
### HttpStatusException
Added two additional public functions to the `HttpStatusException` class which can optionally handle error encoding:
```
public Pair<Integer, JsonNode> getErrorResponse(boolean encodeResponse) {}
public Pair<Integer, JsonNode> getVerboseErrorResponse(boolean encodeResponse) {}
```

If `encodeResponse` is true, the error message will be encoded.

Subclasses of HttpStatusException should implement this function if they want to handle errors differently. The notable exception here is the `CustomErrorException` class, which currently does not implement the encoding function, as it is intended that anyone implementing the `CustomErrorException` as a subclass should handle encoding on their own (if even desired).

### JsonAPI
In the JsonApi endpoint (Elide.java), errors are thrown as exceptions, converted to `HttpStatusExceptions` and passed to the 
`Elide.buildErrorResponse(HttpStatusException error, boolean isVerbose)` function.

This function now additionally checks the `ElideSettings` object to see if errors should be encoded.
If so, the `HttpStatusException` get error response functions are called with the relevant boolean.

Similarly, if `ElideSettings.isReturnErrorObjects()` is true, the messages that are placed in the resulting `JsonNode` are first encoded.

### GraphQL
Two new custom serializers are added to the `ObjectMapper` which is retrieved from the `ElideSettings` object. These serializers will handle conversion of GraphQL `ExecutionResult` and `GraphQLError` objects to strings, which are sent back in the response.

In the case of most normal GraphQL queries, any errors are added to the 200 OK response, alongside any data that may also have been returned from the query. Previously, the `ExecutionResult` retrieved from the GraphQL api was converted to a map using `ExecutionResult.toSpecification()`, which only includes the members of the result object which correspond to the required spec of the GraphQL api. Unfortunately, `toSpecification()` converts the `GraphQLError` objects inside the result to strings for us. To get the serializer to properly encode `GraphQLErrors`, I am instead proposing that the `ExecutionResult` itself is sent to the ObjectMapper, rather than the `toSpecification()` result.

Mutation queries, on error, return an object containing a `List<GraphQLError>` objects. This can be easily converted by the ObjectMapper if it is using the new custom serializer.

Finally, some errors result in exceptions being thrown, which get caught, converted into `HttpStatusException` and passed into `GraphQLEndpoint.buildErrorResponse(...)` (which is analogous to the same function in Elide JsonApi). This can be handled in the same was as the JsonApi endpoint, described above since they rely on the same `HttpStatusException` classes.

## Motivation and Context
Optional encoding of error responses can help in preventing some XSS attacks.
See #871 for more detailed description of current behavior/problem.

## How Has This Been Tested?
Currently this has been tested locally using a simple Elide application with Book and Author models.
Manual testing has been done via send requests with script tags using Postman.
Pending initial discussion of whether this change should be adopted, unit testing should be added before we consider merging.

## Concerns
- Potential issues adding our own serializers to the ObjectMapper (which can be provided via ElideSettings) if the user is already doing something special with the ObjectMapper or other serializers.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The `org.owasp.encoder` dependency which is being included to encode strings for HTML has a `BSD 3-Clause` license, which to my understanding should be acceptable to include in an Apache 2.0 licensed project. Link to owasp-java-encoder: https://github.com/OWASP/owasp-java-encoder
