### PR TITLE
Update Apache Commons Beanutils and ANTLR4 CharStreams

### DIFF
--- a/checkstyle-style.xml
+++ b/checkstyle-style.xml
@@ -139,14 +139,6 @@
       <property name="scope" value="protected"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
-    <module name="LineLength">
-      <metadata name="net.sf.eclipsecs.core.comment" value="Line length of 120 characters except for import lines."/>
-      <property name="severity" value="error"/>
-      <property name="ignorePattern" value="^import.*$"/>
-      <property name="max" value="120"/>
-      <property name="tabWidth" value="4"/>
-      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
-    </module>
     <module name="EqualsHashCode">
       <metadata name="net.sf.eclipsecs.core.comment" value="Verify when Equals is overridden, hashCode is as well."/>
       <property name="severity" value="error"/>
@@ -198,6 +190,14 @@
       <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
       <property name="checkFormat" value="$1"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <metadata name="net.sf.eclipsecs.core.comment" value="Line length of 120 characters except for import lines."/>
+    <property name="severity" value="error"/>
+    <property name="ignorePattern" value="^import.*$"/>
+    <property name="max" value="120"/>
+    <property name="tabWidth" value="4"/>
+    <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
   </module>
   <module name="RegexpSingleline">
     <metadata name="net.sf.eclipsecs.core.comment" value="Don't allow non-ASCII characters."/>

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.7.2</version>
+            <version>${version.antlr4}</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
@@ -218,7 +218,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.7.2</version>
+                <version>${version.antlr4}</version>
                 <configuration>
                     <visitor>true</visitor>
                 </configuration>

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityPermissions.java
@@ -13,9 +13,10 @@ import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.generated.parsers.ExpressionLexer;
 import com.yahoo.elide.generated.parsers.ExpressionParser;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
@@ -120,7 +121,7 @@ public class EntityPermissions implements CheckInstantiator {
     }
 
     public static ParseTree parseExpression(String expression) {
-        ANTLRInputStream is = new ANTLRInputStream(expression);
+        CharStream is = CharStreams.fromString(expression);
         ExpressionLexer lexer = new ExpressionLexer(is);
         lexer.removeErrorListeners();
         lexer.addErrorListener(new BaseErrorListener() {

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/JsonApiParser.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/JsonApiParser.java
@@ -8,9 +8,10 @@ package com.yahoo.elide.parsers;
 import com.yahoo.elide.generated.parsers.CoreLexer;
 import com.yahoo.elide.generated.parsers.CoreParser;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
@@ -55,7 +56,7 @@ public class JsonApiParser {
     public static ParseTree parse(String path) {
         String normalizedPath = normalizePath(path);
 
-        ANTLRInputStream is = new ANTLRInputStream(normalizedPath);
+        CharStream is = CharStreams.fromString(normalizedPath);
         CoreLexer lexer = new CoreLexer(is);
         lexer.removeErrorListeners();
         lexer.addErrorListener(new BaseErrorListener() {

--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -127,7 +127,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.7.2</version>
+                <version>${version.antlr4}</version>
                 <configuration>
                     <visitor>true</visitor>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 
         <!-- dependency versions -->
+        <version.antlr4>4.7.2</version.antlr4>
         <version.logback>1.2.3</version.logback>
         <version.jetty>9.4.20.v20190813</version.jetty>
         <version.restassured>2.9.0</version.restassured>

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,13 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.18</version>
+                            <version>8.24</version>
                             <scope>compile</scope>
                         </dependency>
                     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>1.18.8</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Description
[CVE-2019-10086](https://nvd.nist.gov/vuln/detail/CVE-2019-10086) Upgrade to Apache Commons Beanutils 1.9.4
ANTLR4 Use CharStreams.
Lombok should always be scoped `provided`.

## Motivation and Context
Remove vulnerability.
Replace deprecated code.

## How Has This Been Tested?
Local testing.  Unit testing.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
