### PR TITLE
Remove path logic from aggregation store

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -65,6 +65,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
     private Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
         Table table = queryEngine.getTable(scope.getDictionary().getJsonAliasFor(entityProjection.getType()));
         EntityProjectionTranslator translator = new EntityProjectionTranslator(
+                queryEngine,
                 table,
                 entityProjection,
                 scope.getDictionary());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslator.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
  */
 public class EntityProjectionTranslator {
     private Table queriedTable;
+    private QueryEngine engine;
 
     private EntityProjection entityProjection;
     private Set<ColumnProjection> dimensionProjections;
@@ -46,7 +47,9 @@ public class EntityProjectionTranslator {
     private FilterExpression havingFilter;
     private EntityDictionary dictionary;
 
-    public EntityProjectionTranslator(Table table, EntityProjection entityProjection, EntityDictionary dictionary) {
+    public EntityProjectionTranslator(QueryEngine engine, Table table,
+                                      EntityProjection entityProjection, EntityDictionary dictionary) {
+        this.engine = engine;
         this.queriedTable = table;
         this.entityProjection = entityProjection;
         this.dictionary = dictionary;
@@ -104,7 +107,7 @@ public class EntityProjectionTranslator {
                 .map(timeDimAttr -> {
                     TimeDimension timeDim = queriedTable.getTimeDimension(timeDimAttr.getName());
 
-                    return ColumnProjection.toTimeDimensionProjection(
+                    return engine.constructTimeDimensionProjection(
                             timeDim,
                             timeDimAttr.getAlias(),
                             timeDimAttr.getArguments().stream()
@@ -123,7 +126,7 @@ public class EntityProjectionTranslator {
                     Dimension dimension = queriedTable.getDimension(dimAttr.getName());
                     return dimension == null
                             ? null
-                            : ColumnProjection.toDimensionProjection(
+                            : engine.constructDimensionProjection(
                                     dimension,
                                     dimAttr.getAlias(),
                                     dimAttr.getArguments().stream()
@@ -137,7 +140,7 @@ public class EntityProjectionTranslator {
                     Dimension dimension = queriedTable.getDimension(dimAttr.getName());
                     return dimension == null
                             ? null
-                            : ColumnProjection.toDimensionProjection(
+                            : engine.constructDimensionProjection(
                                 dimension,
                                 dimAttr.getAlias(),
                                 Collections.emptyMap());
@@ -154,7 +157,7 @@ public class EntityProjectionTranslator {
     private List<MetricProjection> resolveMetrics() {
         return entityProjection.getAttributes().stream()
                 .filter(attribute -> queriedTable.isMetric(attribute.getName()))
-                .map(attribute -> ColumnProjection.toMetricProjection(
+                .map(attribute -> engine.constructMetricProjection(
                         queriedTable.getMetric(attribute.getName()),
                         attribute.getAlias(),
                         attribute.getArguments().stream()

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -10,8 +10,15 @@ import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
+import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
+import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
+import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
+import com.yahoo.elide.request.Argument;
 
 import com.google.common.base.Functions;
 
@@ -92,6 +99,38 @@ public abstract class QueryEngine {
      * @return constructed Table
      */
     protected abstract Table constructTable(Class<?> entityClass, EntityDictionary metaDataDictionary);
+
+    /**
+     * Construct a parameterized instance of a Column.
+     * @param dimension The dimension column.
+     * @param alias The client provide alias.
+     * @param arguments The client provided parameterized arguments.
+     * @return
+     */
+    public abstract ColumnProjection constructDimensionProjection(Dimension dimension,
+                                                                  String alias,
+                                                                  Map<String, Argument> arguments);
+
+    /**
+     * Construct a parameterized instance of a Column.
+     * @param dimension The dimension column.
+     * @param alias The client provide alias.
+     * @param arguments The client provided parameterized arguments.
+     * @return
+     */
+    public abstract TimeDimensionProjection constructTimeDimensionProjection(TimeDimension dimension,
+                                                                             String alias,
+                                                                             Map<String, Argument> arguments);
+    /**
+     * Construct a parameterized instance of a Column.
+     * @param metric The metric column.
+     * @param alias The client provide alias.
+     * @param arguments The client provided parameterized arguments.
+     * @return
+     */
+    public abstract MetricProjection constructMetricProjection(Metric metric,
+                                                               String alias,
+                                                               Map<String, Argument> arguments);
 
     /**
      * Query engine is responsible for constructing all Tables and Entities metadata in this metadata store.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
@@ -82,6 +82,10 @@ public class QueryValidator {
                                 tableClass.getSimpleName()));
             }
 
+            if (path.getPathElements().size() > 1) {
+                throw new InvalidOperationException("Relationship traversal not supported for analytic queries.");
+            }
+
             if (queriedTable.isMetric(fieldName)) {
                 if (metrics.stream().noneMatch(m -> m.getAlias().equals(fieldName))) {
                     throw new InvalidOperationException(

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
@@ -26,14 +26,15 @@ import java.util.stream.Collectors;
 
 /**
  * Represents a projected column as an alias in a query.
+ * @param <T> Column type of the projection.
  */
-public interface ColumnProjection extends Serializable {
+public interface ColumnProjection<T extends Column> extends Serializable {
     /**
      * Get the projected column.
      *
      * @return column
      */
-    Column getColumn();
+    T getColumn();
 
     /**
      * Get the projection alias.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
@@ -5,24 +5,11 @@
  */
 package com.yahoo.elide.datastores.aggregation.query;
 
-import com.yahoo.elide.core.exceptions.InvalidOperationException;
-import com.yahoo.elide.core.exceptions.InvalidPredicateException;
-import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
-import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
-import com.yahoo.elide.datastores.aggregation.metadata.models.FunctionArgument;
-import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
-import com.yahoo.elide.datastores.aggregation.metadata.models.MetricFunction;
-import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
-import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain;
 import com.yahoo.elide.request.Argument;
 
 import java.io.Serializable;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.stream.Collectors;
 
 /**
  * Represents a projected column as an alias in a query.
@@ -49,123 +36,4 @@ public interface ColumnProjection<T extends Column> extends Serializable {
      * @return request arguments
      */
     Map<String, Argument> getArguments();
-
-    /**
-     * Project a dimension as alias.
-     *
-     * @param dimension dimension column
-     * @param alias alias
-     * @param arguments arguments of this projection
-     * @return a projection represents that "dimension AS alias"
-     */
-    static ColumnProjection toDimensionProjection(Dimension dimension, String alias, Map<String, Argument> arguments) {
-        return new ColumnProjection() {
-            @Override
-            public Column getColumn() {
-                return dimension;
-            }
-
-            @Override
-            public String getAlias() {
-                return alias;
-            }
-
-            @Override
-            public Map<String, Argument> getArguments() {
-                return arguments;
-            }
-        };
-    }
-
-    /**
-     * Project a time dimension as alias with specific time grain.
-     *
-     * @param dimension time dimension column
-     * @param alias alias
-     * @param arguments arguments of this projection
-     * @return a projection represents that "grain(dimension) AS alias"
-     */
-    static TimeDimensionProjection toTimeDimensionProjection(TimeDimension dimension,
-                                                             String alias,
-                                                             Map<String, Argument> arguments) {
-        Argument grainArgument = arguments.get("grain");
-
-        TimeDimensionGrain resolvedGrain;
-        if (grainArgument == null) {
-            //The first grain is the default.
-            resolvedGrain = dimension.getSupportedGrains().stream()
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException(
-                            String.format("Requested default grain, no grain defined on %s",
-                                    dimension.getName())));
-        } else {
-            String requestedGrainName = grainArgument.getValue().toString().toLowerCase(Locale.ENGLISH);
-
-            resolvedGrain = dimension.getSupportedGrains().stream()
-                    .filter(supportedGrain -> supportedGrain.getGrain().name().toLowerCase(Locale.ENGLISH)
-                            .equals(requestedGrainName))
-                    .findFirst()
-                    .orElseThrow(() -> new InvalidOperationException(
-                            String.format("Unsupported grain %s for field %s",
-                                    requestedGrainName,
-                                    dimension.getName())));
-        }
-
-        return new TimeDimensionProjection() {
-            @Override
-            public TimeDimension getColumn() {
-                return dimension;
-            }
-
-            @Override
-            public String getAlias() {
-                return alias;
-            }
-
-            @Override
-            public Map<String, Argument> getArguments() {
-                return arguments;
-            }
-
-            @Override
-            public TimeGrain getGrain() {
-                return resolvedGrain.getGrain();
-            }
-
-            @Override
-            public TimeZone getTimeZone() {
-                return null;
-            }
-        };
-    }
-
-    static MetricProjection toMetricProjection(Metric metric, String alias, Map<String, Argument> arguments) {
-        MetricFunction function = metric.getMetricFunction();
-
-        Set<String> requiredArguments = function.getArguments().stream()
-                .map(FunctionArgument::getName)
-                .collect(Collectors.toSet());
-
-        if (!requiredArguments.equals(arguments.keySet())) {
-            throw new InvalidPredicateException(
-                    "Provided arguments doesn't match requirement for function " + function.getName() + ".");
-        }
-
-        return new MetricProjection() {
-            @Override
-            public Metric getColumn() {
-                return metric;
-            }
-
-            @Override
-            public String getAlias() {
-                return alias;
-            }
-
-            @Override
-            public Map<String, Argument> getArguments() {
-                return arguments;
-            }
-        };
-    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/MetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/MetricProjection.java
@@ -10,7 +10,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 /**
  * Represents a projected metric column as an alias in a query.
  */
-public interface MetricProjection extends ColumnProjection {
+public interface MetricProjection extends ColumnProjection<Metric> {
     /**
      * Get the projected metric.
      *

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/MetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/MetricProjection.java
@@ -18,13 +18,4 @@ public interface MetricProjection extends ColumnProjection<Metric> {
      */
     @Override
     Metric getColumn();
-
-    /**
-     * Get full expression with provided arguments.
-     *
-     * @return function expression
-     */
-    default String getFunctionExpression() {
-        return getColumn().getMetricFunction().constructExpression(getArguments());
-    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/TimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/TimeDimensionProjection.java
@@ -17,7 +17,7 @@ import java.util.TimeZone;
 /**
  * Represents a requested time dimension in a query.
  */
-public interface TimeDimensionProjection extends ColumnProjection {
+public interface TimeDimensionProjection extends ColumnProjection<TimeDimension> {
     /**
      * Get the projected time dimension.
      *

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -196,7 +196,7 @@ public class SQLQueryEngine extends QueryEngine {
                     return ((SQLMetric) metricProjection.getColumn()).resolve(query, metricProjection, referenceTable);
                 })
                 .reduce(SQLQueryTemplate::merge)
-                .orElse(new SQLQueryTemplate(query, referenceTable));
+                .orElse(new SQLQueryTemplate(query));
 
         return new SQLQueryConstructor(referenceTable).resolveTemplate(
                 query,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -23,7 +23,6 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLMetri
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metric.SQLMetricFunction;
-import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLMetricProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQuery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQueryConstructor;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQueryTemplate;
@@ -36,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -148,35 +146,10 @@ public class SQLQueryEngine extends QueryEngine {
                                 "Non-SQL metric function on " + metricProjection.getAlias());
                     }
 
-                    return ((SQLMetric) metricProjection.getColumn()).resolve(
-                            referenceTable,
-                            metricProjection.getArguments(),
-                            metricProjection.getAlias(),
-                            groupByDimensions,
-                            timeDimension);
+                    return ((SQLMetric) metricProjection.getColumn()).resolve(query, metricProjection, referenceTable);
                 })
                 .reduce(SQLQueryTemplate::merge)
-                .orElse(new SQLQueryTemplate() {
-                    @Override
-                    public SQLTable getTable() {
-                        return (SQLTable) query.getTable();
-                    }
-
-                    @Override
-                    public List<SQLMetricProjection> getMetrics() {
-                        return Collections.emptyList();
-                    }
-
-                    @Override
-                    public Set<ColumnProjection> getNonTimeDimensions() {
-                        return groupByDimensions;
-                    }
-
-                    @Override
-                    public TimeDimensionProjection getTimeDimension() {
-                        return timeDimension;
-                    }
-                });
+                .orElse(new SQLQueryTemplate(query, referenceTable));
 
         return new SQLQueryConstructor(referenceTable).resolveTemplate(
                 query,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLMetric.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLMetric.java
@@ -9,17 +9,11 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.datastores.aggregation.metadata.models.FunctionArgument;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.metadata.models.MetricFunction;
-import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
-import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
+import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metric.SQLMetricFunction;
-import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLMetricProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLQueryTemplate;
-import com.yahoo.elide.request.Argument;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -43,43 +37,23 @@ public class SQLMetric extends Metric {
      * Construct a sql query template for a physical table with provided information.
      * Table name would be filled in when convert the template into real query.
      *
-     * @param sqlReferenceTable Table which expends SQL fragments
-     * @param arguments arguments provided in the request
-     * @param alias result alias
-     * @param dimensions groupBy dimensions
-     * @param timeDimension aggregated time dimension
+     * @param query The entire client query
+     * @param metric The metric to resolve.
      * @return <code>SELECT function(arguments, fields) AS alias GROUP BY dimensions, timeDimension </code>
      */
-    public SQLQueryTemplate resolve(SQLReferenceTable sqlReferenceTable,
-                                    Map<String, Argument> arguments,
-                                    String alias,
-                                    Set<ColumnProjection> dimensions,
-                                    TimeDimensionProjection timeDimension) {
-        MetricProjection projection = ColumnProjection.toMetricProjection(this, alias, arguments);
+    public SQLQueryTemplate resolve(Query query, MetricProjection metric, SQLReferenceTable referenceTable) {
+        Query singleMetricQuery = Query.builder()
+                .metric(metric)
+                .table(query.getTable())
+                .groupByDimensions(query.getGroupByDimensions())
+                .timeDimensions(query.getTimeDimensions())
+                .whereFilter(query.getWhereFilter())
+                .havingFilter(query.getHavingFilter())
+                .sorting(query.getSorting())
+                .pagination(query.getPagination())
+                .scope(query.getScope())
+                .build();
 
-        return new SQLQueryTemplate() {
-            @Override
-            public SQLTable getTable() {
-                return (SQLTable) projection.getColumn().getTable();
-            }
-
-            @Override
-            public List<SQLMetricProjection> getMetrics() {
-                SQLMetricProjection sqlProjection = new SQLMetricProjection(SQLMetric.this,
-                        sqlReferenceTable, alias, arguments);
-
-                return Collections.singletonList(sqlProjection);
-            }
-
-            @Override
-            public Set<ColumnProjection> getNonTimeDimensions() {
-                return dimensions;
-            }
-
-            @Override
-            public TimeDimensionProjection getTimeDimension() {
-                return timeDimension;
-            }
-        };
+        return new SQLQueryTemplate(singleMetricQuery, referenceTable);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLMetric.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLMetric.java
@@ -54,6 +54,6 @@ public class SQLMetric extends Metric {
                 .scope(query.getScope())
                 .build();
 
-        return new SQLQueryTemplate(singleMetricQuery, referenceTable);
+        return new SQLQueryTemplate(singleMetricQuery);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -23,6 +23,7 @@ import java.util.Set;
  * Table stores all resolved physical reference and join paths of all columns.
  */
 public class SQLReferenceTable {
+    @Getter
     private final MetaDataStore metaDataStore;
 
     @Getter

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine.getClassAlias;
 
 import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.Path;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.FormulaValidator;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
@@ -90,16 +89,5 @@ public class SQLReferenceTable {
 
             resolvedJoinPaths.get(tableClass).put(fieldName, joinVisitor.visitColumn(column));
         });
-    }
-
-    /**
-     * Get physical reference for a path.
-     *
-     * @param path path to a field
-     * @param tableAlias table alias as prefix
-     * @return resolved physical reference
-     */
-    public String resolveReference(Path path, String tableAlias) {
-        return new SQLReferenceVisitor(metaDataStore, tableAlias).visitColumn(metaDataStore.getColumn(path));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -9,6 +9,9 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
+import com.yahoo.elide.request.Argument;
+
+import java.util.Map;
 
 /**
  * Column projection that can expand the column into a SQL projection fragment.
@@ -18,7 +21,32 @@ public interface SQLColumnProjection<T extends Column> extends ColumnProjection<
 
     SQLReferenceTable getReferenceTable();
 
-    default String getFunctionExpression() {
+    default String toSQL() {
         return getReferenceTable().getResolvedReference(getColumn().getTable(), getColumn().getName());
+    }
+
+    public static SQLColumnProjection toSQLColumnProjection(ColumnProjection projection,
+                                                            SQLReferenceTable referenceTable) {
+        return new SQLColumnProjection() {
+            @Override
+            public SQLReferenceTable getReferenceTable() {
+                return referenceTable;
+            }
+
+            @Override
+            public Column getColumn() {
+                return projection.getColumn();
+            }
+
+            @Override
+            public String getAlias() {
+                return projection.getAlias();
+            }
+
+            @Override
+            public Map<String, Argument> getArguments() {
+                return projection.getArguments();
+            }
+        };
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
+
+import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
+import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
+
+/**
+ * Column projection that can expand the column into a SQL projection fragment.
+ * @param <T> Column type of the projection.
+ */
+public interface SQLColumnProjection<T extends Column> extends ColumnProjection<T> {
+
+    SQLReferenceTable getReferenceTable();
+
+    default String getFunctionExpression() {
+        return getReferenceTable().getResolvedReference(getColumn().getTable(), getColumn().getName());
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -18,7 +18,12 @@ public interface SQLColumnProjection<T extends Column> extends ColumnProjection<
 
     SQLReferenceTable getReferenceTable();
 
-    default String toSQL() {
+    /**
+     * Generate a SQL fragment for this combination column and client arguments.
+     * @param queryTemplate The query template.
+     * @return
+     */
+    default String toSQL(SQLQueryTemplate queryTemplate) {
         return getReferenceTable().getResolvedReference(getColumn().getTable(), getColumn().getName());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -9,9 +9,6 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
-import com.yahoo.elide.request.Argument;
-
-import java.util.Map;
 
 /**
  * Column projection that can expand the column into a SQL projection fragment.
@@ -23,30 +20,5 @@ public interface SQLColumnProjection<T extends Column> extends ColumnProjection<
 
     default String toSQL() {
         return getReferenceTable().getResolvedReference(getColumn().getTable(), getColumn().getName());
-    }
-
-    public static SQLColumnProjection toSQLColumnProjection(ColumnProjection projection,
-                                                            SQLReferenceTable referenceTable) {
-        return new SQLColumnProjection() {
-            @Override
-            public SQLReferenceTable getReferenceTable() {
-                return referenceTable;
-            }
-
-            @Override
-            public Column getColumn() {
-                return projection.getColumn();
-            }
-
-            @Override
-            public String getAlias() {
-                return projection.getAlias();
-            }
-
-            @Override
-            public Map<String, Argument> getArguments() {
-                return projection.getArguments();
-            }
-        };
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -17,13 +17,12 @@ import java.util.Map;
 /**
  * Metric projection that can expand the metric into a SQL projection fragment.
  */
-public class SQLMetricProjection implements MetricProjection {
+public class SQLMetricProjection implements MetricProjection, SQLColumnProjection<Metric> {
 
     private SQLMetric metric;
     private SQLReferenceTable sqlReferenceTable;
     private String alias;
     private Map<String, Argument> arguments;
-
 
     public SQLMetricProjection(SQLMetric metric,
                                SQLReferenceTable sqlReferenceTable,
@@ -33,6 +32,11 @@ public class SQLMetricProjection implements MetricProjection {
         this.sqlReferenceTable = sqlReferenceTable;
         this.arguments = arguments;
         this.alias = alias;
+    }
+
+    @Override
+    public SQLReferenceTable getReferenceTable() {
+        return sqlReferenceTable;
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -23,16 +23,6 @@ public class SQLMetricProjection implements MetricProjection, SQLColumnProjectio
     private String alias;
     private Map<String, Argument> arguments;
 
-    public SQLMetricProjection(MetricProjection metricProjection,
-                               SQLReferenceTable sqlReferenceTable) {
-        this(
-                metricProjection.getColumn(),
-                sqlReferenceTable,
-                metricProjection.getAlias(),
-                metricProjection.getArguments()
-        );
-    }
-
     public SQLMetricProjection(Metric metric,
                                SQLReferenceTable sqlReferenceTable,
                                String alias,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
-import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLMetric;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.request.Argument;
 
@@ -19,12 +18,22 @@ import java.util.Map;
  */
 public class SQLMetricProjection implements MetricProjection, SQLColumnProjection<Metric> {
 
-    private SQLMetric metric;
+    private Metric metric;
     private SQLReferenceTable sqlReferenceTable;
     private String alias;
     private Map<String, Argument> arguments;
 
-    public SQLMetricProjection(SQLMetric metric,
+    public SQLMetricProjection(MetricProjection metricProjection,
+                               SQLReferenceTable sqlReferenceTable) {
+        this(
+                metricProjection.getColumn(),
+                sqlReferenceTable,
+                metricProjection.getAlias(),
+                metricProjection.getArguments()
+        );
+    }
+
+    public SQLMetricProjection(Metric metric,
                                SQLReferenceTable sqlReferenceTable,
                                String alias,
                                Map<String, Argument> arguments) {
@@ -45,7 +54,7 @@ public class SQLMetricProjection implements MetricProjection, SQLColumnProjectio
     }
 
     @Override
-    public String getFunctionExpression() {
+    public String toSQL() {
         return sqlReferenceTable.getResolvedReference(metric.getTable(), metric.getName());
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -44,7 +44,7 @@ public class SQLMetricProjection implements MetricProjection, SQLColumnProjectio
     }
 
     @Override
-    public String toSQL() {
+    public String toSQL(SQLQueryTemplate queryTemplate) {
         return sqlReferenceTable.getResolvedReference(metric.getTable(), metric.getName());
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
@@ -25,7 +25,6 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
-import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
@@ -156,7 +155,7 @@ public class SQLQueryConstructor {
             throw new InvalidPredicateException("The having clause can only reference fact table aggregations.");
         }
 
-        MetricProjection metric = template.getMetrics().stream()
+        SQLMetricProjection metric = template.getMetrics().stream()
                 // TODO: filter predicate should support alias
                 .filter(invocation -> invocation.getAlias().equals(fieldName))
                 .findFirst()
@@ -316,7 +315,7 @@ public class SQLQueryConstructor {
 
                     Path.PathElement last = path.lastElement().get();
 
-                    MetricProjection metric = template.getMetrics().stream()
+                    SQLMetricProjection metric = template.getMetrics().stream()
                             // TODO: filter predicate should support alias
                             .filter(invocation -> invocation.getAlias().equals(last.getFieldName()))
                             .findFirst()

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
@@ -6,7 +6,6 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 
 import com.yahoo.elide.datastores.aggregation.query.Query;
-import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 
 import com.google.common.collect.Sets;
@@ -38,7 +37,7 @@ public class SQLQueryTemplate {
         this.metrics = metrics;
     }
 
-    public SQLQueryTemplate(Query query, SQLReferenceTable referenceTable) {
+    public SQLQueryTemplate(Query query) {
         table = (SQLTable) query.getTable();
         timeDimension = query.getTimeDimensions().stream()
                 .findFirst()

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
@@ -42,15 +42,15 @@ public class SQLQueryTemplate {
         table = (SQLTable) query.getTable();
         timeDimension = query.getTimeDimensions().stream()
                 .findFirst()
-                .map((timeDim) -> new SQLTimeDimensionProjection(timeDim, referenceTable))
+                .map(SQLTimeDimensionProjection.class::cast)
                 .orElse(null);
 
         nonTimeDimensions = query.getGroupByDimensions().stream()
-                .map((dim) -> SQLColumnProjection.toSQLColumnProjection(dim, referenceTable))
+                .map(SQLColumnProjection.class::cast)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         metrics = query.getMetrics().stream()
-                .map((metric) -> new SQLMetricProjection(metric, referenceTable))
+                .map(SQLMetricProjection.class::cast)
                 .collect(Collectors.toList());
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryTemplate.java
@@ -25,6 +25,11 @@ import java.util.stream.Collectors;
 @Data
 public class SQLQueryTemplate {
 
+    private final SQLTable table;
+    private final List<SQLMetricProjection> metrics;
+    private final Set<SQLColumnProjection> nonTimeDimensions;
+    private final SQLTimeDimensionProjection timeDimension;
+
     public SQLQueryTemplate(SQLTable table, List<SQLMetricProjection> metrics,
                      Set<SQLColumnProjection> nonTimeDimensions, SQLTimeDimensionProjection timeDimension) {
         this.table = table;
@@ -48,11 +53,6 @@ public class SQLQueryTemplate {
                 .map((metric) -> new SQLMetricProjection(metric, referenceTable))
                 .collect(Collectors.toList());
     }
-
-    private final SQLTable table;
-    private final List<SQLMetricProjection> metrics;
-    private final Set<SQLColumnProjection> nonTimeDimensions;
-    private final SQLTimeDimensionProjection timeDimension;
 
     /**
      * Get all GROUP BY dimensions in this query, include time and non-time dimensions.
@@ -79,5 +79,19 @@ public class SQLQueryTemplate {
          merged.addAll(second.getMetrics());
 
          return new SQLQueryTemplate(first.getTable(), merged, first.getNonTimeDimensions(), first.getTimeDimension());
+     }
+
+    /**
+     * Returns the entire list of column projections.
+     * @return metrics and dimensions.
+     */
+     public List<SQLColumnProjection> getColumnProjections() {
+         ArrayList<SQLColumnProjection> columnProjections = new ArrayList<>();
+         columnProjections.addAll(metrics);
+         columnProjections.addAll(nonTimeDimensions);
+         if (timeDimension != null) {
+            columnProjections.add(timeDimension);
+         }
+         return columnProjections;
      }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
+
+import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
+import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
+import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
+import com.yahoo.elide.request.Argument;
+
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * Column projection that can expand the column into a SQL projection fragment.
+ */
+public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimension>, TimeDimensionProjection {
+
+    private final TimeDimension column;
+    private final TimeGrain grain;
+    private final TimeZone timezone;
+    private final SQLReferenceTable sqlReferenceTable;
+    private final String alias;
+    private final Map<String, Argument> arguments;
+
+    public SQLTimeDimensionProjection(TimeDimension column,
+                                      TimeGrain grain,
+                                      TimeZone timezone,
+                                      SQLReferenceTable sqlReferenceTable,
+                                      String alias,
+                                      Map<String, Argument> arguments) {
+        this.column = column;
+        this.sqlReferenceTable = sqlReferenceTable;
+        this.arguments = arguments;
+        this.alias = alias;
+        this.grain = grain;
+        this.timezone = timezone;
+    }
+
+    @Override
+    public SQLReferenceTable getReferenceTable() {
+        return sqlReferenceTable;
+    }
+
+    @Override
+    public TimeDimension getColumn() {
+        return column;
+    }
+
+    public String getFunctionExpression() {
+        return sqlReferenceTable.getResolvedReference(column.getTable(), column.getName());
+    }
+
+    @Override
+    public String getAlias() {
+        return alias;
+    }
+
+    @Override
+    public TimeGrain getGrain() {
+        return null;
+    }
+
+    @Override
+    public TimeZone getTimeZone() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Argument> getArguments() {
+        return arguments;
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.request.Argument;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -28,6 +29,28 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
     private final String alias;
     private final Map<String, Argument> arguments;
 
+    /**
+     * Default constructor for columns that are projected in filter and sorting clauses.
+     * @param column The column in the filter/sorting clause.
+     * @param sqlReferenceTable The reference table.
+     */
+    public SQLTimeDimensionProjection(TimeDimension column,
+                                      SQLReferenceTable sqlReferenceTable) {
+        this(
+                column,
+                column.getSupportedGrains().iterator().next().getGrain(),
+                column.getTimezone(),
+                sqlReferenceTable,
+                column.getName(),
+                new LinkedHashMap<>()
+        );
+    }
+
+    /**
+     * Default constructor to convert a timeDimensionProjection into its SQL equivalent.
+     * @param timeDimensionProjection The timeDimensionProjection to convert.
+     * @param sqlReferenceTable The reference table.
+     */
     public SQLTimeDimensionProjection(TimeDimensionProjection timeDimensionProjection,
                                       SQLReferenceTable sqlReferenceTable) {
         this(
@@ -41,6 +64,15 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
     }
 
 
+    /**
+     * All argument constructor.
+     * @param column The column being projected.
+     * @param grain The selected time grain.
+     * @param timezone The selected time zone.
+     * @param sqlReferenceTable The reference table.
+     * @param alias The client provided alias.
+     * @param arguments List of client provided arguments.
+     */
     public SQLTimeDimensionProjection(TimeDimension column,
                                       TimeGrain grain,
                                       TimeZone timezone,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 
 import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
+import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.request.Argument;
@@ -26,6 +27,19 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
     private final SQLReferenceTable sqlReferenceTable;
     private final String alias;
     private final Map<String, Argument> arguments;
+
+    public SQLTimeDimensionProjection(TimeDimensionProjection timeDimensionProjection,
+                                      SQLReferenceTable sqlReferenceTable) {
+        this(
+                timeDimensionProjection.getColumn(),
+                timeDimensionProjection.getGrain(),
+                timeDimensionProjection.getTimeZone(),
+                sqlReferenceTable,
+                timeDimensionProjection.getAlias(),
+                timeDimensionProjection.getArguments()
+        );
+    }
+
 
     public SQLTimeDimensionProjection(TimeDimension column,
                                       TimeGrain grain,
@@ -51,8 +65,26 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
         return column;
     }
 
-    public String getFunctionExpression() {
-        return sqlReferenceTable.getResolvedReference(column.getTable(), column.getName());
+    @Override
+    public String toSQL() {
+        for (TimeDimensionGrain grainInfo : column.getSupportedGrains()) {
+            if (grainInfo.getGrain().equals(this.getGrain())) {
+                return String.format(
+                        grainInfo.getExpression(),
+                        sqlReferenceTable.getResolvedReference(column.getTable(), column.getName()));
+            }
+        }
+
+
+        TimeDimensionGrain grainInfo = column.getSupportedGrains().stream()
+                .filter(g -> g.getGrain().equals(this.getGrain()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Requested time grain not supported."));
+
+        //TODO - We will likely migrate to a templating language when we support parameterized metrics.
+        return String.format(
+                grainInfo.getExpression(),
+                sqlReferenceTable.getResolvedReference(column.getTable(), column.getName()));
     }
 
     @Override
@@ -62,12 +94,12 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
 
     @Override
     public TimeGrain getGrain() {
-        return null;
+        return grain;
     }
 
     @Override
     public TimeZone getTimeZone() {
-        return null;
+        return timezone;
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -101,7 +101,7 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
     }
 
     @Override
-    public String toSQL() {
+    public String toSQL(SQLQueryTemplate queryTemplate) {
         //TODO - We will likely migrate to a templating language when we support parameterized metrics.
         return String.format(
                 grain.getExpression(),

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -102,14 +102,9 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
 
     @Override
     public String toSQL() {
-        TimeDimensionGrain grainInfo = column.getSupportedGrains().stream()
-                .filter(g -> g.getGrain().equals(this.getGrain()))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Requested time grain not supported."));
-
         //TODO - We will likely migrate to a templating language when we support parameterized metrics.
         return String.format(
-                grainInfo.getExpression(),
+                grain.getExpression(),
                 sqlReferenceTable.getResolvedReference(column.getTable(), column.getName()));
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslatorTest.java
@@ -51,6 +51,7 @@ public class EntityProjectionTranslatorTest extends SQLUnitTest {
     @Test
     public void testBasicTranslation() {
         EntityProjectionTranslator translator = new EntityProjectionTranslator(
+                engine,
                 playerStatsTable,
                 basicProjection,
                 dictionary
@@ -77,6 +78,7 @@ public class EntityProjectionTranslatorTest extends SQLUnitTest {
                 .build();
 
         EntityProjectionTranslator translator = new EntityProjectionTranslator(
+                engine,
                 playerStatsTable,
                 projection,
                 dictionary
@@ -102,6 +104,7 @@ public class EntityProjectionTranslatorTest extends SQLUnitTest {
                 .build();
 
         EntityProjectionTranslator translator = new EntityProjectionTranslator(
+                engine,
                 playerStatsTable,
                 projection,
                 dictionary
@@ -129,6 +132,7 @@ public class EntityProjectionTranslatorTest extends SQLUnitTest {
                 .build();
 
         assertThrows(InvalidOperationException.class, () -> new EntityProjectionTranslator(
+                engine,
                 playerStatsTable,
                 projection,
                 dictionary

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -88,17 +88,17 @@ public abstract class SQLUnitTest {
     }
 
     public static ColumnProjection toProjection(Dimension dimension) {
-        return ColumnProjection.toDimensionProjection(dimension, dimension.getName(), Collections.emptyMap());
+        return engine.constructDimensionProjection(dimension, dimension.getName(), Collections.emptyMap());
     }
 
     public static TimeDimensionProjection toProjection(TimeDimension dimension, TimeGrain grain) {
-        return ColumnProjection.toTimeDimensionProjection(
+        return engine.constructTimeDimensionProjection(
                 dimension,
                 dimension.getName(),
                 Collections.singletonMap("grain", Argument.builder().name("grain").value(grain).build()));
     }
 
     public static MetricProjection invoke(Metric metric) {
-        return ColumnProjection.toMetricProjection(metric, metric.getName(), Collections.emptyMap());
+        return engine.constructMetricProjection(metric, metric.getName(), Collections.emptyMap());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
@@ -6,10 +6,8 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.elide.core.Path;
-import com.yahoo.elide.core.exceptions.InvalidPredicateException;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.Operator;
 import com.yahoo.elide.core.pagination.PaginationImpl;
@@ -658,26 +656,5 @@ public class QueryEngineTest extends SQLUnitTest {
         assertEquals(2, results.size());
         assertEquals(stats1, results.get(0));
         assertEquals(stats2, results.get(1));
-    }
-
-    //TODO - Add Invalid Request Tests
-    @Test
-    public void testInvalidTimeDimensionWhereClause() {
-        FilterPredicate predicate = new FilterPredicate(
-                new Path(PlayerStats.class, dictionary, "recordedDate"),
-                Operator.IN,
-                Lists.newArrayList(Timestamp.valueOf("2019-07-11 00:00:00")));
-
-        Query query = Query.builder()
-                .table(playerStatsTable)
-                .metric(invoke(playerStatsTable.getMetric("highScore")))
-                .whereFilter(predicate)
-                .build();
-
-        InvalidPredicateException exception = assertThrows(
-                InvalidPredicateException.class,
-                () -> engine.executeQuery(query));
-
-        assertEquals("Can't filter on time dimension that's not projected: recordedDate", exception.getMessage());
     }
 }


### PR DESCRIPTION
## Description
Cleanup of AggregationDataStore SQL Generation logic.

1. ColumnProjection and subclasses are solely responsible for generating SQL for a column reference.
2. ColumnProjection and subclasses use the SQLReferenceTable to expand columns to SQL fragments.
3. Metrics and dimensions can now support dynamic SQL generation through client provided parameters.

## Motivation and Context
The SQL generation logic was fragmented in different places.  This consolidates it into a single abstraction.

## How Has This Been Tested?
Existing tests pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
