### PR TITLE
Avoid checking share permission for redundant add

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -651,7 +651,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             return false;
         }
         if (relation instanceof Collection) {
-            return ((Collection) relation).stream().anyMatch((obj -> dictionary.getId(obj).equals(toAddId)));
+            return ((Collection) relation).stream().anyMatch((obj -> toAddId.equals(dictionary.getId(obj))));
         } else {
             return toAddId.equals(dictionary.getId(relation));
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -12,13 +12,58 @@ import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.audit.AuditLogger;
 
 import example.Child;
+import example.ComputedBean;
+import example.FirstClassFields;
+import example.FunWithPermissions;
+import example.Invoice;
+import example.Job;
+import example.Left;
+import example.LineItem;
+import example.MapColorShape;
+import example.NoDeleteEntity;
+import example.NoReadEntity;
+import example.NoShareEntity;
+import example.NoUpdateEntity;
+import example.Parent;
+import example.Right;
 import example.TestCheckMappings;
+import example.packageshareable.ContainerWithPackageShare;
+import example.packageshareable.ShareableWithPackageShare;
+import example.packageshareable.UnshareableWithEntityUnshare;
+import nocreate.NoCreateEntity;
+
+import java.util.HashSet;
 
 public class PersistenceResourceTestSetup extends PersistentResource {
 
     private static final AuditLogger MOCK_AUDIT_LOGGER = mock(AuditLogger.class);
 
+
     protected final ElideSettings elideSettings;
+    void init() {
+        dictionary.bindEntity(Child.class);
+        dictionary.bindEntity(Parent.class);
+        dictionary.bindEntity(FunWithPermissions.class);
+        dictionary.bindEntity(Job.class);
+        dictionary.bindEntity(Left.class);
+        dictionary.bindEntity(Right.class);
+        dictionary.bindEntity(NoReadEntity.class);
+        dictionary.bindEntity(NoDeleteEntity.class);
+        dictionary.bindEntity(NoUpdateEntity.class);
+        dictionary.bindEntity(NoCreateEntity.class);
+        dictionary.bindEntity(NoShareEntity.class);
+        dictionary.bindEntity(example.User.class);
+        dictionary.bindEntity(FirstClassFields.class);
+        dictionary.bindEntity(MapColorShape.class);
+        dictionary.bindEntity(PersistentResourceTest.ChangeSpecModel.class);
+        dictionary.bindEntity(PersistentResourceTest.ChangeSpecChild.class);
+        dictionary.bindEntity(Invoice.class);
+        dictionary.bindEntity(LineItem.class);
+        dictionary.bindEntity(ComputedBean.class);
+        dictionary.bindEntity(ContainerWithPackageShare.class);
+        dictionary.bindEntity(ShareableWithPackageShare.class);
+        dictionary.bindEntity(UnshareableWithEntityUnshare.class);
+    }
 
     public PersistenceResourceTestSetup() {
         super(
@@ -41,5 +86,20 @@ public class PersistenceResourceTestSetup extends PersistentResource {
                 .withDefaultMaxPageSize(10)
                 .withDefaultPageSize(10)
                 .build();
+        init();
+    }
+
+    protected static Child newChild(int id) {
+        Child child = new Child();
+        child.setId(id);
+        child.setParents(new HashSet<>());
+        child.setFriends(new HashSet<>());
+        return child;
+    }
+
+    protected static Child newChild(int id, String name) {
+        Child child = newChild(id);
+        child.setName(name);
+        return child;
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.yahoo.elide.security.User;
+import example.Child;
+import example.FunWithPermissions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSetup {
+    private final RequestScope goodUserScope;
+    PersistentResourceNoopUpdateTest() {
+        goodUserScope = new RequestScope(null, null, mock(DataStoreTransaction.class),
+                new User(1), null, elideSettings);
+        init();
+        reset(goodUserScope.getTransaction());
+    }
+    @Test
+    public void testNOOPToOneAddRelation() {
+        FunWithPermissions fun = new FunWithPermissions();
+        Child child = newChild(1);
+        fun.setRelation3(child);
+
+        User goodUser = new User(1);
+
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+
+        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
+        PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
+        //We do not want the update to one method to be called when we add the existing entity to the relation
+        funResource.addRelation("relation3", childResource);
+
+        verify(tx, never()).updateToOneRelation(eq(tx), eq(fun), any(), any(), eq(goodScope));
+    }
+
+    @Test
+    public void testToOneAddRelation() {
+        FunWithPermissions fun = new FunWithPermissions();
+        Child child = newChild(1);
+
+        User goodUser = new User(1);
+
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+
+        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
+        PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
+        funResource.addRelation("relation3", childResource);
+
+        verify(tx, times(1)).updateToOneRelation(eq(tx), eq(fun), any(), any(), eq(goodScope));
+    }
+
+    @Test
+    public void testNOOPToManyAddRelation() {
+        FunWithPermissions fun = new FunWithPermissions();
+        Child child = newChild(1);
+        Set<Child> children = new HashSet<>();
+        children.add(child);
+        fun.setRelation1(children);
+
+        User goodUser = new User(1);
+
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+
+        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
+        PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
+        //We do not want the update to one method to be called when we add the existing entity to the relation
+        funResource.addRelation("relation1", childResource);
+        verify(tx, never()).updateToManyRelation(eq(tx), eq(child), eq("relation1"), any(), any(), eq(goodScope));
+        //verify(tx, times(1)).updateToManyRelation(eq(tx), eq(child), eq("relation1"), any(), any(), eq(goodScope));
+    }
+
+    @Test
+    public void testToManyAddRelation() {
+        FunWithPermissions fun = new FunWithPermissions();
+        Child child = newChild(1);
+
+        User goodUser = new User(1);
+
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+
+        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
+        PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
+        funResource.addRelation("relation1", childResource);
+        verify(tx, times(1)).updateToManyRelation(eq(tx), eq(fun), eq("relation1"), any(), any(), eq(goodScope));
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
@@ -83,7 +83,6 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
         //We do not want the update to one method to be called when we add the existing entity to the relation
         funResource.addRelation("relation1", childResource);
         verify(tx, never()).updateToManyRelation(eq(tx), eq(child), eq("relation1"), any(), any(), eq(goodScope));
-        //verify(tx, times(1)).updateToManyRelation(eq(tx), eq(child), eq("relation1"), any(), any(), eq(goodScope));
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -109,34 +109,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
                 new User(1), null, elideSettings);
         badUserScope = new RequestScope(null, null, mock(DataStoreTransaction.class),
                 new User(-1), null, elideSettings);
-
         init();
-    }
-
-    void init() {
-        dictionary.bindEntity(Child.class);
-        dictionary.bindEntity(Parent.class);
-        dictionary.bindEntity(FunWithPermissions.class);
-        dictionary.bindEntity(Job.class);
-        dictionary.bindEntity(Left.class);
-        dictionary.bindEntity(Right.class);
-        dictionary.bindEntity(NoReadEntity.class);
-        dictionary.bindEntity(NoDeleteEntity.class);
-        dictionary.bindEntity(NoUpdateEntity.class);
-        dictionary.bindEntity(NoCreateEntity.class);
-        dictionary.bindEntity(NoShareEntity.class);
-        dictionary.bindEntity(example.User.class);
-        dictionary.bindEntity(FirstClassFields.class);
-        dictionary.bindEntity(MapColorShape.class);
-        dictionary.bindEntity(ChangeSpecModel.class);
-        dictionary.bindEntity(ChangeSpecChild.class);
-        dictionary.bindEntity(Invoice.class);
-        dictionary.bindEntity(LineItem.class);
-        dictionary.bindEntity(ComputedBean.class);
-        dictionary.bindEntity(ContainerWithPackageShare.class);
-        dictionary.bindEntity(ShareableWithPackageShare.class);
-        dictionary.bindEntity(UnshareableWithEntityUnshare.class);
-
         reset(goodUserScope.getTransaction());
     }
 
@@ -2258,21 +2231,6 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         parent.setChildren(Sets.newHashSet(child));
         parent.setSpouses(new HashSet<>());
         return parent;
-    }
-
-
-    private static Child newChild(int id) {
-        Child child = new Child();
-        child.setId(id);
-        child.setParents(new HashSet<>());
-        child.setFriends(new HashSet<>());
-        return child;
-    }
-
-    private static Child newChild(int id, String name) {
-        Child child = newChild(id);
-        child.setName(name);
-        return child;
     }
 
     /* ChangeSpec-specific test elements */

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -299,7 +299,7 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
         for (Entity entity : entitySet) {
             graphWalker(entity, this::updateRelationship);
             PersistentResource<?> childResource = entity.toPersistentResource();
-            if (!context.isRoot() && (childResource.isNewlyCreated() || context.parentResource.isNewlyCreated())) {
+            if (!context.isRoot()) {
                 /* add relation between parent and nested entity */
                 context.parentResource.addRelation(context.field.getName(), childResource);
             }


### PR DESCRIPTION
## Description
We have been calling addRelation to parent entity for updates to child
entities in graphql. This checks the share permission for the child
entity and may fail in some cases.
This PR avoids checking the share permission in case when the entity is
already a part of the relation with the parent.

## Motivation and Context

## How Has This Been Tested?
The unit tests are in the file below.
elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
