### PR TITLE
Upgraded dependencies to pass OWASP security scan

### DIFF
--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -77,6 +77,23 @@
             <version>4.5.8-SNAPSHOT</version>
         </dependency>
 
+        <!-- Jetty -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>${version.jetty}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-server</artifactId>
+            <version>${version.jetty}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-server-impl</artifactId>
+            <version>${version.jetty}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-spring-boot-autoconfigure</artifactId>
@@ -102,6 +119,20 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jetty</artifactId>
             <version>${spring.boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlets</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>websocket-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>javax-websocket-server-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -47,7 +47,6 @@
 
     <properties>
         <!-- Versions -->
-        <jetty.version>9.4.17.v20190418</jetty.version>
         <logback.version>1.2.3</logback.version>
         <metrics.version>4.1.1</metrics.version>
 
@@ -118,13 +117,11 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>23.0</version>
+                <version>28.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>
@@ -158,7 +158,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-continuation</artifactId>
-                <version>9.4.22.v20191022</version>
+                <version>${version.jetty}</version>
             </dependency>
             <dependency>
                 <groupId>mysql</groupId>


### PR DESCRIPTION
## Description
OWASP security scan started failing for Jetty and Guava.

## Motivation and Context
Builds are failing.

## How Has This Been Tested?
Build passes.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
