### PR TITLE
Bump dependency-check-maven from 5.2.4 to 5.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.2.4</version>
+                <version>5.3.0</version>
                 <configuration>
                     <failBuildOnCVSS>6</failBuildOnCVSS>
                     <skipSystemScope>true</skipSystemScope>


### PR DESCRIPTION
# Description
Bump dependency-check-maven to latest version 5.3.0

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
