### PR TITLE
To-one Relation Test

### DIFF
--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
@@ -232,28 +232,6 @@ public class JsonApiDSL {
     }
 
     /**
-     * Creates a to-one relationship
-     *
-     * @param field           the field
-     * @param resourceLinkage the resource linkage
-     * @return the relation
-     */
-    public static Relation toOneRelation(String field, ResourceLinkage... resourceLinkage) {
-        return new Relation(field, true, resourceLinkage);
-    }
-
-    /**
-     * Creates a to-many relationship
-     *
-     * @param field           the field
-     * @param resourceLinkage the resource linkage
-     * @return the relation
-     */
-    public static Relation toManyRelation(String field, ResourceLinkage... resourceLinkage) {
-        return new Relation(field, false, resourceLinkage);
-    }
-
-    /**
      * Relation relation.
      *
      * @param field           the field

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
@@ -221,7 +221,7 @@ public class JsonApiDSL {
     }
 
     /**
-     * Relation relation.
+     * Creates a to-many relationship
      *
      * @param field           the field
      * @param resourceLinkage the resource linkage
@@ -229,6 +229,28 @@ public class JsonApiDSL {
      */
     public static Relation relation(String field, ResourceLinkage... resourceLinkage) {
         return new Relation(field, resourceLinkage);
+    }
+
+    /**
+     * Creates a to-one relationship
+     *
+     * @param field           the field
+     * @param resourceLinkage the resource linkage
+     * @return the relation
+     */
+    public static Relation toOneRelation(String field, ResourceLinkage... resourceLinkage) {
+        return new Relation(field, true, resourceLinkage);
+    }
+
+    /**
+     * Creates a to-many relationship
+     *
+     * @param field           the field
+     * @param resourceLinkage the resource linkage
+     * @return the relation
+     */
+    public static Relation toManyRelation(String field, ResourceLinkage... resourceLinkage) {
+        return new Relation(field, false, resourceLinkage);
     }
 
     /**

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -50,7 +50,7 @@ public class JsonApiDSLTest {
     public void verifyRequestWithOneToOneRelationship() {
         String expected = "{\"data\":{\"type\":\"blog\",\"id\":\"1\","
                 + "\"attributes\":{\"title\":\"title\"},"
-                + "\"relationships\":{\"author\":{\"data\":[{\"type\":\"author\",\"id\":\"1\"}]}}}}";
+                + "\"relationships\":{\"author\":{\"data\":{\"type\":\"author\",\"id\":\"1\"}}}}}";
 
         String actual = datum(
                 resource(
@@ -60,7 +60,7 @@ public class JsonApiDSLTest {
                                 attr("title", "title")
                         ),
                         relationships(
-                                relation("author",
+                                toOneRelation("author",
                                         linkage(type("author"), id("1"))
                                 )
                         )

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -72,6 +72,7 @@ public class JsonApiDSLTest {
 
     @Test
     public void verifyRequestWithOneToManyRelationship() {
+        // multi-elements array of resource identifier objects for non-empty to-many relationships.
         String expected = "{\"data\":{\"type\":\"blog\",\"id\":\"1\","
                 + "\"attributes\":{\"title\":\"title\"},"
                 + "\"relationships\":{"
@@ -90,6 +91,29 @@ public class JsonApiDSLTest {
                                       linkage(type("comment"), id("1")),
                                       linkage(type("comment"), id("2"))
                               )
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(actual, expected);
+
+        // single-element array of resource identifier objects for non-empty to-many relationships.
+        expected = "{\"data\":{\"type\":\"blog\",\"id\":\"1\","
+                + "\"attributes\":{\"title\":\"title\"},"
+                + "\"relationships\":{"
+                + "\"comments\":{\"data\":[{\"type\":\"comment\",\"id\":\"1\"}]}}}}";
+
+        actual = datum(
+                resource(
+                        type("blog"),
+                        id("1"),
+                        attributes(
+                                attr("title", "title")
+                        ),
+                        relationships(
+                                relation("comments",
+                                        linkage(type("comment"), id("1"))
+                                )
                         )
                 )
         ).toJSON();

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -7,6 +7,7 @@
 package com.yahoo.elide.contrib.testhelpers.jsonapi;
 
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.*;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relation.TO_ONE;
 import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
@@ -60,7 +61,8 @@ public class JsonApiDSLTest {
                                 attr("title", "title")
                         ),
                         relationships(
-                                toOneRelation("author",
+                                relation("author",
+                                        TO_ONE,
                                         linkage(type("author"), id("1"))
                                 )
                         )


### PR DESCRIPTION
💥 DO NOT MERGE THIS PR UNTIL https://github.com/yahoo/elide/pull/903 is merged

Resolves a test issue.

In a [to-one relationship test](https://github.com/yahoo/elide/blob/RefactorResourceIT/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java#L50), I found the relationship returns [an array](https://github.com/yahoo/elide/blob/RefactorResourceIT/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java#L53)  of resource identifier objects. This is because [relation()](https://github.com/yahoo/elide/blob/RefactorResourceIT/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java#L63) creates to-many relationship by default.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
