### PR TITLE
Expose opaque user in audits

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
@@ -122,17 +122,14 @@ public class LogMessage {
                 singleElementContext.setVariable(name, singleElementExpression);
             }
 
-            final User user = getUser();
+            final Object user = getUser();
             if (user != null) {
-                final Object opaqueUser = user.getOpaqueUser();
-                if (opaqueUser != null) {
-                    final ValueExpression opaqueUserValueExpression = EXPRESSION_FACTORY
-                        .createValueExpression(
-                            opaqueUser, Object.class
-                        );
-                    ctx.setVariable("opaqueUser", opaqueUserValueExpression);
-                    singleElementContext.setVariable("opaqueUser", opaqueUserValueExpression);
-                }
+                final ValueExpression opaqueUserValueExpression = EXPRESSION_FACTORY
+                    .createValueExpression(
+                        user, Object.class
+                    );
+                ctx.setVariable("opaqueUser", opaqueUserValueExpression);
+                singleElementContext.setVariable("opaqueUser", opaqueUserValueExpression);
             }
         }
 
@@ -180,10 +177,13 @@ public class LogMessage {
         return null;
     }
 
-    public User getUser() {
+    public Object getUser() {
         RequestScope requetScope = getRequestScope();
         if (requetScope != null) {
-            return requetScope.getUser();
+            User = requestScope.getUser();
+            if (user != null) {
+                return user.getOpaqueUser();
+            }
         }
         return null;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
@@ -178,8 +178,8 @@ public class LogMessage {
     }
 
     public Object getUser() {
-        RequestScope requetScope = getRequestScope();
-        if (requetScope != null) {
+        RequestScope requestScope = getRequestScope();
+        if (requestScope != null) {
             User user = requestScope.getUser();
             if (user != null) {
                 return user.getOpaqueUser();

--- a/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.ResourceLineage;
 import com.yahoo.elide.security.ChangeSpec;
 
+import com.yahoo.elide.security.User;
 import de.odysseus.el.ExpressionFactoryImpl;
 import de.odysseus.el.util.SimpleContext;
 
@@ -119,6 +120,19 @@ public class LogMessage {
                 }
                 ctx.setVariable(name, expression);
                 singleElementContext.setVariable(name, singleElementExpression);
+            }
+
+            final User user = record.getRequestScope().getUser();
+            if (user != null) {
+                final Object opaqueUser = user.getOpaqueUser();
+                if (opaqueUser != null) {
+                    final ValueExpression opaqueUserValueExpression = EXPRESSION_FACTORY
+                        .createValueExpression(
+                            opaqueUser, Object.class
+                        );
+                    ctx.setVariable("opaqueUser", opaqueUserValueExpression);
+                    singleElementContext.setVariable("opaqueUser", opaqueUserValueExpression);
+                }
             }
         }
 

--- a/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
@@ -180,7 +180,7 @@ public class LogMessage {
     public Object getUser() {
         RequestScope requetScope = getRequestScope();
         if (requetScope != null) {
-            User = requestScope.getUser();
+            User user = requestScope.getUser();
             if (user != null) {
                 return user.getOpaqueUser();
             }

--- a/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
@@ -122,7 +122,7 @@ public class LogMessage {
                 singleElementContext.setVariable(name, singleElementExpression);
             }
 
-            final User user = record.getRequestScope().getUser();
+            final User user = getUser();
             if (user != null) {
                 final Object opaqueUser = user.getOpaqueUser();
                 if (opaqueUser != null) {
@@ -176,6 +176,14 @@ public class LogMessage {
     public RequestScope getRequestScope() {
         if (record != null) {
             return record.getRequestScope();
+        }
+        return null;
+    }
+
+    public User getUser() {
+        RequestScope requetScope = getRequestScope();
+        if (requetScope != null) {
+            return requetScope.getUser();
         }
         return null;
     }

--- a/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.security.User;
 
 import com.google.common.collect.Sets;
 import example.Child;
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +53,13 @@ public class LogMessageTest {
         friend.setId(9);
         child.setFriends(Sets.newHashSet(friend));
 
-        final RequestScope requestScope = new RequestScope(null, null, null, null, null,
+        final RequestScope requestScope = new RequestScope(null, null, null, new User(
+            new Principal() {
+                @Override
+                public String getName() {
+                    return "aaron";
+                }
+            }), null,
                 new ElideSettingsBuilder(null)
                         .withAuditLogger(new TestAuditLogger())
                         .withEntityDictionary(dictionary)
@@ -60,6 +68,14 @@ public class LogMessageTest {
         final PersistentResource<Parent> parentRecord = new PersistentResource<>(parent, null, requestScope.getUUIDFor(parent), requestScope);
         childRecord = new PersistentResource<>(child, parentRecord, requestScope.getUUIDFor(child), requestScope);
         friendRecord = new PersistentResource<>(friend, childRecord, requestScope.getUUIDFor(friend), requestScope);
+    }
+
+    @Test
+    public void verifyOpaqueUserExpressions() {
+        final String[] expressions = { "${opaqueUser.name}", "${opaqueUser.name}" };
+        final LogMessage message = new LogMessage("{0} {1}", childRecord, expressions, 1, Optional.empty());
+        assertEquals("aaron aaron", message.getMessage(), "JEXL substitution evaluates correctly.");
+        assertEquals(Optional.empty(), message.getChangeSpec());
     }
 
     @Test


### PR DESCRIPTION
Resolves #<issue number> (if appropriate)

## Description
Expose opaque user through audits so it can be logged through log statements.

## Motivation and Context
Right now there is no way to get to opaque user information through audit logging interface.  It might be fine if we inject user information through slf4j mdc but if we want to implement our own logger and want to use the log statements through elide to generate the final messages, we need to expose the opaque user.

## How Has This Been Tested?
Test was added.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
