### PR TITLE
Add patch extension to DSL

### DIFF
--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
@@ -12,6 +12,9 @@ import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Data;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Document;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Id;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Include;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperation;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperationType;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchSet;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relation;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relationships;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Resource;
@@ -36,16 +39,6 @@ import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Type;
  * }
  */
 public class JsonApiDSL {
-    /**
-     * Data data.
-     *
-     * @param resource the singular resource
-     * @return a data
-     */
-    public static Data datum(Resource resource) {
-        return new Data(resource);
-    }
-
     /**
      * Data data.
      *
@@ -282,5 +275,23 @@ public class JsonApiDSL {
      */
     public static ResourceLinkage linkage(Type type, Id id) {
         return new ResourceLinkage(id, type);
+    }
+
+    /**
+     * @param patchOperations the set of patch operation
+     * @return the patch set
+     */
+    public static PatchSet patchSet(PatchOperation... patchOperations) {
+        return new PatchSet(patchOperations);
+    }
+
+    /**
+     * @param operation the operation type
+     * @param path the operation path
+     * @param value the operation value
+     * @return
+     */
+    public static PatchOperation patchOperation(PatchOperationType operation, String path, Resource value) {
+        return new PatchOperation(operation, path, value);
     }
 }

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/PatchOperation.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/PatchOperation.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import java.util.LinkedHashMap;
+
+public class PatchOperation extends LinkedHashMap<String, Object> {
+
+   /**
+    * @param operation the operation type
+    * @param path the operation path
+    * @param value the operation value
+    */
+   public PatchOperation(PatchOperationType operation, String path, Resource value) {
+      this.put("op", operation.name());
+      this.put("path", path);
+      this.put("value", value);
+   }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/PatchOperationType.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/PatchOperationType.java
@@ -1,0 +1,5 @@
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+public enum PatchOperationType {
+    add, remove, replace
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/PatchSet.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/PatchSet.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class PatchSet extends ArrayList {
+
+   static private final Gson GSON_INSTANCE = new GsonBuilder()
+           .serializeNulls().create();
+
+   /**
+    * @param patchOperations the set of patch operations
+    */
+   public PatchSet(PatchOperation... patchOperations) {
+      this.addAll(Arrays.asList(patchOperations));
+   }
+
+   /**
+    * To json string.
+    *
+    * @return the string
+    */
+   public String toJSON() {
+      return GSON_INSTANCE.toJson(this);
+   }
+}

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -7,7 +7,8 @@
 package com.yahoo.elide.contrib.testhelpers.jsonapi;
 
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.*;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relation.TO_ONE;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperationType.*;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relation.*;
 import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
@@ -274,6 +275,36 @@ public class JsonApiDSLTest {
                         attributes(
                                 attr("title", "Why You Should use Elide"),
                                 attr("date", "2019-01-01")
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void verifyPatchOperation() {
+        String expected = "[{\"op\":\"add\",\"path\":\"/parent\",\"value\":{\"type\":\"parent\",\"id\":\"1\",\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[{\"type\":\"parent\",\"id\":\"3\"}]}}}},{\"op\":\"add\",\"path\":\"/parent/1/children\",\"value\":{\"type\":\"child\",\"id\":\"2\"}}]";
+
+        String actual = patchSet(
+                patchOperation(add, "/parent",
+                        resource(
+                                type("parent"),
+                                id("1"),
+                                relationships(
+                                        relation("children",
+                                                linkage(type("child"), id("2"))
+                                        ),
+                                        relation("spouses",
+                                                linkage(type("parent"), id("3"))
+                                        )
+                                )
+                        )
+                ),
+                patchOperation(add, "/parent/1/children",
+                        resource(
+                                type("child"),
+                                id("2")
                         )
                 )
         ).toJSON();


### PR DESCRIPTION
## Description

Adds patch extension format to json api dsl

## Motivation and Context

This will assist in refactoring the IT tests

## How Has This Been Tested?

Unit tests have been added

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
