### PR TITLE
Added IsEmpty operation for filter predicate

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/FilterPredicate.java
@@ -51,6 +51,14 @@ public class FilterPredicate implements FilterExpression, Function<RequestScope,
                 .anyMatch(RelationshipType::isToMany);
     }
 
+    public static boolean toManyInPathExceptLastPathElement(EntityDictionary dictionary, Path path) {
+        int pathLength = path.getPathElements().size();
+        return path.getPathElements().stream()
+                .limit(pathLength - 1)
+                .map(element -> dictionary.getRelationshipType(element.getType(), element.getFieldName()))
+                .anyMatch(RelationshipType::isToMany);
+    }
+
     public FilterPredicate(PathElement pathElement, Operator op, List<Object> values) {
         this(new Path(Collections.singletonList(pathElement)), op, values);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/IsEmptyPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/IsEmptyPredicate.java
@@ -10,7 +10,7 @@ import com.yahoo.elide.core.Path;
 import java.util.Collections;
 
 /**
- * Is EMopty Predicate calss
+ * Is EMopty Predicate Class.
  */
 public class IsEmptyPredicate extends FilterPredicate {
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/IsEmptyPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/IsEmptyPredicate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+
+import java.util.Collections;
+
+/**
+ * Is EMopty Predicate calss
+ */
+public class IsEmptyPredicate extends FilterPredicate {
+
+    public IsEmptyPredicate(Path path) {
+        super(path, Operator.ISEMPTY, Collections.emptyList());
+    }
+
+    public IsEmptyPredicate(Path.PathElement pathElement) {
+        super(pathElement, Operator.ISEMPTY, Collections.emptyList());
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/IsEmptyPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/IsEmptyPredicate.java
@@ -10,7 +10,7 @@ import com.yahoo.elide.core.Path;
 import java.util.Collections;
 
 /**
- * Is EMopty Predicate Class.
+ * Is Empty Predicate Class.
  */
 public class IsEmptyPredicate extends FilterPredicate {
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotEmptyPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotEmptyPredicate.java
@@ -10,7 +10,7 @@ import com.yahoo.elide.core.Path;
 import java.util.Collections;
 
 /**
- * Not Empty Predicate Class
+ * Not Empty Predicate Class.
  */
 public class NotEmptyPredicate extends FilterPredicate {
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/NotEmptyPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/NotEmptyPredicate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+
+import java.util.Collections;
+
+/**
+ * Not Empty Predicate Class
+ */
+public class NotEmptyPredicate extends FilterPredicate {
+
+    public NotEmptyPredicate(Path path) {
+        super(path, Operator.NOTEMPTY, Collections.emptyList());
+    }
+
+    public NotEmptyPredicate(Path.PathElement pathElement) {
+        super(pathElement, Operator.NOTEMPTY, Collections.emptyList());
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -336,6 +336,7 @@ public enum Operator {
 
     private static <T> Predicate<T> isEmpty(String field, RequestScope requestScope) {
         return (T entity) -> {
+
             Object val = getFieldValue(entity, field, requestScope);
             if (val == null) { return true; }
             if (val instanceof String) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -14,8 +14,10 @@ import com.yahoo.elide.utils.coerce.CoerceUtil;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -150,6 +152,20 @@ public enum Operator {
             return isFalse();
         }
     },
+
+    ISEMPTY("isempty", false) {
+        @Override
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
+            return isEmpty(field, requestScope);
+        }
+    },
+
+    NOTEMPTY("notempty", false) {
+        @Override
+        public <T> Predicate<T> contextualize(String field, List<Object> values, RequestScope requestScope) {
+            return (entity) -> !isEmpty(field, requestScope).test(entity);
+        }
+    }
     ;
 
     public static final Function<String, String> FOLD_CASE = s -> s.toLowerCase(Locale.ENGLISH);
@@ -171,6 +187,8 @@ public enum Operator {
         FALSE.negated = TRUE;
         ISNULL.negated = NOTNULL;
         NOTNULL.negated = ISNULL;
+        ISEMPTY.negated = NOTEMPTY;
+        NOTEMPTY.negated = ISEMPTY;
     }
 
     /**
@@ -314,6 +332,24 @@ public enum Operator {
 
     private static <T> Predicate<T> isFalse() {
         return (T entity) -> false;
+    }
+
+    private static <T> Predicate<T> isEmpty(String field, RequestScope requestScope) {
+        return (T entity) -> {
+            Object val = getFieldValue(entity, field, requestScope);
+            if (val == null) { return true; }
+            if (val instanceof String) {
+                return ((String) val).isEmpty();
+            }
+            if (val instanceof Collection<?>) {
+                return ((Collection<?>) val).isEmpty();
+            }
+            if (val instanceof Map<?, ?>) {
+                return ((Map<?, ?>) val).isEmpty();
+            }
+
+            return false;
+        };
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -338,7 +338,7 @@ public enum Operator {
         return (T entity) -> {
 
             Object val = getFieldValue(entity, field, requestScope);
-            if (val == null) { return true; }
+            if (val == null) { return false; }
             if (val instanceof Collection<?>) {
                 return ((Collection<?>) val).isEmpty();
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -339,9 +339,6 @@ public enum Operator {
 
             Object val = getFieldValue(entity, field, requestScope);
             if (val == null) { return true; }
-            if (val instanceof String) {
-                return ((String) val).isEmpty();
-            }
             if (val instanceof Collection<?>) {
                 return ((Collection<?>) val).isEmpty();
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
@@ -14,8 +14,6 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.parsers.JsonApiParser;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 
-import com.google.common.collect.ImmutableList;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,11 +29,6 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDialect {
     private final EntityDictionary dictionary;
-    private final ImmutableList<Operator> toManyAllowedOperators = ImmutableList.of(
-            Operator.ISEMPTY,
-            Operator.NOTEMPTY
-    );
-
     public DefaultFilterDialect(EntityDictionary dictionary) {
         this.dictionary = dictionary;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
@@ -196,6 +196,12 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
         return new Path(path);
     }
 
+    /**
+     * Check if the relation type in filter predicate is allowed for an operator.
+     * Defaults behavior is to prevent filter on toMany relationship.
+     * @param filterPredicate
+     * @throws ParseException
+     */
     private void validateFilterPredicate(FilterPredicate filterPredicate) throws ParseException {
         switch (filterPredicate.getOperator()) {
             case ISEMPTY:
@@ -209,6 +215,12 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
         }
     }
 
+    /**
+     * Check if the predicate has toMany relationship that is not target relationship
+     * on which the empty check is performed.
+     * @param filterPredicate
+     * @throws ParseException
+     */
     private void emptyOperatorConditions(FilterPredicate filterPredicate) throws ParseException {
         if (FilterPredicate.toManyInPathExceptLastPathElement(dictionary, filterPredicate.getPath())) {
             throw new ParseException(

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
@@ -14,6 +14,8 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.parsers.JsonApiParser;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,6 +31,10 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDialect {
     private final EntityDictionary dictionary;
+    private final ImmutableList<Operator> toManyAllowedOperators = ImmutableList.of(
+            Operator.ISEMPTY,
+            Operator.NOTEMPTY
+    );
 
     public DefaultFilterDialect(EntityDictionary dictionary) {
         this.dictionary = dictionary;
@@ -128,7 +134,8 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
         List<FilterPredicate> filterPredicates = extractPredicates(filterParams);
 
         for (FilterPredicate filterPredicate : filterPredicates) {
-            if (FilterPredicate.toManyInPath(dictionary, filterPredicate.getPath())) {
+            if (FilterPredicate.toManyInPath(dictionary, filterPredicate.getPath())
+                    && !toManyAllowedOperators.contains(filterPredicate.getOperator())) {
                 throw new ParseException("Invalid toMany join: " + filterPredicate);
             }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -291,6 +291,11 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
             //handles '=isempty=' op before coerce arguments
             // ToMany Association is allowed if the operation in Is Empty
             if (op.equals(ISEMPTY_OP)) {
+                if (FilterPredicate.toManyInPathExceptLastPathElement(dictionary, path)) {
+                    throw new RSQLParseException(
+                            String.format("Invalid association %s. toMany association has to be the target collection.",
+                                    relationship));
+                }
                 return buildIsEmptyOperator(path, arguments);
             }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -288,6 +288,12 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
             List<String> arguments = node.getArguments();
             Path path = buildPath(entityType, relationship);
 
+            //handles '=isempty=' op before coerce arguments
+            // ToMany Association is allowed if the operation in Is Empty
+            if (op.equals(ISEMPTY_OP)) {
+                return buildIsEmptyOperator(path, arguments);
+            }
+
             if (FilterPredicate.toManyInPath(dictionary, path) && !allowNestedToManyAssociations) {
                 throw new RSQLParseException(String.format("Invalid association %s", relationship));
             }
@@ -295,11 +301,6 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
             //handles '=isnull=' op before coerce arguments
             if (op.equals(ISNULL_OP)) {
                 return buildIsNullOperator(path, arguments);
-            }
-
-            //handles '=isempty=' op before coerce arguments
-            if (op.equals(ISEMPTY_OP)) {
-                return buildIsEmptyOperator(path, arguments);
             }
 
             Class<?> relationshipType = path.lastElement()

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -381,7 +381,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
         /**
          * Returns Predicate for '=isempty=' case depending on its arguments.
          * <p>
-         * NOTE: Filter Expression builder specially for '=isnull=' case.
+         * NOTE: Filter Expression builder specially for '=isempty=' case.
          *
          * @return
          */
@@ -394,7 +394,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
                 }
                 return new NotEmptyPredicate(path);
             } catch (InvalidValueException ignored) {
-                throw new RSQLParseException(String.format("Invalid value for operator =isnull= '%s'", arg));
+                throw new RSQLParseException(String.format("Invalid value for operator =isempty= '%s'", arg));
             }
         }
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -291,7 +291,8 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
             //handles '=isempty=' op before coerce arguments
             // ToMany Association is allowed if the operation in Is Empty
             if (op.equals(ISEMPTY_OP)) {
-                if (FilterPredicate.toManyInPathExceptLastPathElement(dictionary, path)) {
+                if (FilterPredicate.toManyInPathExceptLastPathElement(dictionary, path)
+                        && !allowNestedToManyAssociations) {
                     throw new RSQLParseException(
                             String.format("Invalid association %s. toMany association has to be the target collection.",
                                     relationship));

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -16,6 +16,8 @@ import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.security.checks.Check;
 import example.Author;
+import example.Book;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -114,6 +116,37 @@ public class OperatorTest {
         assertTrue(fn.test(author));
         fn = Operator.NOTNULL.contextualize("name", null, requestScope);
         assertFalse(fn.test(author));
+    }
+
+    @Test
+    public void isemptyAndNotemptyTest() throws Exception {
+        author = new Author();
+        author.setId(1L);
+        author.setName("AuthorForTest");
+        author.getBooks().add(new Book());
+
+        fn = Operator.ISEMPTY.contextualize("name", null, requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.ISEMPTY.contextualize("books", null, requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOTEMPTY.contextualize("name", null, requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.NOTEMPTY.contextualize("books", null, requestScope);
+        assertTrue(fn.test(author));
+
+
+        //name is null and books are null
+        author.setBooks(null);
+        author.setName(null);
+        fn = Operator.ISEMPTY.contextualize("name", null, requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.ISEMPTY.contextualize("books", null, requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.NOTEMPTY.contextualize("name", null, requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOTEMPTY.contextualize("books", null, requestScope);
+        assertFalse(fn.test(author));
+
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -122,14 +122,14 @@ public class OperatorTest {
     public void isemptyAndNotemptyTest() throws Exception {
         author = new Author();
         author.setId(1L);
-        author.setName("AuthorForTest");
+        author.setAwards(Arrays.asList("Booker Prize", "National Book Awards"));
         author.getBooks().add(new Book());
 
-        fn = Operator.ISEMPTY.contextualize("name", null, requestScope);
+        fn = Operator.ISEMPTY.contextualize("awards", null, requestScope);
         assertFalse(fn.test(author));
         fn = Operator.ISEMPTY.contextualize("books", null, requestScope);
         assertFalse(fn.test(author));
-        fn = Operator.NOTEMPTY.contextualize("name", null, requestScope);
+        fn = Operator.NOTEMPTY.contextualize("awards", null, requestScope);
         assertTrue(fn.test(author));
         fn = Operator.NOTEMPTY.contextualize("books", null, requestScope);
         assertTrue(fn.test(author));
@@ -137,15 +137,15 @@ public class OperatorTest {
 
         //name is null and books are null
         author.setBooks(null);
-        author.setName(null);
-        fn = Operator.ISEMPTY.contextualize("name", null, requestScope);
+        author.setAwards(Arrays.asList());
+        fn = Operator.ISEMPTY.contextualize("awards", null, requestScope);
         assertTrue(fn.test(author));
         fn = Operator.ISEMPTY.contextualize("books", null, requestScope);
-        assertTrue(fn.test(author));
-        fn = Operator.NOTEMPTY.contextualize("name", null, requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOTEMPTY.contextualize("awards", null, requestScope);
         assertFalse(fn.test(author));
         fn = Operator.NOTEMPTY.contextualize("books", null, requestScope);
-        assertFalse(fn.test(author));
+        assertTrue(fn.test(author));
 
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -124,4 +124,17 @@ public class DefaultFilterDialectTest {
 
         assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams));
     }
+
+    @Test
+    public void testEmptyOperatorException() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter[book.authors.name][isempty]",
+                ""
+        );
+
+        assertThrows(ParseException.class,
+                () -> dialect.parseTypedExpression("/book", queryParams));
+    }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.core.filter.dialect;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -366,5 +367,18 @@ public class RSQLFilterDialectTest {
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
 
         assertEquals("book.title NOTEMPTY []", expression.toString());
+    }
+
+    @Test
+    public void testEmptyOperatorException() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "authors.name=isempty=0"
+        );
+
+        assertThrows(ParseException.class,
+                () -> dialect.parseGlobalExpression("/book", queryParams));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -379,6 +379,6 @@ public class RSQLFilterDialectTest {
         );
 
         assertThrows(ParseException.class,
-                () -> dialect.parseGlobalExpression("/book", queryParams));
+                () -> dialect.parseTypedExpression("/book", queryParams));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -309,4 +309,62 @@ public class RSQLFilterDialectTest {
                 "primitiveId.primitiveId INFIX_CASE_INSENSITIVE [1]"
         );
     }
+
+    //TODO: add test for =isempty= case
+
+    @Test
+    public void testIsemptyOperatorBool() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=isempty=true"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        assertEquals("book.title ISEMPTY []", expression.toString());
+    }
+
+    @Test
+    public void testIsemptyOperatorInt() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "authors=isempty=1"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        assertEquals("book.authors ISEMPTY []", expression.toString());
+    }
+
+    @Test
+    public void testNotemptyOperatorBool() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "authors=isempty=false"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        assertEquals("book.authors NOTEMPTY []", expression.toString());
+    }
+
+    @Test
+    public void testNotemptyOperatorInt() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "title=isempty=0"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+
+        assertEquals("book.title NOTEMPTY []", expression.toString());
+    }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterExecutorTest.java
@@ -19,9 +19,11 @@ import com.yahoo.elide.core.filter.InInsensitivePredicate;
 import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.InfixInsensitivePredicate;
 import com.yahoo.elide.core.filter.InfixPredicate;
+import com.yahoo.elide.core.filter.IsEmptyPredicate;
 import com.yahoo.elide.core.filter.IsNullPredicate;
 import com.yahoo.elide.core.filter.LEPredicate;
 import com.yahoo.elide.core.filter.LTPredicate;
+import com.yahoo.elide.core.filter.NotEmptyPredicate;
 import com.yahoo.elide.core.filter.NotInInsensitivePredicate;
 import com.yahoo.elide.core.filter.NotInPredicate;
 import com.yahoo.elide.core.filter.NotNullPredicate;
@@ -31,11 +33,14 @@ import com.yahoo.elide.core.filter.PrefixInsensitivePredicate;
 import com.yahoo.elide.core.filter.PrefixPredicate;
 import com.yahoo.elide.core.filter.TruePredicate;
 import example.Author;
+import example.Book;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -52,6 +57,7 @@ public class InMemoryFilterExecutorTest {
 
     private PathElement authorIdElement = new PathElement(Author.class, Long.class, "id");
     private PathElement authorNameElement = new PathElement(Author.class, String.class, "name");
+    private PathElement authorBooksElement = new PathElement(Author.class, Book.class, "books");
     private List<Object> listNine = Collections.singletonList("9");
     private List<Object> listTen = Collections.singletonList("10");
     private List<Object> listEleven = Collections.singletonList("11");
@@ -174,6 +180,48 @@ public class InMemoryFilterExecutorTest {
         expression = new NotNullPredicate(authorNameElement);
         fn = expression.accept(visitor);
         assertFalse(fn.test(author));
+    }
+
+    //TODO: isEmptyAndNotEmpty
+    @Test
+    public void isemptyAndNotemptyPredicateTest() throws Exception {
+        author = new Author();
+        author.setId(1L);
+        // When name is empty and books are empty
+        author.setBooks(new HashSet<>());
+
+        expression = new IsEmptyPredicate(authorNameElement);
+        fn = expression.accept(visitor);
+        assertTrue(fn.test(author));
+        expression = new IsEmptyPredicate(authorBooksElement);
+        fn = expression.accept(visitor);
+        assertTrue(fn.test(author));
+
+        expression = new NotEmptyPredicate(authorNameElement);
+        fn = expression.accept(visitor);
+        assertFalse(fn.test(author));
+        expression = new NotEmptyPredicate(authorBooksElement);
+        fn = expression.accept(visitor);
+        assertFalse(fn.test(author));
+
+
+        // When name and books are not empty
+        author.setName("AuthorForTest");
+        author.getBooks().add(new Book());
+
+        expression = new IsEmptyPredicate(authorNameElement);
+        fn = expression.accept(visitor);
+        assertFalse(fn.test(author));
+        expression = new IsEmptyPredicate(authorBooksElement);
+        fn = expression.accept(visitor);
+        assertFalse(fn.test(author));
+
+        expression = new NotEmptyPredicate(authorNameElement);
+        fn = expression.accept(visitor);
+        assertTrue(fn.test(author));
+        expression = new NotEmptyPredicate(authorBooksElement);
+        fn = expression.accept(visitor);
+        assertTrue(fn.test(author));
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterExecutorTest.java
@@ -38,6 +38,7 @@ import example.Book;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,6 +59,7 @@ public class InMemoryFilterExecutorTest {
     private PathElement authorIdElement = new PathElement(Author.class, Long.class, "id");
     private PathElement authorNameElement = new PathElement(Author.class, String.class, "name");
     private PathElement authorBooksElement = new PathElement(Author.class, Book.class, "books");
+    private PathElement authorAwardsElement = new PathElement(Author.class, String.class, "awards");
     private List<Object> listNine = Collections.singletonList("9");
     private List<Object> listTen = Collections.singletonList("10");
     private List<Object> listEleven = Collections.singletonList("11");
@@ -182,22 +184,22 @@ public class InMemoryFilterExecutorTest {
         assertFalse(fn.test(author));
     }
 
-    //TODO: isEmptyAndNotEmpty
     @Test
     public void isemptyAndNotemptyPredicateTest() throws Exception {
         author = new Author();
         author.setId(1L);
         // When name is empty and books are empty
         author.setBooks(new HashSet<>());
+        author.setAwards(new HashSet<>());
 
-        expression = new IsEmptyPredicate(authorNameElement);
+        expression = new IsEmptyPredicate(authorAwardsElement);
         fn = expression.accept(visitor);
         assertTrue(fn.test(author));
         expression = new IsEmptyPredicate(authorBooksElement);
         fn = expression.accept(visitor);
         assertTrue(fn.test(author));
 
-        expression = new NotEmptyPredicate(authorNameElement);
+        expression = new NotEmptyPredicate(authorAwardsElement);
         fn = expression.accept(visitor);
         assertFalse(fn.test(author));
         expression = new NotEmptyPredicate(authorBooksElement);
@@ -206,17 +208,17 @@ public class InMemoryFilterExecutorTest {
 
 
         // When name and books are not empty
-        author.setName("AuthorForTest");
+        author.setAwards(Arrays.asList("Bookery prize"));
         author.getBooks().add(new Book());
 
-        expression = new IsEmptyPredicate(authorNameElement);
+        expression = new IsEmptyPredicate(authorAwardsElement);
         fn = expression.accept(visitor);
         assertFalse(fn.test(author));
         expression = new IsEmptyPredicate(authorBooksElement);
         fn = expression.accept(visitor);
         assertFalse(fn.test(author));
 
-        expression = new NotEmptyPredicate(authorNameElement);
+        expression = new NotEmptyPredicate(authorAwardsElement);
         fn = expression.accept(visitor);
         assertTrue(fn.test(author));
         expression = new NotEmptyPredicate(authorBooksElement);

--- a/elide-core/src/test/java/example/Author.java
+++ b/elide-core/src/test/java/example/Author.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.UUID;
 
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -76,4 +77,8 @@ public class Author {
 
     @Getter @Setter
     private Address homeAddress;
+
+    @ElementCollection
+    @Getter @Setter
+    private Collection<String> awards;
 }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
@@ -12,10 +12,12 @@ import static com.yahoo.elide.core.filter.Operator.IN;
 import static com.yahoo.elide.core.filter.Operator.INFIX;
 import static com.yahoo.elide.core.filter.Operator.INFIX_CASE_INSENSITIVE;
 import static com.yahoo.elide.core.filter.Operator.IN_INSENSITIVE;
+import static com.yahoo.elide.core.filter.Operator.ISEMPTY;
 import static com.yahoo.elide.core.filter.Operator.ISNULL;
 import static com.yahoo.elide.core.filter.Operator.LE;
 import static com.yahoo.elide.core.filter.Operator.LT;
 import static com.yahoo.elide.core.filter.Operator.NOT;
+import static com.yahoo.elide.core.filter.Operator.NOTEMPTY;
 import static com.yahoo.elide.core.filter.Operator.NOTNULL;
 import static com.yahoo.elide.core.filter.Operator.NOT_INSENSITIVE;
 import static com.yahoo.elide.core.filter.Operator.POSTFIX;
@@ -159,6 +161,15 @@ public class FilterTranslator implements FilterOperation<String> {
         operatorGenerators.put(FALSE, (columnAlias, params) -> {
             return "(1 = 0)";
         });
+
+        operatorGenerators.put(ISEMPTY, (columnAlias, params) -> {
+            return String.format("%s IS EMPTY", columnAlias);
+        });
+
+        operatorGenerators.put(NOTEMPTY, (columnAlias, params) -> {
+            return String.format("%s IS NOT EMPTY", columnAlias);
+        });
+
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -37,6 +37,11 @@ public class FilterTranslatorTest {
 
     @Test
     public void testHQLQueryVisitor() throws Exception {
+        List<Path.PathElement> p0Path = Arrays.asList(
+                new Path.PathElement(Book.class, Author.class, "authors")
+        );
+        FilterPredicate p0 = new NotEmptyPredicate(new Path(p0Path));
+
         List<Path.PathElement> p1Path = Arrays.asList(
                 new Path.PathElement(Book.class, Author.class, "authors"),
                 new Path.PathElement(Author.class, String.class, "name")
@@ -54,8 +59,9 @@ public class FilterTranslatorTest {
         FilterPredicate p3 = new InPredicate(new Path(p3Path), "scifi");
 
         OrFilterExpression or = new OrFilterExpression(p2, p3);
-        AndFilterExpression and = new AndFilterExpression(or, p1);
-        NotFilterExpression not = new NotFilterExpression(and);
+        AndFilterExpression and1 = new AndFilterExpression(p0, p1);
+        AndFilterExpression and2 = new AndFilterExpression(or, and1);
+        NotFilterExpression not = new NotFilterExpression(and2);
 
         FilterTranslator filterOp = new FilterTranslator();
         String query = filterOp.apply(not, false);
@@ -67,7 +73,7 @@ public class FilterTranslatorTest {
         String p3Params = p3.getParameters().stream()
                 .map(FilterPredicate.FilterParameter::getPlaceholder).collect(Collectors.joining(", "));
         String expected = "WHERE NOT (((name IN (" + p2Params + ") OR genre IN (" + p3Params + ")) "
-                + "AND authors.name IN (" + p1Params + ")))";
+                + "AND (authors IS NOT EMPTY AND authors.name IN (" + p1Params + "))))";
         assertEquals(expected, query);
     }
 

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -40,6 +40,7 @@
 
     <properties>
         <dataStoreHarness>com.yahoo.elide.datastores.hibernate3.HibernateDataStoreHarness</dataStoreHarness>
+        <excludeTags>emptyOnAttributeCollection</excludeTags>
     </properties>
 
     <dependencies>
@@ -190,6 +191,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <excludeTags>${excludeTags}</excludeTags>
+                    </properties>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -186,16 +186,12 @@
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <failIfNoTests>true</failIfNoTests>
+                    <excludedGroups>${excludeTags}</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <properties>
-                        <excludeTags>${excludeTags}</excludeTags>
-                    </properties>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -247,16 +247,12 @@
                     <reuseForks>true</reuseForks>
                     <trimStackTrace>false</trimStackTrace>
                     <failIfNoTests>true</failIfNoTests>
+                    <excludedGroups>${excludeTags}</excludedGroups>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <properties>
-                        <excludeTags>${excludeTags}</excludeTags>
-                    </properties>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -37,6 +37,10 @@
         <url>https://github.com/yahoo/elide.git</url>
         <tag>HEAD</tag>
     </scm>
+    <properties>
+        <excludeTags>emptyOnAttributeCollection</excludeTags>
+    </properties>
+
 
     <dependencies>
         <!-- Elide (including integration tests) -->
@@ -248,6 +252,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <excludeTags>${excludeTags}</excludeTags>
+                    </properties>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/elide-datastore/elide-datastore-jpa/pom.xml
+++ b/elide-datastore/elide-datastore-jpa/pom.xml
@@ -40,6 +40,7 @@
 
     <properties>
         <dataStoreHarness>com.yahoo.elide.datastores.jpa.JpaDataStoreHarness</dataStoreHarness>
+        <excludeTags>emptyOnAttributeCollection</excludeTags>
     </properties>
 
     <dependencies>
@@ -208,6 +209,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <failIfNoTests>true</failIfNoTests>
+                    <excludedGroups>${excludeTags}</excludedGroups>
                 </configuration>
             </plugin>
         </plugins>

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1473,7 +1473,8 @@ public class FilterIT extends IntegrationTest {
         }
 
         /* param = 1 */
-        result = getAsNode(String.format("/book?filter[book]=chapters=isempty=1"));
+        // Global Expression
+        result = getAsNode(String.format("/book?filter=chapters=isempty=1"));
 
         assertEquals(result.get("data").size(), bookIdsWithEmptyChapters.size());
 
@@ -1558,6 +1559,7 @@ public class FilterIT extends IntegrationTest {
 
         /* Test RSQL Typed */
         /* param = true */
+        //Typed Expression
         result = getAsNode("/book?filter[book]=awards=isempty=false");
 
         assertEquals(result.get("data").size(), bookIdsWithNonEmptyAwards.size());
@@ -1568,7 +1570,8 @@ public class FilterIT extends IntegrationTest {
         }
 
         /* param = 1 */
-        result = getAsNode(String.format("/book?filter[book]=awards=isempty=0"));
+        //Global Expression
+        result = getAsNode(String.format("/book?filter=awards=isempty=0"));
 
         assertEquals(result.get("data").size(), bookIdsWithNonEmptyAwards.size());
 
@@ -1623,6 +1626,31 @@ public class FilterIT extends IntegrationTest {
             assertTrue(book.get("attributes").get("awards").isEmpty());
             assertTrue(bookIdsWithEmptyAwards.contains(book.get("id")));
         }
+
+    }
+
+    @Test
+    void testExceptionOnEmptyOperator() throws IOException {
+        JsonNode result;
+        // Typed Expression
+        result = getAsNode(String.format("/author/%s/books?filter[book.authors.name][notempty]", nullNedId), HttpStatus.SC_BAD_REQUEST);
+        assertEquals(
+                "InvalidPredicateException: Invalid predicate: book.authors.name NOTEMPTY []\n"
+                        + "Invalid query parameter: filter[book.authors.name][notempty]\n"
+                        + "Invalid toMany join. toMany association has to be the target collection.book.authors.name NOTEMPTY []\n"
+                        + "Invalid query parameter: filter[book.authors.name][notempty]",
+                result.get("errors").get(0).asText()
+        );
+
+        //RSQL
+        result = getAsNode(String.format("/author/%s/books?filter[book]=authors.name=isempty=true", nullNedId), HttpStatus.SC_BAD_REQUEST);
+        assertEquals(
+                "InvalidPredicateException: Invalid filter format: filter[book]\n"
+                        + "Invalid query parameter: filter[book]\n"
+                        + "Invalid filter format: filter[book]\n"
+                        + "Invalid association authors.name. toMany association has to be the target collection.",
+                result.get("errors").get(0).asText()
+        );
 
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -1531,6 +1532,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("emptyOnAttributeCollection")
     void testNotEmptyAttributeOnRoot() throws IOException {
         Set<JsonNode> bookIdsWithNonEmptyAwards = new HashSet<>();
         JsonNode result;
@@ -1578,6 +1580,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("emptyOnAttributeCollection")
     void testIsEmptyAttributesOnNonRoot() throws IOException {
         Set<JsonNode> bookIdsWithEmptyAwards = new HashSet<>();
         JsonNode result;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1434,6 +1434,195 @@ public class FilterIT extends IntegrationTest {
         assertEquals(data.size(), 2);
     }
 
+
+    @Test
+    void testIsEmptyRelationshipOnRoot() throws IOException {
+        //Book has ToMany relationship with chapter
+        Set<JsonNode> bookIdsWithEmptyChapters = new HashSet<>();
+        JsonNode result;
+
+        for (JsonNode book : books.get("data")) {
+            if (book.get("relationships").get("chapters").get("data").isEmpty()) {
+                bookIdsWithEmptyChapters.add(book.get("id"));
+            }
+        }
+
+        assertTrue(bookIdsWithEmptyChapters.size() > 0);
+
+        /* Test Default */
+        result = getAsNode("/book?filter[book.chapters][isempty]");
+
+        assertEquals(bookIdsWithEmptyChapters.size(), result.get("data").size());
+
+
+        for (JsonNode book : result.get("data")) {
+            assertTrue(book.get("relationships").get("chapters").get("data").isEmpty());
+            assertTrue(bookIdsWithEmptyChapters.contains(book.get("id")));
+        }
+
+        /* Test RSQL Typed */
+        /* param = true */
+        result = getAsNode("/book?filter[book]=chapters=isempty=true");
+
+        assertEquals(result.get("data").size(), bookIdsWithEmptyChapters.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertTrue(book.get("relationships").get("chapters").get("data").isEmpty());
+            assertTrue(bookIdsWithEmptyChapters.contains(book.get("id")));
+        }
+
+        /* param = 1 */
+        result = getAsNode(String.format("/book?filter[book]=chapters=isempty=1"));
+
+        assertEquals(result.get("data").size(), bookIdsWithEmptyChapters.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertTrue(book.get("relationships").get("chapters").get("data").isEmpty());
+            assertTrue(bookIdsWithEmptyChapters.contains(book.get("id")));
+        }
+
+    }
+
+    @Test
+    void testNotEmptyRelationshipOnNonRoot() throws IOException {
+        //Book has ToMany relationship with chapter
+        Set<JsonNode> bookIdsWithNonEmptyChapters = new HashSet<>();
+        JsonNode result;
+        for (JsonNode book : nullNedBooks.get("data")) {
+            if (!book.get("relationships").get("chapters").get("data").isEmpty()) {
+                bookIdsWithNonEmptyChapters.add(book.get("id"));
+            }
+        }
+
+        assertTrue(bookIdsWithNonEmptyChapters.size() > 0);
+
+        /* Test Default */
+        result = getAsNode(String.format("/author/%s/books?filter[book.chapters][notempty]", nullNedId));
+
+        assertEquals(bookIdsWithNonEmptyChapters.size(), result.get("data").size());
+
+
+        for (JsonNode book : result.get("data")) {
+            assertFalse(book.get("relationships").get("chapters").get("data").isEmpty());
+            assertTrue(bookIdsWithNonEmptyChapters.contains(book.get("id")));
+        }
+
+        /* Test RSQL Typed */
+        /* param = false */
+        result = getAsNode(String.format("/author/%s/books?filter[book]=chapters=isempty=false", nullNedId));
+
+        assertEquals(result.get("data").size(), bookIdsWithNonEmptyChapters.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertFalse(book.get("relationships").get("chapters").get("data").isEmpty());
+            assertTrue(bookIdsWithNonEmptyChapters.contains(book.get("id")));
+        }
+
+        /* param = 0 */
+        result = getAsNode(String.format("/author/%s/books?filter[book]=chapters=isempty=0", nullNedId));
+
+        assertEquals(result.get("data").size(), bookIdsWithNonEmptyChapters.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertFalse(book.get("relationships").get("chapters").get("data").isEmpty());
+            assertTrue(bookIdsWithNonEmptyChapters.contains(book.get("id")));
+        }
+
+    }
+
+    @Test
+    void testNotEmptyAttributeOnRoot() throws IOException {
+        Set<JsonNode> bookIdsWithNonEmptyAwards = new HashSet<>();
+        JsonNode result;
+
+        for (JsonNode book : books.get("data")) {
+            if (!book.get("attributes").get("awards").isEmpty()) {
+                bookIdsWithNonEmptyAwards.add(book.get("id"));
+            }
+        }
+
+        assertTrue(bookIdsWithNonEmptyAwards.size() > 0);
+
+        /* Test Default */
+        result = getAsNode("/book?filter[book.awards][notempty]");
+
+        assertEquals(bookIdsWithNonEmptyAwards.size(), result.get("data").size());
+
+
+        for (JsonNode book : result.get("data")) {
+            assertFalse(book.get("attributes").get("awards").isEmpty());
+            assertTrue(bookIdsWithNonEmptyAwards.contains(book.get("id")));
+        }
+
+        /* Test RSQL Typed */
+        /* param = true */
+        result = getAsNode("/book?filter[book]=awards=isempty=false");
+
+        assertEquals(result.get("data").size(), bookIdsWithNonEmptyAwards.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertFalse(book.get("attributes").get("awards").isEmpty());
+            assertTrue(bookIdsWithNonEmptyAwards.contains(book.get("id")));
+        }
+
+        /* param = 1 */
+        result = getAsNode(String.format("/book?filter[book]=awards=isempty=0"));
+
+        assertEquals(result.get("data").size(), bookIdsWithNonEmptyAwards.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertFalse(book.get("attributes").get("awards").isEmpty());
+            assertTrue(bookIdsWithNonEmptyAwards.contains(book.get("id")));
+        }
+
+    }
+
+    @Test
+    void testIsEmptyAttributesOnNonRoot() throws IOException {
+        Set<JsonNode> bookIdsWithEmptyAwards = new HashSet<>();
+        JsonNode result;
+        for (JsonNode book : nullNedBooks.get("data")) {
+            if (book.get("attributes").get("awards").isEmpty()) {
+                bookIdsWithEmptyAwards.add(book.get("id"));
+            }
+        }
+
+        assertTrue(bookIdsWithEmptyAwards.size() > 0);
+
+        /* Test Default */
+        result = getAsNode(String.format("/author/%s/books?filter[book.awards][isempty]", nullNedId));
+
+        assertEquals(bookIdsWithEmptyAwards.size(), result.get("data").size());
+
+
+        for (JsonNode book : result.get("data")) {
+            assertTrue(book.get("attributes").get("awards").isEmpty());
+            assertTrue(bookIdsWithEmptyAwards.contains(book.get("id")));
+        }
+
+        /* Test RSQL Typed */
+        /* param = false */
+        result = getAsNode(String.format("/author/%s/books?filter[book]=awards=isempty=true", nullNedId));
+
+        assertEquals(result.get("data").size(), bookIdsWithEmptyAwards.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertTrue(book.get("attributes").get("awards").isEmpty());
+            assertTrue(bookIdsWithEmptyAwards.contains(book.get("id")));
+        }
+
+        /* param = 0 */
+        result = getAsNode(String.format("/author/%s/books?filter[book]=awards=isempty=1", nullNedId));
+
+        assertEquals(result.get("data").size(), bookIdsWithEmptyAwards.size());
+
+        for (JsonNode book : result.get("data")) {
+            assertTrue(book.get("attributes").get("awards").isEmpty());
+            assertTrue(bookIdsWithEmptyAwards.contains(book.get("id")));
+        }
+
+    }
+
     @AfterAll
     void cleanUp() {
         for (int id : authorIds) {

--- a/elide-integration-tests/src/test/java/example/Book.java
+++ b/elide-integration-tests/src/test/java/example/Book.java
@@ -15,13 +15,11 @@ import com.yahoo.elide.annotation.SharePermission;
 
 import org.hibernate.annotations.Formula;
 
-import lombok.Getter;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.Collection;
 
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
@@ -53,8 +51,6 @@ public class Book extends BaseId {
     private Collection<Chapter> chapters = new ArrayList<>();
     private String editorName;
     private Publisher publisher;
-
-    @Getter @Setter
     private Collection<String> awards = new ArrayList<>();
 
     public String getTitle() {
@@ -88,6 +84,17 @@ public class Book extends BaseId {
     public long getPublishDate() {
         return this.publishDate;
     }
+
+
+    @ElementCollection(targetClass = String.class)
+    public Collection<String> getAwards() {
+        return awards;
+    }
+
+    public void setAwards(Collection<String> awards) {
+        this.awards = awards;
+    }
+
 
     /**
      * Demonstrates a more complex ranking use case.

--- a/elide-integration-tests/src/test/java/example/Book.java
+++ b/elide-integration-tests/src/test/java/example/Book.java
@@ -15,6 +15,9 @@ import com.yahoo.elide.annotation.SharePermission;
 
 import org.hibernate.annotations.Formula;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -50,6 +53,9 @@ public class Book extends BaseId {
     private Collection<Chapter> chapters = new ArrayList<>();
     private String editorName;
     private Publisher publisher;
+
+    @Getter @Setter
+    private Collection<String> awards = new ArrayList<>();
 
     public String getTitle() {
         return title;

--- a/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch1.json
+++ b/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch1.json
@@ -33,7 +33,8 @@
       "attributes": {
         "title": "The Old Man and the Sea",
         "genre": "Literary Fiction",
-        "language": "English"
+        "language": "English",
+        "awards": ["National Book Award", "Booker Prize"]
       },
       "relationships": {
         "publisher": {

--- a/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch3.json
+++ b/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch3.json
@@ -30,7 +30,8 @@
         "title": "Enders Game",
         "genre": "Science Fiction",
         "language": "English",
-        "publishDate": 1454638927412
+        "publishDate": 1454638927412,
+        "awards": ["Pulitzer Prize"]
       }
     }
   }

--- a/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch4.json
+++ b/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch4.json
@@ -33,7 +33,8 @@
       "attributes": {
         "title": "Foundation",
         "genre": "Science Fiction",
-        "language": "English"
+        "language": "English",
+        "awards": ["BookBrowse Awards"]
       }
     }
   },
@@ -46,7 +47,8 @@
       "attributes": {
         "title": "The Roman Republic",
         "genre": "History",
-        "language": "English"
+        "language": "English",
+        "awards": []
       }
     }
   },


### PR DESCRIPTION
Resolves #1160 

## Description
Added IsEmpty Filter operation with syntax `=isempty=`. 

## Motivation and Context
isempty filter operation are useful in most cases and the community needed support for this operation. 

## How Has This Been Tested?
Added New Test Cases

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
