### PR TITLE
Add JoinTo annotation

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
@@ -8,9 +8,6 @@ package com.yahoo.elide.datastores.aggregation;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.RequestScope;
-import com.yahoo.elide.datastores.aggregation.schema.Schema;
-import com.yahoo.elide.request.EntityProjection;
 
 /**
  * DataStore that supports Aggregation. Uses {@link QueryEngine} to return results.
@@ -29,11 +26,5 @@ public abstract class AggregationDataStore implements DataStore {
     @Override
     public DataStoreTransaction beginTransaction() {
         return new AggregationDataStoreTransaction(queryEngine);
-    }
-
-    public static Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
-        Schema schema = new Schema(entityProjection.getType(), scope.getDictionary());
-        AggregationDataStoreHelper agHelper = new AggregationDataStoreHelper(schema, entityProjection);
-        return agHelper.getQuery();
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.datastores.aggregation;
 
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.datastores.aggregation.schema.Schema;
 import com.yahoo.elide.request.EntityProjection;
 
 import java.io.IOException;
@@ -48,12 +49,19 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
 
     @Override
     public Iterable<Object> loadObjects(EntityProjection entityProjection, RequestScope scope) {
-        Query query = AggregationDataStore.buildQuery(entityProjection, scope);
+        Query query = buildQuery(entityProjection, scope);
         return queryEngine.executeQuery(query);
     }
 
     @Override
     public void close() throws IOException {
 
+    }
+
+    private Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
+        Schema schema = queryEngine.getSchema(entityProjection.getType());
+
+        AggregationDataStoreHelper agHelper = new AggregationDataStoreHelper(schema, entityProjection);
+        return agHelper.getQuery();
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -10,6 +10,8 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.datastores.aggregation.schema.Schema;
 import com.yahoo.elide.request.EntityProjection;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.IOException;
 
 /**
@@ -58,7 +60,8 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
 
     }
 
-    private Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
+    @VisibleForTesting
+    Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
         Schema schema = queryEngine.getSchema(entityProjection.getType());
 
         AggregationDataStoreHelper agHelper = new AggregationDataStoreHelper(schema, entityProjection);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.datastores.aggregation;
 
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.datastores.aggregation.schema.Schema;
 
 /**
  * A {@link QueryEngine} is an abstraction that an AggregationDataStore leverages to run analytic queries (OLAP style)
@@ -49,7 +50,6 @@ import com.yahoo.elide.core.DataStoreTransaction;
  * <p>
  * This is a {@link java.util.function functional interface} whose functional method is {@link #executeQuery(Query)}.
  */
-@FunctionalInterface
 public interface QueryEngine {
 
     /**
@@ -61,4 +61,11 @@ public interface QueryEngine {
      * @return query results
      */
     Iterable<Object> executeQuery(Query query);
+
+    /**
+     * Returns the schema for a given entity class.
+     * @param entityClass The class to map to a schema.
+     * @return The schema that represents the provided entity.
+     */
+    Schema getSchema(Class<?> entityClass);
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLEntityHydrator.java
@@ -71,8 +71,12 @@ public class SQLEntityHydrator extends AbstractEntityHydrator {
                 .getResultList();
 
         return loaded.stream()
-                .map(obj -> new AbstractMap.SimpleImmutableEntry<>(CoerceUtil.coerce((Object) getEntityDictionary()
-                        .getId(obj), getEntityDictionary().getIdType(relationshipType)), obj))
+                .map(obj -> new AbstractMap.SimpleImmutableEntry<>(
+                        CoerceUtil.coerce(
+                                (Object) getEntityDictionary().getId(obj),
+                                getEntityDictionary().getIdType(relationshipType)
+                        ),
+                        obj))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
@@ -43,9 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.persistence.Column;
 import javax.persistence.EntityManager;
-import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 
 /**
@@ -75,6 +73,11 @@ public class SQLQueryEngine implements QueryEngine {
                         Function.identity(),
                         (clazz) -> (new SQLSchema(clazz, dictionary))
                 ));
+    }
+
+    @Override
+    public Schema getSchema(Class<?> entityClass) {
+        return schemas.get(entityClass);
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
@@ -381,7 +381,7 @@ public class SQLQueryEngine implements QueryEngine {
 
         List<String> dimensionProjections = query.getDimensions().stream()
                 .map((SQLDimension.class::cast))
-                .map(SQLDimension::getColumnName)
+                .map(SQLDimension::getColumnReference)
                 .collect(Collectors.toList());
 
         String projectionClause = metricProjections.stream()
@@ -389,7 +389,6 @@ public class SQLQueryEngine implements QueryEngine {
 
         if (!dimensionProjections.isEmpty()) {
             projectionClause = projectionClause + "," + dimensionProjections.stream()
-                    .map((name) -> query.getSchema().getAlias() + "." + name)
                     .collect(Collectors.joining(","));
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
@@ -239,6 +239,10 @@ public class SQLQueryEngine implements QueryEngine {
      * @return A SQL expression
      */
     private String extractJoin(Path.PathElement pathElement) {
+        //TODO - support composite join keys.
+        //TODO - support joins where either side owns the relationship.
+        //TODO - Support INNER and RIGHT joins.
+        //TODO - Support toMany joins.
         String relationshipName = pathElement.getFieldName();
         Class<?> relationshipClass = pathElement.getFieldType();
         String relationshipAlias = FilterPredicate.getTypeAlias(relationshipClass);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
@@ -83,6 +83,8 @@ public class SQLQueryEngine implements QueryEngine {
         //Make sure we actually manage this schema.
         Preconditions.checkNotNull(schema);
 
+        //TODO - Translate filter and sorting clause to account for JoinTo annotation.
+
         //Translate the query into SQL.
         SQLQuery sql = toSQL(query, schema);
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/annotation/JoinTo.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/annotation/JoinTo.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.engine.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated entity field is derived from a join to another table.
+ */
+@Documented
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JoinTo {
+
+    /**
+     * Dot separated path through the entity relationship graph to an attribute.
+     * If the current entity is author, then a path would be "book.publisher.name".
+     * @return
+     */
+    String path();
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLDimension.java
@@ -11,6 +11,9 @@ import com.yahoo.elide.datastores.aggregation.annotation.CardinalitySize;
 import com.yahoo.elide.datastores.aggregation.dimension.Dimension;
 import com.yahoo.elide.datastores.aggregation.dimension.DimensionType;
 
+/**
+ * A dimension but supporting extra metadata needed to generate SQL.
+ */
 public class SQLDimension implements Dimension {
 
     private final Dimension wrapped;
@@ -18,10 +21,24 @@ public class SQLDimension implements Dimension {
     private final String tableAlias;
     private final Path joinPath;
 
+    /**
+     * Constructor
+     * @param dimension a wrapped dimension.
+     * @param columnAlias The column alias in SQL to refer to this dimension.
+     * @param tableAlias The table alias in SQL where this dimension lives.
+     */
     public SQLDimension(Dimension dimension, String columnAlias, String tableAlias) {
         this(dimension, columnAlias, tableAlias, null);
     }
 
+    /**
+     * Constructor
+     * @param dimension a wrapped dimension.
+     * @param columnAlias The column alias in SQL to refer to this dimension.
+     * @param tableAlias The table alias in SQL where this dimension lives.
+     * @param joinPath A '.' separated path through the entity relationship graph that describes
+     *                 how to join the time dimension into the current AnalyticView.
+     */
     public SQLDimension(Dimension dimension, String columnAlias, String tableAlias, Path joinPath) {
         this.wrapped = dimension;
         this.columnAlias = columnAlias;
@@ -72,10 +89,18 @@ public class SQLDimension implements Dimension {
         return tableAlias;
     }
 
+    /**
+     * Returns the join path of this dimension.
+     * @return Something like "author.book.publisher.name"
+     */
     public Path getJoinPath() {
         return joinPath;
     }
 
+    /**
+     * Returns a String that identifies this dimension in a SQL query.
+     * @return Something like "table_alias.column_name"
+     */
     public String getColumnReference() {
         return getTableAlias() + "." + getColumnName();
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLDimension.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.engine.schema;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.datastores.aggregation.annotation.CardinalitySize;
+import com.yahoo.elide.datastores.aggregation.dimension.Dimension;
+import com.yahoo.elide.datastores.aggregation.dimension.DimensionType;
+
+public class SQLDimension implements Dimension {
+
+    private final Dimension wrapped;
+    private final String columnAlias;
+    private final String tableAlias;
+    private final Path joinPath;
+
+    public SQLDimension(Dimension dimension, String columnAlias, String tableAlias) {
+        this(dimension, columnAlias, tableAlias, null);
+    }
+
+    public SQLDimension(Dimension dimension, String columnAlias, String tableAlias, Path joinPath) {
+        this.wrapped = dimension;
+        this.columnAlias = columnAlias;
+        this.tableAlias = tableAlias;
+        this.joinPath = joinPath;
+    }
+
+    @Override
+    public String getName() {
+        return wrapped.getName();
+    }
+
+    @Override
+    public String getLongName() {
+        return wrapped.getLongName();
+    }
+
+    @Override
+    public String getDescription() {
+        return wrapped.getDescription();
+    }
+
+    @Override
+    public DimensionType getDimensionType() {
+        return wrapped.getDimensionType();
+    }
+
+    @Override
+    public Class<?> getDataType() {
+        return wrapped.getDataType();
+    }
+
+    @Override
+    public CardinalitySize getCardinality() {
+        return wrapped.getCardinality();
+    }
+
+    @Override
+    public String getFriendlyName() {
+        return wrapped.getFriendlyName();
+    }
+
+    public String getColumnName() {
+        return columnAlias;
+    }
+
+    public String getTableAlias() {
+        return tableAlias;
+    }
+
+    public Path getJoinPath() {
+        return joinPath;
+    }
+
+    public String getColumnReference() {
+        return getTableAlias() + "." + getColumnName();
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLSchema.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLSchema.java
@@ -80,6 +80,13 @@ public class SQLSchema extends Schema {
         return new SQLDimension(dim, getJoinColumn(path), getJoinTableAlias(path), path);
     }
 
+    /**
+     * Maps a logical entity attribute into a physical SQL column name.
+     * @param entityDictionary The dictionary for this elide instance.
+     * @param clazz The entity class.
+     * @param fieldName The entity attribute.
+     * @return The physical SQL column name.
+     */
     public static String getColumnName(EntityDictionary entityDictionary, Class<?> clazz, String fieldName) {
         Column[] column = entityDictionary.getAttributeOrRelationAnnotations(clazz, Column.class, fieldName);
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLSchema.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLSchema.java
@@ -7,12 +7,20 @@
 package com.yahoo.elide.datastores.aggregation.engine.schema;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.filter.FilterPredicate;
+import com.yahoo.elide.datastores.aggregation.dimension.Dimension;
+import com.yahoo.elide.datastores.aggregation.dimension.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.engine.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.engine.annotation.FromTable;
+import com.yahoo.elide.datastores.aggregation.engine.annotation.JoinTo;
 import com.yahoo.elide.datastores.aggregation.schema.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+
+import javax.persistence.Column;
+import javax.persistence.JoinColumn;
 
 /**
  * A subclass of Schema that supports additional metadata to construct the FROM clause of a SQL query.
@@ -47,5 +55,69 @@ public class SQLSchema extends Schema {
                 throw new IllegalStateException("Entity is missing FromTable or FromSubquery annotations");
             }
         }
+    }
+
+    @Override
+    protected Dimension constructDimension(String dimensionField, Class<?> cls, EntityDictionary entityDictionary) {
+        Dimension dim = super.constructDimension(dimensionField, cls, entityDictionary);
+
+        JoinTo joinTo = entityDictionary.getAttributeOrRelationAnnotation(cls, JoinTo.class, dimensionField);
+
+        if (joinTo == null) {
+            String columnName = getColumnName(entityClass, dimensionField);
+
+            if (dim instanceof TimeDimension) {
+                return new SQLTimeDimension(dim, columnName, getAlias());
+            }
+            return new SQLDimension(dim, columnName, getAlias());
+        }
+
+        Path path = new Path(entityClass, entityDictionary, joinTo.path());
+
+        if (dim instanceof TimeDimension) {
+            return new SQLTimeDimension(dim, getJoinColumn(path), getJoinTableAlias(path), path);
+        }
+        return new SQLDimension(dim, getJoinColumn(path), getJoinTableAlias(path), path);
+    }
+
+    public static String getColumnName(EntityDictionary entityDictionary, Class<?> clazz, String fieldName) {
+        Column[] column = entityDictionary.getAttributeOrRelationAnnotations(clazz, Column.class, fieldName);
+
+        JoinColumn[] joinColumn = entityDictionary.getAttributeOrRelationAnnotations(clazz,
+                JoinColumn.class, fieldName);
+
+        if (column == null || column.length == 0) {
+            if (joinColumn == null || joinColumn.length == 0) {
+                return fieldName;
+            } else {
+                return joinColumn[0].name();
+            }
+        } else {
+            return column[0].name();
+        }
+    }
+
+    /**
+     * Returns the physical database column name of an entity field.
+     * @param clazz The entity which owns the field.
+     * @param fieldName The field name to lookup
+     * @return
+     */
+    private String getColumnName(Class<?> clazz, String fieldName) {
+        return getColumnName(entityDictionary, clazz, fieldName);
+    }
+
+    private String getJoinColumn(Path path) {
+        Path.PathElement last = path.lastElement().get();
+        Class<?> lastClass = last.getType();
+
+        return getColumnName(lastClass, last.getFieldName());
+    }
+
+    private String getJoinTableAlias(Path path) {
+        Path.PathElement last = path.lastElement().get();
+        Class<?> lastClass = last.getType();
+
+        return FilterPredicate.getTypeAlias(lastClass);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLTimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLTimeDimension.java
@@ -13,12 +13,30 @@ import com.yahoo.elide.datastores.aggregation.time.TimeGrain;
 
 import java.util.TimeZone;
 
+/**
+ * A time dimension that supports special sauce needed to generate SQL.
+ * This dimension will be created by the SQLQueryEngine in place of a plain TimeDimension.
+ */
 public class SQLTimeDimension extends SQLDimension implements TimeDimension {
 
+    /**
+     * Constructor
+     * @param dimension a wrapped dimension.
+     * @param columnAlias The column alias in SQL to refer to this dimension.
+     * @param tableAlias The table alias in SQL where this dimension lives.
+     */
     public SQLTimeDimension(Dimension dimension, String columnAlias, String tableAlias) {
         super(dimension, columnAlias, tableAlias);
     }
 
+    /**
+     * Constructor
+     * @param dimension a wrapped dimension.
+     * @param columnAlias The column alias in SQL to refer to this dimension.
+     * @param tableAlias The table alias in SQL where this dimension lives.
+     * @param joinPath A '.' separated path through the entity relationship graph that describes
+     *                 how to join the time dimension into the current AnalyticView.
+     */
     public SQLTimeDimension(Dimension dimension, String columnAlias, String tableAlias, Path joinPath) {
         super(dimension, columnAlias, tableAlias, joinPath);
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLTimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/schema/SQLTimeDimension.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.engine.schema;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.datastores.aggregation.dimension.Dimension;
+import com.yahoo.elide.datastores.aggregation.dimension.TimeDimension;
+import com.yahoo.elide.datastores.aggregation.time.TimeGrain;
+
+import java.util.TimeZone;
+
+public class SQLTimeDimension extends SQLDimension implements TimeDimension {
+
+    public SQLTimeDimension(Dimension dimension, String columnAlias, String tableAlias) {
+        super(dimension, columnAlias, tableAlias);
+    }
+
+    public SQLTimeDimension(Dimension dimension, String columnAlias, String tableAlias, Path joinPath) {
+        super(dimension, columnAlias, tableAlias, joinPath);
+    }
+
+    @Override
+    public TimeZone getTimeZone() {
+        //TODO
+        return null;
+
+    }
+
+    @Override
+    public TimeGrain getTimeGrain() {
+        //TODO
+        return null;
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/schema/Schema.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/schema/Schema.java
@@ -51,13 +51,13 @@ import java.util.stream.Stream;
 public class Schema {
 
     @Getter
-    private final Class<?> entityClass;
+    protected final Class<?> entityClass;
     @Getter
-    private final Set<Metric> metrics;
+    protected final Set<Metric> metrics;
     @Getter
-    private final Set<Dimension> dimensions;
-    @Getter(value = AccessLevel.PRIVATE)
-    private final EntityDictionary entityDictionary;
+    protected final Set<Dimension> dimensions;
+    @Getter(value = AccessLevel.PROTECTED)
+    protected final EntityDictionary entityDictionary;
 
     /**
      * Constructor

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreIntegrationTest.java
@@ -38,7 +38,6 @@ import io.restassured.response.ValidatableResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.ws.rs.core.MediaType;
@@ -65,8 +64,7 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
         entityDictionary.bindEntity(VideoGame.class);
 
         EntityManagerFactory emf = Persistence.createEntityManagerFactory("aggregationStore");
-        EntityManager em = emf.createEntityManager();
-        qE = new SQLQueryEngine(em, entityDictionary);
+        qE = new SQLQueryEngine(emf, entityDictionary);
         return new AggregationDataStoreTestHarness(qE);
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
@@ -74,8 +73,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testFullTableLoad() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -118,8 +116,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testDegenerateDimensionFilter() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -152,8 +149,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testFilterJoin() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -201,8 +197,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSubqueryFilterJoin() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsViewSchema)
@@ -229,8 +224,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSubqueryLoad() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsViewSchema)
@@ -253,8 +247,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSortJoin() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("player.name", Sorting.SortOrder.asc);
@@ -299,8 +292,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testPagination() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Pagination pagination = Pagination.fromOffsetAndLimit(1, 0, true);
 
@@ -336,8 +328,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testHavingClause() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -367,8 +358,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testTheEverythingQuery() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("player.name", Sorting.SortOrder.asc);
@@ -401,8 +391,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSortByMultipleColumns() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("lowScore", Sorting.SortOrder.desc);
@@ -448,8 +437,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testRelationshipHydration() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("country.name", Sorting.SortOrder.desc);
@@ -508,8 +496,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testJoinToGroupBy() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -542,8 +529,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testJoinToFilter() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -578,8 +564,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testJoinToSort() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("countryIsoCode", Sorting.SortOrder.asc);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
@@ -15,7 +15,7 @@ import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 import com.yahoo.elide.datastores.aggregation.Query;
 import com.yahoo.elide.datastores.aggregation.QueryEngine;
-import com.yahoo.elide.datastores.aggregation.dimension.impl.TimeDimension;
+import com.yahoo.elide.datastores.aggregation.dimension.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.engine.schema.SQLSchema;
 import com.yahoo.elide.datastores.aggregation.example.Country;
 import com.yahoo.elide.datastores.aggregation.example.Player;

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
@@ -44,6 +44,9 @@ public class SQLQueryEngineTest {
     private static EntityDictionary dictionary;
     private static RSQLFilterDialect filterParser;
 
+    private static final Country HONG_KONG = new Country();
+    private static final Country USA = new Country();
+
     @BeforeAll
     public static void init() {
         emf = Persistence.createEntityManagerFactory("aggregationStore");
@@ -56,6 +59,14 @@ public class SQLQueryEngineTest {
 
         playerStatsSchema = new SQLSchema(PlayerStats.class, dictionary);
         playerStatsViewSchema = new SQLSchema(PlayerStatsView.class, dictionary);
+
+        HONG_KONG.setIsoCode("HKG");
+        HONG_KONG.setName("Hong Kong");
+        HONG_KONG.setId("344");
+
+        USA.setIsoCode("USA");
+        USA.setName("United States");
+        USA.setId("840");
     }
 
     /**
@@ -158,18 +169,12 @@ public class SQLQueryEngineTest {
         List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
-        Country expectedCountry = new Country();
-        expectedCountry.setId("840");
-        expectedCountry.setIsoCode("USA");
-        expectedCountry.setName("United States");
-
-
         PlayerStats usa0 = new PlayerStats();
         usa0.setId("0");
         usa0.setLowScore(241);
         usa0.setHighScore(2412);
         usa0.setOverallRating("Great");
-        usa0.setCountry(expectedCountry);
+        usa0.setCountry(USA);
         usa0.setRecordedDate(Timestamp.valueOf("2019-07-11 00:00:00"));
 
         PlayerStats usa1 = new PlayerStats();
@@ -177,7 +182,7 @@ public class SQLQueryEngineTest {
         usa1.setLowScore(35);
         usa1.setHighScore(1234);
         usa1.setOverallRating("Good");
-        usa1.setCountry(expectedCountry);
+        usa1.setCountry(USA);
         usa1.setRecordedDate(Timestamp.valueOf("2019-07-12 00:00:00"));
 
         assertEquals(2, results.size());
@@ -462,22 +467,12 @@ public class SQLQueryEngineTest {
         List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
-        Country usa = new Country();
-        usa.setId("840");
-        usa.setIsoCode("USA");
-        usa.setName("United States");
-
-        Country hk = new Country();
-        hk.setId("344");
-        hk.setIsoCode("HKG");
-        hk.setName("Hong Kong");
-
         PlayerStats usa0 = new PlayerStats();
         usa0.setId("0");
         usa0.setLowScore(241);
         usa0.setHighScore(2412);
         usa0.setOverallRating("Great");
-        usa0.setCountry(usa);
+        usa0.setCountry(USA);
         usa0.setRecordedDate(Timestamp.valueOf("2019-07-11 00:00:00"));
 
         PlayerStats usa1 = new PlayerStats();
@@ -485,7 +480,7 @@ public class SQLQueryEngineTest {
         usa1.setLowScore(35);
         usa1.setHighScore(1234);
         usa1.setOverallRating("Good");
-        usa1.setCountry(usa);
+        usa1.setCountry(USA);
         usa1.setRecordedDate(Timestamp.valueOf("2019-07-12 00:00:00"));
 
         PlayerStats hk2 = new PlayerStats();
@@ -493,7 +488,7 @@ public class SQLQueryEngineTest {
         hk2.setLowScore(72);
         hk2.setHighScore(1000);
         hk2.setOverallRating("Good");
-        hk2.setCountry(hk);
+        hk2.setCountry(HONG_KONG);
         hk2.setRecordedDate(Timestamp.valueOf("2019-07-13 00:00:00"));
 
         assertEquals(3, results.size());
@@ -525,7 +520,6 @@ public class SQLQueryEngineTest {
         List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
-        // Only "Good" rating would have total high score less than 2400
         PlayerStats stats1 = new PlayerStats();
         stats1.setId("0");
         stats1.setHighScore(3646);
@@ -540,4 +534,90 @@ public class SQLQueryEngineTest {
         assertEquals(stats1, results.get(0));
         assertEquals(stats2, results.get(1));
     }
+
+    /**
+     * Test grouping by a dimension with a JoinTo annotation.
+     *
+     * @throws Exception exception
+     */
+    @Test
+    public void testJoinToFilter() throws Exception {
+        EntityManager em = emf.createEntityManager();
+        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+
+        Query query = Query.builder()
+                .schema(playerStatsSchema)
+                .metric(playerStatsSchema.getMetric("highScore"), Sum.class)
+                .groupDimension(playerStatsSchema.getDimension("overallRating"))
+                .whereFilter(filterParser.parseFilterExpression("countryIsoCode==USA",
+                        PlayerStats.class, false))
+                .build();
+
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+                .collect(Collectors.toList());
+
+        PlayerStats stats1 = new PlayerStats();
+        stats1.setId("0");
+        stats1.setOverallRating("Good");
+        stats1.setHighScore(1234);
+
+        PlayerStats stats2 = new PlayerStats();
+        stats2.setId("1");
+        stats2.setOverallRating("Great");
+        stats2.setHighScore(2412);
+
+        assertEquals(2, results.size());
+        assertEquals(stats1, results.get(0));
+        assertEquals(stats2, results.get(1));
+    }
+
+    /**
+     * Test grouping by a dimension with a JoinTo annotation.
+     *
+     * @throws Exception exception
+     */
+    @Test
+    public void testJoinToSort() throws Exception {
+        EntityManager em = emf.createEntityManager();
+        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+
+        Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
+        sortMap.put("countryIsoCode", Sorting.SortOrder.asc);
+
+        Query query = Query.builder()
+                .schema(playerStatsSchema)
+                .metric(playerStatsSchema.getMetric("highScore"), Sum.class)
+                .groupDimension(playerStatsSchema.getDimension("overallRating"))
+                .groupDimension(playerStatsSchema.getDimension("country"))
+                .sorting(new Sorting(sortMap))
+                .build();
+
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+                .collect(Collectors.toList());
+
+        PlayerStats stats1 = new PlayerStats();
+        stats1.setId("0");
+        stats1.setOverallRating("Good");
+        stats1.setCountry(HONG_KONG);
+        stats1.setHighScore(1000);
+
+        PlayerStats stats2 = new PlayerStats();
+        stats2.setId("1");
+        stats2.setOverallRating("Good");
+        stats2.setCountry(USA);
+        stats2.setHighScore(1234);
+
+        PlayerStats stats3 = new PlayerStats();
+        stats3.setId("2");
+        stats3.setOverallRating("Great");
+        stats3.setCountry(USA);
+        stats3.setHighScore(2412);
+
+        assertEquals(3, results.size());
+        assertEquals(stats1, results.get(0));
+        assertEquals(stats2, results.get(1));
+        assertEquals(stats3, results.get(2));
+    }
+
+    //TODO - Add Invalid Request Tests
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/PlayerStats.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/PlayerStats.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.datastores.aggregation.annotation.MetricAggregation;
 import com.yahoo.elide.datastores.aggregation.annotation.Temporal;
 import com.yahoo.elide.datastores.aggregation.dimension.EntityDimensionTest;
 import com.yahoo.elide.datastores.aggregation.engine.annotation.FromTable;
+import com.yahoo.elide.datastores.aggregation.engine.annotation.JoinTo;
 import com.yahoo.elide.datastores.aggregation.metric.Max;
 import com.yahoo.elide.datastores.aggregation.metric.Min;
 import com.yahoo.elide.datastores.aggregation.time.TimeGrain;
@@ -62,6 +63,11 @@ public class PlayerStats {
      * A table dimension.
      */
     private Country country;
+
+    /**
+     * A dimension field joined to this table.
+     */
+    private String countryIsoCode;
 
     /**
      * A table dimension.
@@ -140,5 +146,14 @@ public class PlayerStats {
 
     public void setRecordedDate(final Date recordedDate) {
         this.recordedDate = recordedDate;
+    }
+
+    @JoinTo(path = "country.isoCode")
+    public String getCountryIsoCode() {
+        return countryIsoCode;
+    }
+
+    public void setCountryIsoCode(String isoCode) {
+        this.countryIsoCode = isoCode;
     }
 }


### PR DESCRIPTION
## Description
This PR is for the new AggregationDataStore.

The SQLQueryEngine will support a new annotation (JoinTo) that allows attribute columns to be populated by joins that traverse a snowflake schema.

class Publisher {
@JoinTo(“book.category”)
Category bookCategory
}

class Publisher {
@JoinTo(“book.category.name”)
String categoryName
}

Initially, The SQLQueryEngine will only support the simple case of building a left join across a to-one relationship where the left table has the foreign key reference to the right table.

## Motivation and Context
Without this annotation, joins can only be supported in the `@FromSQL` annotation - which requires all joins to be present regardless of whether a given field is needed in the client's request.

Furthermore, the existing SQLQueryEngine did not provide a mechanism to group by dimension attributes (only the dimensions themselves). 

The JoinTo annotation allows a snowflake schema to be flattened into the fact table so they can be filtered on, sorted, and grouped by.

## How Has This Been Tested?
Added new tests for filtering, sorting, and grouping by joined dimension columns.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
