### PR TITLE
Update test dependency on example models

### DIFF
--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-example-models</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -999,7 +999,7 @@ public class EntityDictionary {
                 try {
                     idField = getEntityBinding(cls).getIdField();
                 } catch (NullPointerException e) {
-                    System.out.println("Class: " + cls.getSimpleName() + " ID Field: " + idField);
+                    log.warn("Class: {} ID Field: {}", cls.getSimpleName(), idField);
                 }
             }
             if (idField instanceof Field) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -999,7 +999,7 @@ public class EntityDictionary {
                 try {
                     idField = getEntityBinding(cls).getIdField();
                 } catch (NullPointerException e) {
-                    System.out.println("Class: " + cls.getSimpleName() + " ID Field: " + idField.toString());
+                    System.out.println("Class: " + cls.getSimpleName() + " ID Field: " + idField);
                 }
             }
             if (idField instanceof Field) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/LifecycleHookInvoker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/LifecycleHookInvoker.java
@@ -9,7 +9,6 @@ import com.yahoo.elide.functions.LifeCycleHook;
 
 import io.reactivex.Observer;
 import io.reactivex.disposables.Disposable;
-import lombok.extern.slf4j.Slf4j;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -18,7 +17,6 @@ import java.util.Optional;
 /**
  * RX Java Observer which invokes a lifecycle hook function.
  */
-@Slf4j
 public class LifecycleHookInvoker implements Observer<CRUDEvent> {
 
     private EntityDictionary dictionary;

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -874,7 +874,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      * @return Filter expression for given ids and type.
      */
     private static FilterExpression buildIdFilterExpression(List<String> ids,
-                                                            Class entityType,
+                                                            Class<?> entityType,
                                                             EntityDictionary dictionary,
                                                             RequestScope scope) {
         Class<?> idType = dictionary.getIdType(entityType);
@@ -1026,7 +1026,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             Iterable filteredVal = (Iterable) val;
             resources = new PersistentResourceSet(this, filteredVal, requestScope);
         } else if (type.isToOne()) {
-            resources = new SingleElementSet(
+            resources = new SingleElementSet<>(
                     new PersistentResource<>(val, this, requestScope.getUUIDFor(val), requestScope));
         } else {
             resources.add(new PersistentResource<>(val, this, requestScope.getUUIDFor(val), requestScope));

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -42,7 +42,6 @@ import com.google.common.collect.Sets;
 import org.apache.commons.collections4.CollectionUtils;
 
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -68,7 +67,6 @@ import java.util.stream.Collectors;
  *
  * @param <T> type of resource
  */
-@Slf4j
 public class PersistentResource<T> implements com.yahoo.elide.security.PersistentResource<T> {
     protected T obj;
     private final String type;
@@ -215,7 +213,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             }
         }
 
-        PersistentResource<T> resource = new PersistentResource<T>(
+        PersistentResource<T> resource = new PersistentResource<>(
                 loadClass.cast(obj), null, requestScope.getUUIDFor(obj), requestScope);
         // No need to have read access for a newly created object
         if (!requestScope.getNewResources().contains(resource)) {
@@ -1029,9 +1027,9 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             resources = new PersistentResourceSet(this, filteredVal, requestScope);
         } else if (type.isToOne()) {
             resources = new SingleElementSet(
-                    new PersistentResource(val, this, requestScope.getUUIDFor(val), requestScope));
+                    new PersistentResource<>(val, this, requestScope.getUUIDFor(val), requestScope));
         } else {
-            resources.add(new PersistentResource(val, this, requestScope.getUUIDFor(val), requestScope));
+            resources.add(new PersistentResource<>(val, this, requestScope.getUUIDFor(val), requestScope));
         }
 
         return resources;

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/HashMapStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/HashMapStoreTransaction.java
@@ -13,8 +13,6 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -28,7 +26,6 @@ import javax.persistence.GeneratedValue;
 /**
  * HashMapDataStore transaction handler.
  */
-@Slf4j
 public class HashMapStoreTransaction implements DataStoreTransaction {
     private final Map<Class<?>, Map<String, Object>> dataStore;
     private final List<Operation> operations;

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -2135,7 +2135,6 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
 
     @Test
     public void testRelationChangeSpecType() {
-        try {
             BiFunction<ChangeSpec, BiFunction<ChangeSpecChild, ChangeSpecChild, Boolean>, Boolean> relCheck = (spec, checkFn) -> {
                 if (!(spec.getModified() instanceof ChangeSpecChild) && spec.getModified() != null) {
                     return false;
@@ -2166,9 +2165,6 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
 
             model.getObject().checkFunction = (spec) -> relCheck.apply(spec, (original, modified) -> new ChangeSpecChild(2).equals(original) && modified == null);
             assertTrue(model.updateRelation("child", null));
-        } catch (ForbiddenAccessException e) {
-            e.printStackTrace();
-        }
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
@@ -403,7 +403,7 @@ public class PermissionExecutorTest {
 
     @Test
     public void testUserCheckCache() {
-        PersistentResource resource = newResource(UserCheckCacheRecord.class);
+        PersistentResource<UserCheckCacheRecord> resource = newResource(UserCheckCacheRecord.class);
         RequestScope requestScope = resource.getRequestScope();
         ChangeSpec cspec = new ChangeSpec(null, null, null, null);
         // This should cache for updates, reads, etc.
@@ -413,19 +413,19 @@ public class PermissionExecutorTest {
         requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, cspec);
     }
 
-    public <T> PersistentResource newResource(T obj, Class<T> cls) {
+    public <T> PersistentResource<T> newResource(T obj, Class<T> cls) {
         EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(cls);
         RequestScope requestScope = new RequestScope(null, null, null, null, null, getElideSettings(dictionary));
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 
-    public PersistentResource newResource(Class cls) {
+    public <T> PersistentResource<T> newResource(Class<T> cls) {
         EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(cls);
         RequestScope requestScope = new RequestScope(null, null, null, null, null, getElideSettings(dictionary));
         try {
-            Object obj = cls.newInstance();
+            T obj = cls.newInstance();
             return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
         } catch (InstantiationException | IllegalAccessException e) {
             return null;

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.jayway.restassured</groupId>
+                <groupId>io.rest-assured</groupId>
                 <artifactId>json-schema-validator</artifactId>
                 <version>${version.restassured}</version>
                 <scope>test</scope>
@@ -399,11 +399,11 @@
                         <version>1.11.2</version>
                     </dependency>
 
-                   <dependency>
+                    <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-api</artifactId>
                         <version>1.11.2</version>
-                   </dependency>
+                    </dependency>
                 </dependencies>
                 <configuration>
                     <tagNameFormat>@{project.version}</tagNameFormat>


### PR DESCRIPTION
Resolves #<issue number> (if appropriate)

## Description
Fixed the incorrect compile elide-core dependency on example models.  This should be test scope.
```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ elide-core ---
[INFO] com.yahoo.elide:elide-core:jar:4.5.13-SNAPSHOT
[INFO] +- com.yahoo.elide:elide-annotations:jar:4.5.13-SNAPSHOT:compile
[INFO] +- com.yahoo.elide:elide-example-models:jar:4.5.13-SNAPSHOT:test
```
Also cleaned up PersistentResource type checks.

## Motivation and Context
End product had dependency on example beans.

## How Has This Been Tested?
Unit testing

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
