### PR TITLE
sourceColumn

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -111,6 +111,8 @@ public abstract class QueryEngine {
         metaDataStore.getModelsToBind().stream()
                 .map(model -> constructTable(model, metadataDictionary))
                 .forEach(metaDataStore::addTable);
+
+        metaDataStore.resolveSourceColumn();
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -24,6 +24,7 @@ import com.yahoo.elide.utils.ClassScanner;
 
 import org.hibernate.annotations.Subselect;
 
+import javafx.util.Pair;
 import lombok.Getter;
 
 import java.lang.annotation.Annotation;
@@ -168,5 +169,16 @@ public class MetaDataStore extends HashMapDataStore {
      */
     public static boolean isTableJoin(Class<?> cls, String fieldName, EntityDictionary dictionary) {
         return dictionary.getAttributeOrRelationAnnotation(cls, Join.class, fieldName) != null;
+    }
+
+    public void resolveSourceColumn() {
+        getMetaData(Table.class).forEach(table -> table.getColumns().forEach(column -> {
+            Pair<String, String> sourceTableAndColumn = column.getSourceTableAndColumn();
+            Table sourceTable = (Table) dataStore.get(Table.class).get(sourceTableAndColumn.getKey());
+            Column sourceColumn = column instanceof Metric
+                    ? sourceTable.getMetric(sourceTableAndColumn.getValue())
+                    : sourceTable.getDimension(sourceTableAndColumn.getValue());
+            column.setSourceColumn(sourceColumn);
+        }));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -8,14 +8,15 @@ package com.yahoo.elide.datastores.aggregation.metadata.models;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ToOne;
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.annotation.Meta;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 
-import javafx.util.Pair;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -90,7 +91,16 @@ public abstract class Column {
         }
     }
 
-    public Pair<String, String> getSourceTableAndColumn() {
-        return new Pair<>(table.getId(), getName());
+    /**
+     * Return a Path that navigate to the source of this column.
+     *
+     * @param metadataDictionary metadata dictionary
+     * @return Path to source column
+     */
+    public Path getSourcePath(EntityDictionary metadataDictionary) {
+        Class<?> tableCls = metadataDictionary.getEntityClass(table.getId());
+        Class<?> columnCls = metadataDictionary.getParameterizedType(tableCls, getName());
+
+        return new Path(Collections.singletonList(new Path.PathElement(tableCls, columnCls, getName())));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.datastores.aggregation.annotation.Meta;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 
+import javafx.util.Pair;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -44,6 +45,11 @@ public abstract class Column {
     private Table table;
 
     private ValueType valueType;
+
+    @ToOne
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Column sourceColumn;
 
     @ToString.Exclude
     private Set<String> columnTags;
@@ -82,5 +88,9 @@ public abstract class Column {
                 return ValueType.getScalarType(fieldClass);
             }
         }
+    }
+
+    public Pair<String, String> getSourceTableAndColumn() {
+        return new Pair<>(table.getId(), getName());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLColumn.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLColumn.java
@@ -5,13 +5,32 @@
  */
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata;
 
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
+
+import javafx.util.Pair;
 
 /**
  * Column with physical SQL information like reference and join to path.
  */
 public interface SQLColumn {
+    Table getTable();
+
+    String getName();
+
     String getReference();
 
     JoinPath getJoinPath();
+
+    default Pair<String, String> getSourceTableAndColumn(EntityDictionary metadataDictionary) {
+        JoinPath joinPath = getJoinPath();
+        if (joinPath == null) {
+            return new Pair<>(getTable().getId(), getName());
+        } else {
+            Path.PathElement last = joinPath.lastElement().get();
+            return new Pair<>(metadataDictionary.getJsonAliasFor(last.getType()), last.getFieldName());
+        }
+    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLColumn.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLColumn.java
@@ -5,12 +5,8 @@
  */
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata;
 
-import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
-
-import javafx.util.Pair;
 
 /**
  * Column with physical SQL information like reference and join to path.
@@ -23,14 +19,4 @@ public interface SQLColumn {
     String getReference();
 
     JoinPath getJoinPath();
-
-    default Pair<String, String> getSourceTableAndColumn(EntityDictionary metadataDictionary) {
-        JoinPath joinPath = getJoinPath();
-        if (joinPath == null) {
-            return new Pair<>(getTable().getId(), getName());
-        } else {
-            Path.PathElement last = joinPath.lastElement().get();
-            return new Pair<>(metadataDictionary.getJsonAliasFor(last.getType()), last.getFieldName());
-        }
-    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLDimension.java
@@ -9,7 +9,6 @@ import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEn
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine.getClassAlias;
 
 import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
@@ -28,6 +27,7 @@ public class SQLDimension extends Dimension implements SQLColumn {
     @Getter
     private final JoinPath joinPath;
 
+    @Getter
     private EntityDictionary metadataDictionary;
 
     public SQLDimension(Table table, String fieldName, EntityDictionary dictionary) {
@@ -50,11 +50,6 @@ public class SQLDimension extends Dimension implements SQLColumn {
 
     @Override
     public Pair<String, String> getSourceTableAndColumn() {
-        if (joinPath == null) {
-            return super.getSourceTableAndColumn();
-        } else {
-            Path.PathElement last = joinPath.lastElement().get();
-            return new Pair<>(metadataDictionary.getJsonAliasFor(last.getType()), last.getFieldName());
-        }
+        return getSourceTableAndColumn(metadataDictionary);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLDimension.java
@@ -9,12 +9,12 @@ import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEn
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine.getClassAlias;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.JoinTo;
 
-import javafx.util.Pair;
 import lombok.Getter;
 
 /**
@@ -49,7 +49,7 @@ public class SQLDimension extends Dimension implements SQLColumn {
     }
 
     @Override
-    public Pair<String, String> getSourceTableAndColumn() {
-        return getSourceTableAndColumn(metadataDictionary);
+    public Path getSourcePath(EntityDictionary metadataDictionary) {
+        return joinPath == null ? super.getSourcePath(metadataDictionary) : joinPath;
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLDimension.java
@@ -9,11 +9,13 @@ import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEn
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine.getClassAlias;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.JoinTo;
 
+import javafx.util.Pair;
 import lombok.Getter;
 
 /**
@@ -25,6 +27,8 @@ public class SQLDimension extends Dimension implements SQLColumn {
 
     @Getter
     private final JoinPath joinPath;
+
+    private EntityDictionary metadataDictionary;
 
     public SQLDimension(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);
@@ -39,6 +43,18 @@ public class SQLDimension extends Dimension implements SQLColumn {
             JoinPath path = new JoinPath(tableClass, dictionary, joinTo.path());
             this.reference = generateColumnReference(path, dictionary);
             this.joinPath = path;
+        }
+
+        this.metadataDictionary = dictionary;
+    }
+
+    @Override
+    public Pair<String, String> getSourceTableAndColumn() {
+        if (joinPath == null) {
+            return super.getSourceTableAndColumn();
+        } else {
+            Path.PathElement last = joinPath.lastElement().get();
+            return new Pair<>(metadataDictionary.getJsonAliasFor(last.getType()), last.getFieldName());
         }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTimeDimension.java
@@ -9,12 +9,12 @@ import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEn
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine.getClassAlias;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.JoinTo;
 
-import javafx.util.Pair;
 import lombok.Getter;
 
 /**
@@ -49,7 +49,7 @@ public class SQLTimeDimension extends TimeDimension implements SQLColumn {
     }
 
     @Override
-    public Pair<String, String> getSourceTableAndColumn() {
-        return getSourceTableAndColumn(metadataDictionary);
+    public Path getSourcePath(EntityDictionary metadataDictionary) {
+        return joinPath == null ? super.getSourcePath(metadataDictionary) : joinPath;
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTimeDimension.java
@@ -9,11 +9,13 @@ import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEn
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine.getClassAlias;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.JoinTo;
 
+import javafx.util.Pair;
 import lombok.Getter;
 
 /**
@@ -25,6 +27,8 @@ public class SQLTimeDimension extends TimeDimension implements SQLColumn {
 
     @Getter
     private final JoinPath joinPath;
+
+    private EntityDictionary metadataDictionary;
 
     public SQLTimeDimension(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);
@@ -39,6 +43,18 @@ public class SQLTimeDimension extends TimeDimension implements SQLColumn {
             JoinPath path = new JoinPath(tableClass, dictionary, joinTo.path());
             this.reference = generateColumnReference(path, dictionary);
             this.joinPath = path;
+        }
+
+        this.metadataDictionary = dictionary;
+    }
+
+    @Override
+    public Pair<String, String> getSourceTableAndColumn() {
+        if (joinPath == null) {
+            return super.getSourceTableAndColumn();
+        } else {
+            Path.PathElement last = joinPath.lastElement().get();
+            return new Pair<>(metadataDictionary.getJsonAliasFor(last.getType()), last.getFieldName());
         }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTimeDimension.java
@@ -9,7 +9,6 @@ import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEn
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine.getClassAlias;
 
 import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
@@ -28,6 +27,7 @@ public class SQLTimeDimension extends TimeDimension implements SQLColumn {
     @Getter
     private final JoinPath joinPath;
 
+    @Getter
     private EntityDictionary metadataDictionary;
 
     public SQLTimeDimension(Table table, String fieldName, EntityDictionary dictionary) {
@@ -50,11 +50,6 @@ public class SQLTimeDimension extends TimeDimension implements SQLColumn {
 
     @Override
     public Pair<String, String> getSourceTableAndColumn() {
-        if (joinPath == null) {
-            return super.getSourceTableAndColumn();
-        } else {
-            Path.PathElement last = joinPath.lastElement().get();
-            return new Pair<>(metadataDictionary.getJsonAliasFor(last.getType()), last.getFieldName());
-        }
+        return getSourceTableAndColumn(metadataDictionary);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -39,7 +39,7 @@ public abstract class SQLUnitTest {
     protected static Table playerStatsTable;
     protected static EntityDictionary dictionary;
     protected static RSQLFilterDialect filterParser;
-    protected static MetaDataStore metaDataStore = new MetaDataStore();
+    protected static MetaDataStore metaDataStore;
 
     protected static final Country HONG_KONG = new Country();
     protected static final Country USA = new Country();
@@ -49,6 +49,8 @@ public abstract class SQLUnitTest {
     protected static QueryEngine engine;
 
     public static void init() {
+        metaDataStore = new MetaDataStore();
+
         emf = Persistence.createEntityManagerFactory("aggregationStore");
         dictionary = new EntityDictionary(new HashMap<>());
         dictionary.bindEntity(PlayerStatsWithView.class);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -690,6 +690,7 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("playerName"))
                 .body("data.attributes.valueType",  equalTo("TEXT"))
+                .body("data.relationships.sourceColumn.data.id", equalTo("player.name"))
                 .body("data.relationships.table.data.id", equalTo("playerStats"));
 
         given()
@@ -699,6 +700,7 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("lowScore"))
                 .body("data.attributes.valueType",  equalTo("INTEGER"))
+                .body("data.relationships.sourceColumn.data.id", equalTo("playerStats.lowScore"))
                 .body("data.relationships.table.data.id", equalTo("playerStats"))
                 .body("data.relationships.metricFunction.data.id", equalTo("playerStats.lowScore[min]"))
                 .body("included.id", hasItem("playerStats.lowScore[min]"))
@@ -713,6 +715,7 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("recordedDate"))
                 .body("data.attributes.valueType",  equalTo("TIME"))
+                .body("data.relationships.sourceColumn.data.id", equalTo("playerStats.recordedDate"))
                 .body("data.relationships.table.data.id", equalTo("playerStats"))
                 .body(
                         "data.relationships.supportedGrains.data.id",


### PR DESCRIPTION
Resolves #1005 

## Description
- Add `sourceColumn` field into `Column` model.
- `QueryEngine` would call `MetaDataStore` to resolve source columns.

## How Has This Been Tested?
Metadata integration test is updated.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.