### PR TITLE
Fixed N+1 problems for all toOne relationships

### DIFF
--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -27,8 +27,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.persistence.OneToOne;
-
 /**
  * Abstract class used to construct HQL queries.
  */
@@ -195,12 +193,6 @@ public abstract class AbstractHQLQueryBuilder {
         for (String relationshipName : relationshipNames) {
             RelationshipType type = dictionary.getRelationshipType(entityClass, relationshipName);
             if (type.isToOne() && !type.isComputed()) {
-                // fetch only OneToOne with mappedBy
-                OneToOne oneToOne = dictionary.getAttributeOrRelationAnnotation(
-                        entityClass, OneToOne.class, relationshipName);
-                if (oneToOne == null || oneToOne.mappedBy().isEmpty()) {
-                    continue;
-                }
                 joinString.append(" LEFT JOIN FETCH ");
                 joinString.append(alias);
                 joinString.append(PERIOD);

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -188,11 +189,19 @@ public abstract class AbstractHQLQueryBuilder {
      * @return The JOIN clause that can be added to the FROM clause.
      */
     protected String extractToOneMergeJoins(Class<?> entityClass, String alias) {
+        return extractToOneMergeJoins(entityClass, alias, (unused) -> false);
+    }
+
+    protected String extractToOneMergeJoins(Class<?> entityClass, String alias,
+                                            Function<String, Boolean> skipRelation) {
         List<String> relationshipNames = dictionary.getRelationships(entityClass);
         StringBuilder joinString = new StringBuilder("");
         for (String relationshipName : relationshipNames) {
             RelationshipType type = dictionary.getRelationshipType(entityClass, relationshipName);
             if (type.isToOne() && !type.isComputed()) {
+                if (skipRelation.apply(relationshipName)) {
+                    continue;
+                }
                 joinString.append(" LEFT JOIN FETCH ");
                 joinString.append(alias);
                 joinString.append(PERIOD);

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.core.hibernate.Query;
 import com.yahoo.elide.core.hibernate.Session;
 
 import java.util.Collection;
+import java.util.function.Function;
 
 /**
  * Constructs a HQL query to fetch a hibernate collection proxy.
@@ -26,6 +27,24 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                                           Session session) {
         super(dictionary, session);
         this.relationship = relationship;
+    }
+
+    @Override
+    protected String extractToOneMergeJoins(Class<?> entityClass, String alias) {
+        Function<String, Boolean> shouldSkip = (relationshipName) -> {
+            String inverseRelationName = dictionary.getRelationInverse(entityClass, relationshipName);
+            if (inverseRelationName.isEmpty()) {
+                return false;
+            }
+
+            Class<?> relationshipClass = dictionary.getParameterizedType(entityClass, relationshipName);
+
+            //We don't need (or want) to fetch join the parent object.
+            return relationshipClass.equals(relationship.getParentType()) &&
+                    inverseRelationName.equals(relationship.getRelationshipName());
+        };
+
+        return extractToOneMergeJoins(entityClass, alias, shouldSkip);
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -40,8 +40,8 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
             Class<?> relationshipClass = dictionary.getParameterizedType(entityClass, relationshipName);
 
             //We don't need (or want) to fetch join the parent object.
-            return relationshipClass.equals(relationship.getParentType()) &&
-                    inverseRelationName.equals(relationship.getRelationshipName());
+            return relationshipClass.equals(relationship.getParentType())
+                    && inverseRelationName.equals(relationship.getRelationshipName());
         };
 
         return extractToOneMergeJoins(entityClass, alias, shouldSkip);

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
@@ -108,7 +108,9 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
     public void testFetchJoinClause() {
         String actual = extractToOneMergeJoins(Left.class, "right_alias");
 
-        String expected = " LEFT JOIN FETCH right_alias.noUpdateOne2One  LEFT JOIN FETCH right_alias.one2one ";
+        String expected = " LEFT JOIN FETCH right_alias.noDeleteOne2One  "
+                + "LEFT JOIN FETCH right_alias.noUpdateOne2One  "
+                + "LEFT JOIN FETCH right_alias.one2one ";
         assertEquals(expected, actual);
     }
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -54,7 +54,8 @@ public class RootCollectionFetchQueryBuilderTest {
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
 
-        String expected = "SELECT example_Book FROM example.Book AS example_Book  ";
+        String expected =
+                "SELECT example_Book FROM example.Book AS example_Book  LEFT JOIN FETCH example_Book.publisher  ";
         String actual = query.getQueryText();
 
         assertEquals(expected, actual);
@@ -72,7 +73,8 @@ public class RootCollectionFetchQueryBuilderTest {
                 .withPossibleSorting(Optional.of(new Sorting(sorting)))
                 .build();
 
-        String expected = "SELECT example_Book FROM example.Book AS example_Book   order by example_Book.title asc";
+        String expected = "SELECT example_Book FROM example.Book AS example_Book  "
+                + "LEFT JOIN FETCH example_Book.publisher   order by example_Book.title asc";
         String actual = query.getQueryText();
 
         assertEquals(expected, actual);
@@ -145,8 +147,8 @@ public class RootCollectionFetchQueryBuilderTest {
                 .build();
 
         String expected =
-                "SELECT example_Book FROM example.Book AS example_Book  "
-                + "WHERE example_Book.id IN (:id_XXX)  order by example_Book.title asc";
+                "SELECT example_Book FROM example.Book AS example_Book  LEFT JOIN FETCH example_Book.publisher"
+                + "  WHERE example_Book.id IN (:id_XXX)  order by example_Book.title asc";
 
         String actual = query.getQueryText();
         actual = actual.replaceFirst(":id_\\w+", ":id_XXX");

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.hibernate.hql.RelationshipImpl;
 import com.yahoo.elide.core.hibernate.hql.SubCollectionFetchQueryBuilder;
+import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 
 import example.Author;
@@ -189,6 +190,42 @@ public class SubCollectionFetchQueryBuilderTest {
                 + "JOIN example_Author__fetch.books example_Book "
                 + "LEFT JOIN example_Book.publisher example_Book_publisher  LEFT JOIN FETCH example_Book.publisher  "
                 + "WHERE example_Book_publisher.name IN (:publisher_name_XXX) AND example_Author__fetch=:example_Author__fetch  order by example_Book.title asc";
+
+        String actual = query.getQueryText();
+        actual = actual.replaceFirst(":publisher_name_\\w+", ":publisher_name_XXX");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testFetchJoinExcludesParent() {
+        Publisher publisher = new Publisher();
+        publisher.setId(1);
+
+        Book book = new Book();
+        book.setId(2);
+
+        RelationshipImpl relationship = new RelationshipImpl(
+                Publisher.class,
+                Book.class,
+                BOOKS,
+                publisher,
+                Arrays.asList(book)
+        );
+
+        SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
+                relationship, dictionary, new TestSessionWrapper());
+
+        TestQueryWrapper query = (TestQueryWrapper) builder
+                .withPossibleFilterExpression(Optional.empty())
+                .withPossibleSorting(Optional.empty())
+                .withPossiblePagination(
+                        Optional.of(Pagination.fromOffsetAndLimit(1, 1, false)))
+                .build();
+
+        String expected = "SELECT example_Book FROM example.Publisher example_Publisher__fetch "
+                + "JOIN example_Publisher__fetch.books example_Book "
+                + "WHERE example_Publisher__fetch=:example_Publisher__fetch";
 
         String actual = query.getQueryText();
         actual = actual.replaceFirst(":publisher_name_\\w+", ":publisher_name_XXX");

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -100,7 +100,7 @@ public class SubCollectionFetchQueryBuilderTest {
                 .build();
 
         String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
-                + "JOIN example_Author__fetch.books example_Book "
+                + "JOIN example_Author__fetch.books example_Book LEFT JOIN FETCH example_Book.publisher  "
                 + "WHERE example_Author__fetch=:example_Author__fetch order by example_Book.title asc";
         String actual = query.getQueryText();
 
@@ -141,7 +141,7 @@ public class SubCollectionFetchQueryBuilderTest {
 
         String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
                 + "JOIN example_Author__fetch.books example_Book "
-                + "LEFT JOIN example_Book.publisher example_Book_publisher  "
+                + "LEFT JOIN example_Book.publisher example_Book_publisher  LEFT JOIN FETCH example_Book.publisher  "
                 + "WHERE example_Book_publisher.name IN (:books_publisher_name_XXX) AND example_Author__fetch=:example_Author__fetch ";
         String actual = query.getQueryText();
         actual = actual.replaceFirst(":publisher_name_\\w+_\\w+", ":books_publisher_name_XXX");
@@ -187,7 +187,7 @@ public class SubCollectionFetchQueryBuilderTest {
 
         String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
                 + "JOIN example_Author__fetch.books example_Book "
-                + "LEFT JOIN example_Book.publisher example_Book_publisher  "
+                + "LEFT JOIN example_Book.publisher example_Book_publisher  LEFT JOIN FETCH example_Book.publisher  "
                 + "WHERE example_Book_publisher.name IN (:publisher_name_XXX) AND example_Author__fetch=:example_Author__fetch  order by example_Book.title asc";
 
         String actual = query.getQueryText();

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
@@ -57,9 +57,7 @@ public class SortingIT extends IntegrationTest {
     @Test
     public void testSortingRootCollectionByRelationshipProperty() throws IOException {
         JsonNode result = getAsNode("/book?sort=-publisher.name");
-        //We expect 2 results because the Hibernate does an inner join between book & publisher
-        assertEquals(2, result.get("data").size());
-
+        int size = result.get("data").size();
 
         JsonNode books = result.get("data");
         String firstBookName = books.get(0).get("attributes").get("title").asText();
@@ -69,14 +67,12 @@ public class SortingIT extends IntegrationTest {
         assertEquals("The Old Man and the Sea", secondBookName);
 
         result = getAsNode("/book?sort=publisher.name");
-        //We expect 2 results because the Hibernate does an inner join between book & publisher
-        assertEquals(2, result.get("data").size());
 
         books = result.get("data");
-        firstBookName = books.get(0).get("attributes").get("title").asText();
+        firstBookName = books.get(size - 2).get("attributes").get("title").asText();
         assertEquals("The Old Man and the Sea", firstBookName);
 
-        secondBookName = books.get(1).get("attributes").get("title").asText();
+        secondBookName = books.get(size - 1).get("attributes").get("title").asText();
         assertEquals("For Whom the Bell Tolls", secondBookName);
     }
 


### PR DESCRIPTION
## Description
toOne relationships were only join fetched if they were OneToOne and not the owning side of the relationship.  This fix relaxes the constraint so all toOne joins are join fetched.

## Motivation and Context
Solves N+1 problem.

## How Has This Been Tested?
Verified all existing tests pass.

Verified N+1 problem for ManyToOne and OneToOne (not mapped) is removed (manually be inspecting logs).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
