### PR TITLE
Update EntityProjectionMaker

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -106,7 +106,6 @@ public class EntityBinding {
     public final ConcurrentLinkedDeque<String> relationshipsDeque = new ConcurrentLinkedDeque<>();
 
     public final ConcurrentHashMap<String, RelationshipType> relationshipTypes = new ConcurrentHashMap<>();
-    public final ConcurrentHashMap<String, Class<?>> relationshipParameterTypes = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, String> relationshipToInverse = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, CascadeType[]> relationshipToCascadeTypes = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, AccessibleObject> fieldsToValues = new ConcurrentHashMap<>();
@@ -397,12 +396,6 @@ public class EntityBinding {
         relationshipsDeque.push(fieldName);
         fieldsToValues.put(fieldName, fieldOrMethod);
         fieldsToTypes.put(fieldName, fieldType);
-
-        // check whether the fieldOrMethod is a parameterized type, if so, get the first parameter type
-        Class<?> parameterType = getParameterType(entityClass, fieldOrMethod, Optional.of(0));
-        if (parameterType != null) {
-            relationshipParameterTypes.put(fieldName, parameterType);
-        }
     }
 
     private void bindAttr(AccessibleObject fieldOrMethod, String fieldName, Class<?> fieldType) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -733,17 +733,6 @@ public class EntityDictionary {
     }
 
     /**
-     * Retrieve the parameter type for a relationship type that is a parameterized type.
-     *
-     * @param entityClass Entity class
-     * @param identifier Field to lookup
-     * @return Parameter type for field
-     */
-    public Class<?> getRelationshipParameterType(Class<?> entityClass, String identifier) {
-        return getEntityBinding(entityClass).relationshipParameterTypes.get(identifier);
-    }
-
-    /**
      * Get the true field/method name from an alias.
      *
      * @param entityClass Entity name

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -651,7 +651,7 @@ public class EntityDictionary {
      * }
      * </pre>
      * JSON-API spec does not allow "id" as non-ID field name. If, therefore, there is a non-ID field called "id",
-     * callling this method has undefined behavior
+     * calling this method has undefined behavior
      *
      * @param entityClass Entity class
      * @param identifier  Field to lookup type
@@ -675,23 +675,6 @@ public class EntityDictionary {
      */
     public Class<?> getType(Object entity, String identifier) {
         return getType(entity.getClass(), identifier);
-    }
-
-    /**
-     * Get a bound type for a specific entity type name
-     *
-     * @param identifier  The entity type name in string
-     *
-     * @return Type of entity
-     */
-    public Class<?> getType(String identifier) {
-        for (Class<?> entityType : entityBindings.keySet()) {
-            if (entityType.getSimpleName().equalsIgnoreCase(identifier)) {
-                return entityType;
-            }
-        }
-
-        return null;
     }
 
     /**
@@ -747,6 +730,17 @@ public class EntityDictionary {
      */
     public Class<?> getParameterizedType(Object entity, String identifier, int paramIndex) {
         return getParameterizedType(entity.getClass(), identifier, paramIndex);
+    }
+
+    /**
+     * Retrieve the parameter type for a relationship type that is a parameterized type.
+     *
+     * @param entityClass Entity class
+     * @param identifier Field to lookup
+     * @return Parameter type for field
+     */
+    public Class<?> getRelationshipParameterType(Class<?> entityClass, String identifier) {
+        return getEntityBinding(entityClass).relationshipParameterTypes.get(identifier);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/request/EntityProjection.java
+++ b/elide-core/src/main/java/com/yahoo/elide/request/EntityProjection.java
@@ -10,14 +10,13 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.Singular;
-
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
@@ -196,9 +196,9 @@ public class GraphQLEntityProjectionMaker extends GraphqlBaseVisitor<Void> {
         // check whether this field is a relationship field
         if (getDictionary().getRelationshipType(parentType, nodeName) != RelationshipType.NONE) {
             final Class<?> relationshipType =
-                    this.getDictionary().getRelationshipParameterType(parentType, nodeName) == null
+                    this.getDictionary().getParameterizedType(parentType, nodeName) == null
                     ? this.getDictionary().getType(parentType, nodeName)
-                    : this.getDictionary().getRelationshipParameterType(parentType, nodeName);
+                    : this.getDictionary().getParameterizedType(parentType, nodeName);
 
             // a relationship field; walk sub-tree rooted at this relationship entity
             return walkParentEntity(
@@ -450,6 +450,7 @@ public class GraphQLEntityProjectionMaker extends GraphqlBaseVisitor<Void> {
      * for quick reference later.
      *
      * @param newProjection  The new {@link EntityProjection} to be added
+     * @param nodePath The nodePath of new {@link EntityProjection}
      */
     private void addProjection(EntityProjection newProjection, String nodePath) {
         getAllEntityProjections().add(newProjection);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
@@ -241,8 +241,8 @@ public class GraphQLEntityProjectionMaker extends GraphqlBaseVisitor<Void> {
         }
 
         // not a root field; not a relationship; not an Attribute; this must be a bad field
-        String message = String.format("Unknown property '%s'", nodeName);
-        log.error(nodeName);
+        String message = String.format("Unknown property '%s'", nodePath);
+        log.error(message);
         throw new IllegalStateException(message);
     }
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
@@ -195,14 +195,10 @@ public class GraphQLEntityProjectionMaker extends GraphqlBaseVisitor<Void> {
 
         // check whether this field is a relationship field
         if (getDictionary().getRelationshipType(parentType, nodeName) != RelationshipType.NONE) {
-            Class<?> type = getDictionary().getParameterizedType(parentType, nodeName);
-
-            // if this field is a collection, get the parameter type
-            if (Collection.class.isAssignableFrom(type)) {
-                type = getDictionary().getRelationshipParameterType(parentType, nodeName);
-            }
-
-            final Class<?> relationshipType = type; // assign to a final variable to be used in lambda function
+            final Class<?> relationshipType =
+                    this.getDictionary().getRelationshipParameterType(parentType, nodeName) == null
+                    ? this.getDictionary().getType(parentType, nodeName)
+                    : this.getDictionary().getRelationshipParameterType(parentType, nodeName);
 
             // a relationship field; walk sub-tree rooted at this relationship entity
             return walkParentEntity(

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEntityProjectionMaker.java
@@ -270,34 +270,34 @@ public class GraphQLEntityProjectionMaker extends GraphqlBaseVisitor<Void> {
         }
 
         // argument must comes with parent
-        final Class<?> entityType = Objects.requireNonNull(getParentEntityStack().peek()).getValue();
-        final String entityNodePath = Objects.requireNonNull(getParentEntityStack().peek()).getKey();
-        final EntityProjection entityProjection = getProjectionsByNodePath().get(entityNodePath);
+        final Class<?> parentType = Objects.requireNonNull(getParentEntityStack().peek()).getValue();
+        final String parentNodePath = Objects.requireNonNull(getParentEntityStack().peek()).getKey();
+        final EntityProjection parentProjection = getProjectionsByNodePath().get(parentNodePath);
 
-        if (!getDictionary().isValidField(entityType, argumentName)) {
+        if (!getDictionary().isValidField(parentType, argumentName)) {
             // invalid argument name
-            String message = String.format("'%s' is not a field in '%s'", argumentName, entityType);
+            String message = String.format("'%s' is not a field in '%s'", argumentName, parentType);
             log.error(message);
             throw new IllegalStateException(message);
         }
 
-        Attribute targetAttribute = entityProjection.getAttributeByName(argumentName);
+        Attribute targetAttribute = parentProjection.getAttributeByName(argumentName);
         Argument newArgument = Argument.builder()
                 .name(argumentName)
                 .value(argumentValue)
                 .build();
 
         if (targetAttribute == null) {
-            Class<?> attributeType = getDictionary().getType(entityType, argumentName);
+            Class<?> attributeType = getDictionary().getType(parentType, argumentName);
             targetAttribute = Attribute.builder()
                     .type(attributeType)
                     .name(argumentName)
                     .argument(newArgument)
                     .build();
 
-            Set<Attribute> existingAttribute = new HashSet<>(entityProjection.getAttributes());
+            Set<Attribute> existingAttribute = new HashSet<>(parentProjection.getAttributes());
             existingAttribute.add(targetAttribute);
-            entityProjection.setAttributes(existingAttribute);
+            parentProjection.setAttributes(existingAttribute);
         } else {
             targetAttribute.getArguments().add(newArgument);
         }


### PR DESCRIPTION
Resolves Aaron's comments in https://github.com/yahoo/elide/pull/896

## Description
In original `EntityBinding` class we only store the raw type of the relationship, if the return type of this relationship is a parameterized type, we would lose the parameter information.
- Add `relationshipParameterTypes` in `EntityBinding` to store parameter types.

Update `GraphQLEntityProjectionMaker` to use map from *nodePath* to *entityProjection* instead of *entityClass* to *entityProjection* to allow different fields to have same entity class bu different field names.
