### PR TITLE
Optimize field annotation lookup

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -580,7 +580,7 @@ public class EntityBinding {
      * @param <A> annotation type
      * @return the annotation
      */
-    public <A extends Annotation> A getAnnotation(Class<A> annotationClass, String method) {
+    public <A extends Annotation> A getMethodAnnotation(Class<A> annotationClass, String method) {
         Annotation annotation = annotations.computeIfAbsent(Pair.of(annotationClass, method), key -> {
             try {
                 return Optional.ofNullable((Annotation) entityClass.getMethod(method).getAnnotation(annotationClass))

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -576,6 +576,7 @@ public class EntityBinding {
      * Return annotation for provided method.
      *
      * @param annotationClass the annotation class
+     * @param method the method
      * @param <A> annotation type
      * @return the annotation
      */

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -117,7 +117,7 @@ public class EntityBinding {
     public final ConcurrentHashMap<String, String> aliasesToFields = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<Method, Boolean> requestScopeableMethods = new ConcurrentHashMap<>();
 
-    public final ConcurrentHashMap<Class<? extends Annotation>, Annotation> annotations = new ConcurrentHashMap<>();
+    public final ConcurrentHashMap<Object, Annotation> annotations = new ConcurrentHashMap<>();
 
     public static final EntityBinding EMPTY_BINDING = new EntityBinding();
     private static final String ALL_FIELDS = "*";
@@ -569,6 +569,25 @@ public class EntityBinding {
         Annotation annotation = annotations.computeIfAbsent(annotationClass, cls -> Optional.ofNullable(
                 EntityDictionary.getFirstAnnotation(entityClass, Collections.singletonList(annotationClass)))
                 .orElse(NO_ANNOTATION));
+        return annotation == NO_ANNOTATION ? null : annotationClass.cast(annotation);
+    }
+
+    /**
+     * Return annotation for provided method.
+     *
+     * @param annotationClass the annotation class
+     * @param <A> annotation type
+     * @return the annotation
+     */
+    public <A extends Annotation> A getAnnotation(Class<A> annotationClass, String method) {
+        Annotation annotation = annotations.computeIfAbsent(Pair.of(annotationClass, method), key -> {
+            try {
+                return Optional.ofNullable((Annotation) entityClass.getMethod(method).getAnnotation(annotationClass))
+                        .orElse(NO_ANNOTATION);
+            } catch (NoSuchMethodException | SecurityException e) {
+                throw new IllegalStateException(e);
+            }
+        });
         return annotation == NO_ANNOTATION ? null : annotationClass.cast(annotation);
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -894,6 +894,14 @@ public class EntityDictionary {
         return getEntityBinding(recordClass).getAnnotation(annotationClass);
     }
 
+    /**
+     * Return annotation from class for provided method.
+     * @param recordClass the record class
+     * @param method the method
+     * @param annotationClass the annotation class
+     * @param <A> genericClass
+     * @return the annotation
+     */
     public <A extends Annotation> A getAnnotation(Class<?> recordClass, String method, Class<A> annotationClass) {
         return getEntityBinding(recordClass).getAnnotation(annotationClass, method);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -140,12 +140,7 @@ public class EntityDictionary {
      * @return simple name
      */
     public static String getSimpleName(Class<?> cls) {
-        String simpleName = SIMPLE_NAMES.get(cls);
-        if (simpleName == null) {
-            simpleName = cls.getSimpleName();
-            SIMPLE_NAMES.putIfAbsent(cls, simpleName);
-        }
-        return simpleName;
+        return SIMPLE_NAMES.computeIfAbsent(cls, key -> cls.getSimpleName());
     }
 
     /**
@@ -285,7 +280,7 @@ public class EntityDictionary {
      * @return the {@link Check} mapped to the identifier or {@code null} if the given identifer is unmapped
      */
     public Class<? extends Check> getCheck(String checkIdentifier) {
-        Class<? extends Check> checkCls = checkNames.computeIfAbsent(checkIdentifier, cls -> {
+        return checkNames.computeIfAbsent(checkIdentifier, cls -> {
             try {
                 return Class.forName(checkIdentifier).asSubclass(Check.class);
             } catch (ClassNotFoundException | ClassCastException e) {
@@ -293,7 +288,6 @@ public class EntityDictionary {
                         "Could not instantiate specified check '" + checkIdentifier + "'.", e);
             }
         });
-        return checkCls;
     }
 
     /**
@@ -336,11 +330,10 @@ public class EntityDictionary {
      * @return  List of all inherited entity types
      */
     public List<Class<?>> getSubclassingEntities(Class entityClass) {
-        return subclassingEntities.computeIfAbsent(entityClass, (unused) -> {
-            return entityBindings.keySet().stream()
-                    .filter(c -> c != entityClass && entityClass.isAssignableFrom(c))
-                    .collect(Collectors.toList());
-        });
+        return subclassingEntities.computeIfAbsent(entityClass, unused -> entityBindings
+                .keySet().stream()
+                .filter(c -> c != entityClass && entityClass.isAssignableFrom(c))
+                .collect(Collectors.toList()));
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -285,23 +285,14 @@ public class EntityDictionary {
      * @return the {@link Check} mapped to the identifier or {@code null} if the given identifer is unmapped
      */
     public Class<? extends Check> getCheck(String checkIdentifier) {
-        Class<? extends Check> checkCls = checkNames.get(checkIdentifier);
-
-        if (checkCls == null) {
+        Class<? extends Check> checkCls = checkNames.computeIfAbsent(checkIdentifier, cls -> {
             try {
-                checkCls = Class.forName(checkIdentifier).asSubclass(Check.class);
-                try {
-                    checkNames.putIfAbsent(checkIdentifier, checkCls);
-                } catch (IllegalArgumentException e) {
-                    log.error("HELP! {} {} {}", checkIdentifier, checkCls, checkNames.inverse().get(checkCls));
-                    throw e;
-                }
+                return Class.forName(checkIdentifier).asSubclass(Check.class);
             } catch (ClassNotFoundException | ClassCastException e) {
                 throw new IllegalArgumentException(
                         "Could not instantiate specified check '" + checkIdentifier + "'.", e);
             }
-        }
-
+        });
         return checkCls;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -894,6 +894,10 @@ public class EntityDictionary {
         return getEntityBinding(recordClass).getAnnotation(annotationClass);
     }
 
+    public <A extends Annotation> A getAnnotation(Class<?> recordClass, String method, Class<A> annotationClass) {
+        return getEntityBinding(recordClass).getAnnotation(annotationClass, method);
+    }
+
     public <A extends Annotation> Collection<LifeCycleHook> getTriggers(Class<?> cls,
                                                                         Class<A> annotationClass,
                                                                         String fieldName) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -886,8 +886,8 @@ public class EntityDictionary {
      * @param <A> genericClass
      * @return the annotation
      */
-    public <A extends Annotation> A getAnnotation(Class<?> recordClass, String method, Class<A> annotationClass) {
-        return getEntityBinding(recordClass).getAnnotation(annotationClass, method);
+    public <A extends Annotation> A getMethodAnnotation(Class<?> recordClass, String method, Class<A> annotationClass) {
+        return getEntityBinding(recordClass).getMethodAnnotation(annotationClass, method);
     }
 
     public <A extends Annotation> Collection<LifeCycleHook> getTriggers(Class<?> cls,

--- a/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
@@ -91,22 +91,8 @@ public abstract class FilterExpressionCheck<T> extends InlineCheck<T> {
      */
     protected static Path getFieldPath(Class<?> type, RequestScope requestScope, String method, String defaultPath) {
         EntityDictionary dictionary = coreScope(requestScope).getDictionary();
-        try {
-            FilterExpressionPath fep = getFilterExpressionPath(type, method, dictionary);
-            return new Path(type, dictionary, fep == null ? defaultPath : fep.value());
-        } catch (NoSuchMethodException | SecurityException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    private static FilterExpressionPath getFilterExpressionPath(
-            Class<?> type,
-            String method,
-            EntityDictionary dictionary) throws NoSuchMethodException {
-        FilterExpressionPath path = dictionary.lookupBoundClass(type)
-                .getMethod(method)
-                .getAnnotation(FilterExpressionPath.class);
-        return path;
+        FilterExpressionPath fep = dictionary.getAnnotation(type, method, FilterExpressionPath.class);
+        return new Path(type, dictionary, fep == null ? defaultPath : fep.value());
     }
 
     protected static com.yahoo.elide.core.RequestScope coreScope(RequestScope requestScope) {

--- a/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/FilterExpressionCheck.java
@@ -91,7 +91,7 @@ public abstract class FilterExpressionCheck<T> extends InlineCheck<T> {
      */
     protected static Path getFieldPath(Class<?> type, RequestScope requestScope, String method, String defaultPath) {
         EntityDictionary dictionary = coreScope(requestScope).getDictionary();
-        FilterExpressionPath fep = dictionary.getAnnotation(type, method, FilterExpressionPath.class);
+        FilterExpressionPath fep = dictionary.getMethodAnnotation(type, method, FilterExpressionPath.class);
         return new Path(type, dictionary, fep == null ? defaultPath : fep.value());
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/ExpressionResultCache.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/ExpressionResultCache.java
@@ -29,12 +29,8 @@ public class ExpressionResultCache {
     }
 
     public void putResultFor(Class<? extends Check> checkClass, PersistentResource resource, ExpressionResult result) {
-        Map<PersistentResource, ExpressionResult> cache = computedResults.get(checkClass);
-        if (cache == null) {
-            cache = new IdentityHashMap<>();
-            computedResults.put(checkClass, cache);
-        }
-
+        Map<PersistentResource, ExpressionResult> cache = computedResults.computeIfAbsent(checkClass,
+                unused -> new IdentityHashMap<>());
         cache.put(resource, result);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -795,4 +795,23 @@ public class EntityDictionaryTest extends EntityDictionary {
                 bean.map);
         assertEquals(ImmutableSet.of(3.0, 4.0), bean.set);
     }
+
+    public static class TestCheck extends UserCheck {
+
+        @Override
+        public boolean ok(com.yahoo.elide.security.User user) {
+            throw new IllegalStateException();
+        }
+    }
+
+    @Test
+    public void testCheckLookup() throws Exception {
+        assertEquals(Role.ALL.class, this.getCheck("user has all access"));
+
+        assertEquals(TestCheck.class, this.getCheck("com.yahoo.elide.core.EntityDictionaryTest$TestCheck"));
+
+        assertThrows(IllegalArgumentException.class, () -> this.getCheck("UnknownClassName"));
+
+        assertThrows(IllegalArgumentException.class, () -> this.getCheck(String.class.getName()));
+    }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -709,7 +709,7 @@ public class EntityDictionaryTest extends EntityDictionary {
     public void testAnnotationNoSuchMethod() {
         bindEntity(Book.class);
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> getAnnotation(Book.class, "NoMethod", FilterExpressionPath.class));
+                () -> getMethodAnnotation(Book.class, "NoMethod", FilterExpressionPath.class));
         assertTrue(e.getCause() instanceof NoSuchMethodException, e.toString());
     }
 
@@ -717,7 +717,7 @@ public class EntityDictionaryTest extends EntityDictionary {
     public void testAnnotationFilterExpressionPath() {
         bindEntity(Book.class);
         FilterExpressionPath fe =
-                getAnnotation(Book.class, "getEditor", FilterExpressionPath.class);
+                getMethodAnnotation(Book.class, "getEditor", FilterExpressionPath.class);
         assertEquals("publisher.editor", fe.value());
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import com.yahoo.elide.Injector;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.FilterExpressionPath;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.MappedInterface;
 import com.yahoo.elide.annotation.OnUpdatePreSecurity;
@@ -702,6 +703,22 @@ public class EntityDictionaryTest extends EntityDictionary {
 
         Annotation first = getFirstAnnotation(Foo.class, Arrays.asList(Exclude.class, Include.class));
         assertTrue(first instanceof Exclude);
+    }
+
+    @Test
+    public void testAnnotationNoSuchMethod() {
+        bindEntity(Book.class);
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> getAnnotation(Book.class, "NoMethod", FilterExpressionPath.class));
+        assertTrue(e.getCause() instanceof NoSuchMethodException, e.toString());
+    }
+
+    @Test
+    public void testAnnotationFilterExpressionPath() {
+        bindEntity(Book.class);
+        FilterExpressionPath fe =
+                getAnnotation(Book.class, "getEditor", FilterExpressionPath.class);
+        assertEquals("publisher.editor", fe.value());
     }
 
     @Test


### PR DESCRIPTION
## Description
Profiling showed a hotspot for `entityClass.getMethod(method)` in the FilterExpressionCheck.

Cleanup some `get/if null put` logic with more readable `computeIfAbsent`
 
## Motivation and Context
Reduces overhead for `FilterExpressionPath` lookup.

## How Has This Been Tested?
Local testing with profiler.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
