### PR TITLE
Implements #900 - elide-swagger to support @ApiModelProperty annotation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Change Log
+## 4.5.1
+**Features**
+ * Issue #900. Add `@ApiModelProperty` support to `elide-swagger` that makes it possible to customize `description`, `example`, `readOnly` and `required` attributes of object definitions in resulting generates Swagger document.
+
 ## 4.5.0
 **Features**
  * Issue #815.  Added the ability to customize the JPQL generation for a filter operator globally or for a specific entity attribute.

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolver.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolver.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.contrib.swagger.property.Relationship;
 import com.yahoo.elide.core.EntityDictionary;
 
 import com.fasterxml.jackson.databind.type.SimpleType;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.converter.ModelConverter;
@@ -22,7 +23,6 @@ import io.swagger.jackson.ModelResolver;
 import io.swagger.models.Model;
 import io.swagger.models.properties.Property;
 import io.swagger.util.Json;
-import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -100,7 +100,9 @@ public class JsonApiModelResolver extends ModelResolver {
         return entitySchema;
     }
 
-    private Property processAttribute(Class<?> clazz, String attributeName, Class<?> attributeClazz, ModelConverterContext context, Iterator<ModelConverter> next) {
+    private Property processAttribute(Class<?> clazz, String attributeName, Class<?> attributeClazz,
+        ModelConverterContext context, Iterator<ModelConverter> next) {
+
         Property attribute = super.resolveProperty(attributeClazz, context, null, next);
 
         String permissions = getFieldPermissions(clazz, attributeName);

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolver.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolver.java
@@ -15,16 +15,20 @@ import com.yahoo.elide.core.EntityDictionary;
 
 import com.fasterxml.jackson.databind.type.SimpleType;
 
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.converter.ModelConverter;
 import io.swagger.converter.ModelConverterContext;
 import io.swagger.jackson.ModelResolver;
 import io.swagger.models.Model;
 import io.swagger.models.properties.Property;
 import io.swagger.util.Json;
+import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Swagger ModelResolvers map POJO classes to Swagger com.yahoo.elide.contrib.swagger.models.
@@ -70,9 +74,7 @@ public class JsonApiModelResolver extends ModelResolver {
         for (String attributeName : attributeNames) {
             Class<?> attributeClazz = dictionary.getType(clazz, attributeName);
 
-            Property attribute = super.resolveProperty(attributeClazz, context, null, next);
-
-            attribute.setDescription(getFieldPermissions(clazz, attributeName));
+            Property attribute = processAttribute(clazz, attributeName, attributeClazz, context, next);
             entitySchema.addAttribute(attributeName, attribute);
         }
 
@@ -98,6 +100,44 @@ public class JsonApiModelResolver extends ModelResolver {
         return entitySchema;
     }
 
+    private Property processAttribute(Class<?> clazz, String attributeName, Class<?> attributeClazz, ModelConverterContext context, Iterator<ModelConverter> next) {
+        Property attribute = super.resolveProperty(attributeClazz, context, null, next);
+
+        String permissions = getFieldPermissions(clazz, attributeName);
+        String description = getFieldDescription(clazz, attributeName);
+
+        attribute.setDescription(joinNonEmpty("\n", description, permissions));
+        attribute.setExample((Object) getFieldExample(clazz, attributeName));
+        attribute.setReadOnly(getFieldReadOnly(clazz, attributeName));
+        attribute.setRequired(getFieldRequired(clazz, attributeName));
+
+        return attribute;
+    }
+
+    private ApiModelProperty getApiModelProperty(Class<?> clazz, String fieldName) {
+        return dictionary.getAttributeOrRelationAnnotation(clazz, ApiModelProperty.class, fieldName);
+    }
+
+    private boolean getFieldRequired(Class<?> clazz, String fieldName) {
+        ApiModelProperty property = getApiModelProperty(clazz, fieldName);
+        return property != null && property.required();
+    }
+
+    private boolean getFieldReadOnly(Class<?> clazz, String fieldName) {
+        ApiModelProperty property = getApiModelProperty(clazz, fieldName);
+        return property != null && property.readOnly();
+    }
+
+    private String getFieldExample(Class<?> clazz, String fieldName) {
+        ApiModelProperty property = getApiModelProperty(clazz, fieldName);
+        return property == null ? "" : property.example();
+    }
+
+    private String getFieldDescription(Class<?> clazz, String fieldName) {
+        ApiModelProperty property = getApiModelProperty(clazz, fieldName);
+        return property == null ? "" : property.value();
+    }
+
     /**
      * Get the class-level permission annotation value.
      *
@@ -108,10 +148,14 @@ public class JsonApiModelResolver extends ModelResolver {
         String createPermissions = getCreatePermission(clazz);
         String deletePermissions = getDeletePermission(clazz);
 
+        createPermissions = (createPermissions == null) ? "" : "Create Permissions : (" + createPermissions + ")";
+        deletePermissions = (deletePermissions == null) ? "" : "Delete Permissions : (" + deletePermissions + ")";
+        return joinNonEmpty("\n", createPermissions, deletePermissions);
+    }
 
-        createPermissions = (createPermissions == null) ? "" : "Create Permissions : (" + createPermissions + ")\n";
-        deletePermissions = (deletePermissions == null) ? "" : "Delete Permissions : (" + deletePermissions + ")\n";
-        return createPermissions + deletePermissions;
+    private String joinNonEmpty(String delimiter, String... elements) {
+        return Arrays.stream(elements).filter(StringUtils::isNotBlank)
+            .collect(Collectors.joining(delimiter));
     }
 
     /**
@@ -125,9 +169,9 @@ public class JsonApiModelResolver extends ModelResolver {
         String readPermissions = getReadPermission(clazz, fieldName);
         String updatePermissions = getUpdatePermission(clazz, fieldName);
 
-        readPermissions = (readPermissions == null) ? "" : "Read Permissions : (" + readPermissions + ")\n";
-        updatePermissions = (updatePermissions == null) ? "" : "Update Permissions : (" + updatePermissions + ")\n";
-        return readPermissions + updatePermissions;
+        readPermissions = (readPermissions == null) ? "" : "Read Permissions : (" + readPermissions + ")";
+        updatePermissions = (updatePermissions == null) ? "" : "Update Permissions : (" + updatePermissions + ")";
+        return joinNonEmpty("\n", readPermissions, updatePermissions);
     }
 
     /**

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
@@ -5,14 +5,15 @@
  */
 package com.yahoo.elide.contrib.swagger;
 
+import com.google.common.collect.ImmutableMap;
 import com.yahoo.elide.contrib.swagger.model.Resource;
-import com.yahoo.elide.contrib.swagger.models.Author;
 import com.yahoo.elide.contrib.swagger.models.Book;
 import com.yahoo.elide.contrib.swagger.models.Publisher;
 import com.yahoo.elide.core.EntityDictionary;
 
 import com.google.common.collect.Maps;
 
+import io.swagger.models.properties.StringProperty;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -25,33 +26,36 @@ import java.util.Map;
 
 
 public class JsonApiModelResolverTest {
-    EntityDictionary dictionary;
+
+    private static final String KEY_BOOK = "book";
+    private static final String KEY_PUBLISHER = "publisher";
+
+    private static final Map<String, Class> ENTITIES =
+        ImmutableMap.of(KEY_BOOK, Book.class,
+                        KEY_PUBLISHER, Publisher.class);
+
+    private ModelConverters converters;
 
     @BeforeSuite
     public void setup() {
-        dictionary = new EntityDictionary(Maps.newHashMap());
+        EntityDictionary dictionary = new EntityDictionary(Maps.newHashMap());
 
-        dictionary.bindEntity(Book.class);
-        dictionary.bindEntity(Author.class);
-        dictionary.bindEntity(Publisher.class);
+        dictionary.bindEntity(ENTITIES.get(KEY_BOOK));
+        dictionary.bindEntity(ENTITIES.get(KEY_PUBLISHER));
+
+        converters = ModelConverters.getInstance();
+        converters.addConverter(new JsonApiModelResolver(dictionary));
     }
 
     @Test
-    public void testBookPermissions() throws Exception {
-        ModelConverters converters = ModelConverters.getInstance();
-        converters.addConverter(new JsonApiModelResolver(dictionary));
+    public void testBookPermissions() {
+        StringProperty entity = getStringProperty(KEY_BOOK, "type");
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "attributes");
+        ObjectProperty relationships = getObjectProperty(KEY_BOOK, "relationships");
 
-        Map<String, Model> models = converters.readAll(Book.class);
-
-        Resource bookModel = (Resource) models.get("book");
-
-        String entityPermissions = bookModel.getProperties().get("type").getDescription();
+        String entityPermissions = entity.getDescription();
         Assert.assertEquals(entityPermissions,
-                "Create Permissions : (Principal is author)\nDelete Permissions : (Deny All)");
-
-
-        ObjectProperty attributes = (ObjectProperty) bookModel.getProperties().get("attributes");
-        ObjectProperty relationships = (ObjectProperty) bookModel.getProperties().get("relationships");
+            "Create Permissions : (Principal is author)\nDelete Permissions : (Deny All)");
 
         String titlePermissions = attributes.getProperties().get("title").getDescription();
         Assert.assertEquals(titlePermissions,  "Read Permissions : (Principal is author OR Principal is publisher)");
@@ -63,16 +67,9 @@ public class JsonApiModelResolverTest {
     }
 
     @Test
-    public void testModelResolution() throws Exception {
-        ModelConverters converters = ModelConverters.getInstance();
-        converters.addConverter(new JsonApiModelResolver(dictionary));
-
-        Map<String, Model> models = converters.readAll(Publisher.class);
-
-        Resource publisherModel = (Resource) models.get("publisher");
-
-        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
-        ObjectProperty relationships = (ObjectProperty) publisherModel.getProperties().get("relationships");
+    public void testModelResolution() {
+        ObjectProperty attributes = getObjectProperty(KEY_PUBLISHER, "attributes");
+        ObjectProperty relationships = getObjectProperty(KEY_PUBLISHER, "relationships");
 
         Assert.assertEquals(attributes.getProperties().size(), 3);
         Assert.assertEquals(relationships.getProperties().size(), 2);
@@ -84,14 +81,7 @@ public class JsonApiModelResolverTest {
 
     @Test
     public void testDescription() {
-        ModelConverters converters = ModelConverters.getInstance();
-        converters.addConverter(new JsonApiModelResolver(dictionary));
-
-        Map<String, Model> models = converters.readAll(Publisher.class);
-
-        Resource publisherModel = (Resource) models.get("publisher");
-
-        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+        ObjectProperty attributes = getObjectProperty(KEY_PUBLISHER, "attributes");
 
         String phoneDescription = attributes.getProperties().get("phone").getDescription();
         Assert.assertEquals(phoneDescription,  "Phone number");
@@ -99,14 +89,7 @@ public class JsonApiModelResolverTest {
 
     @Test
     public void testExample() {
-        ModelConverters converters = ModelConverters.getInstance();
-        converters.addConverter(new JsonApiModelResolver(dictionary));
-
-        Map<String, Model> models = converters.readAll(Publisher.class);
-
-        Resource publisherModel = (Resource) models.get("publisher");
-
-        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+        ObjectProperty attributes = getObjectProperty(KEY_PUBLISHER, "attributes");
 
         Object phoneExample = attributes.getProperties().get("phone").getExample();
         Assert.assertEquals(phoneExample,  "555-000-1111");
@@ -114,29 +97,16 @@ public class JsonApiModelResolverTest {
 
     @Test
     public void testConcatenatedDescriptionAndPermissions() {
-        ModelConverters converters = ModelConverters.getInstance();
-        converters.addConverter(new JsonApiModelResolver(dictionary));
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "attributes");
 
-        Map<String, Model> models = converters.readAll(Book.class);
-
-        Resource bookModel = (Resource) models.get("book");
-
-        ObjectProperty attributes = (ObjectProperty) bookModel.getProperties().get("attributes");
-
-        String isbnDescription = attributes.getProperties().get("year").getDescription();
-        Assert.assertEquals(isbnDescription,  "Year published\nRead Permissions : (Principal is author OR Principal is publisher)");
+        String yearDescription = attributes.getProperties().get("year").getDescription();
+        Assert.assertEquals(yearDescription,
+            "Year published\nRead Permissions : (Principal is author OR Principal is publisher)");
     }
 
     @Test
     public void testRequired() {
-        ModelConverters converters = ModelConverters.getInstance();
-        converters.addConverter(new JsonApiModelResolver(dictionary));
-
-        Map<String, Model> models = converters.readAll(Book.class);
-
-        Resource publisherModel = (Resource) models.get("book");
-
-        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "attributes");
 
         boolean titleRequired = attributes.getProperties().get("title").getRequired();
         Assert.assertTrue(titleRequired);
@@ -144,16 +114,22 @@ public class JsonApiModelResolverTest {
 
     @Test
     public void testReadOnly() {
-        ModelConverters converters = ModelConverters.getInstance();
-        converters.addConverter(new JsonApiModelResolver(dictionary));
-
-        Map<String, Model> models = converters.readAll(Book.class);
-
-        Resource publisherModel = (Resource) models.get("book");
-
-        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "attributes");
 
         Boolean titleReadOnly = attributes.getProperties().get("year").getReadOnly();
         Assert.assertTrue(titleReadOnly);
+    }
+
+    private Resource getModel(String entityKey) {
+        Map<String, Model> models = converters.readAll(ENTITIES.get(entityKey));
+        return (Resource) models.get(entityKey);
+    }
+
+    private ObjectProperty getObjectProperty(String entityKey, String propertyKey) {
+        return (ObjectProperty) getModel(entityKey).getProperties().get(propertyKey);
+    }
+
+    private StringProperty getStringProperty(String entityKey, String propertyKey) {
+        return (StringProperty) getModel(entityKey).getProperties().get(propertyKey);
     }
 }

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
@@ -47,19 +47,19 @@ public class JsonApiModelResolverTest {
 
         String entityPermissions = bookModel.getProperties().get("type").getDescription();
         Assert.assertEquals(entityPermissions,
-                "Create Permissions : (Principal is author)\nDelete Permissions : (Deny All)\n");
+                "Create Permissions : (Principal is author)\nDelete Permissions : (Deny All)");
 
 
         ObjectProperty attributes = (ObjectProperty) bookModel.getProperties().get("attributes");
         ObjectProperty relationships = (ObjectProperty) bookModel.getProperties().get("relationships");
 
         String titlePermissions = attributes.getProperties().get("title").getDescription();
-        Assert.assertEquals(titlePermissions,  "Read Permissions : (Principal is author OR Principal is publisher)\n");
+        Assert.assertEquals(titlePermissions,  "Read Permissions : (Principal is author OR Principal is publisher)");
 
         String publisherPermissions = relationships.getProperties().get("publisher").getDescription();
         Assert.assertEquals(publisherPermissions,
                 "Read Permissions : (Principal is author OR Principal is publisher)\n"
-                        + "Update Permissions : (Principal is publisher)\n");
+                        + "Update Permissions : (Principal is publisher)");
     }
 
     @Test
@@ -74,11 +74,86 @@ public class JsonApiModelResolverTest {
         ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
         ObjectProperty relationships = (ObjectProperty) publisherModel.getProperties().get("relationships");
 
-        Assert.assertEquals(attributes.getProperties().size(), 2);
+        Assert.assertEquals(attributes.getProperties().size(), 3);
         Assert.assertEquals(relationships.getProperties().size(), 2);
         Assert.assertTrue(attributes.getProperties().containsKey("billingAddress"));
         Assert.assertTrue(attributes.getProperties().containsKey("billingCodes"));
         Assert.assertTrue(relationships.getProperties().containsKey("books"));
         Assert.assertTrue(relationships.getProperties().containsKey("exclusiveAuthors"));
+    }
+
+    @Test
+    public void testDescription() {
+        ModelConverters converters = ModelConverters.getInstance();
+        converters.addConverter(new JsonApiModelResolver(dictionary));
+
+        Map<String, Model> models = converters.readAll(Publisher.class);
+
+        Resource publisherModel = (Resource) models.get("publisher");
+
+        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+
+        String phoneDescription = attributes.getProperties().get("phone").getDescription();
+        Assert.assertEquals(phoneDescription,  "Phone number");
+    }
+
+    @Test
+    public void testExample() {
+        ModelConverters converters = ModelConverters.getInstance();
+        converters.addConverter(new JsonApiModelResolver(dictionary));
+
+        Map<String, Model> models = converters.readAll(Publisher.class);
+
+        Resource publisherModel = (Resource) models.get("publisher");
+
+        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+
+        Object phoneExample = attributes.getProperties().get("phone").getExample();
+        Assert.assertEquals(phoneExample,  "555-000-1111");
+    }
+
+    @Test
+    public void testConcatenatedDescriptionAndPermissions() {
+        ModelConverters converters = ModelConverters.getInstance();
+        converters.addConverter(new JsonApiModelResolver(dictionary));
+
+        Map<String, Model> models = converters.readAll(Book.class);
+
+        Resource bookModel = (Resource) models.get("book");
+
+        ObjectProperty attributes = (ObjectProperty) bookModel.getProperties().get("attributes");
+
+        String isbnDescription = attributes.getProperties().get("year").getDescription();
+        Assert.assertEquals(isbnDescription,  "Year published\nRead Permissions : (Principal is author OR Principal is publisher)");
+    }
+
+    @Test
+    public void testRequired() {
+        ModelConverters converters = ModelConverters.getInstance();
+        converters.addConverter(new JsonApiModelResolver(dictionary));
+
+        Map<String, Model> models = converters.readAll(Book.class);
+
+        Resource publisherModel = (Resource) models.get("book");
+
+        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+
+        boolean titleRequired = attributes.getProperties().get("title").getRequired();
+        Assert.assertTrue(titleRequired);
+    }
+
+    @Test
+    public void testReadOnly() {
+        ModelConverters converters = ModelConverters.getInstance();
+        converters.addConverter(new JsonApiModelResolver(dictionary));
+
+        Map<String, Model> models = converters.readAll(Book.class);
+
+        Resource publisherModel = (Resource) models.get("book");
+
+        ObjectProperty attributes = (ObjectProperty) publisherModel.getProperties().get("attributes");
+
+        Boolean titleReadOnly = attributes.getProperties().get("year").getReadOnly();
+        Assert.assertTrue(titleReadOnly);
     }
 }

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
@@ -5,15 +5,14 @@
  */
 package com.yahoo.elide.contrib.swagger;
 
-import com.google.common.collect.ImmutableMap;
 import com.yahoo.elide.contrib.swagger.model.Resource;
 import com.yahoo.elide.contrib.swagger.models.Book;
 import com.yahoo.elide.contrib.swagger.models.Publisher;
 import com.yahoo.elide.core.EntityDictionary;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
-import io.swagger.models.properties.StringProperty;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -21,6 +20,7 @@ import org.testng.annotations.Test;
 import io.swagger.converter.ModelConverters;
 import io.swagger.models.Model;
 import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.StringProperty;
 
 import java.util.Map;
 

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
@@ -302,7 +302,7 @@ public class SwaggerBuilderTest {
                 .collect(Collectors.toSet());
 
         long filterParams = paramNames.stream().filter((name) -> name.startsWith("filter")).count();
-        Assert.assertEquals(filterParams, 13);
+        Assert.assertEquals(filterParams, 24);
 
         Assert.assertTrue(paramNames.contains("filter"));
         Assert.assertTrue(paramNames.contains("filter[book]"));

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Book.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Book.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Set;
 
@@ -38,5 +39,9 @@ public class Book {
     }
 
     @NotNull
+    @ApiModelProperty(required = true)
     public String title;
+
+    @ApiModelProperty(value = "Year published", example = "1999", readOnly = true)
+    public String year;
 }

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Publisher.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Publisher.java
@@ -6,7 +6,6 @@
 package com.yahoo.elide.contrib.swagger.models;
 
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.UpdatePermission;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Map;

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Publisher.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Publisher.java
@@ -6,6 +6,8 @@
 package com.yahoo.elide.contrib.swagger.models;
 
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.UpdatePermission;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Map;
 import java.util.Set;
@@ -44,4 +46,7 @@ public class Publisher {
     public Address billingAddress;
 
     public Map<String, Integer> billingCodes;
+
+    @ApiModelProperty(value = "Phone number", example = "555-000-1111")
+    public String phone;
 }


### PR DESCRIPTION
Resolves #900

## Description
`JsonApiModelResolver` additionally to processing permission annotations, processes `@ApiModelProperty` to transfer the following attributes to the resulting generated swagger document:
* `description` - sets contents of `value` annotation attribute, if present, to the `description` property attribute in swagger document, and concatenates permissions on next lines for backward compatibility
* `example` - sets value of `example` annotation attribute, if present, to the `example` property attribute in swagger document
* `readOnly` - sets value of `readOnly` annotation attribute, if present, to the `read-only` property attribute in swagger document
* `required` - sets value of `required` annotation attribute, if present, to the `required` property attribute in swagger document

Additional changes:
* lines in the `description` attribute are formatted properly - no extra empty lines

## Motivation and Context
Described in detail in issue #900

## How Has This Been Tested?
* existing tests have been adjusted to the new number of attributes
* new tests added to verify new functionality and backward compatibility

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
