### PR TITLE
Elide-5.x Add TimeDimensions to AggregationStore table

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -57,6 +57,10 @@ public class Table {
     @ToString.Exclude
     private Set<Dimension> dimensions;
 
+    @OneToMany
+    @ToString.Exclude
+    private Set<TimeDimension> timeDimensions;
+
     @ToString.Exclude
     private Set<String> tableTags;
 
@@ -81,8 +85,12 @@ public class Table {
                 .map(Metric.class::cast)
                 .collect(Collectors.toSet());
         this.dimensions = this.columns.stream()
-                .filter(col -> !(col instanceof Metric))
+                .filter(col -> !(col instanceof Metric || col instanceof TimeDimension))
                 .map(Dimension.class::cast)
+                .collect(Collectors.toSet());
+        this.timeDimensions = this.columns.stream()
+                .filter(col -> (col instanceof TimeDimension))
+                .map(TimeDimension.class::cast)
                 .collect(Collectors.toSet());
 
         Meta meta = cls.getAnnotation(Meta.class);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -726,9 +726,9 @@ public class AggregationDataStoreIntegrationTest extends IntegrationTest {
                                 "playerStats.player2Name",
                                 "playerStats.countryIsoCode",
                                 "playerStats.subCountryIsoCode",
-                                "playerStats.recordedDate",
                                 "playerStats.overallRating"))
-                .body("data.relationships.metrics.data.id", hasItems("playerStats.lowScore", "playerStats.highScore"));
+                .body("data.relationships.metrics.data.id", hasItems("playerStats.lowScore", "playerStats.highScore"))
+                .body("data.relationships.timeDimensions.data.id", hasItems("playerStats.recordedDate"));
 
         given()
                 .accept("application/vnd.api+json")


### PR DESCRIPTION
## Description
Add TimeDimensions as an attribute to the Aggregation Store Table.

## Motivation and Context
Time Dimension is not present in AggregationStore Table endpoint's schema. This is a concept defined in the metadata rfc. https://www.github.com/yahoo/elide/issues/1005

## How Has This Been Tested?
i) Existing test cases passed
ii) The test case was updated.

## Screenshots (if appropriate):
NA

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
