### PR TITLE
Enforce ReadPermission for filter joins

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EnforceJoinFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EnforceJoinFilterExpressionVisitor.java
@@ -31,15 +31,14 @@ public class EnforceJoinFilterExpressionVisitor implements FilterExpressionVisit
         this.resource = resource;
     }
 
+    /**
+     * Enforce ReadPermission on provided query filter
+     *
+     * @return true if allowed, false if rejected
+     */
     @Override
     public Boolean visitPredicate(FilterPredicate filterPredicate) {
         RequestScope requestScope = resource.getRequestScope();
-
-        // enforce filter checking only when user filter is present
-        if (!requestScope.getQueryParams().isPresent()
-                || !requestScope.getQueryParams().get().keySet().stream().anyMatch(k -> k.startsWith("filter["))) {
-            return true;
-        }
         Set<PersistentResource> val = Collections.singleton(resource);
         for (Path.PathElement pathElement : filterPredicate.getPath().getPathElements()) {
             Class<?> entityClass = pathElement.getType();

--- a/elide-core/src/main/java/com/yahoo/elide/core/EnforceJoinFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EnforceJoinFilterExpressionVisitor.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
+import com.yahoo.elide.core.filter.FilterPredicate;
+import com.yahoo.elide.core.filter.expression.AndFilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
+import com.yahoo.elide.core.filter.expression.NotFilterExpression;
+import com.yahoo.elide.core.filter.expression.OrFilterExpression;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Enforce read permission on filter join
+ */
+public class EnforceJoinFilterExpressionVisitor implements FilterExpressionVisitor<Boolean> {
+    private PersistentResource<?> resource;
+
+    public EnforceJoinFilterExpressionVisitor(PersistentResource<?> resource) {
+        this.resource = resource;
+    }
+
+    @Override
+    public Boolean visitPredicate(FilterPredicate filterPredicate) {
+        RequestScope requestScope = resource.getRequestScope();
+
+        // enforce filter checking only when user filter is present
+        if (!requestScope.getQueryParams().isPresent()
+                || !requestScope.getQueryParams().get().keySet().stream().anyMatch(k -> k.startsWith("filter["))) {
+            return true;
+        }
+        Set<PersistentResource> val = Collections.singleton(resource);
+        for (Path.PathElement pathElement : filterPredicate.getPath().getPathElements()) {
+            Class<?> entityClass = pathElement.getType();
+            String fieldName = pathElement.getFieldName();
+
+            if ("this".equals(fieldName)) {
+                continue;
+            }
+
+            try {
+                val = val.stream()
+                        .filter(Objects::nonNull)
+                        .flatMap(x -> getValueChecked(x, fieldName, requestScope))
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet());
+            } catch (IllegalArgumentException e) {
+                // Not a persistent resource
+            } catch (ForbiddenAccessException e) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private Stream<PersistentResource> getValueChecked(PersistentResource<?> resource, String fieldName,
+            RequestScope requestScope) {
+        // checkFieldAwareReadPermissions
+        requestScope.getPermissionExecutor().checkSpecificFieldPermissions(resource, null, ReadPermission.class,
+                fieldName);
+        Object obj = PersistentResource.getValue(resource.getObject(), fieldName, requestScope);
+        PersistentResourceSet persistentResourceSet;
+        if (obj instanceof Iterable) {
+            persistentResourceSet = new PersistentResourceSet(resource, (Iterable) obj, requestScope);
+        } else if (obj != null) {
+            persistentResourceSet = new PersistentResourceSet(resource, Collections.singleton(obj), requestScope);
+        } else {
+            return Stream.empty();
+        }
+
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(persistentResourceSet.iterator(), 0), false);
+    }
+
+    @Override
+    public Boolean visitAndExpression(AndFilterExpression expression) {
+        Boolean left = expression.getLeft().accept(this);
+        Boolean right = expression.getRight().accept(this);
+        // neither rejected
+        return left && right;
+    }
+
+    @Override
+    public Boolean visitOrExpression(OrFilterExpression expression) {
+        Boolean left = expression.getLeft().accept(this);
+        Boolean right = expression.getRight().accept(this);
+        // neither rejected
+        return left && right;
+    }
+
+    @Override
+    public Boolean visitNotExpression(NotFilterExpression expression) {
+        // check rejected
+        return expression.getNegated().accept(this);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -566,14 +566,9 @@ public class EntityBinding {
      * @return the annotation
      */
     public <A extends Annotation> A getAnnotation(Class<A> annotationClass) {
-        Annotation annotation = annotations.get(annotationClass);
-        if (annotation == null) {
-            annotation = EntityDictionary.getFirstAnnotation(entityClass, Collections.singletonList(annotationClass));
-            if (annotation == null) {
-                annotation = NO_ANNOTATION;
-            }
-            annotations.putIfAbsent(annotationClass, annotation);
-        }
+        Annotation annotation = annotations.computeIfAbsent(annotationClass, cls -> Optional.ofNullable(
+                EntityDictionary.getFirstAnnotation(entityClass, Collections.singletonList(annotationClass)))
+                .orElse(NO_ANNOTATION));
         return annotation == NO_ANNOTATION ? null : annotationClass.cast(annotation);
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -320,7 +320,18 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             throw new InvalidObjectIdentifierException(missedIds.toString(), dictionary.getJsonAliasFor(loadClass));
         }
 
+        if (filter.isPresent()) {
+            allResources = allResources.stream()
+                    .filter(resource -> enforceJoinFilter(resource, filter.get()))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
         return allResources;
+    }
+
+    private static boolean enforceJoinFilter(PersistentResource resource, FilterExpression filter) {
+        EnforceJoinFilterExpressionVisitor visitor = new EnforceJoinFilterExpressionVisitor(resource);
+        return filter.accept(visitor);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1552,6 +1552,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
     /**
      * Filter a set of PersistentResources.
+     * Verify fields have ReadPermission on filter join.
      *
      * @param permission the permission
      * @param resources  the resources
@@ -1571,8 +1572,9 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                 // object will behave as expected.
                 if (!resource.getRequestScope().getNewResources().contains(resource)) {
                     resource.checkFieldAwarePermissions(permission);
-                    // enforce ReadPermission on filter join
-                    if (filter.isPresent() && !filter.get().accept(new EnforceJoinFilterExpressionVisitor(resource))) {
+                    // Verify fields have ReadPermission on filter join
+                    if (filter.isPresent()
+                            && !filter.get().accept(new VerifyFieldAccessFilterExpressionVisitor(resource))) {
                         continue;
                     }
                 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResourceSet.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResourceSet.java
@@ -9,6 +9,8 @@ import com.google.common.collect.UnmodifiableIterator;
 
 import java.util.AbstractSet;
 import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
 
 /**
  * Stream iterable list as a set of PersistentResource.
@@ -50,5 +52,10 @@ public class PersistentResourceSet<T> extends AbstractSet<PersistentResource<T>>
     @Override
     public int size() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Spliterator<PersistentResource<T>> spliterator() {
+        return Spliterators.spliteratorUnknownSize(iterator(), 0);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -24,7 +24,6 @@ import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
 import com.yahoo.elide.core.filter.dialect.ParseException;
-import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
@@ -270,27 +269,14 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      * @return The global filter expression evaluated at the first load
      */
     public Optional<FilterExpression> getLoadFilterExpression(Class<?> loadClass) {
-        Optional<FilterExpression> permissionFilter;
-        permissionFilter = getPermissionExecutor().getReadPermissionFilter(loadClass);
-        Optional<FilterExpression> globalFilterExpressionOptional;
+        Optional<FilterExpression> filterExpression;
         if (globalFilterExpression == null) {
             String typeName = dictionary.getJsonAliasFor(loadClass);
-            globalFilterExpressionOptional =  getFilterExpressionByType(typeName);
+            filterExpression =  getFilterExpressionByType(typeName);
         } else {
-            globalFilterExpressionOptional = Optional.of(globalFilterExpression);
+            filterExpression = Optional.of(globalFilterExpression);
         }
-
-        if (globalFilterExpressionOptional.isPresent() && permissionFilter.isPresent()) {
-            return Optional.of(new AndFilterExpression(globalFilterExpressionOptional.get(),
-                    permissionFilter.get()));
-        }
-        if (globalFilterExpressionOptional.isPresent()) {
-            return globalFilterExpressionOptional;
-        }
-        if (permissionFilter.isPresent()) {
-            return permissionFilter;
-        }
-        return Optional.empty();
+        return filterExpression;
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
 import com.yahoo.elide.core.filter.expression.NotFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
@@ -80,18 +81,18 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
 
     @Override
     public Boolean visitAndExpression(AndFilterExpression expression) {
-        Boolean left = expression.getLeft().accept(this);
-        Boolean right = expression.getRight().accept(this);
+        FilterExpression left = expression.getLeft();
+        FilterExpression right = expression.getRight();
         // are both allowed
-        return left && right;
+        return left.accept(this) && right.accept(this);
     }
 
     @Override
     public Boolean visitOrExpression(OrFilterExpression expression) {
-        Boolean left = expression.getLeft().accept(this);
-        Boolean right = expression.getRight().accept(this);
+        FilterExpression left = expression.getLeft();
+        FilterExpression right = expression.getRight();
         // are both allowed
-        return left && right;
+        return left.accept(this) && right.accept(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
@@ -24,10 +24,10 @@ import java.util.stream.StreamSupport;
 /**
  * Enforce read permission on filter join
  */
-public class EnforceJoinFilterExpressionVisitor implements FilterExpressionVisitor<Boolean> {
+public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressionVisitor<Boolean> {
     private PersistentResource<?> resource;
 
-    public EnforceJoinFilterExpressionVisitor(PersistentResource<?> resource) {
+    public VerifyFieldAccessFilterExpressionVisitor(PersistentResource<?> resource) {
         this.resource = resource;
     }
 
@@ -60,7 +60,6 @@ public class EnforceJoinFilterExpressionVisitor implements FilterExpressionVisit
                 return false;
             }
         }
-
         return true;
     }
 
@@ -86,7 +85,7 @@ public class EnforceJoinFilterExpressionVisitor implements FilterExpressionVisit
     public Boolean visitAndExpression(AndFilterExpression expression) {
         Boolean left = expression.getLeft().accept(this);
         Boolean right = expression.getRight().accept(this);
-        // neither rejected
+        // are both allowed
         return left && right;
     }
 
@@ -94,13 +93,13 @@ public class EnforceJoinFilterExpressionVisitor implements FilterExpressionVisit
     public Boolean visitOrExpression(OrFilterExpression expression) {
         Boolean left = expression.getLeft().accept(this);
         Boolean right = expression.getRight().accept(this);
-        // neither rejected
+        // are both allowed
         return left && right;
     }
 
     @Override
     public Boolean visitNotExpression(NotFilterExpression expression) {
-        // check rejected
+        // is negated expression allowed
         return expression.getNegated().accept(this);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
@@ -16,13 +16,11 @@ import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
- * Enforce read permission on filter join
+ * Enforce read permission on filter join.
  */
 public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressionVisitor<Boolean> {
     private PersistentResource<?> resource;
@@ -32,7 +30,7 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
     }
 
     /**
-     * Enforce ReadPermission on provided query filter
+     * Enforce ReadPermission on provided query filter.
      *
      * @return true if allowed, false if rejected
      */
@@ -41,7 +39,6 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
         RequestScope requestScope = resource.getRequestScope();
         Set<PersistentResource> val = Collections.singleton(resource);
         for (Path.PathElement pathElement : filterPredicate.getPath().getPathElements()) {
-            Class<?> entityClass = pathElement.getType();
             String fieldName = pathElement.getFieldName();
 
             if ("this".equals(fieldName)) {
@@ -78,7 +75,7 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
             return Stream.empty();
         }
 
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(persistentResourceSet.iterator(), 0), false);
+        return persistentResourceSet.stream();
     }
 
     @Override

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -385,7 +385,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
             Set<PersistentResource> resources =
                     Sets.newHashSet(child1Resource, child2Resource, child3Resource, child4Resource);
 
-            Set<PersistentResource> results = PersistentResource.filter(ReadPermission.class, resources);
+            Set<PersistentResource> results = PersistentResource.filter(ReadPermission.class, Optional.empty(), resources);
             assertEquals(2, results.size(), "Only a subset of the children are readable");
             assertTrue(results.contains(child1Resource), "Readable children includes children with positive IDs");
             assertTrue(results.contains(child3Resource), "Readable children includes children with positive IDs");
@@ -400,7 +400,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
             Set<PersistentResource> resources =
                     Sets.newHashSet(child1Resource, child2Resource, child3Resource, child4Resource);
 
-            Set<PersistentResource> results = PersistentResource.filter(ReadPermission.class, resources);
+            Set<PersistentResource> results = PersistentResource.filter(ReadPermission.class, Optional.empty(), resources);
             assertEquals(0, results.size(), "No children are readable by an invalid user");
         }
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
+import com.yahoo.elide.core.filter.FilterPredicate;
+import com.yahoo.elide.core.filter.InPredicate;
+import com.yahoo.elide.core.filter.expression.AndFilterExpression;
+import com.yahoo.elide.core.filter.expression.NotFilterExpression;
+import com.yahoo.elide.core.filter.expression.OrFilterExpression;
+import com.yahoo.elide.security.PermissionExecutor;
+
+import com.google.common.collect.Sets;
+
+import example.Author;
+import example.Book;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class VerifyFieldAccessFilterExpressionVisitorTest {
+
+    private static final String ENTITY = "entity";
+    private static final String GENRE = "genre";
+    private static final String HOME = "homeAddress";
+    private static final String NAME = "name";
+    private static final String SCIFI = "scifi";
+    private RequestScope scope;
+
+    @BeforeEach
+    public void setupMocks() {
+        // this will test with the default interface implementation
+        scope = mock(RequestScope.class);
+        EntityDictionary dictionary = mock(EntityDictionary.class);
+        PermissionExecutor permissionExecutor = mock(PermissionExecutor.class);
+
+        when(scope.getDictionary()).thenReturn(dictionary);
+        when(dictionary.getIdType(String.class)).thenReturn((Class) Long.class);
+        when(dictionary.getValue(ENTITY, NAME, scope)).thenReturn(3L);
+        when(scope.getPermissionExecutor()).thenReturn(permissionExecutor);
+    }
+
+    @Test
+    public void testAccept() throws Exception {
+        Path p1Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, Author.class, "authors"),
+                new Path.PathElement(Author.class, String.class, NAME)
+        ));
+        FilterPredicate p1 = new InPredicate(p1Path, "foo", "bar");
+
+        Path p2Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, String.class, NAME)
+        ));
+        FilterPredicate p2 = new InPredicate(p2Path, "blah");
+
+        Path p3Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, String.class, GENRE)
+        ));
+        FilterPredicate p3 = new InPredicate(p3Path, SCIFI);
+
+        //P4 is a duplicate of P3
+        Path p4Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, String.class, GENRE)
+        ));
+        FilterPredicate p4 = new InPredicate(p4Path, SCIFI);
+
+        OrFilterExpression or = new OrFilterExpression(p2, p3);
+        AndFilterExpression and1 = new AndFilterExpression(or, p1);
+        AndFilterExpression and2 = new AndFilterExpression(and1, p4);
+        NotFilterExpression not = new NotFilterExpression(and2);
+
+        Book book = new Book();
+        Author author = new Author();
+        book.setAuthors(Sets.newHashSet(author));
+        author.setBooks(Sets.newHashSet(book));
+
+        PersistentResource<Book> resource = new PersistentResource<>(book, null, "", scope);
+        //First test collecting the predicates in a Set
+        VerifyFieldAccessFilterExpressionVisitor visitor = new VerifyFieldAccessFilterExpressionVisitor(resource);
+        assertTrue(not.accept(visitor));
+        assertTrue(and1.accept(visitor));
+        assertTrue(and2.accept(visitor));
+        assertTrue(or.accept(visitor));
+        assertTrue(p1.accept(visitor));
+        assertTrue(p2.accept(visitor));
+        assertTrue(p3.accept(visitor));
+        assertTrue(p4.accept(visitor));
+
+        PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
+        verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, NAME);
+    }
+
+    @Test
+    public void testReject() throws Exception {
+        Path p1Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, Author.class, "authors"),
+                new Path.PathElement(Author.class, String.class, NAME)
+        ));
+        FilterPredicate p1 = new InPredicate(p1Path, "foo", "bar");
+
+        Path p2Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, String.class, HOME)
+        ));
+        FilterPredicate p2 = new InPredicate(p2Path, "blah");
+
+        Path p3Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, String.class, GENRE)
+        ));
+        FilterPredicate p3 = new InPredicate(p3Path, SCIFI);
+
+        //P4 is a duplicate of P3
+        Path p4Path = new Path(Arrays.asList(
+                new Path.PathElement(Book.class, String.class, GENRE)
+        ));
+        FilterPredicate p4 = new InPredicate(p4Path, SCIFI);
+
+        OrFilterExpression or = new OrFilterExpression(p2, p3);
+        AndFilterExpression and1 = new AndFilterExpression(or, p1);
+        AndFilterExpression and2 = new AndFilterExpression(and1, p4);
+        NotFilterExpression not = new NotFilterExpression(and2);
+
+        Book book = new Book();
+        Author author = new Author();
+        book.setAuthors(Sets.newHashSet(author));
+        author.setBooks(Sets.newHashSet(book));
+        PersistentResource<Book> resource = new PersistentResource<>(book, null, "", scope);
+
+        PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
+        when(permissionExecutor.checkSpecificFieldPermissions(resource, null, ReadPermission.class, HOME))
+            .thenThrow(ForbiddenAccessException.class);
+
+        //First test collecting the predicates in a Set
+        VerifyFieldAccessFilterExpressionVisitor visitor = new VerifyFieldAccessFilterExpressionVisitor(resource);
+        assertFalse(not.accept(visitor));
+        assertFalse(and1.accept(visitor));
+        assertFalse(and2.accept(visitor));
+        assertFalse(or.accept(visitor));
+        assertTrue(p1.accept(visitor));
+        assertFalse(p2.accept(visitor));
+        assertTrue(p3.accept(visitor));
+        assertTrue(p4.accept(visitor));
+
+        verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, HOME);
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -88,8 +88,9 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         author.setBooks(Sets.newHashSet(book));
 
         PersistentResource<Book> resource = new PersistentResource<>(book, null, "", scope);
-        //First test collecting the predicates in a Set
+
         VerifyFieldAccessFilterExpressionVisitor visitor = new VerifyFieldAccessFilterExpressionVisitor(resource);
+        // unrestricted fields
         assertTrue(not.accept(visitor));
         assertTrue(and1.accept(visitor));
         assertTrue(and2.accept(visitor));
@@ -142,14 +143,16 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         when(permissionExecutor.checkSpecificFieldPermissions(resource, null, ReadPermission.class, HOME))
             .thenThrow(ForbiddenAccessException.class);
 
-        //First test collecting the predicates in a Set
         VerifyFieldAccessFilterExpressionVisitor visitor = new VerifyFieldAccessFilterExpressionVisitor(resource);
+        // restricted HOME field
         assertFalse(not.accept(visitor));
         assertFalse(and1.accept(visitor));
         assertFalse(and2.accept(visitor));
         assertFalse(or.accept(visitor));
-        assertTrue(p1.accept(visitor));
         assertFalse(p2.accept(visitor));
+
+        // unrestricted fields
+        assertTrue(p1.accept(visitor));
         assertTrue(p3.accept(visitor));
         assertTrue(p4.accept(visitor));
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1370,9 +1370,8 @@ public class FilterIT extends IntegrationTest {
         assertEquals(0, data.size(), result.toString());
 
         /* Test RSQL */
-        result = getAsNode(
-                String.format("book?filter[book]=authors.homeAddress=='main'", hemingwayId),
-                HttpStatus.SC_BAD_REQUEST);
+        result = getAsNode("book?filter=authors.homeAddress=='main'");
+        data = result.get("data");
         assertEquals(0, data.size(), result.toString());
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1363,6 +1363,21 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    void testFailFilterBookByAuthorAddress() throws IOException {
+        /* Test default */
+        JsonNode result = getAsNode("book?filter[book.authors.homeAddress]=main&include=authors");
+        JsonNode data = result.get("data");
+        assertEquals(0, data.size(), result.toString());
+
+        /* Test RSQL */
+        result = getAsNode(
+                String.format("book?filter[book]=authors.homeAddress=='main'", hemingwayId),
+                HttpStatus.SC_BAD_REQUEST);
+        assertEquals(0, data.size(), result.toString());
+    }
+
+
+    @Test
     void testGetBadRelationshipRoot() throws IOException {
         /* Test Default */
         JsonNode result = getAsNode(

--- a/elide-integration-tests/src/test/java/example/Author.java
+++ b/elide-integration-tests/src/test/java/example/Author.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.Paginate;
+import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.SharePermission;
 
 import lombok.Builder;
@@ -72,6 +73,11 @@ public class Author {
     @ManyToMany(mappedBy = "authors")
     @Getter @Setter
     private Collection<Book> books = new ArrayList<>();
+
+    @Getter @Setter
+    @ReadPermission(expression = "deny all")
+    private String homeAddress;
+
     @Override
     public String toString() {
         return "Author: " + id;

--- a/elide-integration-tests/src/test/java/example/Author.java
+++ b/elide-integration-tests/src/test/java/example/Author.java
@@ -53,6 +53,17 @@ public class Author {
     @Exclude
     private String naturalKey = UUID.randomUUID().toString();
 
+    @Getter @Setter
+    private String name;
+
+    @ManyToMany(mappedBy = "authors")
+    @Getter @Setter
+    private Collection<Book> books = new ArrayList<>();
+
+    @Getter @Setter
+    @ReadPermission(expression = "deny all")
+    private String homeAddress;
+
     @Override
     public int hashCode() {
         return naturalKey.hashCode();
@@ -66,17 +77,6 @@ public class Author {
 
         return ((Author) obj).naturalKey.equals(naturalKey);
     }
-
-    @Getter @Setter
-    private String name;
-
-    @ManyToMany(mappedBy = "authors")
-    @Getter @Setter
-    private Collection<Book> books = new ArrayList<>();
-
-    @Getter @Setter
-    @ReadPermission(expression = "deny all")
-    private String homeAddress;
 
     @Override
     public String toString() {

--- a/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch1.json
+++ b/elide-integration-tests/src/test/resources/FilterIT/book_author_publisher_patch1.json
@@ -6,7 +6,8 @@
       "id": "12345678-1234-1234-1234-1234567890ab",
       "type": "author",
       "attributes": {
-        "name": "Ernest Hemingway"
+        "name": "Ernest Hemingway",
+        "homeAddress": "main"
       },
       "relationships": {
         "books": {

--- a/elide-integration-tests/src/test/resources/SortingIT/addAuthorBookPublisher1.json
+++ b/elide-integration-tests/src/test/resources/SortingIT/addAuthorBookPublisher1.json
@@ -7,7 +7,8 @@
       "id": "12345678-1234-1234-1234-1234567890ab",
       "type": "author",
       "attributes": {
-        "name": "Ernest Hemingway"
+        "name": "Ernest Hemingway",
+        "homeAddress": "main"
       },
       "relationships": {
         "books": {


### PR DESCRIPTION
## Description
Enforce ReadPermission for filter joins.
Clean up duplicated filter expression builder in RequestScope.getLoadFilterExpression

## Motivation and Context
Restricts filter join access to fields that pass ReadPermission.

## How Has This Been Tested?
Build tests.  Added additional Integration test.  
Tested locally with end product.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
