### PR TITLE
Consolidate JSON API Content Type constant

### DIFF
--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiOperation.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiOperation.java
@@ -5,13 +5,15 @@
  */
 package com.yahoo.elide.contrib.swagger;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+
 import io.swagger.models.Operation;
 
 /**
  * Operation that consumes and produces JSON API mime type.
  */
 public class JsonApiOperation extends Operation {
-    public static final String JSON_API_MIME = "application/vnd.api+json";
+    public static final String JSON_API_MIME = JSONAPI_CONTENT_TYPE;
 
     public JsonApiOperation() {
         super();

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -67,6 +67,9 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 @Slf4j
 public class Elide {
+    public static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
+    public static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
+            "application/vnd.api+json; ext=jsonpatch";
 
     @Getter private final ElideSettings elideSettings;
     @Getter private final AuditLogger auditLogger;

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.resources;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.annotation.PATCH;
@@ -32,7 +34,7 @@ import javax.ws.rs.core.UriInfo;
  * Default endpoint/servlet for using Elide and JSONAPI.
  */
 @Singleton
-@Produces("application/vnd.api+json")
+@Produces(JSONAPI_CONTENT_TYPE)
 @Path("/")
 public class JsonApiEndpoint {
     protected final Elide elide;
@@ -41,8 +43,9 @@ public class JsonApiEndpoint {
     public static final DefaultOpaqueUserFunction DEFAULT_GET_USER = securityContext -> securityContext;
 
     @Inject
-    public JsonApiEndpoint(@Named("elide") Elide elide,
-                           @Named("elideUserExtractionFunction") DefaultOpaqueUserFunction getUser) {
+    public JsonApiEndpoint(
+            @Named("elide") Elide elide,
+            @Named("elideUserExtractionFunction") DefaultOpaqueUserFunction getUser) {
         this.elide = elide;
         this.getUser = getUser == null ? DEFAULT_GET_USER : getUser;
     }
@@ -57,7 +60,7 @@ public class JsonApiEndpoint {
      */
     @POST
     @Path("{path:.*}")
-    @Consumes("application/vnd.api+json")
+    @Consumes(JSONAPI_CONTENT_TYPE)
     public Response post(
         @PathParam("path") String path,
         @Context SecurityContext securityContext,
@@ -95,7 +98,7 @@ public class JsonApiEndpoint {
      */
     @PATCH
     @Path("{path:.*}")
-    @Consumes("application/vnd.api+json")
+    @Consumes(JSONAPI_CONTENT_TYPE)
     public Response patch(
         @HeaderParam("Content-Type") String contentType,
         @HeaderParam("accept") String accept,
@@ -115,7 +118,7 @@ public class JsonApiEndpoint {
      */
     @DELETE
     @Path("{path:.*}")
-    @Consumes("application/vnd.api+json")
+    @Consumes(JSONAPI_CONTENT_TYPE)
     public Response delete(
         @PathParam("path") String path,
         @Context SecurityContext securityContext,

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -294,7 +295,7 @@ public class LifeCycleTest {
 
         String bookBody = "{\"data\":{\"type\":\"book\",\"id\":1,\"attributes\": {\"title\":\"Grapes of Wrath\"}}}";
 
-        String contentType = "application/vnd.api+json";
+        String contentType = JSONAPI_CONTENT_TYPE;
         ElideResponse response = elide.patch(contentType, contentType, "/book/1", bookBody, null);
         assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
 
@@ -337,7 +338,7 @@ public class LifeCycleTest {
 
         String bookBody = "{\"data\":{\"type\":\"book\",\"id\":1,\"attributes\": {\"title\":\"Grapes of Wrath\"}}}";
 
-        String contentType = "application/vnd.api+json";
+        String contentType = JSONAPI_CONTENT_TYPE;
         ElideResponse response = elide.patch(contentType, contentType, "/book/1", bookBody, null);
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
         assertEquals(

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/BridgeableStoreTest.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/BridgeableStoreTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.datastores.multiplex;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -97,7 +98,7 @@ public class BridgeableStoreTest extends IntegrationTest {
     @Test
     public void testFetchBridgeableStoreToMany() {
         String result = given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/1?include=redisActions")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -111,14 +112,14 @@ public class BridgeableStoreTest extends IntegrationTest {
     @Test
     public void testFetchBridgeableStoreLoadSingleObjectToMany() {
         String result = given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/1/redisActions/1")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract().body().asString();
 
         given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/2/redisActions/3")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -132,7 +133,7 @@ public class BridgeableStoreTest extends IntegrationTest {
     @Test
     public void testFetchBridgeableStoreLoadSingleObjectFromBadSourceToMany() {
         String result = given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/1/redisActions/3")
                 .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND)
@@ -142,7 +143,7 @@ public class BridgeableStoreTest extends IntegrationTest {
     @Test
     public void testFetchBridgeableStoreToOne() {
         String result = given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/1?include=specialAction")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -156,14 +157,14 @@ public class BridgeableStoreTest extends IntegrationTest {
     @Test
     public void testFetchBridgeableStoreLoadSingleObjectToOne() {
         String result = given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/1/specialAction")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract().body().asString();
 
         given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/2/specialAction")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -177,7 +178,7 @@ public class BridgeableStoreTest extends IntegrationTest {
     @Test
     public void testFetchBridgeableStoreLoadSingleObjectFromBadSourceToOne() {
         given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/hibernateUser/1/redisActions/3")
                 .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND)

--- a/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/SearchDataStoreITTest.java
+++ b/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/SearchDataStoreITTest.java
@@ -6,14 +6,19 @@
 
 package com.yahoo.elide.datastores.search;
 
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.*;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.initialization.AbstractApiResourceInitializer;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -27,7 +32,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
     @Test
     public void getEscapedItem() {
         given()
-            .contentType("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
             .when()
             .get("/item?filter[item]=name==*-Luc*")
             .then()
@@ -39,7 +44,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
     public void testObjectIndexing() {
        /* Add a new item */
        given()
-           .contentType("application/vnd.api+json")
+           .contentType(JSONAPI_CONTENT_TYPE)
            .body(
                    data(
                        resource(
@@ -58,7 +63,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
 
         /* This query hits the index */
         given()
-            .contentType("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
             .when()
             .get("/item?filter[item]=name==*DrU*")
             .then()
@@ -67,7 +72,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
 
         /* This query hits the DB */
         given()
-            .contentType("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
             .when()
             .get("/item")
             .then()
@@ -76,7 +81,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
 
         /* Delete the newly added item */
         given()
-            .contentType("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
             .when()
             .delete("/item/1000")
             .then()
@@ -84,7 +89,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
 
         /* This query hits the index */
         given()
-            .contentType("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
             .when()
             .get("/item?filter[item]=name==*DrU*")
             .then()
@@ -93,7 +98,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
 
         /* This query hits the DB */
         given()
-            .contentType("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
             .when()
             .get("/item")
             .then()

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/assignedIdLongTests/AssignedIdLongIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/assignedIdLongTests/AssignedIdLongIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.assignedIdLongTests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -21,7 +22,6 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 public class AssignedIdLongIT extends IntegrationTest {
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     @Test
     public void testResponseCodeOnUpdate() {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/auditTests/AuditIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/auditTests/AuditIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.auditTests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -33,8 +34,6 @@ import org.junit.jupiter.api.Test;
  */
 public class AuditIT extends IntegrationTest {
     private final InMemoryLogger logger = AuditIntegrationTestApplicationResourceConfig.LOGGER;
-
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     public AuditIT() {
         super(AuditIntegrationTestApplicationResourceConfig.class, JsonApiEndpoint.class.getPackage().getName());

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.errorEncodingTests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
@@ -24,9 +26,6 @@ import org.junit.jupiter.api.Test;
 public class EncodedErrorObjectsIT extends IntegrationTest {
 
     private static final String GRAPHQL_CONTENT_TYPE = "application/json";
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
-    private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
-            "application/vnd.api+json; ext=jsonpatch";
     private final JsonParser jsonParser = new JsonParser();
 
     public EncodedErrorObjectsIT() {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorResponsesIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorResponsesIT.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.errorEncodingTests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
@@ -27,9 +29,6 @@ import org.junit.jupiter.api.Test;
 public class EncodedErrorResponsesIT extends IntegrationTest {
 
     private static final String GRAPHQL_CONTENT_TYPE = "application/json";
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
-    private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
-            "application/vnd.api+json; ext=jsonpatch";
     private final JsonParser jsonParser = new JsonParser();
 
     public EncodedErrorResponsesIT() {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.errorEncodingTests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
@@ -29,9 +31,6 @@ import org.junit.jupiter.api.Test;
 public class VerboseEncodedErrorResponsesIT extends IntegrationTest {
 
     private static final String GRAPHQL_CONTENT_TYPE = "application/json";
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
-    private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
-            "application/vnd.api+json; ext=jsonpatch";
     private final JsonParser jsonParser = new JsonParser();
 
     public VerboseEncodedErrorResponsesIT() {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorObjectsTests/ErrorObjectsIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorObjectsTests/ErrorObjectsIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.errorObjectsTests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
@@ -28,8 +29,6 @@ import javax.ws.rs.core.MediaType;
 
 public class ErrorObjectsIT extends IntegrationTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
-
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     public ErrorObjectsIT() {
         super(ErrorObjectsIntegrationTestApplicationResourceConfig.class, JsonApiEndpoint.class.getPackage().getName());

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/fieldLevelTest/FieldLevelParentClassIdIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/fieldLevelTest/FieldLevelParentClassIdIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.fieldLevelTest;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -23,8 +24,6 @@ import org.junit.jupiter.api.Test;
 
 public class FieldLevelParentClassIdIT extends IntegrationTest {
     private final JsonParser jsonParser = new JsonParser();
-
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     @Test
     public void testResponseCodeOnUpdate() {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/inheritance/InheritanceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/inheritance/InheritanceIT.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.inheritance;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
@@ -27,8 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class InheritanceIT extends IntegrationTest {
-
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     @Test
     public void testEmployeeHierarchy() {
@@ -74,7 +73,7 @@ public class InheritanceIT extends IntegrationTest {
                 );
 
         given()
-                .contentType("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
                 .when()
                 .get("/manager/1")
                 .then()

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/AnyPolymorphismIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import io.restassured.response.Response;
 
 public class AnyPolymorphismIT extends IntegrationTest {
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     private static final Resource TRACTOR_PROPERTY = resource(
             type("property"),

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/BookAuthorIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/BookAuthorIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 
 public class BookAuthorIT extends IntegrationTest {
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     private static final String ATTRIBUTES = "attributes";
     private static final String RELATIONSHIPS = "relationships";

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
@@ -30,8 +31,6 @@ import java.util.Locale;
 import java.util.Set;
 
 public class FilterIT extends IntegrationTest {
-
-    private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION = "application/vnd.api+json; ext=jsonpatch";
 
     private final JsonParser jsonParser = new JsonParser();
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GenerateIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GenerateIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
@@ -32,8 +33,8 @@ class GenerateIT extends IntegrationTest {
         );
 
         given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .body(datum(resource))
             .post("/generate")
             .then()

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/MapEnumIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/MapEnumIT.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -42,8 +44,8 @@ class MapEnumIT extends IntegrationTest {
                 )
         );
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(datum(resource))
                 .post("/mapColorShape")
                 .then()
@@ -55,14 +57,14 @@ class MapEnumIT extends IntegrationTest {
 
         // Update MapColorShape using Patch
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(datum(resource))
                 .patch("/mapColorShape/1")
                 .then().statusCode(HttpStatus.SC_NO_CONTENT);
 
         given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/mapColorShape/1")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -84,8 +86,8 @@ class MapEnumIT extends IntegrationTest {
         );
         // Create MapColorShape using Patch extension
         given()
-                .contentType("application/vnd.api+json; ext=jsonpatch")
-                .accept("application/vnd.api+json; ext=jsonpatch")
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body("[\n"
                         + "{\n"
                         + "  \"op\": \"add\",\n"
@@ -106,7 +108,7 @@ class MapEnumIT extends IntegrationTest {
                 .statusCode(HttpStatus.SC_OK);
 
         given()
-                .accept("application/vnd.api+json")
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/mapColorShape/1")
                 .then()
                 .statusCode(HttpStatus.SC_OK)

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -62,8 +64,8 @@ class PaginateIT extends IntegrationTest {
     private void createPaginationEntities() {
         BiConsumer<String, Integer> createEntities = (type, numberOfEntities) -> {
             IntStream.range(0, numberOfEntities).forEach(value -> given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                     datum(
                         resource(
@@ -102,8 +104,8 @@ class PaginateIT extends IntegrationTest {
         String tempPubId = "12345678-1234-1234-1234-1234567890ae";
 
         given()
-            .contentType("application/vnd.api+json; ext=jsonpatch")
-            .accept("application/vnd.api+json; ext=jsonpatch")
+            .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+            .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
             .body(
                 patchSet(
                     patchOperation(add, "/author", resource(
@@ -157,8 +159,8 @@ class PaginateIT extends IntegrationTest {
             .statusCode(OK_200);
 
         given()
-            .contentType("application/vnd.api+json; ext=jsonpatch")
-            .accept("application/vnd.api+json; ext=jsonpatch")
+            .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+            .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
             .body(
                 patchSet(
                     patchOperation(add, "/author", resource(
@@ -201,8 +203,8 @@ class PaginateIT extends IntegrationTest {
             .statusCode(OK_200);
 
         given()
-            .contentType("application/vnd.api+json; ext=jsonpatch")
-            .accept("application/vnd.api+json; ext=jsonpatch")
+            .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+            .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
             .body(
                 patchSet(
                     patchOperation(add, "/author", resource(
@@ -243,8 +245,8 @@ class PaginateIT extends IntegrationTest {
             .statusCode(OK_200);
 
         given()
-            .contentType("application/vnd.api+json; ext=jsonpatch")
-            .accept("application/vnd.api+json; ext=jsonpatch")
+            .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+            .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
             .body(
                 patchSet(
                     patchOperation(add, "/author", resource(
@@ -299,8 +301,8 @@ class PaginateIT extends IntegrationTest {
         String tempSpouseId = "12345678-1234-1234-1234-1234567890af";
 
         given()
-            .contentType("application/vnd.api+json; ext=jsonpatch")
-            .accept("application/vnd.api+json; ext=jsonpatch")
+            .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+            .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
             .body(
                 patchSet(
                     patchOperation(add, "/parent", resource(

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
@@ -84,9 +86,6 @@ import javax.ws.rs.core.Response.Status;
  * The type Config resource test.
  */
 public class ResourceIT extends IntegrationTest {
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
-    private static final String JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION =
-            "application/vnd.api+json; ext=jsonpatch";
     private final JsonParser jsonParser = new JsonParser();
 
     private static final Resource PARENT1 = resource(

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ShareableIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ShareableIT.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
@@ -52,8 +54,8 @@ class ShareableIT extends IntegrationTest {
     public void testUnshareableForbiddenAccess() {
         // Create container
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -67,8 +69,8 @@ class ShareableIT extends IntegrationTest {
 
         // Create unshareable
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -82,8 +84,8 @@ class ShareableIT extends IntegrationTest {
 
         // Fail to add unshareable to container's unshareables (unshareable is not shareable)
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -98,8 +100,8 @@ class ShareableIT extends IntegrationTest {
 
         // Fail to replace container's unshareables collection (unshareable is not shareable)
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -114,8 +116,8 @@ class ShareableIT extends IntegrationTest {
 
         // Fail to update unshareable's container (container is not shareable)
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -130,8 +132,8 @@ class ShareableIT extends IntegrationTest {
 
         // Fail to set unshareable's container (container is not shareable)
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -149,8 +151,8 @@ class ShareableIT extends IntegrationTest {
     public void testShareableForbiddenAccess() {
         // Create container
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -165,8 +167,8 @@ class ShareableIT extends IntegrationTest {
 
         // Create shareable
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -181,8 +183,8 @@ class ShareableIT extends IntegrationTest {
 
         // Fail to update shareable's container (container is not shareable)
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -197,8 +199,8 @@ class ShareableIT extends IntegrationTest {
 
         // Fail to set shareable's container (container is not shareable)
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -216,8 +218,8 @@ class ShareableIT extends IntegrationTest {
     public void testShareablePost() {
         // Create container
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -232,8 +234,8 @@ class ShareableIT extends IntegrationTest {
 
         // Create shareable
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -248,8 +250,8 @@ class ShareableIT extends IntegrationTest {
 
         // Add shareable to container's shareables
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -263,8 +265,8 @@ class ShareableIT extends IntegrationTest {
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/container/1")
                 .then().statusCode(HttpStatus.SC_OK)
                 .body(equalTo(datum(
@@ -285,8 +287,8 @@ class ShareableIT extends IntegrationTest {
     public void testShareablePatch() {
         // Create container
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(datum(
                         resource(
                                 type("container"),
@@ -298,8 +300,8 @@ class ShareableIT extends IntegrationTest {
 
         // Create shareable
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(datum(
                         resource(
                                 type("shareable"),
@@ -311,8 +313,8 @@ class ShareableIT extends IntegrationTest {
 
         // Add shareable to container's shareables
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(datum(
                         resource(
                                 type("shareable"),
@@ -324,8 +326,8 @@ class ShareableIT extends IntegrationTest {
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .get("/container/1")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -346,8 +348,8 @@ class ShareableIT extends IntegrationTest {
     @Test
     public void testCreateContainerAndUnshareables() throws Exception {
         Response response = given()
-                .contentType("application/vnd.api+json; ext=jsonpatch")
-                .accept("application/vnd.api+json; ext=jsonpatch")
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body("    [\n"
                         + "      {\n"
                         + "        \"op\": \"add\",\n"
@@ -408,8 +410,8 @@ class ShareableIT extends IntegrationTest {
     @Test
     public void testCreateContainerAndShareables() throws Exception {
         Response patchResponse = given()
-                .contentType("application/vnd.api+json; ext=jsonpatch")
-                .accept("application/vnd.api+json; ext=jsonpatch")
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body("    [\n"
                         + "      {\n"
                         + "        \"op\": \"add\",\n"
@@ -470,8 +472,8 @@ class ShareableIT extends IntegrationTest {
     @Test
     public void addUnsharedRelationship() {
         given()
-                .contentType("application/vnd.api+json")
-                .accept("application/vnd.api+json")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
                 .body(
                         datum(
                                 resource(

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -27,28 +28,28 @@ public class SortingIT extends IntegrationTest {
     public void setup() {
 
         given()
-                .contentType("application/vnd.api+json; ext=jsonpatch")
-                .accept("application/vnd.api+json; ext=jsonpatch")
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(jsonParser.getJson("/SortingIT/addAuthorBookPublisher1.json"))
                 .patch("/");
 
 
         given()
-                .contentType("application/vnd.api+json; ext=jsonpatch")
-                .accept("application/vnd.api+json; ext=jsonpatch")
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(jsonParser.getJson("/SortingIT/addAuthorBookPublisher2.json"))
                 .patch("/");
 
         given()
-                .contentType("application/vnd.api+json; ext=jsonpatch")
-                .accept("application/vnd.api+json; ext=jsonpatch")
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(jsonParser.getJson("/SortingIT/addAuthorBookPublisher3.json"))
                 .patch("/");
 
 
         given()
-                .contentType("application/vnd.api+json; ext=jsonpatch")
-                .accept("application/vnd.api+json; ext=jsonpatch")
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
                 .body(jsonParser.getJson("/SortingIT/addAuthorBookPublisher4.json"))
                 .patch("/");
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/UserTypeIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/UserTypeIT.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.tests;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -64,16 +65,16 @@ class UserTypeIT extends IntegrationTest {
         );
 
         given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .body(datum(resource))
             .post("/person")
             .then()
             .statusCode(HttpStatus.SC_CREATED);
 
         String actual = given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .get("/person/1")
             .then()
             .statusCode(HttpStatus.SC_OK)
@@ -112,24 +113,24 @@ class UserTypeIT extends IntegrationTest {
         );
 
         given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .body(datum(original))
             .post("/person")
             .then()
             .statusCode(HttpStatus.SC_CREATED);
 
         given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .body(datum(modified))
             .patch("/person/2")
             .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
 
         String actual = given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .get("/person/2")
             .then()
             .statusCode(HttpStatus.SC_OK).extract().body().asString();
@@ -158,16 +159,16 @@ class UserTypeIT extends IntegrationTest {
 
 
         given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .body(datum(resource))
             .post("/person")
             .then()
             .statusCode(HttpStatus.SC_CREATED);
 
         String actual = given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .get("/person/3")
             .then()
             .statusCode(HttpStatus.SC_OK).extract().body().asString();
@@ -208,16 +209,16 @@ class UserTypeIT extends IntegrationTest {
         );
 
         given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .body(datum(resource))
             .post("/person")
             .then()
             .statusCode(HttpStatus.SC_CREATED);
 
         String actual = given()
-            .contentType("application/vnd.api+json")
-            .accept("application/vnd.api+json")
+            .contentType(JSONAPI_CONTENT_TYPE)
+            .accept(JSONAPI_CONTENT_TYPE)
             .get("/person/4")
             .then()
             .statusCode(HttpStatus.SC_OK).extract().body().asString();

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/triggers/LifeCycleHookIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/triggers/LifeCycleHookIT.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.triggers;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
@@ -25,12 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
 public class LifeCycleHookIT extends IntegrationTest {
-
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     @BeforeEach
     public void resetMocks() {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.spring.controllers;
 
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.spring.config.ElideConfigProperties;
@@ -42,7 +44,7 @@ public class JsonApiController {
 
     private final Elide elide;
     private final ElideConfigProperties settings;
-    public static final String JSON_API_CONTENT_TYPE = "application/vnd.api+json";
+    public static final String JSON_API_CONTENT_TYPE = JSONAPI_CONTENT_TYPE;
 
     @Autowired
     public JsonApiController(Elide elide, ElideConfigProperties settings) {

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -11,18 +11,17 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.hasKey;
 
+import com.google.common.collect.Maps;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import com.yahoo.elide.standalone.models.Post;
-
-import com.google.common.collect.Maps;
 import io.swagger.models.Info;
 import io.swagger.models.Swagger;
-
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -39,8 +38,6 @@ import java.util.Properties;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ElideStandaloneTest {
     private ElideStandalone elide;
-
-    private static final String JSONAPI_CONTENT_TYPE = "application/vnd.api+json";
 
     @BeforeAll
     public void init() throws Exception {


### PR DESCRIPTION
## Description
Move string constants for JSONAPI content types to one location.

## Motivation and Context
Stability

## How Has This Been Tested?
Build, unit tests

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.