### PR TITLE
Expose audit logger in standalone

### DIFF
--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -8,6 +8,8 @@ package com.yahoo.elide.standalone.config;
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
 
+import com.yahoo.elide.audit.AuditLogger;
+import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
@@ -72,7 +74,8 @@ public interface ElideStandaloneSettings {
                 .withUseFilterExpressions(true)
                 .withEntityDictionary(dictionary)
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
-                .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary));
+                .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
+                .withAuditLogger(getAuditLogger());
 
         if (enableIS06081Dates()) {
             builder = builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
@@ -228,5 +231,14 @@ public interface ElideStandaloneSettings {
      */
     default void updateServletContextHandler(ServletContextHandler servletContextHandler) {
         // Do nothing
+    }
+
+    /**
+     * Gets the audit logger for elide
+     *
+     * @return Default: Slf4jLogger
+     */
+    default AuditLogger getAuditLogger() {
+        return new Slf4jLogger();
     }
 }

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -48,9 +48,7 @@ public class ElideStandaloneTest {
         elide = new ElideStandalone(new ElideStandaloneSettings() {
 
             @Override
-            public ElideSettings getElideSettings(ServiceLocator injector) {
-                EntityDictionary dictionary = new EntityDictionary(getCheckMappings());
-
+            public Properties getDatabaseProperties() {
                 Properties options = new Properties();
 
                 options.put("hibernate.show_sql", "true");
@@ -63,22 +61,12 @@ public class ElideStandaloneTest {
                 options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE;");
                 options.put("javax.persistence.jdbc.user", "sa");
                 options.put("javax.persistence.jdbc.password", "");
+                return options;
+            }
 
-                EntityManagerFactory entityManagerFactory = Util.getEntityManagerFactory(Post.class.getPackage().getName(), options);
-                DataStore dataStore = new JpaDataStore(
-                        () -> { return entityManagerFactory.createEntityManager(); },
-                        (em -> { return new NonJtaTransaction(em); }));
-
-                dataStore.populateEntityDictionary(dictionary);
-
-                ElideSettingsBuilder builder = new ElideSettingsBuilder(dataStore)
-                        .withUseFilterExpressions(true)
-                        .withEntityDictionary(dictionary)
-                        .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
-                        .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
-                        .withAuditLogger(getAuditLogger());
-
-                return builder.build();
+            @Override
+            public String getModelPackageName() {
+                return Post.class.getPackage().getName();
             }
 
             @Override
@@ -116,7 +104,7 @@ public class ElideStandaloneTest {
                   "           \"id\": \"1\",\n" +
                   "           \"attributes\": {\n" +
                   "             \"content\": \"This is my first post. woot.\",\n" +
-                  "             \"date\" : \"0\"\n" +
+                  "             \"date\" : \"2019-01-01T00:00Z\"\n" +
                   "           }\n" +
                   "         }\n" +
                   "       }")

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -75,7 +75,8 @@ public class ElideStandaloneTest {
                         .withUseFilterExpressions(true)
                         .withEntityDictionary(dictionary)
                         .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
-                        .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary));
+                        .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
+                        .withAuditLogger(getAuditLogger());
 
                 return builder.build();
             }


### PR DESCRIPTION
Resolves #<issue number> (if appropriate)

## Description
Change the elide standalone settings interface to be able to provide an audit logger.

## Motivation and Context
Right now elide standalone has no way of configuring the audit logger, this exposes it as part of the interface so it can be customized.

## How Has This Been Tested?
Updated existing test.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
