### PR TITLE
Fixes #1007 - Remove reserved '__' from graphQL schema type names.

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -154,7 +154,7 @@ public class GraphQLConversionUtils {
      */
     public GraphQLList classToInputMap(Class<?> keyClazz,
                                        Class<?> valueClazz) {
-        String mapName = toValidNameName("__input__" + keyClazz.getName() + valueClazz.getCanonicalName() + MAP);
+        String mapName = toValidNameName("_input__" + keyClazz.getName() + valueClazz.getCanonicalName() + MAP);
 
         if (mapConversions.containsKey(mapName)) {
             return mapConversions.get(mapName);
@@ -396,7 +396,7 @@ public class GraphQLConversionUtils {
         }
 
         GraphQLInputObjectType.Builder objectBuilder = newInputObject();
-        objectBuilder.name(toValidNameName("__input__" + clazz.getName()));
+        objectBuilder.name(toValidNameName("_input__" + clazz.getName()));
 
         for (String attribute : nonEntityDictionary.getAttributes(clazz)) {
             log.info("Building input object attribute: {}", attribute);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -109,7 +109,7 @@ public class ModelBuilder {
                 .build();
 
         pageInfoObject = newObject()
-                .name("__pageInfoObject")
+                .name("_pageInfoObject")
                 .field(newFieldDefinition()
                         .name("hasNextPage")
                         .dataFetcher(dataFetcher)
@@ -158,7 +158,7 @@ public class ModelBuilder {
         resolveInputObjectRelationships();
 
         /* Construct root object */
-        GraphQLObjectType.Builder root = newObject().name("__root");
+        GraphQLObjectType.Builder root = newObject().name("_root");
         for (Class<?> clazz : rootClasses) {
             String entityName = dictionary.getJsonAliasFor(clazz);
             root.field(newFieldDefinition()
@@ -175,7 +175,7 @@ public class ModelBuilder {
         }
 
         GraphQLObjectType queryRoot = root.build();
-        GraphQLObjectType mutationRoot = root.name("__mutation_root").build();
+        GraphQLObjectType mutationRoot = root.name("_mutation_root").build();
 
         /*
          * Walk the object graph (avoiding cycles) and construct the GraphQL output object types.
@@ -239,7 +239,7 @@ public class ModelBuilder {
         String entityName = dictionary.getJsonAliasFor(entityClass);
 
         GraphQLObjectType.Builder builder = newObject()
-                .name("__node__" + entityName);
+                .name("_node__" + entityName);
 
         String id = dictionary.getIdFieldName(entityClass);
 
@@ -314,7 +314,7 @@ public class ModelBuilder {
 
     private GraphQLList buildEdgesObject(String relationName, GraphQLOutputType entityType) {
         return new GraphQLList(newObject()
-                .name("__edges__" + relationName)
+                .name("_edges__" + relationName)
                 .field(newFieldDefinition()
                         .name("node")
                         .dataFetcher(dataFetcher)

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -114,7 +114,7 @@ public class ModelBuilderTest {
         assertNotNull(bookField.getArgument(AFTER));
 
         /* book.publisher is a 'to one' relationship so it should be missing all but the data parameter */
-        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType("__node__" + BOOK);
+        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType("_node__" + BOOK);
         GraphQLFieldDefinition publisherField = bookType.getFieldDefinition("publisher");
         assertNotNull(publisherField.getArgument(DATA));
         assertNull(publisherField.getArgument(FILTER));
@@ -142,7 +142,7 @@ public class ModelBuilderTest {
         assertNotEquals(schema.getType(BOOK), null);
         assertNotEquals(schema.getType(AUTHOR_INPUT), null);
         assertNotEquals(schema.getType(BOOK_INPUT), null);
-        assertNotEquals(schema.getType("__root"), null);
+        assertNotEquals(schema.getType("_root"), null);
 
         GraphQLObjectType bookType = getConnectedType((GraphQLObjectType) schema.getType(BOOK), null);
         GraphQLObjectType authorType = getConnectedType((GraphQLObjectType) schema.getType(AUTHOR), null);

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/fetchWithFragment.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/fetchWithFragment.json
@@ -21,9 +21,9 @@
             ],
             "__typename": "book"
           },
-          "__typename": "__node__author"
+          "__typename": "_node__author"
         },
-        "__typename": "__edges__author"
+        "__typename": "_edges__author"
       },
       {
         "node": {
@@ -39,9 +39,9 @@
             ],
             "__typename": "book"
           },
-          "__typename": "__node__author"
+          "__typename": "_node__author"
         },
-        "__typename": "__edges__author"
+        "__typename": "_edges__author"
       }
     ]
   }


### PR DESCRIPTION
Resolves #1007

## Description
Removes __ from generated type names in GraphQL schema.

## Motivation and Context
__ is reserved in GraphQL.  Graphiql barfs on this.

## How Has This Been Tested?
Build passes.  Manually ran graphiql.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
