### PR TITLE
Support no metric query

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
@@ -19,8 +19,6 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.AnalyticView;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 
-import org.apache.commons.collections.CollectionUtils;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,16 +52,6 @@ public class QueryValidator {
     public void validate() {
         validateHavingClause(query.getHavingFilter());
         validateSorting();
-        validateMetricFunction();
-    }
-
-    /**
-     * Checks to make sure at least one metric is being aggregated on.
-     */
-    private void validateMetricFunction() {
-        if (CollectionUtils.isEmpty(metrics)) {
-            throw new InvalidOperationException("Must provide at least one metric in query");
-        }
     }
 
     /**
@@ -145,6 +133,12 @@ public class QueryValidator {
             throw new UnsupportedOperationException(
                     "Currently sorting on double nested fields is not supported");
         }
+
+        if (metrics.isEmpty() && pathElements.size() > 1) {
+            throw new UnsupportedOperationException(
+                    "Query with no metric can't sort on nested field.");
+        }
+
         Path.PathElement currentElement = pathElements.get(0);
         String currentField = currentElement.getFieldName();
         Class<?> currentClass = currentElement.getType();

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryConstructor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryConstructor.java
@@ -90,7 +90,9 @@ public class SQLQueryConstructor {
         Set<ColumnProjection> groupByDimensions = template.getGroupByDimensions();
 
         if (!groupByDimensions.isEmpty()) {
-            builder.groupByClause(constructGroupByWithReference(groupByDimensions, queriedTable));
+            if (!clientQuery.getMetrics().isEmpty()) {
+                builder.groupByClause(constructGroupByWithReference(groupByDimensions, queriedTable));
+            }
 
             joinPaths.addAll(extractJoinPaths(groupByDimensions, queriedTable));
         }
@@ -199,6 +201,10 @@ public class SQLQueryConstructor {
                     return resolveSQLColumnReference(dimension, queriedTable) + " AS " + dimension.getAlias();
                 })
                 .collect(Collectors.toList());
+
+        if (metricProjections.isEmpty()) {
+            return "DISTINCT " + String.join(",", dimensionProjections);
+        }
 
         return Stream.concat(metricProjections.stream(), dimensionProjections.stream())
                 .collect(Collectors.joining(","));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.core.filter.expression.PredicateExtractionVisitor;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.datastores.aggregation.QueryEngine;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.metric.MetricFunctionInvocation;
 import com.yahoo.elide.datastores.aggregation.metadata.models.AnalyticView;
 import com.yahoo.elide.datastores.aggregation.metadata.models.MetricFunction;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
@@ -37,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -169,7 +171,22 @@ public class SQLQueryEngine implements QueryEngine {
                             timeDimension);
                 })
                 .reduce(SQLQueryTemplate::merge)
-                .orElseThrow(() -> new InvalidPredicateException("Metric function not found"));
+                .orElse(new SQLQueryTemplate() {
+                    @Override
+                    public List<MetricFunctionInvocation> getMetrics() {
+                        return Collections.emptyList();
+                    }
+
+                    @Override
+                    public Set<ColumnProjection> getNonTimeDimensions() {
+                        return groupByDimensions;
+                    }
+
+                    @Override
+                    public TimeDimensionProjection getTimeDimension() {
+                        return timeDimension;
+                    }
+                });
 
         return new SQLQueryConstructor(metadataDictionary).resolveTemplate(
                 query,

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/QueryValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/QueryValidatorTest.java
@@ -36,15 +36,19 @@ public class QueryValidatorTest extends SQLUnitTest {
 
     @Test
     public void testNoMetricQuery() {
+        Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
+        sortMap.put("country.name", Sorting.SortOrder.asc);
+
         Query query = Query.builder()
                 .analyticView(playerStatsTable)
                 .groupByDimension(toProjection(playerStatsTable.getDimension("overallRating")))
+                .sorting(new Sorting(sortMap))
                 .build();
 
         QueryValidator validator = new QueryValidator(query, Collections.singleton("overallRating"), dictionary);
 
-        InvalidOperationException exception = assertThrows(InvalidOperationException.class, validator::validate);
-        assertEquals("Invalid operation: 'Must provide at least one metric in query'", exception.getMessage());
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class, validator::validate);
+        assertEquals("Query with no metric can't sort on nested field.", exception.getMessage());
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -117,6 +117,60 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
     }
 
     @Test
+    public void noMetricQueryTest() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "playerStatsWithView",
+                                arguments(
+                                        argument("sort", "\"countryViewRelationshipIsoCode\"")
+                                ),
+                                selections(
+                                        field(
+                                                "country",
+                                                selections(
+                                                        field("name"),
+                                                        field("isoCode")
+                                                )
+                                        ),
+                                        field("countryViewRelationshipIsoCode")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "playerStatsWithView",
+                                selections(
+                                        field(
+                                                "country",
+                                                selections(
+                                                        field("name", "Hong Kong"),
+                                                        field("isoCode", "HKG")
+                                                )
+                                        ),
+                                        field("countryViewRelationshipIsoCode", "HKG")
+                                ),
+                                selections(
+                                        field(
+                                                "country",
+                                                selections(
+                                                        field("name", "United States"),
+                                                        field("isoCode", "USA")
+                                                )
+                                        ),
+                                        field("countryViewRelationshipIsoCode", "USA")
+                                )
+                        )
+                )
+        ).toResponse();
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
+
+    @Test
     public void whereFilterTest() throws Exception {
         String graphQLRequest = document(
                 selection(
@@ -605,29 +659,6 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
         ).toQuery();
 
         String expected = "\"Exception while fetching data (/playerStats) : Invalid operation: 'Can't sort on highScore as it is not present in query'\"";
-
-        runQueryWithExpectedError(graphQLRequest, expected);
-    }
-
-    @Test
-    public void noMetricQueryTest() throws Exception {
-        String graphQLRequest = document(
-                selection(
-                        field(
-                                "playerStats",
-                                selections(
-                                        field(
-                                                "country",
-                                                selections(
-                                                        field("name")
-                                                )
-                                        )
-                                )
-                        )
-                )
-        ).toQuery();
-
-        String expected = "\"Exception while fetching data (/playerStats) : Invalid operation: 'Must provide at least one metric in query'\"";
 
         runQueryWithExpectedError(graphQLRequest, expected);
     }


### PR DESCRIPTION
Query without any metric would be constructed as `SELECT DISTINCT ...` with out `GROUP BY` clauses.

## Description
- Allow query without metric
- Construct `SELECT DISTINCT` query
- Update query sorting validation
- Remove query metric validation

## Motivation and Context
- To address the druid dimension use case.

## How Has This Been Tested?
Unit test and Integration test are updated.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
