### PR TITLE
Fixes Issue #1211

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <spring.boot.version>2.2.4.RELEASE</spring.boot.version>
-        <tomcat.version>9.0.30</tomcat.version>
+        <tomcat.version>9.0.33</tomcat.version>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <min_jdk_version>1.8</min_jdk_version>
         <max_jdk_version>1.8</max_jdk_version>
@@ -90,6 +90,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.12</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+            <version>1.2.2</version>
             <optional>true</optional>
         </dependency>
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.spring.controllers;
 
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Configuration;
@@ -82,10 +83,11 @@ public class SwaggerController {
      */
     @GetMapping(value = "/{name}", produces = JSON_CONTENT_TYPE)
     public ResponseEntity<String> list(@PathVariable("name") String name) {
+        String encodedName = Encode.forHtml(name);
 
-        if (documents.containsKey(name)) {
-            return ResponseEntity.status(HttpStatus.OK).body(documents.get(name));
+        if (documents.containsKey(encodedName)) {
+            return ResponseEntity.status(HttpStatus.OK).body(documents.get(encodedName));
         }
-        return ResponseEntity.status(404).body("Unknown document: " + name);
+        return ResponseEntity.status(404).body("Unknown document: " + encodedName);
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
@@ -246,6 +246,15 @@ public class ControllerTest extends IntegrationTest {
     }
 
     @Test
+    public void swaggerXSSDocumentTest() {
+        when()
+                .get("/doc/<script>")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body(equalTo("Unknown document: &lt;script&gt;"));
+    }
+
+    @Test
     public void graphqlTestForbiddenCreate() {
         ArtifactGroup group = new ArtifactGroup();
         group.setDeprecated(true);


### PR DESCRIPTION
Resolves #1211

## Description
HTML escapes the document path parameter for the Swagger Controller.

## Motivation and Context
XSS mitigation.

## How Has This Been Tested?
IT Test with `<script>` tag.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
