### PR TITLE
Fix deserialization for optional top-level meta object (#913)

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
@@ -43,7 +43,6 @@ public class JsonApiDocument {
 
     public void setData(Data<Resource> data) {
         this.data = data;
-        this.meta = null;
     }
 
     public Data<Resource> getData() {

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Meta.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Meta.java
@@ -5,8 +5,11 @@
  */
 package com.yahoo.elide.jsonapi.models;
 
+import com.yahoo.elide.jsonapi.serialization.MetaDeserializer;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Map;
 
@@ -14,6 +17,7 @@ import java.util.Map;
  * Model for representing JSON API meta information.
  */
 @JsonAutoDetect
+@JsonDeserialize(using = MetaDeserializer.class)
 public class Meta extends KeyValMap {
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/MetaDeserializer.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/MetaDeserializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.jsonapi.serialization;
+
+import com.yahoo.elide.jsonapi.models.Meta;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Custom deserializer for top-level meta object.
+ */
+public class MetaDeserializer extends JsonDeserializer<Meta> {
+    private final static ObjectMapper MAPPER = new MappingJsonFactory().getCodec();
+
+    @Override
+    public Meta deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+        // Optional top-level meta member must be an object
+        return node.isObject() ? new Meta(MAPPER.convertValue(node, Map.class)) : null;
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
+import com.yahoo.elide.jsonapi.models.Meta;
 import com.yahoo.elide.jsonapi.models.Relationship;
 import com.yahoo.elide.jsonapi.models.Resource;
 import com.yahoo.elide.jsonapi.models.ResourceIdentifier;
@@ -227,6 +228,26 @@ public class JsonApiTest {
     }
 
     @Test
+    public void readSingleWithMeta() throws IOException {
+        String doc = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":{\"type\":\"child\",\"id\":\"2\"}}}},\"meta\":{\"additional\":\"info\"}}";
+
+        JsonApiDocument jsonApiDocument = mapper.readJsonApiDocument(doc);
+
+        Meta meta = jsonApiDocument.getMeta();
+        Data<Resource> dataObj = jsonApiDocument.getData();
+        Resource data = dataObj.getSingleValue();
+        Map<String, Object> attributes = data.getAttributes();
+        Map<String, Relationship> relations = data.getRelationships();
+
+        assertEquals(meta.getMetaMap().get("additional"), "info");
+        assertEquals(data.getType(), "parent");
+        assertEquals(data.getId(), "123");
+        assertEquals(attributes.get("firstName"), "bob");
+        assertEquals(relations.get("children").getData().getSingleValue().getType(), "child");
+        assertEquals(relations.get("children").getData().getSingleValue().getId(), "2");
+    }
+
+    @Test
     public void readSingleIncluded() throws Exception {
         String doc = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"links\":{\"self\":\"/parent/123/relationships/child\",\"related\":\"/parent/123/child\"},\"data\":{\"type\":\"child\",\"id\":\"2\"}}}},\"included\":[{\"type\":\"child\",\"id\":\"2\",\"relationships\":{\"parents\":{\"links\":{\"self\":\"/parent/123/relationships/child\",\"related\":\"/parent/123/child\"},\"data\":{\"type\":\"parent\",\"id\":\"123\"}}}}]}";
 
@@ -286,5 +307,25 @@ public class JsonApiTest {
         assertEquals(includedChild.getType(), "child");
         assertEquals(includedChild.getId(), "2");
         assertEquals(parent.getId(), "123");
+    }
+
+    @Test
+    public void readListWithMeta() throws IOException {
+        String doc = "{\"data\":[{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"links\":{\"self\":\"/parent/123/relationships/child\",\"related\":\"/parent/123/child\"},\"data\":{\"type\":\"child\",\"id\":\"2\"}}}}],\"meta\":{\"additional\":\"info\"}}";
+
+        JsonApiDocument jsonApiDocument = mapper.readJsonApiDocument(doc);
+
+        Meta meta = jsonApiDocument.getMeta();
+        Data<Resource> list = jsonApiDocument.getData();
+        Resource data = list.get().iterator().next();
+        Map<String, Object> attributes = data.getAttributes();
+        List<Resource> included = jsonApiDocument.getIncluded();
+
+        assertEquals(meta.getMetaMap().get("additional"), "info");
+        assertEquals(data.getType(), "parent");
+        assertEquals(data.getId(), "123");
+        assertEquals(attributes.get("firstName"), "bob");
+        assertEquals(data.getRelationships().get("children").getData().getSingleValue().getId(), "2");
+        assertNull(included);
     }
 }


### PR DESCRIPTION
Resolves #913 

## Description
Adds a custom deserializer for `Meta`.

## Motivation and Context
This fixes the `meta` deserialization problem documented in #913 

## How Has This Been Tested?
Added tests `readSingleWithMeta()` and `readListWithMeta()` to `JsonApiTest.java` to verify that the `meta` object is being properly deserialized.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
