### PR TITLE
Support for multiple queries at root is added

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
@@ -38,9 +38,9 @@ public class GraphQLRequestScope extends RequestScope {
         super("/", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
         this.projectionInfo = projectionInfo;
 
-        // TODO: handle multiple projection in one graphQL query
+        // Entity Projection is retrieved from projectionInfo. This shall be removed.
         if (projectionInfo.getProjections().size() > 0) {
-            this.setEntityProjection(projectionInfo.getProjections().iterator().next());
+            this.setEntityProjection(projectionInfo.getProjections().entrySet().iterator().next().getValue());
         }
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/containers/RootContainer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/containers/RootContainer.java
@@ -16,7 +16,10 @@ public class RootContainer implements GraphQLContainer {
     public Object processFetch(Environment context, PersistentResourceFetcher fetcher) {
         return fetcher.fetchObject(
                 context.requestScope,
-                context.requestScope.getEntityProjection(),  // root-level projection
+                context.requestScope
+                        .getProjectionInfo()
+                        .getProjections()
+                        .get(context.outputType.getName()),  // root-level projection
                 context.ids
         );
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLProjectionInfo.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLProjectionInfo.java
@@ -12,7 +12,6 @@ import graphql.language.SourceLocation;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -21,7 +20,7 @@ import java.util.Map;
  */
 @AllArgsConstructor
 public class GraphQLProjectionInfo {
-    @Getter private final Collection<EntityProjection> projections;
+    @Getter private final Map<String, EntityProjection> projections;
 
     @Getter private final Map<SourceLocation, Relationship> relationshipMap;
 }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -27,11 +27,6 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     }
 
     @Test
-    public void testRootMultiple() throws Exception {
-        assertParsingFails(loadGraphQLRequest("fetch/rootMultiple.graphql"));
-    }
-
-    @Test
     public void testRootUnknownField() throws Exception {
         assertParsingFails(loadGraphQLRequest("fetch/rootUnknownField.graphql"));
     }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -791,6 +791,89 @@ public class GraphQLEndpointTest {
         assertHasErrors(response);
     }
 
+
+    @Test
+    public void testMultipleRoot() throws JSONException {
+        String graphQLRequest = document(
+                selections(
+                        field(
+                                "author",
+                                selections(
+                                        field("id"),
+                                        field("name")
+                                )
+                        ),
+                        field(
+                                "author",
+                                selections(
+                                        field(
+                                                "books",
+                                                selection(
+                                                        field("title")
+                                                )
+                                        )
+                                )
+                        ),
+                        field(
+                                "book",
+                                selections(
+                                        field("id"),
+                                        field("title"),
+                                        field(
+                                                "authors",
+                                                selection(
+                                                        field("name")
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String graphQLResponse = document(
+                selections(
+                        field(
+                                "author",
+                                selections(
+                                        field("id", "1"),
+                                        field("name", "Ricky Carmichael"),
+                                        field(
+                                                "books",
+                                                selections(
+                                                        field("title", "My first book")
+                                                )
+                                        )
+                                ),
+                                selections(
+                                        field("id", "2"),
+                                        field("name", "The Silent Author"),
+                                        field(
+                                                "books", "", false
+                                        )
+                                )
+                        ),
+                        field(
+                                "book",
+                                selections(
+                                        field("id", "1"),
+                                        field("title", "My first book"),
+                                        field(
+                                                "authors",
+                                                selection(
+                                                        field("name", "Ricky Carmichael")
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ).toResponse();
+
+
+        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        assert200EqualBody(response, graphQLResponse);
+    }
+
+
     private static String graphQLRequestToJSON(String request) {
         return graphQLRequestToJSON(request, new HashMap<>());
     }

--- a/elide-graphql/src/test/java/graphqlEndpointTestModels/Author.java
+++ b/elide-graphql/src/test/java/graphqlEndpointTestModels/Author.java
@@ -28,7 +28,7 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Transient;
 
-@Include
+@Include(rootLevel = true)
 @Entity
 @CreatePermission(expression = Author.PERMISSION)
 @ReadPermission(expression = Author.PERMISSION)


### PR DESCRIPTION
Resolves #994

## Description
GraphQL now handles multiple queries all at the root level. The EntityProjection for all entities that are queried at the root level is mapped to its entity name in GraphQLProjectionInfo. The root container selects the EntityProjection using the entity name which is obtained from Environment Context.

## Motivation and Context
Multiple queries in the same transaction were previously not working. 

## How Has This Been Tested?
Unit testing that hits GraphQL Endpoint querying Author and Book entity both at root level. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
