### PR TITLE
Improving class scanning performance for MetadataStore

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/utils/ClassScanner.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/ClassScanner.java
@@ -10,6 +10,7 @@ import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ScanResult;
 
 import java.lang.annotation.Annotation;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,15 +47,19 @@ public class ClassScanner {
     /**
      * Scans all classes accessible from the context class loader which belong to the current class loader.
      *
-     * @param annotation  Annotation to search
+     * @param annotations  One or more annotation to search for
      * @return The classes
      */
-    static public Set<Class<?>> getAnnotatedClasses(Class<? extends Annotation> annotation) {
+    static public Set<Class<?>> getAnnotatedClasses(Class<? extends Annotation> ...annotations) {
+        Set<Class<?>> result = new HashSet<>();
         try (ScanResult scanResult = new ClassGraph().enableAllInfo().scan()) {
-            return scanResult.getClassesWithAnnotation(annotation.getCanonicalName()).stream()
-                    .map((ClassInfo::loadClass))
-                    .collect(Collectors.toSet());
+            for (Class<? extends Annotation> annotation : annotations) {
+                result.addAll(scanResult.getClassesWithAnnotation(annotation.getCanonicalName()).stream()
+                        .map((ClassInfo::loadClass))
+                        .collect(Collectors.toSet()));
+            }
         }
+        return result;
     }
 
     /**

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.utils.ClassScanner;
 import org.junit.jupiter.api.Test;
 import java.util.Set;
@@ -37,6 +38,16 @@ public class ClassScannerTest {
         assertEquals(20, classes.size());
         for (Class<?> cls : classes) {
             assertTrue(cls.isAnnotationPresent(ReadPermission.class));
+        }
+    }
+
+    @Test
+    public void testGetAnyAnnotatedClasses() {
+        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(ReadPermission.class, UpdatePermission.class);
+        assertEquals(37, classes.size());
+        for (Class<?> cls : classes) {
+            assertTrue(cls.isAnnotationPresent(ReadPermission.class)
+                    || cls.isAnnotationPresent(UpdatePermission.class));
         }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -25,7 +25,6 @@ import com.yahoo.elide.utils.ClassScanner;
 
 import org.hibernate.annotations.Subselect;
 
-import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -47,22 +46,19 @@ public class MetaDataStore extends HashMapDataStore {
 
         ClassScanner.getAllClasses(Table.class.getPackage().getName()).forEach(cls -> dictionary.bindEntity(cls));
 
+        Set<Class<?>> modelsToBind = ClassScanner.getAnnotatedClasses(METADATA_STORE_ANNOTATIONS);
+
         // bind data models in the package
-        for (Class<? extends Annotation> cls : METADATA_STORE_ANNOTATIONS) {
-            ClassScanner.getAnnotatedClasses(cls).forEach(modelClass -> {
+        modelsToBind.forEach(modelClass -> {
                 dictionary.bindEntity(modelClass);
-            });
-        }
+        });
 
         // resolve meta data from the bound models
-        for (Class<? extends Annotation> cls : METADATA_STORE_ANNOTATIONS) {
-            ClassScanner.getAnnotatedClasses(cls).forEach(modelClass -> {
-                addTable(
-                        isAnalyticView(modelClass)
-                                ? new AnalyticView(modelClass, dictionary)
-                                : new Table(modelClass, dictionary));
-            });
-        }
+        modelsToBind.forEach(modelClass -> {
+            addTable(isAnalyticView(modelClass)
+                ? new AnalyticView(modelClass, dictionary)
+                : new Table(modelClass, dictionary));
+        });
     }
 
     @Override


### PR DESCRIPTION

## Description
Improves performance by reducing the amount of class scanning that is required to build the MetadataStore's metadata.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
