### PR TITLE
Elide 5.x pr7 Async Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dependency-reduced-pom.xml
 .project
 */.project
 */*/.project
+*.factorypath
+*.vscode

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ For example API calls, look at:
 
 Security is documented in depth [here](http://elide.io/pages/guide/03-security.html).
 
+## Async API
+
+For using Async API feature please refer to below examples: 
+https://github.com/yahoo/elide-standalone-example/pull/3
+https://github.com/yahoo/elide-spring-boot-example/pull/4
+
 ## Contribute
 Please refer to [the contributing.md file](CONTRIBUTING.md) for information about how to get involved. We welcome issues, questions, and pull requests.
 

--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -1,0 +1,97 @@
+<!--
+  ~ Copyright 2020, Yahoo Inc.
+  ~ Licensed under the Apache License, Version 2.0
+  ~ See LICENSE file in project root for terms.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>elide-async</artifactId>
+    <packaging>jar</packaging>
+    <name>Elide Async</name>
+    <description>Elide Async</description>
+    <url>https://github.com/yahoo/elide</url>
+    <parent>
+        <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
+        <version>5.0.0-pr7-SNAPSHOT</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>Yahoo! Inc.</name>
+        <url>http://www.yahoo.com</url>
+    </organization>
+
+    <developers>
+        <developer>
+            <name>Yahoo Inc.</name>
+            <url>https://github.com/yahoo</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <developerConnection>scm:git:ssh://git@github.com/yahoo/elide.git</developerConnection>
+        <url>https://github.com/yahoo/elide.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <junit.version>5.5.2</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-graphql</artifactId>
+            <version>5.0.0-pr7-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.3</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+    <pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>gmaven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generateStubs</goal>
+                            <goal>compile</goal>
+                            <goal>generateTestStubs</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+   </pluginManagement>
+    </build>
+</project>

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Transient;
+
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.OnCreatePostCommit;
+import com.yahoo.elide.annotation.OnCreatePreSecurity;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
+import com.yahoo.elide.async.service.AsyncExecutorService;
+import com.yahoo.elide.core.RequestScope;
+
+import lombok.Data;
+
+/**
+ * Model for Async Query
+ */
+@Entity
+@Include(type = "query", rootLevel = true)
+@ReadPermission(expression = "Principal is Owner")
+@UpdatePermission(expression = "Prefab.Role.None")
+@DeletePermission(expression = "Prefab.Role.None")
+@Data
+public class AsyncQuery implements PrincipalOwned {
+    @Id
+    private UUID id; //Can be generated or provided.
+
+    private String query;  //JSON-API PATH or GraphQL payload.
+
+    private QueryType queryType; //GRAPHQL, JSONAPI
+
+    @UpdatePermission(expression = "Principal is Owner AND value is Cancelled")
+    private QueryStatus status;
+
+    @OneToOne(mappedBy = "query", cascade = CascadeType.REMOVE)
+    private AsyncQueryResult result;
+
+    private Date createdOn;
+
+    private Date updatedOn;
+
+    @Inject
+    @Transient
+    private AsyncExecutorService asyncExecutorService;
+
+    @Exclude
+    private String principalName;
+
+    @Exclude
+    protected String naturalKey = UUID.randomUUID().toString();
+
+    @Override
+    public String getPrincipalName() {
+        return principalName;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        createdOn = updatedOn = new Date();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedOn = new Date();
+    }
+
+    @OnCreatePreSecurity
+    public void extractPrincipalName(RequestScope scope) {
+    	setPrincipalName(scope.getUser().getName());
+    }
+    
+    @OnCreatePostCommit
+    public void executeQueryFromExecutor(RequestScope scope) {
+        asyncExecutorService.executeQuery(this, scope.getUser());
+    }
+
+    @Override
+    public int hashCode() {
+        return naturalKey.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof AsyncQuery)) {
+            return false;
+        }
+
+        return ((AsyncQuery) obj).naturalKey.equals(naturalKey);
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models;
+
+import java.util.Date;
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
+
+import lombok.Data;
+
+/**
+ * Model for Async Query Result
+ */
+@Entity
+@Include(type="queryResult")
+@ReadPermission(expression = "Principal is Owner")
+@UpdatePermission(expression = "Prefab.Role.None")
+@CreatePermission(expression = "Prefab.Role.None")
+@DeletePermission(expression = "Prefab.Role.None")
+@Data
+public class AsyncQueryResult implements PrincipalOwned {
+    @Id
+    private UUID id; //Matches UUID in query.
+
+    private Integer contentLength;
+
+    private String responseBody; //success or errors
+
+    private Integer status; // HTTP Status
+
+    private Date createdOn;
+
+    private Date updatedOn;
+
+    @OneToOne
+    private AsyncQuery query;
+
+    @Exclude
+    protected String naturalKey = UUID.randomUUID().toString();
+
+    @Exclude
+    public String getPrincipalName() {
+        return query.getPrincipalName();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        createdOn = updatedOn = new Date();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedOn = new Date();
+    }
+
+    @Override
+    public int hashCode() {
+        return naturalKey.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof AsyncQuery)) {
+            return false;
+        }
+
+        return ((AsyncQuery) obj).naturalKey.equals(naturalKey);
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/PrincipalOwned.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/PrincipalOwned.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models;
+
+/**
+ * Get principal owner name interface
+ */
+public interface PrincipalOwned {
+    public String getPrincipalName();
+}
+

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/QueryStatus.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/QueryStatus.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models;
+
+/**
+ * ENUM of possible query statuses.
+ */
+public enum QueryStatus {
+    COMPLETE,
+    QUEUED,
+    PROCESSING,
+    CANCELLED,
+    TIMEDOUT,
+    FAILURE
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/QueryType.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/QueryType.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models;
+
+/**
+ * ENUM of supported query types.
+ */
+public enum QueryType {
+    GRAPHQL_V1_0,
+    JSONAPI_V1_0
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models.security;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.PrincipalOwned;
+import com.yahoo.elide.async.models.QueryStatus;
+import com.yahoo.elide.security.ChangeSpec;
+import com.yahoo.elide.security.RequestScope;
+import com.yahoo.elide.security.checks.OperationCheck;
+
+/**
+ * Operation Checks on the Async Query and Result objects.
+ */
+public class AsyncQueryOperationChecks {
+    @SecurityCheck(AsyncQueryOwner.PRINCIPAL_IS_OWNER)
+    public static class AsyncQueryOwner extends OperationCheck<Object> {
+
+        public static final String PRINCIPAL_IS_OWNER = "Principal is Owner";
+
+        @Override
+        public boolean ok(Object object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            Principal principal = requestScope.getUser().getPrincipal();
+            return ((PrincipalOwned) object).getPrincipalName().equals(principal.getName());
+        }
+    }
+
+    @SecurityCheck(AsyncQueryStatusValue.VALUE_IS_CANCELLED)
+    public static class AsyncQueryStatusValue extends OperationCheck<AsyncQuery> {
+
+        public static final String VALUE_IS_CANCELLED = "value is Cancelled";
+
+        @Override
+        public boolean ok(AsyncQuery object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            return changeSpec.get().getModified().toString().equals(QueryStatus.CANCELLED.name());
+        }
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.yahoo.elide.Elide;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service to execute Async queries. It will schedule task to track long
+ * running queries and kills them. It will also schedule task to update
+ * orphan query statuses after host/app crash or restart.
+ */
+@Slf4j
+@Singleton
+public class AsyncCleanerService {
+
+    private final int DEFAULT_CLEANUP_DELAY_MINUTES = 360;
+    private final int MAX_CLEANUP_INTIAL_DELAY_MINUTES = 100;
+
+    private static AsyncCleanerService asyncCleanerService;
+    private ScheduledExecutorService cleanerService;
+
+    @Inject
+    public AsyncCleanerService(Elide elide, Integer maxRunTimeMinutes, Integer queryCleanupDays, AsyncQueryDAO asyncQueryDao) {
+
+    	//If query is still running for twice than maxRunTime, then interrupt did not work due to host/app crash.
+    	int queryRunTimeThresholdMinutes = maxRunTimeMinutes * 2;
+    	
+        // Setting up query cleaner that marks long running query as TIMEDOUT.
+        ScheduledExecutorService cleaner = AsyncCleanerService.getInstance().getExecutorService();
+        AsyncQueryCleanerThread cleanUpTask = new AsyncQueryCleanerThread(queryRunTimeThresholdMinutes, elide, queryCleanupDays, asyncQueryDao);
+
+        // Since there will be multiple hosts running the elide service,
+        // setting up random delays to avoid all of them trying to cleanup at the same time.
+        Random random = new Random();
+        int initialDelayMinutes = random.ints(0, MAX_CLEANUP_INTIAL_DELAY_MINUTES).limit(1).findFirst().getAsInt();
+        log.debug("Initial Delay for cleaner service is {}", initialDelayMinutes);
+
+        //Having a delay of at least DEFAULT_CLEANUP_DELAY between two cleanup attempts.
+        //Or maxRunTimeMinutes * 2 so that this process does not coincides with query interrupt process.
+        cleaner.scheduleWithFixedDelay(cleanUpTask, initialDelayMinutes, Math.max(DEFAULT_CLEANUP_DELAY_MINUTES, queryRunTimeThresholdMinutes), TimeUnit.MINUTES);
+    }
+
+    private static AsyncCleanerService getInstance() {
+        if (asyncCleanerService == null) {
+          synchronized (AsyncCleanerService.class) {
+        	  asyncCleanerService = new AsyncCleanerService();
+          }
+        }
+        return asyncCleanerService;
+    }
+
+    private AsyncCleanerService() {
+      cleanerService = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    private ScheduledExecutorService getExecutorService() {
+      return cleanerService;
+    }
+
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.QueryStatus;
+import com.yahoo.elide.graphql.QueryRunner;
+import com.yahoo.elide.security.User;
+
+/**
+ * Service to execute Async queries. It will schedule task to track long
+ * running queries and kills them. It will also schedule task to update
+ * orphan query statuses after host/app crash or restart.
+ */
+@Singleton
+public class AsyncExecutorService {
+
+    private final int DEFAULT_THREADPOOL_SIZE = 6;
+
+    private Elide elide;
+    private QueryRunner runner;
+    private ExecutorService executor;
+    private ExecutorService interruptor;
+    private int maxRunTime;
+    private static AsyncExecutorService asyncExecutorService;
+    private AsyncQueryDAO asyncQueryDao;
+    
+
+    @Inject
+    public AsyncExecutorService(Elide elide, Integer threadPoolSize, Integer maxRunTime, AsyncQueryDAO asyncQueryDao) {
+        this.elide = elide;
+        this.runner = new QueryRunner(elide);
+        this.maxRunTime = maxRunTime;
+        executor = AsyncExecutorService.getInstance(threadPoolSize == null ? DEFAULT_THREADPOOL_SIZE : threadPoolSize).getExecutorService();
+        interruptor = AsyncExecutorService.getInstance(threadPoolSize == null ? DEFAULT_THREADPOOL_SIZE : threadPoolSize).getInterruptorService();
+        this.asyncQueryDao = asyncQueryDao;
+    }
+
+    public void executeQuery(AsyncQuery queryObj, User user) {
+        AsyncQueryThread queryWorker = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao);
+        // Change async query in Datastore to queued
+        asyncQueryDao.updateAsyncQuery(queryObj.getId(), (asyncQueryObj) -> {
+            asyncQueryObj.setStatus(QueryStatus.QUEUED);
+            });
+        AsyncQueryInterruptThread queryInterruptWorker = new AsyncQueryInterruptThread(elide, executor.submit(queryWorker), queryObj.getId(), new Date(), 
+                maxRunTime, asyncQueryDao);
+        interruptor.execute(queryInterruptWorker);
+    }
+
+    private static AsyncExecutorService getInstance(int threadPoolSize) {
+        if (asyncExecutorService == null) {
+          synchronized (AsyncExecutorService.class) {
+        	  asyncExecutorService = new AsyncExecutorService(threadPoolSize);
+            }
+          }
+        return asyncExecutorService;
+    }
+
+    private AsyncExecutorService(int threadPoolSize) {
+    	executor = Executors.newFixedThreadPool(threadPoolSize);
+    	interruptor = Executors.newFixedThreadPool(threadPoolSize);
+    }
+
+    private ExecutorService getExecutorService() {
+        return executor;
+    }
+
+    private ExecutorService getInterruptorService() {
+        return interruptor;
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.text.Format;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.QueryStatus;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.request.EntityProjection;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Runnable thread for updating AsyncQueryThread status
+ * beyond the max run time and if not terminated by interrupt process
+ * due to app/host crash or restart.
+ */
+@Slf4j
+@Data
+@AllArgsConstructor
+public class AsyncQueryCleanerThread implements Runnable {
+
+    private int maxRunTimeMinutes;
+    private Elide elide;
+    private int queryCleanupDays;
+    private AsyncQueryDAO asyncQueryDao;
+
+    @Override
+    public void run() {
+        deleteAsyncQuery();
+        timeoutAsyncQuery();
+    }
+
+    /**
+     * This method updates the status of long running async query which
+     * were not interrupted due to host crash/app shutdown to TIMEDOUT.
+     * */
+    @SuppressWarnings("unchecked")
+    private void deleteAsyncQuery() {
+
+        //Calculate date to clean up
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        cal.add(Calendar.DATE, -(queryCleanupDays));
+        Date cleanupDate = cal.getTime();
+        Format dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        String cleanupDateFormatted = dateFormat.format(cleanupDate);
+        log.debug("cleanupDateFormatted = {}", cleanupDateFormatted);
+
+        String filterExpression = "createdOn=le='" + cleanupDateFormatted + "'";
+
+        Iterable<Object> loaded = getFilteredResults(filterExpression);
+
+        asyncQueryDao.deleteAsyncQueryAndResultCollection(loaded);
+
+    }
+    
+    /**
+     * This method updates the status of long running async query which
+     * were not interrupted due to host crash/app shutdown to TIMEDOUT.
+     * */
+	@SuppressWarnings("unchecked")
+    private void timeoutAsyncQuery() {
+
+        //Calculate date to filter for clean up
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        cal.add(Calendar.MINUTE, -(maxRunTimeMinutes));
+        Date filterDate = cal.getTime();
+        Format dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        String filterDateFormatted = dateFormat.format(filterDate);
+        log.debug("FilterDateFormatted = {}", filterDateFormatted);
+        String filterExpression = "status=in=(" + QueryStatus.PROCESSING.toString() + ","
+                + QueryStatus.QUEUED.toString() + ");createdOn=le='" + filterDateFormatted + "'";
+
+        Iterable<Object> loaded = getFilteredResults(filterExpression);
+
+        asyncQueryDao.updateAsyncQueryCollection(loaded, (asyncQuery) -> {
+            asyncQuery.setStatus(QueryStatus.PROCESSING);
+            });
+    }
+
+	@SuppressWarnings("unchecked")
+	private Iterable<Object> getFilteredResults(String filterExpression) {
+        EntityDictionary dictionary = elide.getElideSettings().getDictionary();
+        RSQLFilterDialect filterParser = new RSQLFilterDialect(dictionary);
+
+        Iterable<Object> loaded = (Iterable<Object>) asyncQueryDao.executeInTransaction(elide.getDataStore(), (tx, scope) -> {
+            try {
+                FilterExpression filter = filterParser.parseFilterExpression(filterExpression, AsyncQuery.class, false);
+
+                EntityProjection asyncQueryCollection = EntityProjection.builder()
+                        .type(AsyncQuery.class)
+                        .filterExpression(filter)
+                        .build();
+
+                Iterable<Object> loadedObj = tx.loadObjects(asyncQueryCollection, scope);
+                return loadedObj;
+            } catch (Exception e) {
+                log.error("Exception: {}", e);
+            }
+            return null;
+        });
+        return loaded;
+	}
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
@@ -88,7 +88,7 @@ public class AsyncQueryCleanerThread implements Runnable {
         Iterable<Object> loaded = getFilteredResults(filterExpression);
 
         asyncQueryDao.updateAsyncQueryCollection(loaded, (asyncQuery) -> {
-            asyncQuery.setStatus(QueryStatus.PROCESSING);
+            asyncQuery.setStatus(QueryStatus.TIMEDOUT);
             });
     }
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryDAO.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.util.UUID;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.AsyncQueryResult;
+import com.yahoo.elide.core.DataStore;
+
+/**
+ * Utility interface which uses the elide datastore to modify, update and create
+ * AsyncQuery and AsyncQueryResult Objects
+ */
+public interface AsyncQueryDAO {
+
+    /**
+     * Set elide object
+     * @param elide Elide Object.
+     */
+    public void setElide(Elide elide);
+
+    /**
+     * Set data store object
+     * @param dataStore Datastore Object from Elide.
+     */
+    public void setDataStore(DataStore dataStore);
+
+    /**
+     * This method updates the model for AsyncQuery with passed value.
+     * @param asyncQueryId Unique UUID for the AsyncQuery Object
+     * @param updateFunction Functional interface for updating AsyncQuery Object
+     * @return AsyncQuery Object
+     */
+    public AsyncQuery updateAsyncQuery(UUID asyncQueryId, UpdateQuery updateFunction);
+
+    /**
+     * This method updates a collection of AsyncQuery objects from database and
+     * returns the objects updated.
+     * @param asyncQueryList Iterable list of AsyncQuery objects to be updated
+     * @return query object list updated
+     */
+    public Iterable<Object> updateAsyncQueryCollection(Iterable<Object> asyncQueryList, UpdateQuery updateFunction);
+
+    /**
+     * This method deletes a collection of AsyncQuery and AsyncQueryResult objects from database and
+     * returns the objects deleted.
+     * @param asyncQueryList Iterable list of AsyncQuery objects to be deleted
+     * @return query object list deleted
+     */
+    public Iterable<Object> deleteAsyncQueryAndResultCollection(Iterable<Object> asyncQueryList);
+
+    /**
+     * This method persists the model for AsyncQueryResult, AsyncQuery object and establishes the relationship
+     * @param status ElideResponse status from AsyncQuery
+     * @param responseBody ElideResponse responseBody from AsyncQuery
+     * @param asyncQuery AsyncQuery object to be associated with the AsyncQueryResult object
+     * @param asyncQueryId UUID of the AsyncQuery to be associated with the AsyncQueryResult object
+     * @return AsyncQueryResult Object
+     */
+    public AsyncQueryResult setAsyncQueryAndResult(Integer status, String responseBody, AsyncQuery asyncQuery, UUID asyncQueryId);
+
+    /**
+     * This method creates a transaction from the datastore, performs the DB action using
+     * a generic functional interface and closes the transaction.
+     * @param dataStore Elide datastore retrieved from Elide object
+     * @param action Functional interface to perform DB action
+     * @return Object Returns Entity Object (AsyncQueryResult or AsyncResult)
+     */
+    public Object executeInTransaction(DataStore dataStore, Transactional action);
+
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryInterruptThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryInterruptThread.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.util.Date;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.QueryStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Runnable thread for terminating AsyncQueryThread executing
+ * beyond the max run time and update status.
+ */
+@Slf4j
+@Data
+@AllArgsConstructor
+public class AsyncQueryInterruptThread implements Runnable {
+
+    private Elide elide;
+    private Future<?> task;
+    private UUID id;
+    private Date submittedOn;
+    private int maxRunTimeMinutes;
+    private AsyncQueryDAO asyncQueryDao;
+
+    @Override
+    public void run() {
+        interruptQuery();
+    }
+
+    /**
+     * This is the main method which interrupts the Async Query request, if it has executed beyond
+     * the maximum run time.
+     */
+    protected void interruptQuery() {
+        try {
+            long interruptTimeMillies = calculateTimeOut(maxRunTimeMinutes, submittedOn);
+            
+            if(interruptTimeMillies > 0) {
+               log.debug("Waiting on the future with the given timeout for {}", interruptTimeMillies);
+               task.get(interruptTimeMillies, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            // Incase the future.get is interrupted , the underlying query may still have succeeded
+            log.error("InterruptedException: {}", e);
+        } catch (ExecutionException e) {
+            // Query Status set to failure will be handled by the processQuery method
+            log.error("ExecutionException: {}", e);
+        } catch (TimeoutException e) {
+            log.error("TimeoutException: {}", e);
+            task.cancel(true);
+            asyncQueryDao.updateAsyncQuery(id, (asyncQueryObj) -> {
+                asyncQueryObj.setStatus(QueryStatus.TIMEDOUT);
+                });
+        }
+    }
+    
+    /**
+     * Method to calculate the time left to interrupt since submission of thread 
+     * in Milliseconds.
+     * @param interruptTimeMinutes max duration to run the query
+     * @param submittedOn time when query was submitted
+     * @return Interrupt time left
+     */
+    private long calculateTimeOut(long maxRunTimeMinutes, Date submittedOn) {
+        long maxRunTimeMinutesMillies = maxRunTimeMinutes * 60 * 1000;
+        long interruptTimeMillies = maxRunTimeMinutesMillies - ((new Date()).getTime() - submittedOn.getTime());
+        
+        return interruptTimeMillies;
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.net.URISyntaxException;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideResponse;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.QueryStatus;
+import com.yahoo.elide.async.models.QueryType;
+import com.yahoo.elide.graphql.QueryRunner;
+import com.yahoo.elide.security.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Runnable thread for executing the query provided in Async Query.
+ * It will also update the query status and result object at different
+ * stages of execution.
+ */
+@Slf4j
+@Data
+@AllArgsConstructor
+public class AsyncQueryThread implements Runnable {
+
+    private AsyncQuery queryObj;
+    private User user;
+    private Elide elide;
+    private QueryRunner runner;
+    private AsyncQueryDAO asyncQueryDao;
+
+    @Override
+    public void run() {
+        processQuery();
+    }
+
+    /**
+     * This is the main method which processes the Async Query request, executes the query and updates
+     * values for AsyncQuery and AsyncQueryResult models accordingly.
+     */
+    protected void processQuery() {
+        try {
+            // Change async query to processing
+            asyncQueryDao.updateAsyncQuery(queryObj.getId(), (asyncQuery) -> {
+                asyncQuery.setStatus(QueryStatus.PROCESSING);
+                });
+            ElideResponse response = null;
+            log.debug("AsyncQuery Object from request: {}", queryObj);
+            if (queryObj.getQueryType().equals(QueryType.JSONAPI_V1_0)) {
+                MultivaluedMap<String, String> queryParams = getQueryParams(queryObj.getQuery());
+                log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
+                response = elide.get(getPath(queryObj.getQuery()), queryParams, user);
+                log.debug("JSONAPI_V1_0 getResponseCode: {}, JSONAPI_V1_0 getBody: {}", response.getResponseCode(), response.getBody());
+            }
+            else if (queryObj.getQueryType().equals(QueryType.GRAPHQL_V1_0)) {
+                response = runner.run(queryObj.getQuery(), user);
+                log.debug("GRAPHQL_V1_0 getResponseCode: {}, GRAPHQL_V1_0 getBody: {}", response.getResponseCode(), response.getBody());
+            }
+            if (response != null){
+                // If we receive a response update Query Status to complete
+                queryObj.setStatus(QueryStatus.COMPLETE);
+
+                // Create AsyncQueryResult entry for AsyncQuery and add queryResult object to query object
+                asyncQueryDao.setAsyncQueryAndResult(response.getResponseCode(), response.getBody(), queryObj, queryObj.getId());
+
+            } else {
+                // If no response is returned on AsyncQuery request we set the QueryStatus to FAILURE
+                // No AsyncQueryResult will be set for this case
+                asyncQueryDao.updateAsyncQuery(queryObj.getId(), (asyncQueryObj) -> {
+                    asyncQueryObj.setStatus(QueryStatus.FAILURE);
+                 });
+            }
+        } catch (Exception e) {
+            log.error("Exception: {}", e);
+            // If an Exception is encountered we set the QueryStatus to FAILURE
+            //No AsyncQueryResult will be set for this case
+            asyncQueryDao.updateAsyncQuery(queryObj.getId(), (asyncQueryObj) -> {
+                asyncQueryObj.setStatus(QueryStatus.FAILURE);
+            });
+        }
+    }
+
+    /**
+     * This method parses the url and gets the query params and adds them into a MultivaluedMap
+     * to be used by underlying Elide.get method
+     * @param query query from the Async request
+     * @throws URISyntaxException URISyntaxException from malformed or incorrect URI
+     * @return MultivaluedMap with query parameters
+     */
+    protected MultivaluedMap<String, String> getQueryParams(String query) throws URISyntaxException {
+        URIBuilder uri;
+        uri = new URIBuilder(query);
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+        for (NameValuePair queryParam : uri.getQueryParams()) {
+            queryParams.add(queryParam.getName(), queryParam.getValue());
+        }
+        return queryParams;
+    }
+
+    /**
+     * This method parses the url and gets the query params and retrieves path
+     * to be used by underlying Elide.get method
+     * @param query query from the Async request
+     * @throws URISyntaxException URISyntaxException from malformed or incorrect URI
+     * @return Path extracted from URI
+     */
+    protected String getPath(String query) throws URISyntaxException {
+        URIBuilder uri;
+        uri = new URIBuilder(query);
+        return uri.getPath();
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.UUID;
+
+import javax.inject.Singleton;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.AsyncQueryResult;
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.jsonapi.models.JsonApiDocument;
+import com.yahoo.elide.request.EntityProjection;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Utility class which implements AsyncQueryDAO
+ */
+@Singleton
+@Slf4j
+public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
+
+    private Elide elide;
+    private DataStore dataStore;
+
+    public DefaultAsyncQueryDAO() {}
+
+    public DefaultAsyncQueryDAO(Elide elide, DataStore dataStore) {
+    	this.elide = elide;
+    	this.dataStore = dataStore;
+    }
+
+    @Override
+    public void setElide(Elide elide) {
+        this.elide = elide;
+    }
+
+    @Override
+    public void setDataStore(DataStore dataStore) {
+        this.dataStore = dataStore;
+    }
+
+    @Override
+    public AsyncQuery updateAsyncQuery(UUID asyncQueryId, UpdateQuery updateFunction) {
+        log.debug("updateAsyncQuery");
+        AsyncQuery queryObj = (AsyncQuery) executeInTransaction(dataStore, (tx, scope) -> {
+            EntityProjection asyncQueryCollection = EntityProjection.builder()
+                    .type(AsyncQuery.class)
+                    .build();
+            AsyncQuery query = (AsyncQuery) tx.loadObject(asyncQueryCollection, asyncQueryId, scope);
+            updateFunction.update(query);
+            tx.save(query, scope);
+            return query;
+        });
+        return queryObj;
+    }
+
+    @Override
+    public Iterable<Object> updateAsyncQueryCollection(Iterable<Object> asyncQueryList, UpdateQuery updateFunction) {
+        log.debug("updateAsyncQueryCollection");
+        executeInTransaction(dataStore, (tx, scope) -> {
+            EntityProjection asyncQueryCollection = EntityProjection.builder()
+                    .type(AsyncQuery.class)
+                    .build();
+
+            Iterator<Object> itr = asyncQueryList.iterator();
+            while(itr.hasNext()) {
+                AsyncQuery query = (AsyncQuery) itr.next();
+                AsyncQuery asyncQuery = (AsyncQuery) tx.loadObject(asyncQueryCollection, query.getId(), scope);
+                updateFunction.update(asyncQuery);
+                tx.save(asyncQuery, scope);
+            }
+            return asyncQueryList;
+        });
+        return asyncQueryList;
+    }
+
+    @Override
+    public Iterable<Object> deleteAsyncQueryAndResultCollection(Iterable<Object> asyncQueryList) {
+        log.debug("deleteAsyncQueryAndResultCollection");
+        executeInTransaction(dataStore, (tx, scope) -> {
+            EntityProjection asyncQueryCollection = EntityProjection.builder()
+                    .type(AsyncQuery.class)
+                    .build();
+
+            Iterator<Object> itr = asyncQueryList.iterator();
+
+            while(itr.hasNext()) {
+                AsyncQuery query = (AsyncQuery) itr.next();
+                AsyncQuery asyncQuery = (AsyncQuery) tx.loadObject(asyncQueryCollection, query.getId(), scope);
+                if(asyncQuery != null) {
+                    tx.delete(asyncQuery, scope);
+                }
+            }
+
+            return asyncQueryList;
+        });
+        return asyncQueryList;
+    }
+
+    @Override
+    public AsyncQueryResult setAsyncQueryAndResult(Integer status, String responseBody, AsyncQuery asyncQuery, UUID asyncQueryId) {
+        log.debug("createAsyncQueryResult");
+        AsyncQueryResult queryResultObj = (AsyncQueryResult) executeInTransaction(dataStore, (tx, scope) -> {
+            AsyncQueryResult asyncQueryResult = new AsyncQueryResult();
+            asyncQueryResult.setStatus(status);
+            asyncQueryResult.setResponseBody(responseBody);
+            asyncQueryResult.setContentLength(responseBody.length());
+            asyncQueryResult.setQuery(asyncQuery);
+            asyncQueryResult.setId(asyncQueryId);
+            asyncQuery.setResult(asyncQueryResult);
+            tx.createObject(asyncQueryResult, scope);
+            tx.save(asyncQuery, scope);
+            return asyncQueryResult;
+        });
+        return queryResultObj;
+    }
+
+    @Override
+    public Object executeInTransaction(DataStore dataStore, Transactional action) {
+        log.debug("executeInTransaction");
+        Object result = null;
+        try (DataStoreTransaction tx = dataStore.beginTransaction()) {
+	        JsonApiDocument jsonApiDoc = new JsonApiDocument();
+	        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+	        RequestScope scope = new RequestScope("query", jsonApiDoc, tx, null, queryParams, elide.getElideSettings());
+            result = action.execute(tx, scope);
+            tx.commit(scope);
+            tx.flush(scope);
+        } catch (IOException e) {
+            log.error("IOException: {}", e);
+        } catch (Exception e) {
+            log.error("Exception: {}", e);
+        }
+        return result;
+    }
+
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/Transactional.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/Transactional.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.RequestScope;
+
+/**
+ * Function which will be invoked for executing elide async transactions.
+ */
+@FunctionalInterface
+public interface Transactional {
+    public Object execute(DataStoreTransaction tx, RequestScope scope);
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/UpdateQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/UpdateQuery.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import com.yahoo.elide.async.models.AsyncQuery;
+
+/**
+ * Function which will be invoked for updating elide async query.
+ */
+@FunctionalInterface
+public interface UpdateQuery {
+    public void update(AsyncQuery query);
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -94,6 +94,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-async</artifactId>
+            <version>5.0.0-pr7-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.12</version>

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import lombok.Data;
+
+/**
+ * Extra properties for setting up async query support.
+ */
+@Data
+public class AsyncProperties extends ControllerProperties {
+
+    /**
+     * Default thread pool size.
+     */
+    private int threadPoolSize = 6;
+
+    /**
+     * Default max query run time.
+     */
+    private int maxRunTimeMinutes = 60;
+
+    /**
+     * Whether or not the cleanup is enabled.
+     */
+    private boolean cleanupEnabled = false;
+
+    /**
+     * Default retention of async query and results.
+     */
+    private int queryCleanupDays = 7;
+
+    /**
+     * Whether or not to use the default implementation of AsyncQueryDAO.
+     * If false, the user will provide custom implementation of AsyncQueryDAO.
+     */
+    private boolean defaultAsyncQueryDAO = true;
+
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncCleanupConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncCleanupConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.service.AsyncCleanerService;
+import com.yahoo.elide.async.service.AsyncQueryDAO;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Async Configuration For Elide Services.  Override any of the beans (by defining your own) to change
+ * the default behavior.
+ */
+@Configuration
+@EnableConfigurationProperties(ElideConfigProperties.class)
+@ConditionalOnExpression("${elide.async.cleanupEnabled:false}")
+public class ElideAsyncCleanupConfiguration {
+
+    /**
+     * Configure the AsyncCleanerService used for cleaning up async query requests.
+     * @param elide elideObject.
+     * @param settings Elide settings.
+     * @return a AsyncCleanerService.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public AsyncCleanerService buildAsyncCleanerService(Elide elide, ElideConfigProperties settings,
+            AsyncQueryDAO asyncQueryDao) {
+        return new AsyncCleanerService(elide, settings.getAsync().getMaxRunTimeMinutes(),
+                settings.getAsync().getQueryCleanupDays(), asyncQueryDao);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.service.AsyncExecutorService;
+import com.yahoo.elide.async.service.AsyncQueryDAO;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Async Configuration For Elide Services.  Override any of the beans (by defining your own) to change
+ * the default behavior.
+ */
+@Configuration
+@EntityScan(basePackageClasses = AsyncQuery.class)
+@EnableConfigurationProperties(ElideConfigProperties.class)
+@ConditionalOnExpression("${elide.async.enabled:false}")
+public class ElideAsyncConfiguration {
+
+    /**
+     * Configure the AsyncExecutorService used for submitting async query requests.
+     * @param elide elideObject.
+     * @param settings Elide settings.
+     * @return a AsyncExecutorService.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public AsyncExecutorService buildAsyncExecutorService(Elide elide, ElideConfigProperties settings,
+            AsyncQueryDAO asyncQueryDao) {
+        return new AsyncExecutorService(elide, settings.getAsync().getThreadPoolSize(),
+                settings.getAsync().getMaxRunTimeMinutes(), asyncQueryDao);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncQueryDAOConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncQueryDAOConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.service.AsyncQueryDAO;
+import com.yahoo.elide.async.service.DefaultAsyncQueryDAO;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Async Configuration For Elide Services.  Override any of the beans (by defining your own) to change
+ * the default behavior.
+ */
+@Configuration
+@EnableConfigurationProperties(ElideConfigProperties.class)
+@ConditionalOnExpression("${elide.async.defaultAsyncQueryDAO:true}")
+public class ElideAsyncQueryDAOConfiguration {
+
+    /**
+     * Configure the AsyncQueryDAO used by async query requests.
+     * @param elide elideObject.
+     * @return an AsyncQueryDAO object.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public AsyncQueryDAO buildAsyncQueryDAO(Elide elide) {
+        return new DefaultAsyncQueryDAO(elide, elide.getDataStore());
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -32,6 +32,11 @@ public class ElideConfigProperties {
     private SwaggerControllerProperties swagger;
 
     /**
+     * Settings for the Async.
+     */
+    private AsyncProperties async;
+
+    /**
      * Default pagination size for collections if the client doesn't paginate.
      */
     private int pageSize = 500;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
  com.yahoo.elide.spring.config.ElideAutoConfiguration, \
+ com.yahoo.elide.spring.config.ElideAsyncQueryDAOConfiguration, \
+ com.yahoo.elide.spring.config.ElideAsyncConfiguration, \
  com.yahoo.elide.spring.controllers.JsonApiController, \
  com.yahoo.elide.spring.controllers.GraphqlController, \
  com.yahoo.elide.spring.controllers.SwaggerController

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/App.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/App.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.spring;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @SpringBootApplication
+@EntityScan
 public class App {
     public static void main(String[] args) throws Exception {
         SpringApplication.run(App.class, args);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -13,6 +13,13 @@ elide:
     path: /doc
     enabled: true
     version: "1.0"
+  async:
+    enabled: true
+    threadPoolSize: 7
+    maxRunTimeMinutes: 65
+    cleanupEnabled: true
+    queryCleanupDays: 7
+    defaultAsyncQueryDAO: true
 
 spring:
   jpa:

--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -82,6 +82,12 @@
             <artifactId>elide-swagger</artifactId>
             <version>5.0.0-pr7-SNAPSHOT</version>
         </dependency>
+        
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-async</artifactId>
+            <version>5.0.0-pr7-SNAPSHOT</version>
+        </dependency>
 
         <!-- Jetty -->
         <dependency>

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2019, Yahoo Inc.
+  ~ Copyright 2020, Yahoo Inc.
   ~ Licensed under the Apache License, Version 2.0
   ~ See LICENSE file in project root for terms.
   -->

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -73,6 +73,11 @@
             <artifactId>elide-swagger</artifactId>
             <version>5.0.0-pr7-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-async</artifactId>
+            <version>5.0.0-pr7-SNAPSHOT</version>
+        </dependency>
 
         <!-- JPA -->
         <dependency>

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
@@ -124,7 +124,6 @@ public class ElideStandalone {
             jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
         }
 
-
         elideStandaloneSettings.updateServletContextHandler(context);
 
         try {

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.standalone;
 
+import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.utils.ClassScanner;
 import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl;
 import org.hibernate.jpa.boot.internal.PersistenceUnitInfoDescriptor;
@@ -23,7 +24,8 @@ import javax.persistence.spi.PersistenceUnitInfo;
  */
 public class Util {
 
-    public static EntityManagerFactory getEntityManagerFactory(String modelPackageName, Properties options) {
+    public static EntityManagerFactory getEntityManagerFactory(String modelPackageName, boolean includeAsyncModel, 
+            Properties options) {
 
         // Configure default options for example service
         if (options.isEmpty()) {
@@ -52,11 +54,28 @@ public class Util {
         }
 
         PersistenceUnitInfo persistenceUnitInfo = new PersistenceUnitInfoImpl("elide-stand-alone",
-                getAllEntities(modelPackageName), options);
+                combineModelEntities(modelPackageName, includeAsyncModel), options);
 
         return new EntityManagerFactoryBuilderImpl(
                 new PersistenceUnitInfoDescriptor(persistenceUnitInfo), new HashMap<>())
                 .build();
+    }
+
+    /**
+     * Combine the model entities with Async model.
+     *
+     * @param modelPackageName Package name
+     * @param includeAsyncModel Include Async model package Name
+     * @return All entities combined from both package.
+     */
+    public static List<String> combineModelEntities(String modelPackageName, boolean includeAsyncModel) {
+
+        List<String> modelEntities = getAllEntities(modelPackageName);
+
+        if (includeAsyncModel) {
+            modelEntities.addAll(getAllEntities(AsyncQuery.class.getPackage().getName()));
+        }
+        return modelEntities;
     }
 
     /**

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -10,7 +10,12 @@ import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.standalone.Util;
-
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.AsyncQueryResult;
+import com.yahoo.elide.async.service.AsyncExecutorService;
+import com.yahoo.elide.async.service.AsyncCleanerService;
+import com.yahoo.elide.async.service.AsyncQueryDAO;
+import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -18,9 +23,11 @@ import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
 
+import io.swagger.models.Info;
 import io.swagger.models.Swagger;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,7 +64,8 @@ public class ElideResourceConfig extends ResourceConfig {
         register(new AbstractBinder() {
             @Override
             protected void configure() {
-                bind(Util.getAllEntities(settings.getModelPackageName())).to(Set.class).named("elideAllModels");
+                bind(Util.combineModelEntities(settings.getModelPackageName(), settings.enableAsync())).to(Set.class)
+                        .named("elideAllModels");
             }
         });
 
@@ -76,6 +84,25 @@ public class ElideResourceConfig extends ResourceConfig {
                 bind(elideSettings).to(ElideSettings.class);
                 bind(elideSettings.getDictionary()).to(EntityDictionary.class);
                 bind(elideSettings.getDataStore()).to(DataStore.class).named("elideDataStore");
+
+                // Binding async service
+                if(settings.enableAsync()) {
+                    AsyncQueryDAO asyncQueryDao = settings.getAsyncQueryDAO();
+                    asyncQueryDao.setElide(elide);
+                    asyncQueryDao.setDataStore(elide.getDataStore());
+                    bind(asyncQueryDao).to(AsyncQueryDAO.class);
+
+                    AsyncExecutorService asyncExecService = new AsyncExecutorService(elide, settings.getAsyncThreadSize(),
+                            settings.getMaxRunTimeMinutes(), asyncQueryDao);
+                    bind(asyncExecService).to(AsyncExecutorService.class);
+
+                    // Binding async cleanup service
+                    if(settings.enableAsyncCleanup()) {
+                        AsyncCleanerService asyncCleanerService = new AsyncCleanerService(elide, settings.getMaxRunTimeMinutes(),
+                                 settings.getQueryCleanupDays(), asyncQueryDao);
+                        bind(asyncCleanerService).to(AsyncCleanerService.class);
+                    }
+                }
             }
         });
 
@@ -85,6 +112,21 @@ public class ElideResourceConfig extends ResourceConfig {
             protected void configure() {
                 Map<String, Swagger> swaggerDocs = settings.enableSwagger();
                 if (!swaggerDocs.isEmpty()) {
+                    // Include the async models in swagger docs
+                    if(settings.enableAsync()) {
+                        EntityDictionary dictionary = new EntityDictionary(new HashMap());
+                        dictionary.bindEntity(AsyncQuery.class);
+                        dictionary.bindEntity(AsyncQueryResult.class);
+                         
+                        Info info = new Info().title("Async Service").version("1.0");
+
+                        SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
+
+                        Swagger swagger = builder.build().basePath("/api/v1");
+
+                        swaggerDocs.put("async", swagger);
+                    }
+
                     bind(swaggerDocs).named("swagger").to(new TypeLiteral<Map<String, Swagger>>() { });
                 }
             }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -18,6 +18,8 @@ import com.yahoo.elide.datastores.jpa.JpaDataStore;
 import com.yahoo.elide.datastores.jpa.transaction.NonJtaTransaction;
 import com.yahoo.elide.security.checks.Check;
 import com.yahoo.elide.standalone.Util;
+import com.yahoo.elide.async.service.AsyncQueryDAO;
+import com.yahoo.elide.async.service.DefaultAsyncQueryDAO;
 
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -62,7 +64,7 @@ public interface ElideStandaloneSettings {
      */
     default ElideSettings getElideSettings(ServiceLocator injector) {
         EntityManagerFactory entityManagerFactory = Util.getEntityManagerFactory(getModelPackageName(),
-                getDatabaseProperties());
+                enableAsync(), getDatabaseProperties());
         DataStore dataStore = new JpaDataStore(
                 () -> { return entityManagerFactory.createEntityManager(); },
                 (em -> { return new NonJtaTransaction(em); }));
@@ -167,6 +169,60 @@ public interface ElideStandaloneSettings {
     default boolean enableGraphQL() {
         return true;
     }
+    
+    /**
+     * Enable the support for Async querying feature. If false, the async feature will be disabled.
+     *
+     * @return Default: False
+     */
+    default boolean enableAsync() {
+        return false;
+    }
+
+    /**
+     * Enable the support for cleaning up Async query history. If false, the async cleanup feature will be disabled.
+     *
+     * @return Default: False
+     */
+    default boolean enableAsyncCleanup() {
+        return false;
+    }
+
+    /**
+     * Thread Size for Async queries to run in parallel.
+     *
+     * @return Default: 5
+     */
+    default Integer getAsyncThreadSize() {
+        return 5;
+    }
+
+    /**
+     * Maximum Query Run time for Async Queries to mark as TIMEDOUT.
+     *
+     * @return Default: 60
+     */
+    default Integer getMaxRunTimeMinutes() {
+        return 60;
+    }
+
+    /**
+     * Number of days history to retain for async query executions and results.
+     *
+     * @return Default: 7
+     */
+    default Integer getQueryCleanupDays() {
+        return 7;
+    }
+
+    /**
+     * Implementation of AsyncQueryDAO to use.
+     *
+     * @return AsyncQueryDAO type object.
+     */
+    default AsyncQueryDAO getAsyncQueryDAO() {
+        return new DefaultAsyncQueryDAO();
+    }
 
     /**
      * Whether Dates should be ISO8601 strings (true) or epochs (false).
@@ -185,7 +241,6 @@ public interface ElideStandaloneSettings {
         return true;
     }
 
-
     /**
      * Enable swagger documentation by returning non empty map object.
      * @return Map object that maps document name to swagger object.
@@ -193,7 +248,6 @@ public interface ElideStandaloneSettings {
     default Map<String, Swagger> enableSwagger() {
         return new HashMap<>();
     }
-
 
     /**
      * JAX-RS filters to register with the web service.
@@ -215,7 +269,6 @@ public interface ElideStandaloneSettings {
         // Do nothing by default
         return (x) -> { };
     }
-
 
     /**
      * Gets properties to configure the database

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>elide-integration-tests</module>
         <module>elide-example</module>
         <module>elide-contrib</module>
+        <module>elide-async</module>
         <module>elide-standalone</module>
         <module>elide-spring</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2016, Yahoo Inc.
+  ~ Copyright 2020, Yahoo Inc.
   ~ Licensed under the Apache License, Version 2.0
   ~ See LICENSE file in project root for terms.
   -->


### PR DESCRIPTION
Elide Async Feature

Co-authored-by: abhino abhino@gmail.com

## Description
These changes add the Elide Async Feature to Elide-5.x versions. The Elide Async API will support two new entities for asynchronous scheduled queries. Each Elide instance will run a background ExecutorService process which is responsible for running the query (AsyncQuery) in the background and posting the results to the database (AsyncQueryResult).

The ExecutorService executes queries programmatically using the Elide and QueryRunner interfaces. A post-commit hook (Elide lifecycle hook) on the AsyncRequest model queues up a task in the executor service to run the query. 

Additionally there are two additional services to support this feature:
1) The AsyncQueryInterruptor service handles any long running query beyond the max runtime. This service terminates the async query if max run time is reached and sets the status in the result to TIMEDOUT.

2) Should the service be stopped or crash with tasks running, the tasks can hang in the PROCESSING state. Therefore, the AsyncQueryCleaner service looks for expired AsnycQueries in the PROCESSING state and mark them as TIMEDOUT after a timeout.

Both the elide Standalone and Elide-Spring have been updated to include this feature and are configurable - the updates are part of separate pull requests as mentioned above.

Changes in elide-spring
- New properties class for Async related properties like enable/disable, number of threads for executing the async queries in parallel, the maximum run time for individual threads before they are automatically killed, number of instances hosting the elide service in parallel (to avoid all hosts trying to update status of orphan queries in parallel).
- New Async Configuration for binding AsyncExecutor Service when Async is enabled. It also adds Async Models to the dictionary.
- Adds the Async models to Swagger if Async and Swagger are enabled. The Async models are available on /swagger/doc/async path
- Added EntityScan to Main class with model packages path since earlier it will bind all models with `@Entity` annotation, but we don't want Async models to be bound if async is not enabled. 
 
Changes in elide-standalone
- Changes to the methods in Util class to combine the Async models with package models.  
- Binds AsyncExecutor Service when Async is enabled.
- Adds the Async models to Swagger if Async and Swagger are enabled. The Async models are available on /swagger/doc/async path
- Additional methods added to ElideStandaloneSettings.java for configuring the Async Feature like enable/disable, number of threads for executing the async queries in parallel, the maximum run time for individual threads before they are automatically killed, number of instances hosting the elide service in parallel (to avoid all hosts trying to update status of orphan queries in parallel). 
   
## Motivation and Context
The Async module would help users who have potentially long running queries/requests submit asynchronous requests and view the results later. 

## How Has This Been Tested?
The feature has been tested with elide-standalone and elide-spring with sample application implementations.
Additional unit tests and integration tests will be added for the Async features.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.