### PR TITLE
Fixing GraphQL Logging on ForbiddenAccessExceptions to match JSON-API

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.ErrorObjects;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.core.exceptions.CustomErrorException;
+import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.core.exceptions.HttpStatusException;
 import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 import com.yahoo.elide.core.exceptions.TransactionException;
@@ -216,7 +217,13 @@ public class QueryRunner {
                     .responseCode(e.getResponse().getStatus())
                     .body(e.getResponse().getEntity().toString()).build();
         } catch (HttpStatusException e) {
-            log.debug("Caught HTTP status exception {}", e.getStatus(), e);
+            if (e instanceof ForbiddenAccessException) {
+                if (log.isDebugEnabled()) {
+                    log.debug("{}", ((ForbiddenAccessException) e).getLoggedMessage());
+                }
+            } else {
+                log.debug("Caught HTTP status exception {}", e.getStatus(), e);
+            }
             return buildErrorResponse(new HttpStatusException(200, "") {
                 @Override
                 public int getStatus() {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/models/ArtifactGroup.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/models/ArtifactGroup.java
@@ -9,7 +9,7 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.spring.checks.AdminCheck;
-import lombok.ToString;
+import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +19,7 @@ import javax.persistence.OneToMany;
 
 @Include(rootLevel = true, type = "group")
 @Entity
-@ToString
+@Data
 public class ArtifactGroup {
     @Id
     private String name = "";


### PR DESCRIPTION
## Description
GraphQL doesn't log the verbose error messages on ForbiddenAccessException like its cousin JSON-API.

## Motivation and Context
Logging should be the same across both.

## How Has This Been Tested?
Manually tested in the logs.  I also added a test to ensure the API doesn't change on errors for GraphQL going forward.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
