### PR TITLE
Honor ApiModelProperty annotations for relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dependency-reduced-pom.xml
 *.class
 *tags
 **.swp
+.project
+*/.project
+*/*/.project

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.contrib.swagger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -120,6 +121,14 @@ public class JsonApiModelResolverTest {
     }
 
     @Test
+    public void testExampleRelationship() {
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "relationships");
+
+        Object authorsExample = attributes.getProperties().get("authors").getExample();
+        assertEquals("[\"author1\", \"author2\", \"author3\"]", authorsExample);
+    }
+
+    @Test
     public void testNoExampleWithoutAnnotation() {
         ObjectProperty attributes = getObjectProperty(KEY_AUTHOR, "attributes");
 
@@ -145,6 +154,15 @@ public class JsonApiModelResolverTest {
     }
 
     @Test
+    public void testConcatenatedDescriptionAndPermissionsRelationship() {
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "relationships");
+
+        String authorsDescription = attributes.getProperties().get("authors").getDescription();
+        assertEquals("Writers\nRead Permissions : (Principal is author OR Principal is publisher)"
+                + "\nUpdate Permissions : (Principal is author)", authorsDescription);
+    }
+
+    @Test
     public void testRequired() {
         ObjectProperty attributes = getObjectProperty(KEY_BOOK, "attributes");
 
@@ -158,6 +176,22 @@ public class JsonApiModelResolverTest {
 
         Boolean titleReadOnly = attributes.getProperties().get("year").getReadOnly();
         assertTrue(titleReadOnly);
+    }
+
+    @Test
+    public void testRequiredRelationship() {
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "relationships");
+
+        Boolean authorsRequired = attributes.getProperties().get("authors").getRequired();
+        assertFalse(authorsRequired);
+    }
+
+    @Test
+    public void testReadOnlyRelationship() {
+        ObjectProperty attributes = getObjectProperty(KEY_BOOK, "relationships");
+
+        Boolean authorsReadOnly = attributes.getProperties().get("authors").getReadOnly();
+        assertTrue(authorsReadOnly);
     }
 
     private Resource getModel(String entityKey) {

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Book.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/models/Book.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
+
 import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Set;
@@ -28,6 +29,9 @@ import javax.validation.constraints.NotNull;
 public class Book {
     @OneToMany
     @Max(10)
+    @UpdatePermission(expression = "Principal is author")
+    @ApiModelProperty(value = "Writers", required = false, readOnly = true,
+        example = "[\"author1\", \"author2\", \"author3\"]")
     public Set<Author> getAuthors() {
         return null;
     }


### PR DESCRIPTION
Resolves #1095 

## Description
Elide will honor ApiModelProperty annotations for relationships - overriding the default behavior.

## Motivation and Context
Elide was ignoring the ApiModelProperty annotations for relationships

## How Has This Been Tested?
Added new test cases.

## Screenshots (if appropriate):
N/A

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
