### PR TITLE
Added InMemoryStore to list of datastores that run IT tests

### DIFF
--- a/elide-datastore/elide-datastore-inmemorydb/pom.xml
+++ b/elide-datastore/elide-datastore-inmemorydb/pom.xml
@@ -38,16 +38,17 @@
         <tag>HEAD</tag>
     </scm>
 
+    <properties>
+        <dataStoreHarness>com.yahoo.elide.initialization.InMemoryDataStoreHarness</dataStoreHarness>
+        <excludeTags>skipInMemory</excludeTags>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-integration-tests</artifactId>
@@ -56,11 +57,50 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Test deps -->
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
-            <version>1.0.2</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -68,8 +108,30 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <failIfNoTests>true</failIfNoTests>
+                    <excludedGroups>${excludeTags}</excludedGroups>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/elide-datastore/elide-datastore-jpa/pom.xml
+++ b/elide-datastore/elide-datastore-jpa/pom.xml
@@ -96,9 +96,6 @@
             </exclusions>
         </dependency>
 
-
-
-        <!-- Hibernate 5 -->
         <!-- Integration test -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -281,6 +281,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testRootFilterNotInSingle() throws IOException {
         int nonLiteraryFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
@@ -309,6 +310,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testRootFilterNotInMultiple() throws IOException {
         int nonFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
@@ -420,6 +422,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testRootFilterPrefixWithSpecialChars() throws IOException {
         int titleStartsWithTheBookCount = 0;
         for (JsonNode node : books.get("data")) {
@@ -447,6 +450,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testRootFilterInfix() throws IOException {
         int titleContainsTheBookCount = 0;
         for (JsonNode node : books.get("data")) {
@@ -851,6 +855,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testNonRootFilterInfix() throws IOException {
         int titleContainsTheBookCount = 0;
         for (JsonNode node : asimovBooks.get("data")) {
@@ -1147,6 +1152,7 @@ public class FilterIT extends IntegrationTest {
      * Verifies that issue 508 is closed.
      */
     @Test
+    @Tag("skipInMemory")
     void testIssue508() throws IOException {
         JsonNode result = getAsNode("book?filter=(authors.name=='Thomas Harris',publisher.name=='Default Publisher')&page[totals]");
 
@@ -1192,6 +1198,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testGetBooksFilteredByAuthors() throws IOException {
         /* Test Default */
         JsonNode result = getAsNode("book?filter[book.authors.name]=Null Ned");
@@ -1215,6 +1222,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testGetBooksFilteredByAuthorsId() throws IOException {
         String nullNedIdStr = String.valueOf(nullNedId);
         /* Test Default */
@@ -1239,6 +1247,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testGetBooksFilteredByAuthorAndTitle() throws IOException {
         /* Test Default */
         JsonNode result = getAsNode("book?filter[book.authors.name]=Null Ned&filter[book.title]=Life with Null Ned");
@@ -1260,6 +1269,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testFilterAuthorsByBookChapterTitle() throws IOException {
         /* Test Default */
         JsonNode result = getAsNode("/author?sort=-name&filter[author.books.chapters.title][in]=Viva la Roma!,Mamma mia I wantz some pizza!");

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GenerateIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GenerateIT.java
@@ -17,6 +17,7 @@ import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Resource;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.initialization.IntegrationTest;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 class GenerateIT extends IntegrationTest {
 
     @Test
+    @Tag("skipInMemory")
     public void testGeneratePost() {
 
         Resource resource = resource(

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.yahoo.elide.initialization.IntegrationTest;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import io.restassured.response.Response;
@@ -515,6 +516,7 @@ class PaginateIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     void testPaginateAnnotationTotalsWithToManyJoinFilter() {
         /* Test RSQL Global */
         String url = "/author?page[totals]&filter=books.title=in=('The Roman Republic','Foundation','Life With Null Ned')";

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -66,6 +66,7 @@ import example.User;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -1716,6 +1717,7 @@ public class ResourceIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     //Verifies violation of unique column constraint.
     public void patchExtBadValue() throws IOException {
         String request = jsonParser.getJson("/ResourceIT/patchExtBadValue.req.json");

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.utils.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -55,6 +56,7 @@ public class SortingIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     public void testSortingRootCollectionByRelationshipProperty() throws IOException {
         JsonNode result = getAsNode("/book?sort=-publisher.name");
         //We expect 2 results because the Hibernate does an inner join between book & publisher
@@ -106,6 +108,7 @@ public class SortingIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     public void testSortingRootCollectionByRelationshipPropertyWithJoinFilter() throws IOException {
         JsonNode result = getAsNode("/book?filter[book.authors.name][infixi]=Hemingway&sort=-publisher.name");
         //We expect 2 results because the Hibernate does an inner join between book & publisher

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/UserTypeIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/UserTypeIT.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Resource;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.initialization.IntegrationTest;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -50,6 +51,7 @@ class UserTypeIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     public void testUserTypePost() throws Exception {
         Resource resource = resource(
                 type("person"),
@@ -85,6 +87,7 @@ class UserTypeIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     public void testUserTypePatch() throws Exception {
         Resource original = resource(
                 type("person"),
@@ -139,6 +142,7 @@ class UserTypeIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     public void testUserTypeMissingUserTypeField() throws Exception {
         Resource resource = resource(
                 type("person"),
@@ -177,6 +181,7 @@ class UserTypeIT extends IntegrationTest {
     }
 
     @Test
+    @Tag("skipInMemory")
     public void testUserTypeMissingUserTypeProperties() throws Exception {
 
         Map<String, Object> partialZip = new HashMap<>();


### PR DESCRIPTION
## Description
Runs elide-integration-tests against the in-memory store.

## Motivation and Context
InMemoryStore should be a first class citizen and run all IT tests.

## How Has This Been Tested?
Runs all IT tests (except the ones where there are known problems).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
