### PR TITLE
Fix GraphQL Nested UPDATE bug.

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/security/PersistentResource.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/security/PersistentResource.java
@@ -22,4 +22,12 @@ public interface PersistentResource<T> {
     T getObject();
     Class<T> getResourceClass();
     RequestScope getRequestScope();
+
+    /**
+     * Returns whether or not this resource was created in this transaction.
+     * @return True if this resource is newly created.
+     */
+    default boolean isNewlyCreated() {
+        return getRequestScope().getNewResources().contains(this);
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -95,15 +95,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         return String.format("PersistentResource{type=%s, id=%s}", type, uuid.orElse(getId()));
     }
 
-    /**
-     * Returns whether this persistent resource was created in the current transaction.
-     * @return true if this resources is newly created.  False otherwise.
-     */
-    public boolean isNewlyCreated() {
-        return requestScope.getNewPersistentResources().contains(this);
-    }
-
-    /**
+   /**
      * Create a resource in the database.
      * @param parent - The immediate ancestor in the lineage or null if this is a root.
      * @param entityClass the entity class

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -96,6 +96,14 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
     }
 
     /**
+     * Returns whether this persistent resource was created in the current transaction.
+     * @return true if this resources is newly created.  False otherwise.
+     */
+    public boolean isNewlyCreated() {
+        return requestScope.getNewPersistentResources().contains(this);
+    }
+
+    /**
      * Create a resource in the database.
      * @param parent - The immediate ancestor in the lineage or null if this is a root.
      * @param entityClass the entity class
@@ -1270,8 +1278,6 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      */
     protected void setValueChecked(String fieldName, Object newValue) {
         Object existingValue = getValueUnchecked(fieldName);
-        ChangeSpec spec = new ChangeSpec(this, fieldName, existingValue, newValue);
-        boolean isNewlyCreated = requestScope.getNewPersistentResources().contains(this);
 
         // TODO: Need to refactor this logic. For creates this is properly converted in the executor. This logic
         // should be explicitly encapsulated here, not there.
@@ -1587,8 +1593,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      */
     private void triggerUpdate(String fieldName, Object original, Object value) {
         ChangeSpec changeSpec = new ChangeSpec(this, fieldName, original, value);
-        boolean isNewlyCreated = requestScope.getNewPersistentResources().contains(this);
-        CRUDEvent.CRUDAction action = isNewlyCreated
+        CRUDEvent.CRUDAction action = isNewlyCreated()
                 ? CRUDEvent.CRUDAction.CREATE
                 : CRUDEvent.CRUDAction.UPDATE;
 

--- a/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/executors/ActivePermissionExecutor.java
@@ -126,7 +126,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             // for newly created object in PatchRequest limit to User checks
-            if (requestScope.getNewPersistentResources().contains(resource)) {
+            if (resource.isNewlyCreated()) {
                 return executeUserChecksDeferInline(annotationClass, expression);
             }
             return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -298,7 +298,9 @@ public class PersistentResourceFetcher implements DataFetcher {
         /* fixup relationships */
         for (Entity entity : entitySet) {
             graphWalker(entity, this::updateRelationship);
-            if (!context.isRoot()) { /* add relation between parent and nested entity */
+            PersistentResource childResource = entity.toPersistentResource();
+            if (!context.isRoot() && childResource.isNewlyCreated()) {
+                /* add relation between parent and nested entity */
                 context.parentResource.addRelation(context.field.getName(), entity.toPersistentResource());
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>5.0.0</version>
                 <configuration>
-                    <failBuildOnCVSS>6</failBuildOnCVSS>
+                    <failBuildOnCVSS>9</failBuildOnCVSS>
                     <skipSystemScope>true</skipSystemScope>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -510,7 +510,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>5.0.0</version>
                 <configuration>
-                    <failBuildOnCVSS>9</failBuildOnCVSS>
+                    <failBuildOnCVSS>6</failBuildOnCVSS>
                     <skipSystemScope>true</skipSystemScope>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                     <suppressionFile>suppressions.xml</suppressionFile>


### PR DESCRIPTION
## Description
GraphQL during an UPDATE or UPSERT of a nested entity will attempt to add the nested entity to its parent relationship.  This is unnecessary for UPDATE (and also UPSERT where the object already exists).  

Normally, this would be harmless, but SharePermission barfs.  

## Motivation and Context
Explained above.

## How Has This Been Tested?
All existing GraphQL tests pass.

Manually tested the fix in another project.   Note - SharePermission is being removed in Elide 5.0 - so this bug would never have manifested.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
