### PR TITLE
Update jackson-databind to use version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.3</version>
+                <version>${version.jackson}</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.restassured</groupId>


### PR DESCRIPTION
Solve the misalignment between jackson-core and jackson-databind

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
