### PR TITLE
function name fixed to enableISO8601Dates

### DIFF
--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -74,7 +74,7 @@ public interface ElideStandaloneSettings {
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
                 .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary));
 
-        if (enableIS06081Dates()) {
+        if (enableISO8601Dates()) {
             builder = builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
         }
 
@@ -167,7 +167,7 @@ public interface ElideStandaloneSettings {
      * Whether Dates should be ISO8601 strings (true) or epochs (false).
      * @return
      */
-    default boolean enableIS06081Dates() {
+    default boolean enableISO8601Dates() {
         return true;
     }
 


### PR DESCRIPTION

## Description
Changed the function name from `enableIS06081Dates` to `enableISO8601Dates`

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
