### PR TITLE
Add data collection class hierarchy parameterized attributes

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -52,6 +52,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -116,10 +117,12 @@ public class EntityBinding {
     public final ConcurrentHashMap<String, Class<?>> fieldsToTypes = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, String> aliasesToFields = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<Method, Boolean> requestScopeableMethods = new ConcurrentHashMap<>();
+    public final ConcurrentHashMap<AccessibleObject, Map<String, Object>> attributeArgumets = new ConcurrentHashMap<>();
 
     public final ConcurrentHashMap<Class<? extends Annotation>, Annotation> annotations = new ConcurrentHashMap<>();
 
     public static final EntityBinding EMPTY_BINDING = new EntityBinding();
+    public static final Map<String, Object> EMPTY_ATTRIBUTES_ARGS = new ConcurrentHashMap<>();
     private static final String ALL_FIELDS = "*";
 
     /* empty binding constructor */
@@ -585,5 +588,35 @@ public class EntityBinding {
         }
 
         return results;
+    }
+
+    /**
+     * Add a collection of arguments to the attributes of this Entity.
+     * @param attribute attribute name to which argument has to be added
+     * @param arguments Map object that contains name and value of each argument.
+     */
+    public void addArgumentsToAttribute(String attribute, Map<String, Object> arguments) {
+        AccessibleObject fieldObject = fieldsToValues.get(attribute);
+        if (fieldObject != null && arguments != null) {
+            Map<String, Object> existingArgs = attributeArgumets.get(fieldObject);
+            if (existingArgs != null) {
+                //Replace any argument names with new value
+                existingArgs.putAll(arguments);
+            } else {
+                attributeArgumets.put(fieldObject, arguments);
+            }
+        }
+    }
+
+    /**
+     * Returns the Collection of all attributes of an argument.
+     * @param attribute Name of the argument for ehich arguments are to be retrieved.
+     * @return A Map object that contains name and value of each argument for the given attribute.
+     */
+    public Map<String, Object> getAttributeArguments(String attribute) {
+        AccessibleObject fieldObject = fieldsToValues.get(attribute);
+        return (fieldObject != null)
+                ? attributeArgumets.getOrDefault(fieldObject, EMPTY_ATTRIBUTES_ARGS)
+                : EMPTY_ATTRIBUTES_ARGS;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -1411,4 +1411,24 @@ public class EntityDictionary {
             bindEntity(entityClass);
         }
     }
+
+    /**
+     * Add a collection of argument to the attributes
+     * @param cls The entity
+     * @param attributeName attribute name to which argument has to be added
+     * @param arguments Map object that contains name and value of each argument.
+     */
+    public void addArgumentsToAttributes(Class<?> cls, String attributeName, Map<String, Object> arguments) {
+        getEntityBinding(cls).addArgumentsToAttribute(attributeName, arguments);
+    }
+
+    /**
+     * Returns the Collection of all attributes of an argument.
+     * @param cls The entity
+     * @param attributeName Name of the argument for ehich arguments are to be retrieved.
+     * @return A Map object that contains name and value of each argument for the given attribute.
+     */
+    public Map<String, Object> getAttributeArguments(Class<?> cls, String attributeName) {
+        return entityBindings.getOrDefault(cls, EMPTY_BINDING).getAttributeArguments(attributeName);
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.core.exceptions.InvalidCollectionException;
 import com.yahoo.elide.generated.parsers.CoreBaseVisitor;
 import com.yahoo.elide.generated.parsers.CoreParser;
 import com.yahoo.elide.parsers.JsonApiParser;
+import com.yahoo.elide.request.Argument;
 import com.yahoo.elide.request.Attribute;
 import com.yahoo.elide.request.EntityProjection;
 
@@ -307,6 +308,15 @@ public class EntityProjectionMaker
                 .map(attributeName -> Attribute.builder()
                     .name(attributeName)
                     .type(dictionary.getType(entityClass, attributeName))
+                    .arguments(
+                            dictionary.getAttributeArguments(entityClass, attributeName)
+                                    .entrySet()
+                                    .stream()
+                                    .map(argumentEntry -> Argument.builder()
+                                            .name(argumentEntry.getKey())
+                                            .value(argumentEntry.getValue())
+                                            .build())
+                                    .collect(Collectors.toSet()))
                     .build())
                 .collect(Collectors.toSet());
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.graphql;
 
+import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
@@ -16,6 +17,7 @@ import com.yahoo.elide.core.EntityDictionary;
 
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
@@ -31,7 +33,9 @@ import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Contains methods that convert from a class to a GraphQL input or query type.
@@ -420,6 +424,42 @@ public class GraphQLConversionUtils {
         inputConversions.put(clazz, object);
 
         return object;
+    }
+
+    /**
+     * Build an Argument list object for the given attribute
+     * @param entityClass The Entity class to which this attribute belongs to.
+     * @param attribute The name of the attribute.
+     * @param fetcher The data fetcher to associated with the newly created GraphQL Query Type
+     * @return Newly created GraphQLArgument Collection for the given attribute
+     */
+    public List<GraphQLArgument> attributeArgumentToQueryObject(Class<?> entityClass,
+                                                                String attribute,
+                                                                DataFetcher fetcher) {
+        return attributeArgumentToQueryObject(entityClass, attribute, fetcher, entityDictionary);
+    }
+
+    /**
+     * Build an Argument list object for the given attribute
+     * @param entityClass The Entity class to which this attribute belongs to.
+     * @param attribute The name of the attribute.
+     * @param fetcher The data fetcher to associated with the newly created GraphQL Query Type
+     * @param dictionary The dictionary that contains the runtime type information for the parent class.
+     * @return Newly created GraphQLArgument Collection for the given attribute
+     */
+    public List<GraphQLArgument> attributeArgumentToQueryObject(Class<?> entityClass,
+                                                                String attribute,
+                                                                DataFetcher fetcher,
+                                                                EntityDictionary dictionary) {
+        return dictionary.getAttributeArguments(entityClass,attribute)
+                .entrySet()
+                .stream()
+                .map(argumentEntry -> newArgument()
+                        .name(argumentEntry.getKey())
+                        .type(fetchScalarOrObjectInput(argumentEntry.getValue().getClass()))
+                        .build())
+                .collect(Collectors.toList());
+
     }
 
     private GraphQLOutputType fetchScalarOrObjectOutput(Class<?> conversionClass,

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -255,9 +255,10 @@ public class ModelBuilder {
                 continue;
             }
 
-            log.debug("Building query attribute {} {} for entity {}",
+            log.debug("Building query attribute {} {} with arguments {} for entity {}",
                     attribute,
                     attributeClass.getName(),
+                    dictionary.getAttributeArguments(attributeClass,attribute).toString(),
                     entityClass.getName());
 
             GraphQLType attributeType =
@@ -269,6 +270,7 @@ public class ModelBuilder {
 
             builder.field(newFieldDefinition()
                     .name(attribute)
+                    .argument(generator.attributeArgumentToQueryObject(entityClass, attribute, dataFetcher))
                     .dataFetcher(dataFetcher)
                     .type((GraphQLOutputType) attributeType)
             );


### PR DESCRIPTION
Resolves #890 

## Description
Added `addArgumentsToAttribute` to `EntityDictionary` that accepts Map object as argument for an attribute in an Entity. `getAttributeArguments` method retrieves this object.
This method is used by EntityProjectionMaker to populate the argument set for the attribute. 
ModelBuilder uses getAttributeArguments method to expose the argument in the schema.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit testing or `ModelBuilder` class checks whether the GraphQL schema contains arguments to the attribute that was added by explicitly calling `addArgumentsToAttributes` method.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
