### PR TITLE
Restore provided on jpa

### DIFF
--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -78,6 +78,7 @@
             <groupId>javax.persistence</groupId>
             <artifactId>javax.persistence-api</artifactId>
             <version>2.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Description
Reverses JPA dependency change from (#894)

## Motivation and Context
Resolved downstream build conflict with hibernate-jpa-2.0-api.

## How Has This Been Tested?
Local build.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
