### PR TITLE
Added manual override in JpaDataStore to explicitly bind entities

### DIFF
--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/JpaDataStore.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/JpaDataStore.java
@@ -10,10 +10,11 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.datastore.JPQLDataStore;
 import com.yahoo.elide.datastores.jpa.transaction.JpaTransaction;
 
-import javax.persistence.EntityManager;
-import javax.persistence.metamodel.EntityType;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.EntityType;
 
 /**
  * Implementation for JPA EntityManager data store.

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/JpaDataStore.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/JpaDataStore.java
@@ -12,6 +12,8 @@ import com.yahoo.elide.datastores.jpa.transaction.JpaTransaction;
 
 import javax.persistence.EntityManager;
 import javax.persistence.metamodel.EntityType;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Implementation for JPA EntityManager data store.
@@ -19,15 +21,28 @@ import javax.persistence.metamodel.EntityType;
 public class JpaDataStore implements JPQLDataStore {
     protected final EntityManagerSupplier entityManagerSupplier;
     protected final JpaTransactionSupplier transactionSupplier;
+    protected final Set<Class<?>> modelsToBind;
 
     public JpaDataStore(EntityManagerSupplier entityManagerSupplier,
-                        JpaTransactionSupplier transactionSupplier) {
+                        JpaTransactionSupplier transactionSupplier,
+                        Class<?> ... models) {
         this.entityManagerSupplier = entityManagerSupplier;
         this.transactionSupplier = transactionSupplier;
+        this.modelsToBind = new HashSet<>();
+        for (Class<?> model : models) {
+            modelsToBind.add(model);
+        }
     }
 
     @Override
     public void populateEntityDictionary(EntityDictionary dictionary) {
+        // If the user provided models, we'll manually add them and skip scanning for entities.
+        if (! modelsToBind.isEmpty()) {
+            modelsToBind.stream().forEach((model) -> bindEntityClass(model, dictionary));
+            return;
+        }
+
+        // Use the entities defined in the entity manager factory.
         for (EntityType type : entityManagerSupplier.get().getMetamodel().getEntities()) {
             try {
                 Class<?> mappedClass = type.getJavaType();

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
@@ -63,7 +63,6 @@ public class JpaDataStoreTest {
 
         JpaDataStore store = new JpaDataStore(() -> { return managerMock; }, (unused) -> { return null; });
         EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
-        dictionary.bindEntity(Test.class);
 
 
         try {
@@ -73,5 +72,30 @@ public class JpaDataStoreTest {
         } finally {
             FilterTranslator.registerJPQLGenerator(Operator.IN, Test.class, "name", null);
         }
+    }
+
+    @Test
+    public void verifyManualEntityBinding() {
+
+        @Include
+        @Entity
+        class Test {
+            @Id
+            private long id;
+
+            private String name;
+        }
+
+        Metamodel mockModel = mock(Metamodel.class);
+        when(mockModel.getEntities()).thenReturn(Sets.newHashSet());
+
+        EntityManager managerMock = mock(EntityManager.class);
+        when(managerMock.getMetamodel()).thenReturn(mockModel);
+
+        JpaDataStore store = new JpaDataStore(() -> { return managerMock; }, (unused) -> { return null; }, Test.class);
+        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
+        store.populateEntityDictionary(dictionary);
+
+        assertNotNull(dictionary.lookupBoundClass(Test.class));
     }
 }

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
@@ -30,7 +30,6 @@ import javax.persistence.Id;
 import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.Metamodel;
 
-
 public class JpaDataStoreTest {
     public static class TestGenerator implements JPQLPredicateGenerator {
         @Override


### PR DESCRIPTION
## Description
There is a common use case where we want to restrict the entities a JPA store manages.

This can be done at the persistence unit level (by configuring the EntityManager in persistence.xml or other means).  It can also be done by subclassing the store and manually binding the entities you want the store to manage.

This PR simplifies this by allowing the constructor to take a list of entities to manually bind.

## Motivation and Context
Simplifies a common scenario where we want multiple JpaDataStores - some with specific logic for a given entity and a general one that manages everything else.

## How Has This Been Tested?
Unit Tests

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
