### PR TITLE
Refactored metric SQL expansion to occur dynamically at query time ra…

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -17,13 +17,13 @@ import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
-import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLMetric;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metric.SQLMetricFunction;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLMetricProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQuery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQueryConstructor;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQueryTemplate;
@@ -149,6 +149,7 @@ public class SQLQueryEngine extends QueryEngine {
                     }
 
                     return ((SQLMetric) metricProjection.getColumn()).resolve(
+                            referenceTable,
                             metricProjection.getArguments(),
                             metricProjection.getAlias(),
                             groupByDimensions,
@@ -162,7 +163,7 @@ public class SQLQueryEngine extends QueryEngine {
                     }
 
                     @Override
-                    public List<MetricProjection> getMetrics() {
+                    public List<SQLMetricProjection> getMetrics() {
                         return Collections.emptyList();
                     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLMetric.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLMetric.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metric.SQLMetricFunction;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLMetricProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQueryTemplate;
 import com.yahoo.elide.request.Argument;
 
@@ -42,13 +43,15 @@ public class SQLMetric extends Metric {
      * Construct a sql query template for a physical table with provided information.
      * Table name would be filled in when convert the template into real query.
      *
+     * @param sqlReferenceTable Table which expends SQL fragments
      * @param arguments arguments provided in the request
      * @param alias result alias
      * @param dimensions groupBy dimensions
      * @param timeDimension aggregated time dimension
      * @return <code>SELECT function(arguments, fields) AS alias GROUP BY dimensions, timeDimension </code>
      */
-    public SQLQueryTemplate resolve(Map<String, Argument> arguments,
+    public SQLQueryTemplate resolve(SQLReferenceTable sqlReferenceTable,
+                                    Map<String, Argument> arguments,
                                     String alias,
                                     Set<ColumnProjection> dimensions,
                                     TimeDimensionProjection timeDimension) {
@@ -61,8 +64,11 @@ public class SQLMetric extends Metric {
             }
 
             @Override
-            public List<MetricProjection> getMetrics() {
-                return Collections.singletonList(projection);
+            public List<SQLMetricProjection> getMetrics() {
+                SQLMetricProjection sqlProjection = new SQLMetricProjection(SQLMetric.this,
+                        sqlReferenceTable, alias, arguments);
+
+                return Collections.singletonList(sqlProjection);
             }
 
             @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -12,7 +12,6 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.FormulaValidator;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
-import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 
 import lombok.Getter;
@@ -90,10 +89,6 @@ public class SQLReferenceTable {
                     new SQLReferenceVisitor(metaDataStore, getClassAlias(tableClass)).visitColumn(column));
 
             resolvedJoinPaths.get(tableClass).put(fieldName, joinVisitor.visitColumn(column));
-
-            if (column instanceof Metric) {
-                ((Metric) column).getMetricFunction().setExpression(getResolvedReference(table, fieldName));
-            }
         });
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Yahoo Inc.
+ * Copyright 2020, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
+
+import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
+import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLMetric;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
+import com.yahoo.elide.request.Argument;
+
+import java.util.Map;
+
+/**
+ * Metric projection that can expand the metric into a SQL projection fragment.
+ */
+public class SQLMetricProjection implements MetricProjection {
+
+    private SQLMetric metric;
+    private SQLReferenceTable sqlReferenceTable;
+    private String alias;
+    private Map<String, Argument> arguments;
+
+
+    public SQLMetricProjection(SQLMetric metric,
+                               SQLReferenceTable sqlReferenceTable,
+                               String alias,
+                               Map<String, Argument> arguments) {
+        this.metric = metric;
+        this.sqlReferenceTable = sqlReferenceTable;
+        this.arguments = arguments;
+        this.alias = alias;
+    }
+
+    @Override
+    public Metric getColumn() {
+        return metric;
+    }
+
+    @Override
+    public String getFunctionExpression() {
+        return sqlReferenceTable.getResolvedReference(metric.getTable(), metric.getName());
+    }
+
+    @Override
+    public String getAlias() {
+        return alias;
+    }
+
+    @Override
+    public Map<String, Argument> getArguments() {
+        return arguments;
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 
 import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
-import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 
@@ -34,7 +33,7 @@ public interface SQLQueryTemplate {
      *
      * @return invoked metrics
      */
-    List<MetricProjection> getMetrics();
+    List<SQLMetricProjection> getMetrics();
 
     /**
      * Get all non-time dimensions in this query.
@@ -77,7 +76,7 @@ public interface SQLQueryTemplate {
             }
 
             @Override
-            public List<MetricProjection> getMetrics() {
+            public List<SQLMetricProjection> getMetrics() {
                 return wrapped.getMetrics();
             }
 
@@ -104,7 +103,7 @@ public interface SQLQueryTemplate {
         assert this.getTable().equals(second.getTable());
 
         SQLQueryTemplate first = this;
-        List<MetricProjection> merged = new ArrayList<>(first.getMetrics());
+        List<SQLMetricProjection> merged = new ArrayList<>(first.getMetrics());
         merged.addAll(second.getMetrics());
 
         return new SQLQueryTemplate() {
@@ -114,7 +113,7 @@ public interface SQLQueryTemplate {
             }
 
             @Override
-            public List<MetricProjection> getMetrics() {
+            public List<SQLMetricProjection> getMetrics() {
                 return merged;
             }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -754,7 +754,7 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.relationships.metricFunction.data.id", equalTo("playerStats.lowScore[min]"))
                 .body("included.id", hasItem("playerStats.lowScore[min]"))
                 .body("included.attributes.description", hasItem("sql min function"))
-                .body("included.attributes.expression", hasItem("MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore)"))
+                .body("included.attributes.expression", hasItem("MIN(%s)"))
                 .body("included.attributes.longName", hasItem("min"));
 
         given()


### PR DESCRIPTION
…ther than statically during service initialization

## Description
Metric SQL generation should be done at query time rather than resolving the references statically during service startup.  This allows us to to support parameterized metrics.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
