### PR TITLE
Fix elide4.5.5

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
@@ -35,7 +35,7 @@ public abstract class FilterExpressionCheck<T> extends InlineCheck<T> {
      * @param requestScope Request scope object
      * @return FilterExpression for FilterExpressionCheck.
      */
-    public abstract FilterExpression getFilterExpression(Class entityClass, RequestScope requestScope);
+    public abstract FilterExpression getFilterExpression(Class<?> entityClass, RequestScope requestScope);
 
     /* NOTE: Filter Expression checks and user checks are intended to be _distinct_ */
     @Override

--- a/elide-example/elide-blog-example/pom.xml
+++ b/elide-example/elide-blog-example/pom.xml
@@ -11,6 +11,7 @@
     <description>Elide example using javax.persistence, MySQL and Elide Security</description>
     <groupId>com.yahoo.elide</groupId>
     <version>4.5.6-SNAPSHOT</version>
+    <url>https://github.com/yahoo/elide</url>
 
     <issueManagement>
         <system>GitHub Issues</system>
@@ -129,6 +130,32 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description
Elide 4.5.5 release had two issues:
1. There was a compilation change required in FilterExpressionCheck that break SEMVER.
2. elide-blog-example had pom issues that prevented artifacts syncing with maven central.

## Motivation and Context
See above.

## How Has This Been Tested?
Build passes.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
