### PR TITLE
Moved entityManager creation to happen separately for each query

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -10,6 +10,8 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.datastores.aggregation.schema.Schema;
 import com.yahoo.elide.request.EntityProjection;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.IOException;
 
 /**
@@ -58,7 +60,8 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
 
     }
 
-    private Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
+    @VisibleForTesting
+    Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
         Schema schema = queryEngine.getSchema(entityProjection.getType());
 
         AggregationDataStoreHelper agHelper = new AggregationDataStoreHelper(schema, entityProjection);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLEntityHydrator.java
@@ -71,8 +71,12 @@ public class SQLEntityHydrator extends AbstractEntityHydrator {
                 .getResultList();
 
         return loaded.stream()
-                .map(obj -> new AbstractMap.SimpleImmutableEntry<>(CoerceUtil.coerce((Object) getEntityDictionary()
-                        .getId(obj), getEntityDictionary().getIdType(relationshipType)), obj))
+                .map(obj -> new AbstractMap.SimpleImmutableEntry<>(
+                        CoerceUtil.coerce(
+                                (Object) getEntityDictionary().getId(obj),
+                                getEntityDictionary().getIdType(relationshipType)
+                        ),
+                        obj))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngine.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 import javax.persistence.Table;
 
 /**
@@ -52,14 +53,14 @@ import javax.persistence.Table;
 @Slf4j
 public class SQLQueryEngine implements QueryEngine {
 
-    private EntityManager entityManager;
+    private EntityManagerFactory emf;
     private EntityDictionary dictionary;
 
     @Getter
     private Map<Class<?>, SQLSchema> schemas;
 
-    public SQLQueryEngine(EntityManager entityManager, EntityDictionary dictionary) {
-        this.entityManager = entityManager;
+    public SQLQueryEngine(EntityManagerFactory emf, EntityDictionary dictionary) {
+        this.emf = emf;
         this.dictionary = dictionary;
 
         // Construct the list of schemas that will be managed by this query engine.
@@ -82,6 +83,7 @@ public class SQLQueryEngine implements QueryEngine {
 
     @Override
     public Iterable<Object> executeQuery(Query query) {
+        EntityManager entityManager = emf.createEntityManager();
         SQLSchema schema = schemas.get(query.getSchema().getEntityClass());
 
         //Make sure we actually manage this schema.

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreIntegrationTest.java
@@ -38,7 +38,6 @@ import io.restassured.response.ValidatableResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.ws.rs.core.MediaType;
@@ -65,8 +64,7 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
         entityDictionary.bindEntity(VideoGame.class);
 
         EntityManagerFactory emf = Persistence.createEntityManagerFactory("aggregationStore");
-        EntityManager em = emf.createEntityManager();
-        qE = new SQLQueryEngine(em, entityDictionary);
+        qE = new SQLQueryEngine(emf, entityDictionary);
         return new AggregationDataStoreTestHarness(qE);
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/engine/SQLQueryEngineTest.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
@@ -74,8 +73,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testFullTableLoad() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -118,8 +116,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testDegenerateDimensionFilter() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -152,8 +149,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testFilterJoin() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -201,8 +197,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSubqueryFilterJoin() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsViewSchema)
@@ -229,8 +224,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSubqueryLoad() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsViewSchema)
@@ -253,8 +247,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSortJoin() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("player.name", Sorting.SortOrder.asc);
@@ -299,8 +292,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testPagination() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Pagination pagination = Pagination.fromOffsetAndLimit(1, 0, true);
 
@@ -336,8 +328,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testHavingClause() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -367,8 +358,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testTheEverythingQuery() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("player.name", Sorting.SortOrder.asc);
@@ -401,8 +391,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testSortByMultipleColumns() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("lowScore", Sorting.SortOrder.desc);
@@ -448,8 +437,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testRelationshipHydration() {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("country.name", Sorting.SortOrder.desc);
@@ -508,8 +496,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testJoinToGroupBy() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -542,8 +529,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testJoinToFilter() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Query query = Query.builder()
                 .schema(playerStatsSchema)
@@ -578,8 +564,7 @@ public class SQLQueryEngineTest {
      */
     @Test
     public void testJoinToSort() throws Exception {
-        EntityManager em = emf.createEntityManager();
-        QueryEngine engine = new SQLQueryEngine(em, dictionary);
+        QueryEngine engine = new SQLQueryEngine(emf, dictionary);
 
         Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
         sortMap.put("countryIsoCode", Sorting.SortOrder.asc);


### PR DESCRIPTION
Changed SQLQueyEngine so that EntityManager is created separately for each new query instead of being created once when the Engine was initialized.
