### PR TITLE
Fixes #1244: Incorrect pagination with ToMany filtering

### DIFF
--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -48,6 +48,7 @@ public abstract class AbstractHQLQueryBuilder {
     protected static final String FETCH = " FETCH ";
     protected static final String SELECT = "SELECT ";
     protected static final String AS = " AS ";
+    protected static final String DISTINCT = "DISTINCT ";
 
     protected static final boolean USE_ALIAS = true;
     protected static final boolean NO_ALIAS = false;
@@ -241,5 +242,18 @@ public abstract class AbstractHQLQueryBuilder {
             }
         }
         return sortingRules;
+    }
+
+    /**
+     * Returns whether filter expression contains toMany relationship
+     * @param filterExpression
+     * @return
+     */
+    protected boolean containsOneToMany(FilterExpression filterExpression) {
+        PredicateExtractionVisitor visitor = new PredicateExtractionVisitor(new ArrayList<>());
+        Collection<FilterPredicate> predicates = filterExpression.accept(visitor);
+
+        return predicates.stream()
+                .anyMatch(predicate -> FilterPredicate.toManyInPath(dictionary, predicate.getPath()));
     }
 }

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -6,13 +6,20 @@
 package com.yahoo.elide.datastores.hibernate.hql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.InPredicate;
+import com.yahoo.elide.core.filter.dialect.CaseSensitivityStrategy;
+import com.yahoo.elide.core.filter.dialect.ParseException;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.hibernate.hql.RootCollectionFetchQueryBuilder;
+import com.yahoo.elide.core.pagination.Pagination;
 import com.yahoo.elide.core.sort.Sorting;
 
 import example.Author;
@@ -24,9 +31,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -35,8 +40,7 @@ public class RootCollectionFetchQueryBuilderTest {
     private EntityDictionary dictionary;
 
     private static final String TITLE = "title";
-    private static final String BOOKS = "books";
-    private static final String PUBLISHER = "publisher";
+    private RSQLFilterDialect filterParser;
 
     @BeforeAll
     public void initialize() {
@@ -45,6 +49,7 @@ public class RootCollectionFetchQueryBuilderTest {
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Publisher.class);
         dictionary.bindEntity(Chapter.class);
+        filterParser = new RSQLFilterDialect(dictionary, new CaseSensitivityStrategy.UseColumnCollation());
     }
 
     @Test
@@ -81,26 +86,10 @@ public class RootCollectionFetchQueryBuilderTest {
     }
 
     @Test
-    public void testRootFetchWithJoinFilter() {
+    public void testRootFetchWithJoinFilter() throws ParseException {
 
-        List<Path.PathElement> chapterTitlePath = Arrays.asList(
-                new Path.PathElement(Author.class, Book.class, BOOKS),
-                new Path.PathElement(Book.class, Chapter.class, "chapters"),
-                new Path.PathElement(Chapter.class, String.class, TITLE)
-        );
-
-        FilterPredicate titlePredicate = new InPredicate(
-                new Path(chapterTitlePath),
-                "ABC", "DEF");
-
-        List<Path.PathElement>  publisherNamePath = Arrays.asList(
-                new Path.PathElement(Author.class, Book.class, BOOKS),
-                new Path.PathElement(Book.class, Publisher.class, PUBLISHER),
-                new Path.PathElement(Publisher.class, String.class, "name")
-        );
-
-        FilterPredicate publisherNamePredicate = new InPredicate(
-                new Path(publisherNamePath), "Pub1");
+        final FilterExpression titlePredicate = filterParser.parseFilterExpression("books.chapters.title=in=('ABC','DEF')", Author.class, true);
+        final FilterExpression publisherNamePredicate = filterParser.parseFilterExpression("books.publisher.name=in='Pub1'", Author.class, true);
 
         OrFilterExpression expression = new OrFilterExpression(titlePredicate, publisherNamePredicate);
 
@@ -126,6 +115,59 @@ public class RootCollectionFetchQueryBuilderTest {
         actual = actual.replaceFirst(":books_publisher_name_\\w\\w\\w\\w+", ":books_publisher_name_XXX");
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDistinctRootFetchWithToManyJoinFilterAndPagination() throws ParseException {
+        final Pagination pagination = Pagination.fromOffsetAndLimit(10, 0, false);
+
+        final FilterExpression titlePredicate = filterParser.parseFilterExpression("books.chapters.title=in=('ABC','DEF')", Author.class, true);
+        final FilterExpression publisherNamePredicate = filterParser.parseFilterExpression("books.publisher.name=in='Pub1'", Author.class, true);
+
+        OrFilterExpression expression = new OrFilterExpression(titlePredicate, publisherNamePredicate);
+
+        RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
+                Author.class, dictionary, new TestSessionWrapper());
+
+        builder.withPossiblePagination(Optional.of(pagination));
+
+        TestQueryWrapper query = (TestQueryWrapper) builder
+                .withPossibleFilterExpression(Optional.of(expression))
+                .build();
+
+
+        String expected =
+                "SELECT DISTINCT example_Author FROM example.Author AS example_Author  "
+                + "LEFT JOIN example_Author.books example_Author_books  "
+                + "LEFT JOIN example_Author_books.chapters example_Book_chapters   "
+                + "LEFT JOIN example_Author_books.publisher example_Book_publisher  "
+                + "WHERE (example_Book_chapters.title IN (:books_chapters_title_XXX, :books_chapters_title_XXX) "
+                + "OR example_Book_publisher.name IN (:books_publisher_name_XXX)) ";
+
+        String actual = query.getQueryText();
+        actual = actual.replaceFirst(":books_chapters_title_\\w\\w\\w\\w+", ":books_chapters_title_XXX");
+        actual = actual.replaceFirst(":books_chapters_title_\\w\\w\\w\\w+", ":books_chapters_title_XXX");
+        actual = actual.replaceFirst(":books_publisher_name_\\w\\w\\w\\w+", ":books_publisher_name_XXX");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testDistinctRootFetchWithToManyJoinFilterAndSortOverRelationshipAndPagination() throws ParseException {
+        final FilterExpression titlePredicate = filterParser.parseFilterExpression("books.chapters.title=in=('ABC','DEF')", Author.class, true);
+        final FilterExpression publisherNamePredicate = filterParser.parseFilterExpression("books.publisher.name=in='Pub1'", Author.class, true);
+        final Pagination pagination = Pagination.fromOffsetAndLimit(10, 0, false);
+        final Sorting sorting = Sorting.parseSortRule("-books.title");
+
+        OrFilterExpression expression = new OrFilterExpression(titlePredicate, publisherNamePredicate);
+
+        RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
+            Author.class, dictionary, new TestSessionWrapper());
+        builder.withPossibleFilterExpression(Optional.of(expression));
+        builder.withPossiblePagination(Optional.of(pagination));
+        builder.withPossibleSorting(Optional.of(sorting));
+
+        assertThrows(InvalidValueException.class, builder::build);
     }
 
     @Test

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
@@ -8,7 +8,9 @@ package com.yahoo.elide.tests;
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.initialization.IntegrationTest;
 import com.yahoo.elide.utils.JsonParser;
 
@@ -102,28 +104,9 @@ public class SortingIT extends IntegrationTest {
     }
 
     @Test
-    public void testSortingRootCollectionByRelationshipPropertyWithJoinFilter() throws IOException {
-        JsonNode result = getAsNode("/book?filter[book.authors.name][infixi]=Hemingway&sort=-publisher.name");
-        //We expect 2 results because the Hibernate does an inner join between book & publisher
-        assertEquals(2, result.get("data").size());
-
-        JsonNode books = result.get("data");
-        String firstBookName = books.get(0).get("attributes").get("title").asText();
-        assertEquals("For Whom the Bell Tolls", firstBookName);
-
-        String secondBookName = books.get(1).get("attributes").get("title").asText();
-        assertEquals("The Old Man and the Sea", secondBookName);
-
-        result = getAsNode("/book?filter[book.authors.name][infixi]=Hemingway&sort=publisher.name");
-        //We expect 2 results because the Hibernate does an inner join between book & publisher
-        assertEquals(2, result.get("data").size());
-
-        books = result.get("data");
-        firstBookName = books.get(0).get("attributes").get("title").asText();
-        assertEquals("The Old Man and the Sea", firstBookName);
-
-        secondBookName = books.get(1).get("attributes").get("title").asText();
-        assertEquals("For Whom the Bell Tolls", secondBookName);
+    public void testSortingRootCollectionByRelationshipPropertyWithJoinFilterAndPagination() throws IOException {
+        final JsonNode result = getAsNode("/book?filter[book.authors.name][infixi]=Hemingway&sort=-publisher.name", HttpStatus.SC_BAD_REQUEST);
+        assertNotNull(result.get("errors"));
     }
 
     @Test


### PR DESCRIPTION
Resolves #1244

## Description
When creating query, check if pagination and ToMany relationship is present, if so add DISTINCT to query.

## Motivation and Context
See the issue

## How Has This Been Tested?
Unit tests

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
