### PR TITLE
Change the way types are named in the GraphQL schema

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -56,7 +56,7 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
     @Test
     public void testGraphQLSchema() throws IOException {
         String graphQLRequest = "{"
-                + "__type(name: \"_edges__playerStatsWithView\") {"
+                + "__type(name: \"PlayerStatsWithViewEdge\") {"
                 + "   name "
                 + "     fields {"
                 + "         name "

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/graphql/responses/testGraphQLSchema.json
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/graphql/responses/testGraphQLSchema.json
@@ -1,12 +1,12 @@
 {
   "data": {
     "__type": {
-      "name": "_edges__playerStatsWithView",
+      "name": "PlayerStatsWithViewEdge",
       "fields": [
         {
           "name": "node",
           "type": {
-            "name": "_node__playerStatsWithView",
+            "name": "PlayerStatsWithView",
             "fields": [
               {
                 "name": "id",

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -363,7 +363,7 @@ public class GraphQLConversionUtils {
         }
 
         GraphQLObjectType.Builder objectBuilder = newObject();
-        objectBuilder.name(nameUtils.toOutputTypeName(clazz));
+        objectBuilder.name(nameUtils.toNonElideOutputTypeName(clazz));
 
         for (String attribute : nonEntityDictionary.getAttributes(clazz)) {
             Class<?> attributeClass = nonEntityDictionary.getType(clazz, attribute);
@@ -409,7 +409,7 @@ public class GraphQLConversionUtils {
         }
 
         GraphQLInputObjectType.Builder objectBuilder = newInputObject();
-        objectBuilder.name(nameUtils.toInputTypeName(clazz));
+        objectBuilder.name(nameUtils.toNonElideInputTypeName(clazz));
 
         for (String attribute : nonEntityDictionary.getAttributes(clazz)) {
             log.info("Building input object attribute: {}", attribute);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -45,7 +45,6 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 public class GraphQLConversionUtils {
-    protected static final String MAP = "Map";
     protected static final String KEY = "key";
     protected static final String VALUE = "value";
     protected static final String ERROR_MESSAGE = "Value should either be integer, String or float";
@@ -59,9 +58,11 @@ public class GraphQLConversionUtils {
     private final Map<Class, GraphQLInputObjectType> inputConversions = new HashMap<>();
     private final Map<Class, GraphQLEnumType> enumConversions = new HashMap<>();
     private final Map<String, GraphQLList> mapConversions = new HashMap<>();
+    private final GraphQLNameUtils nameUtils;
 
     public GraphQLConversionUtils(EntityDictionary dictionary) {
         this.entityDictionary = dictionary;
+        this.nameUtils = new GraphQLNameUtils(dictionary);
         registerCustomScalars();
     }
 
@@ -120,10 +121,10 @@ public class GraphQLConversionUtils {
 
         Enum [] values = (Enum []) enumClazz.getEnumConstants();
 
-        GraphQLEnumType.Builder builder = newEnum().name(toValidNameName(enumClazz.getName()));
+        GraphQLEnumType.Builder builder = newEnum().name(nameUtils.toOutputTypeName(enumClazz));
 
         for (Enum value : values) {
-            builder.value(toValidNameName(value.name()), value);
+            builder.value(value.toString(), value);
         }
 
         GraphQLEnumType enumResult = builder.build();
@@ -142,7 +143,7 @@ public class GraphQLConversionUtils {
      * @return The created type.
      */
     public GraphQLList classToQueryMap(Class<?> keyClazz, Class<?> valueClazz, DataFetcher fetcher) {
-        String mapName = toValidNameName(keyClazz.getName() + valueClazz.getCanonicalName() + MAP);
+        String mapName = nameUtils.toMapEntryOutputName(keyClazz, valueClazz);
 
         if (mapConversions.containsKey(mapName)) {
             return mapConversions.get(mapName);
@@ -179,7 +180,7 @@ public class GraphQLConversionUtils {
      */
     public GraphQLList classToInputMap(Class<?> keyClazz,
                                        Class<?> valueClazz) {
-        String mapName = toValidNameName("_input__" + keyClazz.getName() + valueClazz.getCanonicalName() + MAP);
+        String mapName = nameUtils.toMapEntryInputName(keyClazz, valueClazz);
 
         if (mapConversions.containsKey(mapName)) {
             return mapConversions.get(mapName);
@@ -294,19 +295,6 @@ public class GraphQLConversionUtils {
     }
 
     /**
-     * Helper function converts a string into a valid name.
-     *
-     * @param input Input string
-     * @return Sanitized form of input string
-     */
-    protected String toValidNameName(String input) {
-        return input
-                .replace(".", "_") // Replaces package qualifier on class names
-                .replace("$", "__1") // Replaces inner-class qualifier
-                .replace("[", "___2"); // Replaces primitive list qualifier ([B == array of bytes)
-    }
-
-    /**
      * Helper function which converts an attribute of an entity to a GraphQL Input Type.
      * @param parentClass The parent entity class (Can either be an elide entity or not).
      * @param attributeClass The attribute class.
@@ -375,7 +363,7 @@ public class GraphQLConversionUtils {
         }
 
         GraphQLObjectType.Builder objectBuilder = newObject();
-        objectBuilder.name(toValidNameName(clazz.getName()));
+        objectBuilder.name(nameUtils.toOutputTypeName(clazz));
 
         for (String attribute : nonEntityDictionary.getAttributes(clazz)) {
             Class<?> attributeClass = nonEntityDictionary.getType(clazz, attribute);
@@ -421,7 +409,7 @@ public class GraphQLConversionUtils {
         }
 
         GraphQLInputObjectType.Builder objectBuilder = newInputObject();
-        objectBuilder.name(toValidNameName("_input__" + clazz.getName()));
+        objectBuilder.name(nameUtils.toInputTypeName(clazz));
 
         for (String attribute : nonEntityDictionary.getAttributes(clazz)) {
             log.info("Building input object attribute: {}", attribute);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
@@ -8,13 +8,13 @@ package com.yahoo.elide.graphql;
 
 import com.yahoo.elide.core.EntityDictionary;
 
-import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 
 public class GraphQLNameUtils {
     private static final String MAP_SUFFIX = "Map";
     private static final String INPUT_SUFFIX = "Input";
-    private static final String NODE_SUFFIX = "Node";
-    private static final String EDGES_SUFFIX = "Edges";
+    private static final String CONNECTION_SUFFIX = "Connection";
+    private static final String EDGE_SUFFIX = "Edge";
 
     private final EntityDictionary dictionary;
 
@@ -23,8 +23,10 @@ public class GraphQLNameUtils {
     }
 
     public String toOutputTypeName(Class<?> clazz) {
-        return Optional.ofNullable(dictionary.getJsonAliasFor(clazz))
-                       .orElse(clazz.getSimpleName());
+        if (dictionary.hasBinding(clazz)) {
+            return StringUtils.capitalize(dictionary.getJsonAliasFor(clazz));
+        }
+        return clazz.getSimpleName();
     }
 
     public String toInputTypeName(Class<?> clazz) {
@@ -36,14 +38,26 @@ public class GraphQLNameUtils {
     }
 
     public String toMapEntryInputName(Class<?> keyClazz, Class<?> valueClazz) {
-        return toOutputTypeName(keyClazz) + toOutputTypeName(valueClazz) + MAP_SUFFIX + INPUT_SUFFIX;
+        return toMapEntryOutputName(keyClazz, valueClazz) + INPUT_SUFFIX;
     }
 
     public String toEdgesName(Class<?> clazz) {
-        return toOutputTypeName(clazz) + EDGES_SUFFIX;
+        return toOutputTypeName(clazz) + EDGE_SUFFIX;
     }
 
     public String toNodeName(Class<?> clazz) {
-        return toOutputTypeName(clazz) + NODE_SUFFIX;
+        return toOutputTypeName(clazz);
+    }
+
+    public String toConnectionName(Class<?> clazz) {
+        return toOutputTypeName(clazz) + CONNECTION_SUFFIX;
+    }
+
+    public String toNonElideOutputTypeName(Class<?> clazz) {
+        return StringUtils.uncapitalize(toOutputTypeName(clazz));
+    }
+
+    public String toNonElideInputTypeName(Class<?> clazz) {
+        return StringUtils.uncapitalize(toInputTypeName(clazz));
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.graphql;
+
+import com.yahoo.elide.core.EntityDictionary;
+
+import java.util.Optional;
+
+public class GraphQLNameUtils {
+    private static final String MAP_SUFFIX = "Map";
+    private static final String INPUT_SUFFIX = "Input";
+    private static final String NODE_SUFFIX = "Node";
+    private static final String EDGES_SUFFIX = "Edges";
+
+    private final EntityDictionary dictionary;
+
+    public GraphQLNameUtils(EntityDictionary dictionary) {
+        this.dictionary = dictionary;
+    }
+
+    public String toOutputTypeName(Class<?> clazz) {
+        return Optional.ofNullable(dictionary.getJsonAliasFor(clazz))
+                       .orElse(clazz.getSimpleName());
+    }
+
+    public String toInputTypeName(Class<?> clazz) {
+        return toOutputTypeName(clazz) + INPUT_SUFFIX;
+    }
+
+    public String toMapEntryOutputName(Class<?> keyClazz, Class<?> valueClazz) {
+        return toOutputTypeName(keyClazz) + toOutputTypeName(valueClazz) + MAP_SUFFIX;
+    }
+
+    public String toMapEntryInputName(Class<?> keyClazz, Class<?> valueClazz) {
+        return toOutputTypeName(keyClazz) + toOutputTypeName(valueClazz) + MAP_SUFFIX + INPUT_SUFFIX;
+    }
+
+    public String toEdgesName(Class<?> clazz) {
+        return toOutputTypeName(clazz) + EDGES_SUFFIX;
+    }
+
+    public String toNodeName(Class<?> clazz) {
+        return toOutputTypeName(clazz) + NODE_SUFFIX;
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -48,8 +48,8 @@ public class ModelBuilder {
     public static final String ARGUMENT_AFTER = "after";
     public static final String ARGUMENT_OPERATION = "op";
     public static final String OBJECT_PAGE_INFO = "PageInfo";
-    public static final String OBJECT_MUTATION_ROOT = "MutationRoot";
-    public static final String OBJECT_QUERY_ROOT = "QueryRoot";
+    public static final String OBJECT_MUTATION = "Mutation";
+    public static final String OBJECT_QUERY = "Query";
 
     private EntityDictionary dictionary;
     private DataFetcher dataFetcher;
@@ -162,7 +162,7 @@ public class ModelBuilder {
         resolveInputObjectRelationships();
 
         /* Construct root object */
-        GraphQLObjectType.Builder root = newObject().name(OBJECT_QUERY_ROOT);
+        GraphQLObjectType.Builder root = newObject().name(OBJECT_QUERY);
         for (Class<?> clazz : rootClasses) {
             String entityName = dictionary.getJsonAliasFor(clazz);
             root.field(newFieldDefinition()
@@ -179,7 +179,7 @@ public class ModelBuilder {
         }
 
         GraphQLObjectType queryRoot = root.build();
-        GraphQLObjectType mutationRoot = root.name(OBJECT_MUTATION_ROOT).build();
+        GraphQLObjectType mutationRoot = root.name(OBJECT_MUTATION).build();
 
         /*
          * Walk the object graph (avoiding cycles) and construct the GraphQL output object types.
@@ -209,7 +209,7 @@ public class ModelBuilder {
             return connectionObjectRegistry.get(entityClass);
         }
 
-        String entityName = nameUtils.toOutputTypeName(entityClass);
+        String entityName = nameUtils.toConnectionName(entityClass);
 
         GraphQLObjectType connectionObject = newObject()
                 .name(entityName)
@@ -283,7 +283,7 @@ public class ModelBuilder {
                 continue;
             }
 
-            String relationshipEntityName = nameUtils.toOutputTypeName(relationshipClass);
+            String relationshipEntityName = nameUtils.toConnectionName(relationshipClass);
             RelationshipType type = dictionary.getRelationshipType(entityClass, relationship);
 
             if (type.isToOne()) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -26,6 +26,7 @@ import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.PaginationImpl;
 import com.yahoo.elide.core.sort.SortingImpl;
+import com.yahoo.elide.graphql.GraphQLNameUtils;
 import com.yahoo.elide.graphql.ModelBuilder;
 import com.yahoo.elide.request.Attribute;
 import com.yahoo.elide.request.EntityProjection;
@@ -72,6 +73,8 @@ public class GraphQLEntityProjectionMaker {
     private final Map<String, EntityProjection> rootProjections = new HashMap<>();
     private final Map<SourceLocation, Attribute> attributeMap = new HashMap<>();
 
+    private final GraphQLNameUtils nameUtils;
+
     /**
      * Constructor.
      *
@@ -87,6 +90,7 @@ public class GraphQLEntityProjectionMaker {
 
         this.variableResolver = new VariableResolver(variables);
         this.fragmentResolver = new FragmentResolver();
+        this.nameUtils = new GraphQLNameUtils(entityDictionary);
     }
 
     /**
@@ -231,7 +235,7 @@ public class GraphQLEntityProjectionMaker {
         FragmentDefinition fragmentDefinition = fragmentResolver.get(fragmentName);
 
         // type name in type condition of the Fragment must match the entity projection type name
-        if (entityDictionary.getJsonAliasFor(projectionBuilder.getType())
+        if (nameUtils.toConnectionName(projectionBuilder.getType())
                 .equals(fragmentDefinition.getTypeCondition().getName())) {
             fragmentDefinition.getSelectionSet().getSelections()
                     .forEach(selection -> addSelection(selection, projectionBuilder));

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -55,18 +55,23 @@ public class ModelBuilderTest {
     // Meta fields
     private static final String PAGE_INFO = "pageInfo";
 
-    private static final String BOOK = "book";
-    private static final String BOOKS = "books";
-    private static final String BOOK_INPUT = "bookInput";
-    private static final String NAME = "name";
-    private static final String AUTHOR = "author";
-    private static final String AUTHOR_INPUT = "authorInput";
-    private static final String AUTHORS = "authors";
-    private static final String TITLE = "title";
-    private static final String PUBLISH_DATE = "publishDate";
-    private static final String GENRE = "genre";
-    private static final String LANGUAGE = "language";
-    private static final String WEIGHT_LBS = "weightLbs";
+    private static final String TYPE_QUERY = "Query";
+    private static final String TYPE_BOOK_CONNECTION = "BookConnection";
+    private static final String TYPE_BOOK_INPUT = "BookInput";
+    private static final String TYPE_BOOK = "Book";
+    private static final String TYPE_AUTHOR_CONNECTION = "AuthorConnection";
+    private static final String TYPE_AUTHOR_INPUT = "AuthorInput";
+
+    private static final String FIELD_BOOK = "book";
+    private static final String FIELD_BOOKS = "books";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_AUTHORS = "authors";
+    private static final String FIELD_TITLE = "title";
+    private static final String FIELD_PUBLISH_DATE = "publishDate";
+    private static final String FIELD_GENRE = "genre";
+    private static final String FIELD_LANGUAGE = "language";
+    private static final String FIELD_WEIGHT_LBS = "weightLbs";
+    private static final String FIELD_PUBLISHER = "publisher";
 
     // TODO: We need more tests. I've updated the models to contain all of the situations below, but we should _esnure_
     // the generated result is exactly correct:
@@ -95,7 +100,7 @@ public class ModelBuilderTest {
 
         GraphQLSchema schema = builder.build();
 
-        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(BOOK);
+        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK_CONNECTION);
         assertNotNull(bookType.getFieldDefinition(PAGE_INFO));
     }
 
@@ -107,10 +112,10 @@ public class ModelBuilderTest {
         GraphQLSchema schema = builder.build();
         GraphQLObjectType root = schema.getQueryType();
         assertNotNull(root);
-        assertNotNull(root.getFieldDefinition(BOOK));
+        assertNotNull(root.getFieldDefinition(FIELD_BOOK));
 
         /* The root 'book' should have all query parameters defined */
-        GraphQLFieldDefinition bookField = root.getFieldDefinition(BOOK);
+        GraphQLFieldDefinition bookField = root.getFieldDefinition(FIELD_BOOK);
         assertNotNull(bookField.getArgument(DATA));
         assertNotNull(bookField.getArgument(FILTER));
         assertNotNull(bookField.getArgument(SORT));
@@ -118,8 +123,8 @@ public class ModelBuilderTest {
         assertNotNull(bookField.getArgument(AFTER));
 
         /* book.publisher is a 'to one' relationship so it should be missing all but the data parameter */
-        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType("_node__" + BOOK);
-        GraphQLFieldDefinition publisherField = bookType.getFieldDefinition("publisher");
+        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
+        GraphQLFieldDefinition publisherField = bookType.getFieldDefinition(FIELD_PUBLISHER);
         assertNotNull(publisherField.getArgument(DATA));
         assertNull(publisherField.getArgument(FILTER));
         assertNull(publisherField.getArgument(SORT));
@@ -127,7 +132,7 @@ public class ModelBuilderTest {
         assertNull(publisherField.getArgument(AFTER));
 
         /* book.authors is a 'to many' relationship so it should have all query parameters defined */
-        GraphQLFieldDefinition authorField = bookType.getFieldDefinition(AUTHORS);
+        GraphQLFieldDefinition authorField = bookType.getFieldDefinition(FIELD_AUTHORS);
         assertNotNull(authorField.getArgument(DATA));
         assertNotNull(authorField.getArgument(FILTER));
         assertNotNull(authorField.getArgument(SORT));
@@ -142,54 +147,54 @@ public class ModelBuilderTest {
 
         GraphQLSchema schema = builder.build();
 
-        assertNotEquals(schema.getType(AUTHOR), null);
-        assertNotEquals(schema.getType(BOOK), null);
-        assertNotEquals(schema.getType(AUTHOR_INPUT), null);
-        assertNotEquals(schema.getType(BOOK_INPUT), null);
-        assertNotEquals(schema.getType("_root"), null);
+        assertNotEquals(schema.getType(TYPE_AUTHOR_CONNECTION), null);
+        assertNotEquals(schema.getType(TYPE_BOOK_CONNECTION), null);
+        assertNotEquals(schema.getType(TYPE_AUTHOR_INPUT), null);
+        assertNotEquals(schema.getType(TYPE_BOOK_INPUT), null);
+        assertNotEquals(schema.getType(TYPE_QUERY), null);
 
-        GraphQLObjectType bookType = getConnectedType((GraphQLObjectType) schema.getType(BOOK), null);
-        GraphQLObjectType authorType = getConnectedType((GraphQLObjectType) schema.getType(AUTHOR), null);
+        GraphQLObjectType bookType = getConnectedType((GraphQLObjectType) schema.getType(TYPE_BOOK_CONNECTION), null);
+        GraphQLObjectType authorType = getConnectedType((GraphQLObjectType) schema.getType(TYPE_AUTHOR_CONNECTION), null);
 
-        assertTrue(bookType.getFieldDefinition(TITLE).getType().equals(Scalars.GraphQLString));
-        assertTrue(bookType.getFieldDefinition(GENRE).getType().equals(Scalars.GraphQLString));
-        assertTrue(bookType.getFieldDefinition(LANGUAGE).getType().equals(Scalars.GraphQLString));
-        assertTrue(bookType.getFieldDefinition(PUBLISH_DATE).getType().equals(Scalars.GraphQLLong));
-        assertTrue(bookType.getFieldDefinition(WEIGHT_LBS).getType().equals(Scalars.GraphQLBigDecimal));
+        assertTrue(bookType.getFieldDefinition(FIELD_TITLE).getType().equals(Scalars.GraphQLString));
+        assertTrue(bookType.getFieldDefinition(FIELD_GENRE).getType().equals(Scalars.GraphQLString));
+        assertTrue(bookType.getFieldDefinition(FIELD_LANGUAGE).getType().equals(Scalars.GraphQLString));
+        assertTrue(bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getType().equals(Scalars.GraphQLLong));
+        assertTrue(bookType.getFieldDefinition(FIELD_WEIGHT_LBS).getType().equals(Scalars.GraphQLBigDecimal));
 
         GraphQLObjectType addressType = (GraphQLObjectType) authorType.getFieldDefinition("homeAddress").getType();
         assertTrue(addressType.getFieldDefinition("street1").getType().equals(Scalars.GraphQLString));
         assertTrue(addressType.getFieldDefinition("street2").getType().equals(Scalars.GraphQLString));
 
 
-        GraphQLObjectType authorsType = (GraphQLObjectType) bookType.getFieldDefinition(AUTHORS).getType();
+        GraphQLObjectType authorsType = (GraphQLObjectType) bookType.getFieldDefinition(FIELD_AUTHORS).getType();
         GraphQLObjectType authorsNodeType = getConnectedType(authorsType, null);
 
         assertTrue(authorsNodeType.equals(authorType));
 
-        assertTrue(authorType.getFieldDefinition(NAME).getType().equals(Scalars.GraphQLString));
+        assertTrue(authorType.getFieldDefinition(FIELD_NAME).getType().equals(Scalars.GraphQLString));
 
         assertTrue(validateEnum(Author.AuthorType.class,
                 (GraphQLEnumType) authorType.getFieldDefinition(TYPE).getType()));
 
         // Node type != connection type
-        GraphQLObjectType booksNodeType = (GraphQLObjectType) authorType.getFieldDefinition(BOOKS).getType();
+        GraphQLObjectType booksNodeType = (GraphQLObjectType) authorType.getFieldDefinition(FIELD_BOOKS).getType();
         assertFalse(booksNodeType.equals(bookType));
 
-        GraphQLInputObjectType bookInputType = (GraphQLInputObjectType) schema.getType(BOOK_INPUT);
-        GraphQLInputObjectType authorInputType = (GraphQLInputObjectType) schema.getType(AUTHOR_INPUT);
+        GraphQLInputObjectType bookInputType = (GraphQLInputObjectType) schema.getType(TYPE_BOOK_INPUT);
+        GraphQLInputObjectType authorInputType = (GraphQLInputObjectType) schema.getType(TYPE_AUTHOR_INPUT);
 
-        assertTrue(bookInputType.getField(TITLE).getType().equals(Scalars.GraphQLString));
-        assertTrue(bookInputType.getField(GENRE).getType().equals(Scalars.GraphQLString));
-        assertTrue(bookInputType.getField(LANGUAGE).getType().equals(Scalars.GraphQLString));
-        assertTrue(bookInputType.getField(PUBLISH_DATE).getType().equals(Scalars.GraphQLLong));
+        assertTrue(bookInputType.getField(FIELD_TITLE).getType().equals(Scalars.GraphQLString));
+        assertTrue(bookInputType.getField(FIELD_GENRE).getType().equals(Scalars.GraphQLString));
+        assertTrue(bookInputType.getField(FIELD_LANGUAGE).getType().equals(Scalars.GraphQLString));
+        assertTrue(bookInputType.getField(FIELD_PUBLISH_DATE).getType().equals(Scalars.GraphQLLong));
 
-        GraphQLList authorsInputType = (GraphQLList) bookInputType.getField(AUTHORS).getType();
+        GraphQLList authorsInputType = (GraphQLList) bookInputType.getField(FIELD_AUTHORS).getType();
         assertTrue(authorsInputType.getWrappedType().equals(authorInputType));
 
-        assertTrue(authorInputType.getField(NAME).getType().equals(Scalars.GraphQLString));
+        assertTrue(authorInputType.getField(FIELD_NAME).getType().equals(Scalars.GraphQLString));
 
-        GraphQLList booksInputType = (GraphQLList) authorInputType.getField(BOOKS).getType();
+        GraphQLList booksInputType = (GraphQLList) authorInputType.getField(FIELD_BOOKS).getType();
         assertTrue(booksInputType.getWrappedType().equals(bookInputType));
     }
 
@@ -198,17 +203,17 @@ public class ModelBuilderTest {
         Set<ArgumentType> arguments = new HashSet<>();
         arguments.add(new ArgumentType(SORT, Sorting.SortOrder.class));
         arguments.add(new ArgumentType(TYPE, String.class));
-        dictionary.addArgumentsToAttribute(Book.class, PUBLISH_DATE, arguments);
+        dictionary.addArgumentsToAttribute(Book.class, FIELD_PUBLISH_DATE, arguments);
 
         DataFetcher fetcher = mock(DataFetcher.class);
         ModelBuilder builder = new ModelBuilder(dictionary, fetcher);
 
         GraphQLSchema schema = builder.build();
 
-        GraphQLObjectType bookType = getConnectedType((GraphQLObjectType) schema.getType(BOOK), null);
-        assertEquals(2, bookType.getFieldDefinition(PUBLISH_DATE).getArguments().size());
-        assertTrue(bookType.getFieldDefinition(PUBLISH_DATE).getArgument(SORT).getType() instanceof GraphQLEnumType);
-        assertTrue(bookType.getFieldDefinition(PUBLISH_DATE).getArgument(TYPE).getType().equals(Scalars.GraphQLString));
+        GraphQLObjectType bookType = getConnectedType((GraphQLObjectType) schema.getType(TYPE_BOOK_CONNECTION), null);
+        assertEquals(2, bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getArguments().size());
+        assertTrue(bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getArgument(SORT).getType() instanceof GraphQLEnumType);
+        assertTrue(bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getArgument(TYPE).getType().equals(Scalars.GraphQLString));
     }
 
     private GraphQLObjectType getConnectedType(GraphQLObjectType root, String connectionName) {

--- a/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentCorrect.graphql
+++ b/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentCorrect.graphql
@@ -4,7 +4,7 @@ query namedQuery {
   }
 }
 
-fragment AuthorFields on author {
+fragment AuthorFields on AuthorConnection {
   edges {
     node {
       id
@@ -18,7 +18,7 @@ fragment AuthorFields on author {
   }
 }
 
-fragment BookFields on book {
+fragment BookFields on BookConnection {
   edges {
     node {
       id

--- a/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentInline.graphql
+++ b/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentInline.graphql
@@ -4,12 +4,12 @@ query namedQuery {
   }
 }
 
-fragment AuthorFields on author {
+fragment AuthorFields on AuthorConnection {
   edges {
     node {
       id
       books {
-        ... on book {
+        ... on BookConnection {
           edges {
             node {
               id

--- a/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentLoop.graphql
+++ b/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentLoop.graphql
@@ -4,7 +4,7 @@ query namedQuery {
   }
 }
 
-fragment AuthorFields on author {
+fragment AuthorFields on AuthorConnection {
   edges {
     node {
       id
@@ -18,7 +18,7 @@ fragment AuthorFields on author {
   }
 }
 
-fragment BookFields on book {
+fragment BookFields on BookConnection {
   edges {
     node {
       id

--- a/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentUnknown.graphql
+++ b/elide-graphql/src/test/resources/graphql/requests/fetch/fragmentUnknown.graphql
@@ -4,7 +4,7 @@ query namedQuery {
   }
 }
 
-fragment AuthorFields on author {
+fragment AuthorFields on AuthorConnection {
   edges {
     node {
       id
@@ -18,7 +18,7 @@ fragment AuthorFields on author {
   }
 }
 
-fragment BookFields on book {
+fragment BookFields on BookConnection {
   edges {
     node {
       id

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentCorrect.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentCorrect.json
@@ -19,11 +19,11 @@
                 }
               }
             ],
-            "__typename": "book"
+            "__typename": "BookConnection"
           },
-          "__typename": "_node__author"
+          "__typename": "Author"
         },
-        "__typename": "_edges__author"
+        "__typename": "AuthorEdge"
       },
       {
         "node": {
@@ -37,11 +37,11 @@
                 }
               }
             ],
-            "__typename": "book"
+            "__typename": "BookConnection"
           },
-          "__typename": "_node__author"
+          "__typename": "Author"
         },
-        "__typename": "_edges__author"
+        "__typename": "AuthorEdge"
       }
     ]
   }


### PR DESCRIPTION
## Motivation and context
Change the way types are named in the GraphQL schema to help with client generation tools and to be more human readable.

## Description
These changes are based on the Relay specification:
https://relay.dev/docs/en/graphql-server-specification.html

|                      | Type Name (Initially)                                               | Type Name (Now)                        |
|----------------------|---------------------------------------------------------------------|----------------------------------------|
| Node                 | \_node\_\_\<entityName\>                                                 | \<EntityName\>                           |
| Edge                 | \_edges\_\_\<entityName\>                                                | \<EntityName\>Edge                       |
| Connection           | \<entityName\>                                                        | \<EntityName\>Connection                 |
| Query                | \_root                                                               | Query                                  |
| Mutation             | \_mutation\_root                                                      | Mutation                               |
| PageInfo             | \_pageInfoObject                                                     | PageInfo                               |
| Input                | \<entityName\>Input                                                   | \<EntityName\>Input                      |
| Non elide obj        | \<my\_package\>\_\<EntityName\>                                           | \<*e*ntityName>                         |
| Non elide obj input  | \_input\_\_\<entityName\>Input                                           | \<*e*ntityName\>Input                    |
| Map Entry            | \<my\_package\>\_\<KeyClassName\>\<my\_package\>\_\<ValueClassName\>Map         | \<KeyClassName\>\<ValueClassName\>Map      |
| Map Entry Input      | \_input\_\_\<my\_package\>\_\<KeyClassName\>\<my\_package\>\_\<ValueClassName\>Map | \<KeyClassName\>\<ValueClassName\>MapInput |

In this case, the definition of a non-Elide type is a type that will be generated by the `GraphQLConversionUtils#attributeToQueryObject` or `GraphQLConversionUtils#attributeToInputObject` methods.
So some types can be Elide and non-Elide types at the same time. 
For example, if an Elide type is also the key or the value of a map. 
Therefore, there will  be two types generated for the same entity. 
To avoid name collisions, the first letter of the non-Elide type is not capitalized. 
We can also prefix or suffix the type to be even less ambiguous.

Speaking of name collisions, there can still be collisions if for example two classes have the same name but are not in the same package or if the name of a class matches one of the generated names (the `Type Name (now)` column)

## How Has This Been Tested?
* Used an elide-spring-boot application with about 50 entities to test multiple use cases (map, non-elide object, etc.).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.