### PR TITLE
Allow replacement of custom serde scan

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -98,7 +98,7 @@ public class Elide {
     }
 
     protected void registerCustomSerde() {
-        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(ElideTypeConverter.class);
+        Set<Class<?>> classes = registerCustomSerdeScan();
 
         for (Class<?> clazz : classes) {
             if (!Serde.class.isAssignableFrom(clazz)) {
@@ -147,6 +147,10 @@ public class Elide {
                         jsonGenerator.writeObject(serde.serialize(obj));
                     }
                 }));
+    }
+
+    protected Set<Class<?>> registerCustomSerdeScan() {
+        return ClassScanner.getAnnotatedClasses(ElideTypeConverter.class);
     }
 
     /**


### PR DESCRIPTION
## Description
Allow override of registerCustomSerdeScan.

## Motivation and Context
Improved performance at startup.

## How Has This Been Tested?
Local testing limited to scan of a single package.

```java
    @Override
    protected Set<Class<?>> registerCustomSerdeScan() {
        return ClassScanner.getAnnotatedClasses(
            OffsetDateTimeSerde.class.getPackage(),
            ElideTypeConverter.class);
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
