### PR TITLE
Hydrate GraphQL Schema with parameterized attributes

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/ArgumentType.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/ArgumentType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import lombok.Getter;
+
+/**
+ * Argument Type wraps an argument to the type of value it accepts.
+ */
+public class ArgumentType {
+    @Getter
+    private String name;
+    @Getter
+    private Class<?> type;
+
+    public ArgumentType(String name, Class<?> type) {
+        this.name = name;
+        this.type = type;
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -51,8 +51,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Predicate;
@@ -116,10 +118,12 @@ public class EntityBinding {
     public final ConcurrentHashMap<String, Class<?>> fieldsToTypes = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, String> aliasesToFields = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<Method, Boolean> requestScopeableMethods = new ConcurrentHashMap<>();
+    public final ConcurrentHashMap<AccessibleObject, Set<ArgumentType>> attributeArgumets = new ConcurrentHashMap<>();
 
     public final ConcurrentHashMap<Class<? extends Annotation>, Annotation> annotations = new ConcurrentHashMap<>();
 
     public static final EntityBinding EMPTY_BINDING = new EntityBinding();
+    public static final Set<ArgumentType> EMPTY_ATTRIBUTES_ARGS = new HashSet<>();
     private static final String ALL_FIELDS = "*";
 
     /* empty binding constructor */
@@ -585,5 +589,36 @@ public class EntityBinding {
         }
 
         return results;
+    }
+
+
+    /**
+     * Add a collection of arguments to the attributes of this Entity.
+     * @param attribute attribute name to which argument has to be added
+     * @param arguments Set of Argument Type for the attribute
+     */
+    public void addArgumentsToAttribute(String attribute, Set<ArgumentType> arguments) {
+        AccessibleObject fieldObject = fieldsToValues.get(attribute);
+        if (fieldObject != null && arguments != null) {
+            Set<ArgumentType> existingArgs = attributeArgumets.get(fieldObject);
+            if (existingArgs != null) {
+                //Replace any argument names with new value
+                existingArgs.addAll(arguments);
+            } else {
+                attributeArgumets.put(fieldObject, arguments);
+            }
+        }
+    }
+
+    /**
+     * Returns the Collection of all attributes of an argument.
+     * @param attribute Name of the argument for ehich arguments are to be retrieved.
+     * @return A Set of ArgumentType for the given attribute.
+     */
+    public Set<ArgumentType> getAttributeArguments(String attribute) {
+        AccessibleObject fieldObject = fieldsToValues.get(attribute);
+        return (fieldObject != null)
+                ? attributeArgumets.getOrDefault(fieldObject, EMPTY_ATTRIBUTES_ARGS)
+                : EMPTY_ATTRIBUTES_ARGS;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -123,7 +123,7 @@ public class EntityBinding {
     public final ConcurrentHashMap<Class<? extends Annotation>, Annotation> annotations = new ConcurrentHashMap<>();
 
     public static final EntityBinding EMPTY_BINDING = new EntityBinding();
-    public static final Set<ArgumentType> EMPTY_ATTRIBUTES_ARGS = new HashSet<>();
+    public static final Set<ArgumentType> EMPTY_ATTRIBUTES_ARGS = Collections.unmodifiableSet(new HashSet<>());
     private static final String ALL_FIELDS = "*";
 
     /* empty binding constructor */

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -1411,4 +1411,24 @@ public class EntityDictionary {
             bindEntity(entityClass);
         }
     }
+
+    /**
+     * Add a collection of argument to the attributes
+     * @param cls The entity
+     * @param attributeName attribute name to which argument has to be added
+     * @param arguments Set of Argument type containing name and type of each argument.
+     */
+    public void addArgumentsToAttributes(Class<?> cls, String attributeName, Set<ArgumentType> arguments) {
+        getEntityBinding(cls).addArgumentsToAttribute(attributeName, arguments);
+    }
+
+    /**
+     * Returns the Collection of all attributes of an argument.
+     * @param cls The entity
+     * @param attributeName Name of the argument for ehich arguments are to be retrieved.
+     * @return A Set of ArgumentType for the given attribute.
+     */
+    public Set<ArgumentType> getAttributeArguments(Class<?> cls, String attributeName) {
+        return entityBindings.getOrDefault(cls, EMPTY_BINDING).getAttributeArguments(attributeName);
+    }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -427,11 +427,11 @@ public class GraphQLConversionUtils {
     }
 
     /**
-     * Build an Argument list object for the given attribute
+     * Build an Argument list object for the given attribute.
      * @param entityClass The Entity class to which this attribute belongs to.
      * @param attribute The name of the attribute.
-     * @param fetcher The data fetcher to associated with the newly created GraphQL Query Type
-     * @return Newly created GraphQLArgument Collection for the given attribute
+     * @param fetcher The data fetcher to associated with the newly created GraphQL Query Type.
+     * @return Newly created GraphQLArgument Collection for the given attribute.
      */
     public List<GraphQLArgument> attributeArgumentToQueryObject(Class<?> entityClass,
                                                                 String attribute,
@@ -451,7 +451,7 @@ public class GraphQLConversionUtils {
                                                                 String attribute,
                                                                 DataFetcher fetcher,
                                                                 EntityDictionary dictionary) {
-        return dictionary.getAttributeArguments(entityClass,attribute)
+        return dictionary.getAttributeArguments(entityClass, attribute)
                 .stream()
                 .map(argumentType -> newArgument()
                         .name(argumentType.getName())

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.graphql;
 
+import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
@@ -16,6 +17,7 @@ import com.yahoo.elide.core.EntityDictionary;
 
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectField;
@@ -31,7 +33,9 @@ import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Contains methods that convert from a class to a GraphQL input or query type.
@@ -421,6 +425,42 @@ public class GraphQLConversionUtils {
 
         return object;
     }
+
+    /**
+     * Build an Argument list object for the given attribute
+     * @param entityClass The Entity class to which this attribute belongs to.
+     * @param attribute The name of the attribute.
+     * @param fetcher The data fetcher to associated with the newly created GraphQL Query Type
+     * @return Newly created GraphQLArgument Collection for the given attribute
+     */
+    public List<GraphQLArgument> attributeArgumentToQueryObject(Class<?> entityClass,
+                                                                String attribute,
+                                                                DataFetcher fetcher) {
+        return attributeArgumentToQueryObject(entityClass, attribute, fetcher, entityDictionary);
+    }
+
+    /**
+     * Build an Argument list object for the given attribute
+     * @param entityClass The Entity class to which this attribute belongs to.
+     * @param attribute The name of the attribute.
+     * @param fetcher The data fetcher to associated with the newly created GraphQL Query Type
+     * @param dictionary The dictionary that contains the runtime type information for the parent class.
+     * @return Newly created GraphQLArgument Collection for the given attribute
+     */
+    public List<GraphQLArgument> attributeArgumentToQueryObject(Class<?> entityClass,
+                                                                String attribute,
+                                                                DataFetcher fetcher,
+                                                                EntityDictionary dictionary) {
+        return dictionary.getAttributeArguments(entityClass,attribute)
+                .stream()
+                .map(argumentType -> newArgument()
+                        .name(argumentType.getName())
+                        .type(fetchScalarOrObjectInput(argumentType.getType()))
+                        .build())
+                .collect(Collectors.toList());
+
+    }
+
 
     private GraphQLOutputType fetchScalarOrObjectOutput(Class<?> conversionClass,
                                                         DataFetcher fetcher) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -255,9 +255,10 @@ public class ModelBuilder {
                 continue;
             }
 
-            log.debug("Building query attribute {} {} for entity {}",
+            log.debug("Building query attribute {} {} with arguments {} for entity {}",
                     attribute,
                     attributeClass.getName(),
+                    dictionary.getAttributeArguments(attributeClass,attribute).toString(),
                     entityClass.getName());
 
             GraphQLType attributeType =
@@ -269,6 +270,7 @@ public class ModelBuilder {
 
             builder.field(newFieldDefinition()
                     .name(attribute)
+                    .argument(generator.attributeArgumentToQueryObject(entityClass, attribute, dataFetcher))
                     .dataFetcher(dataFetcher)
                     .type((GraphQLOutputType) attributeType)
             );

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -258,7 +258,7 @@ public class ModelBuilder {
             log.debug("Building query attribute {} {} with arguments {} for entity {}",
                     attribute,
                     attributeClass.getName(),
-                    dictionary.getAttributeArguments(attributeClass,attribute).toString(),
+                    dictionary.getAttributeArguments(attributeClass, attribute).toString(),
                     entityClass.getName());
 
             GraphQLType attributeType =

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -7,9 +7,9 @@
 package com.yahoo.elide.graphql;
 
 import static graphql.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Resolves #890 

## Description
Added `addArgumentsToAttribute` to `EntityDictionary` that accepts Map object as argument for an attribute in an Entity. `getAttributeArguments` method retrieves this object.
This method is used by EntityProjectionMaker to populate the argument set for the attribute. 
ModelBuilder uses getAttributeArguments method to expose the argument in the schema.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit testing or `ModelBuilder` class checks whether the GraphQL schema contains arguments to the attribute that was added by explicitly calling `addArgumentsToAttributes` method.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
