### PR TITLE
JsonApiDocument hashCode and equals were inconsistent

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -313,7 +313,7 @@ public class Elide {
         } catch (ConstraintViolationException e) {
             log.debug("Constraint violation exception caught", e);
             String message = "Constraint violation";
-            if (!e.getConstraintViolations().isEmpty()) {
+            if (e.getConstraintViolations() != null && !e.getConstraintViolations().isEmpty()) {
                 // Return error for the first constraint violation
                 message = e.getConstraintViolations().iterator().next().getMessage();
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -102,11 +102,11 @@ public interface DataStoreTransaction extends Closeable {
      * @return a new instance of type T
      */
     default <T> T createNewObject(Class<T> entityClass) {
-        T obj = null;
+        T obj;
         try {
             obj = entityClass.newInstance();
         } catch (java.lang.InstantiationException | IllegalAccessException e) {
-            //do nothing
+            obj = null;
         }
         return obj;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -272,7 +272,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     public Optional<FilterExpression> getLoadFilterExpression(Class<?> loadClass) {
         Optional<FilterExpression> permissionFilter;
         permissionFilter = getPermissionExecutor().getReadPermissionFilter(loadClass);
-        Optional<FilterExpression> globalFilterExpressionOptional = null;
+        Optional<FilterExpression> globalFilterExpressionOptional;
         if (globalFilterExpression == null) {
             String typeName = dictionary.getJsonAliasFor(loadClass);
             globalFilterExpressionOptional =  getFilterExpressionByType(typeName);

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
@@ -98,7 +98,8 @@ public class JsonApiDocument {
         }
         JsonApiDocument other = (JsonApiDocument) obj;
         Collection<Resource> resources = Optional.ofNullable(data).map(Data::get).orElse(Collections.emptySet());
-        Collection<Resource> otherResources = Optional.ofNullable(other.data).map(Data::get).orElse(Collections.emptySet());
+        Collection<Resource> otherResources =
+                Optional.ofNullable(other.data).map(Data::get).orElse(Collections.emptySet());
 
         if (resources.size() != otherResources.size() || !resources.stream().allMatch(otherResources::contains)) {
             return false;

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
@@ -84,12 +84,11 @@ public class JsonApiDocument {
 
     @Override
     public int hashCode() {
+        Collection<Resource> resources = data == null ? null : data.get();
         return new HashCodeBuilder(37, 79)
-            .append(data)
-            .append(meta)
-            .append(includedRecs)
+            .append(resources == null ? 0 : resources.stream().mapToInt(Object::hashCode).sum())
             .append(links)
-            .append(included)
+            .append(included == null ? 0 : included.stream().mapToInt(Object::hashCode).sum())
             .build();
     }
 
@@ -99,15 +98,16 @@ public class JsonApiDocument {
             return false;
         }
         JsonApiDocument other = (JsonApiDocument) obj;
-        Collection<Resource> resources = data.get();
-        if ((resources == null || other.getData().get() == null) && resources != other.getData().get()) {
+        Collection<Resource> resources = data == null ? null : data.get();
+        Collection<Resource> otherResources = other.data == null ? null : other.data.get();
+
+        if (resources == null ^ otherResources == null) {
             return false;
         }
-        if (resources != null) {
-            if (resources.size() != other.getData().get().size()
-                || !resources.stream().allMatch(other.getData().get()::contains)) {
-                return false;
-            }
+        if (resources != null
+                && (resources.size() != otherResources.size()
+                        || !resources.stream().allMatch(other.getData().get()::contains))) {
+            return false;
         }
         // TODO: Verify links and meta?
         if (other.getIncluded() == null) {

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
@@ -46,9 +46,6 @@ public class JsonApiDocument {
     }
 
     public Data<Resource> getData() {
-        if (data == null) {
-            return null;
-        }
         return data;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
@@ -14,6 +14,7 @@ import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -95,15 +96,15 @@ public class JsonApiDocument {
             return false;
         }
         JsonApiDocument other = (JsonApiDocument) obj;
-        Collection<Resource> resources = data == null ? null : data.get();
-        Collection<Resource> otherResources = other.data == null ? null : other.data.get();
+        Collection<Resource> resources = data == null ? Collections.emptySet() : data.get();
+        Collection<Resource> otherResources = other.data == null ? Collections.emptySet() : other.data.get();
 
         if (resources == null ^ otherResources == null) {
             return false;
         }
         if (resources != null
                 && (resources.size() != otherResources.size()
-                        || !resources.stream().allMatch(other.getData().get()::contains))) {
+                        || !resources.stream().allMatch(otherResources::contains))) {
             return false;
         }
         // TODO: Verify links and meta?

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiDocument.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * JSON API Document.
@@ -96,15 +97,10 @@ public class JsonApiDocument {
             return false;
         }
         JsonApiDocument other = (JsonApiDocument) obj;
-        Collection<Resource> resources = data == null ? Collections.emptySet() : data.get();
-        Collection<Resource> otherResources = other.data == null ? Collections.emptySet() : other.data.get();
+        Collection<Resource> resources = Optional.ofNullable(data).map(Data::get).orElse(Collections.emptySet());
+        Collection<Resource> otherResources = Optional.ofNullable(other.data).map(Data::get).orElse(Collections.emptySet());
 
-        if (resources == null ^ otherResources == null) {
-            return false;
-        }
-        if (resources != null
-                && (resources.size() != otherResources.size()
-                        || !resources.stream().allMatch(otherResources::contains))) {
+        if (resources.size() != otherResources.size() || !resources.stream().allMatch(otherResources::contains)) {
             return false;
         }
         // TODO: Verify links and meta?

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/RelationshipTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/RelationshipTerminalState.java
@@ -55,13 +55,10 @@ public class RelationshipTerminalState extends BaseState {
         Optional<MultivaluedMap<String, String>> queryParams = requestScope.getQueryParams();
 
         Map<String, Relationship> relationships = record.toResourceWithSortingAndPagination().getRelationships();
-        Relationship relationship = null;
         if (relationships != null) {
-            relationship = relationships.get(relationshipName);
-        }
+            Relationship relationship = relationships.get(relationshipName);
 
-        // Handle valid relationship
-        if (relationship != null) {
+            // Handle valid relationship
 
             // Set data
             Data<Resource> data = relationship.getData();

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -90,6 +91,7 @@ public class JsonApiTest {
 
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -110,6 +112,7 @@ public class JsonApiTest {
 
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -133,6 +136,7 @@ public class JsonApiTest {
 
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -155,6 +159,7 @@ public class JsonApiTest {
 
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -180,6 +185,7 @@ public class JsonApiTest {
 
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -193,6 +199,7 @@ public class JsonApiTest {
 
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -206,6 +213,7 @@ public class JsonApiTest {
 
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -224,6 +232,7 @@ public class JsonApiTest {
         assertEquals("bob", attributes.get("firstName"));
         assertEquals("child", relations.get("children").getData().getSingleValue().getType());
         assertEquals("2", relations.get("children").getData().getSingleValue().getId());
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -244,6 +253,7 @@ public class JsonApiTest {
         assertEquals(attributes.get("firstName"), "bob");
         assertEquals(relations.get("children").getData().getSingleValue().getType(), "child");
         assertEquals(relations.get("children").getData().getSingleValue().getId(), "2");
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -267,6 +277,7 @@ public class JsonApiTest {
         assertEquals("child", includedChild.getType());
         assertEquals("2", includedChild.getId());
         assertEquals("123", parent.getId());
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -285,6 +296,7 @@ public class JsonApiTest {
         assertEquals("bob", attributes.get("firstName"));
         assertEquals("2", data.getRelationships().get("children").getData().getSingleValue().getId());
         assertNull(included);
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -306,6 +318,7 @@ public class JsonApiTest {
         assertEquals("child", includedChild.getType());
         assertEquals("2", includedChild.getId());
         assertEquals("123", parent.getId());
+        checkEquality(jsonApiDocument);
     }
 
     @Test
@@ -326,5 +339,21 @@ public class JsonApiTest {
         assertEquals(attributes.get("firstName"), "bob");
         assertEquals(data.getRelationships().get("children").getData().getSingleValue().getId(), "2");
         assertNull(included);
+        checkEquality(jsonApiDocument);
+    }
+
+    private void checkEquality(JsonApiDocument doc1) {
+        JsonApiDocument doc2;
+        try {
+            String json = mapper.writeJsonApiDocument(doc1);
+            doc2 = mapper.readJsonApiDocument(json);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        if (doc2.getData() == null) {
+            doc2.setData(doc1.getData());
+        }
+        assertEquals(doc1.hashCode(), doc2.hashCode());
+        assertEquals(doc1, doc2);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -238,6 +238,21 @@ public class JsonApiTest {
     }
 
     @Test
+    public void writeNullObject() throws JsonProcessingException {
+        String expected = "{\"data\":null}";
+
+        JsonApiDocument jsonApiDocument = new JsonApiDocument();
+        jsonApiDocument.setData(null);
+
+        assertNull(jsonApiDocument.getData());
+        String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertNull(jsonApiDocument.getData());
+
+        assertEquals(expected, doc);
+        checkEquality(jsonApiDocument);
+    }
+
+    @Test
     public void readSingle() throws IOException {
         String doc = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":{\"type\":\"child\",\"id\":\"2\"}}}}}";
 

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -89,7 +89,10 @@ public class JsonApiTest {
 
         String expected = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":null},\"relationships\":{\"children\":{\"data\":[]},\"spouses\":{\"data\":[]}}}}";
 
+        Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertEquals(data, jsonApiDocument.getData());
+
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
     }
@@ -110,7 +113,10 @@ public class JsonApiTest {
 
         String expected = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}}}";
 
+        Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertEquals(data, jsonApiDocument.getData());
+
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
     }
@@ -134,7 +140,10 @@ public class JsonApiTest {
 
         String expected = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}},\"included\":[{\"type\":\"child\",\"id\":\"2\",\"attributes\":{\"name\":null},\"relationships\":{\"friends\":{\"data\":[]},\"parents\":{\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}}}]}";
 
+        Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertEquals(data, jsonApiDocument.getData());
+
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
     }
@@ -157,7 +166,10 @@ public class JsonApiTest {
 
         String expected = "{\"data\":[{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}}]}";
 
+        Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertEquals(data, jsonApiDocument.getData());
+
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
     }
@@ -183,7 +195,10 @@ public class JsonApiTest {
 
         String expected = "{\"data\":[{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}}],\"included\":[{\"type\":\"child\",\"id\":\"2\",\"attributes\":{\"name\":null},\"relationships\":{\"friends\":{\"data\":[]},\"parents\":{\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}}}]}";
 
+        Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertEquals(data, jsonApiDocument.getData());
+
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
     }
@@ -197,7 +212,10 @@ public class JsonApiTest {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
         jsonApiDocument.setData(empty);
 
+        Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertEquals(data, jsonApiDocument.getData());
+
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
     }
@@ -211,7 +229,10 @@ public class JsonApiTest {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
         jsonApiDocument.setData(empty);
 
+        Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
+        assertEquals(data, jsonApiDocument.getData());
+
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
     }
@@ -349,9 +370,6 @@ public class JsonApiTest {
             doc2 = mapper.readJsonApiDocument(json);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        }
-        if (doc2.getData() == null) {
-            doc2.setData(doc1.getData());
         }
         assertEquals(doc1.hashCode(), doc2.hashCode());
         assertEquals(doc1, doc2);


### PR DESCRIPTION
## Description
Pulled out only the code changes from #1162 for easier review.
- JsonApiDocument hashCode and equals were inconsistent.
- Correctly process empty ConstraintViolations
- Remove unnecessary initializations in code

## Motivation and Context
Stability

## How Has This Been Tested?
Unit testing

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
