### PR TITLE
call PersistentResource get relationship

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
@@ -70,7 +70,8 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
                 .getRelationshipType(entity.getClass(), fieldName) == RelationshipType.NONE) {
             return Stream.empty();
         }
-        return resource.getRelationChecked(fieldName, Optional.empty(), Optional.empty(), Optional.empty()).stream();
+        Optional<FilterExpression> filterExpression = requestScope.getExpressionForRelation(resource, fieldName);
+        return resource.getRelationChecked(fieldName, filterExpression, Optional.empty(), Optional.empty()).stream();
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
@@ -70,8 +70,8 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
                 .getRelationshipType(entity.getClass(), fieldName) == RelationshipType.NONE) {
             return Stream.empty();
         }
-        Optional<FilterExpression> filterExpression = requestScope.getExpressionForRelation(resource, fieldName);
-        return resource.getRelationChecked(fieldName, filterExpression, Optional.empty(), Optional.empty()).stream();
+        // use no filter to allow the read directly from loaded resource
+        return resource.getRelationChecked(fieldName, Optional.empty(), Optional.empty(), Optional.empty()).stream();
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -52,8 +53,6 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
                         .flatMap(x -> getValueChecked(x, fieldName, requestScope))
                         .filter(Objects::nonNull)
                         .collect(Collectors.toSet());
-            } catch (IllegalArgumentException e) {
-                // Not a persistent resource
             } catch (ForbiddenAccessException e) {
                 return false;
             }
@@ -66,17 +65,12 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
         // checkFieldAwareReadPermissions
         requestScope.getPermissionExecutor().checkSpecificFieldPermissions(resource, null, ReadPermission.class,
                 fieldName);
-        Object obj = PersistentResource.getValue(resource.getObject(), fieldName, requestScope);
-        PersistentResourceSet persistentResourceSet;
-        if (obj instanceof Iterable) {
-            persistentResourceSet = new PersistentResourceSet(resource, (Iterable) obj, requestScope);
-        } else if (obj != null) {
-            persistentResourceSet = new PersistentResourceSet(resource, Collections.singleton(obj), requestScope);
-        } else {
+        Object entity = resource.getObject();
+        if (entity == null || resource.getDictionary()
+                .getRelationshipType(entity.getClass(), fieldName) == RelationshipType.NONE) {
             return Stream.empty();
         }
-
-        return persistentResourceSet.stream();
+        return resource.getRelationChecked(fieldName, Optional.empty(), Optional.empty(), Optional.empty()).stream();
     }
 
     @Override

--- a/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -21,8 +21,6 @@ import com.yahoo.elide.core.filter.expression.NotFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.security.PermissionExecutor;
 
-import com.google.common.collect.Sets;
-
 import example.Author;
 import example.Book;
 
@@ -30,10 +28,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 public class VerifyFieldAccessFilterExpressionVisitorTest {
 
-    private static final String ENTITY = "entity";
     private static final String GENRE = "genre";
     private static final String HOME = "homeAddress";
     private static final String NAME = "name";
@@ -44,13 +42,15 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
     public void setupMocks() {
         // this will test with the default interface implementation
         scope = mock(RequestScope.class);
-        EntityDictionary dictionary = mock(EntityDictionary.class);
         PermissionExecutor permissionExecutor = mock(PermissionExecutor.class);
+        DataStoreTransaction transaction = mock(DataStoreTransaction.class);
+        EntityDictionary dictionary = new EntityDictionary(Collections.emptyMap());
+        dictionary.bindEntity(Book.class);
+        dictionary.bindEntity(Author.class);
 
         when(scope.getDictionary()).thenReturn(dictionary);
-        when(dictionary.getIdType(String.class)).thenReturn((Class) Long.class);
-        when(dictionary.getValue(ENTITY, NAME, scope)).thenReturn(3L);
         when(scope.getPermissionExecutor()).thenReturn(permissionExecutor);
+        when(scope.getTransaction()).thenReturn(transaction);
     }
 
     @Test
@@ -84,8 +84,8 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         Book book = new Book();
         Author author = new Author();
-        book.setAuthors(Sets.newHashSet(author));
-        author.setBooks(Sets.newHashSet(book));
+        book.setAuthors(Collections.singleton(author));
+        author.setBooks(Collections.singleton(book));
 
         PersistentResource<Book> resource = new PersistentResource<>(book, null, "", scope);
 
@@ -135,8 +135,8 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         Book book = new Book();
         Author author = new Author();
-        book.setAuthors(Sets.newHashSet(author));
-        author.setBooks(Sets.newHashSet(book));
+        book.setAuthors(Collections.singleton(author));
+        author.setBooks(Collections.singleton(book));
         PersistentResource<Book> resource = new PersistentResource<>(book, null, "", scope);
 
         PermissionExecutor permissionExecutor = scope.getPermissionExecutor();


### PR DESCRIPTION
## Description
Updated VerifyFieldAccessFilterExpressionVisitor to call PersistentResorce get relationship to cross datastore transition.

## Motivation and Context
Will properly use proper transaction to request the relationship results.

## How Has This Been Tested?
Build testing.  Locally testing with our product.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
