### PR TITLE
Fixing Spring JSON-API controller to allow JSON-API PATCH content type

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.spring.controllers;
 
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
@@ -45,6 +46,7 @@ public class JsonApiController {
     private final Elide elide;
     private final ElideConfigProperties settings;
     public static final String JSON_API_CONTENT_TYPE = JSONAPI_CONTENT_TYPE;
+    public static final String JSON_API_PATCH_CONTENT_TYPE = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 
     @Autowired
     public JsonApiController(Elide elide, ElideConfigProperties settings) {
@@ -72,13 +74,13 @@ public class JsonApiController {
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
-    @PatchMapping(value = "/**", consumes = JSON_API_CONTENT_TYPE)
+    @PatchMapping(value = "/**", consumes = { JSON_API_CONTENT_TYPE, JSON_API_PATCH_CONTENT_TYPE})
     public ResponseEntity<String> elidePatch(@RequestBody String body,
                                              HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         ElideResponse response = elide
-                .patch(JSON_API_CONTENT_TYPE, JSON_API_CONTENT_TYPE, pathname, body, authentication);
+                .patch(request.getContentType(), request.getContentType(), pathname, body, authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
@@ -17,10 +17,13 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchOperation;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchSet;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relation;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relationships;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperationType.add;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.contains;
@@ -93,6 +96,7 @@ public class ControllerTest extends IntegrationTest {
             .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
+
         when()
                 .get("/json/group")
                 .then()
@@ -135,6 +139,30 @@ public class ControllerTest extends IntegrationTest {
                 .patch("/json/group/com.example.repository")
                 .then()
                 .statusCode(HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void jsonApiPatchExtensionTest() {
+        given()
+                .contentType(JsonApiController.JSON_API_PATCH_CONTENT_TYPE)
+                .accept(JsonApiController.JSON_API_PATCH_CONTENT_TYPE)
+                .body(
+                        patchSet(
+                                patchOperation(add, "/group",
+                                        resource(
+                                                type("group"),
+                                                id("com.example.repository.foo"),
+                                                attributes(
+                                                    attr("commonName", "Foo")
+                                                )
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .patch("/json")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
     }
 
     @Test


### PR DESCRIPTION
## Description
The spring Elide controller does not accept the JSON-API patch content type extension. 

## Motivation and Context
Elide with spring does not support JSON-API patch extension.

## How Has This Been Tested?
Added a new controller test.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
