### PR TITLE
QueryEngine result cache

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -53,7 +53,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
     @Override
     public Iterable<Object> loadObjects(EntityProjection entityProjection, RequestScope scope) {
         Query query = buildQuery(entityProjection, scope);
-        return queryEngine.executeQuery(query);
+        return queryEngine.executeQuery(query, true);
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
+import com.yahoo.elide.datastores.aggregation.query.Cache;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
@@ -66,7 +67,8 @@ import java.util.stream.Collectors;
  * Implementor must assume that {@link DataStoreTransaction} will never keep reference to any internal state of a
  * {@link QueryEngine} object. This ensures the plugability of various {@link QueryEngine} implementations.
  * <p>
- * This is a {@link java.util.function functional interface} whose functional method is {@link #executeQuery(Query)}.
+ * This is a {@link java.util.function functional interface} whose functional method is
+ * {@link #executeQuery(Query, boolean)}.
  */
 public abstract class QueryEngine {
     @Getter
@@ -77,18 +79,26 @@ public abstract class QueryEngine {
 
     private final Map<String, Table> tables;
 
+    protected final Cache cache;
+
     /**
      * QueryEngine is constructed with a metadata store and is responsible for constructing all Tables and Entities
      * metadata in this metadata store.
      *
      * @param metaDataStore a metadata store
+     * @param cache the cache for query results, or null
      */
-    public QueryEngine(MetaDataStore metaDataStore) {
+    public QueryEngine(MetaDataStore metaDataStore, Cache cache) {
         this.metaDataStore = metaDataStore;
         this.metadataDictionary = metaDataStore.getDictionary();
         populateMetaData(metaDataStore);
         this.tables = metaDataStore.getMetaData(Table.class).stream()
                 .collect(Collectors.toMap(Table::getId, Functions.identity()));
+        if (cache != null) {
+            this.cache = cache;
+        } else {
+            this.cache = new NoCache();
+        }
     }
 
     /**
@@ -154,13 +164,13 @@ public abstract class QueryEngine {
 
     /**
      * Executes the specified {@link Query} against a specific persistent storage, which understand the provided
-     * {@link Query}.
+     * {@link Query}. Results may be taken from a cache, if configured.
      *
-     * @param query  The query customized for a particular persistent storage or storage client
-     *
+     * @param query    The query customized for a particular persistent storage or storage client
+     * @param useCache Whether to use the cache, if configured
      * @return query results
      */
-    public abstract Iterable<Object> executeQuery(Query query);
+    public abstract Iterable<Object> executeQuery(Query query, boolean useCache);
 
     /**
      * Returns the schema for a given entity class.
@@ -169,5 +179,17 @@ public abstract class QueryEngine {
      */
     public Table getTable(String classAlias) {
         return tables.get(classAlias);
+    }
+
+    private static class NoCache implements Cache {
+        @Override
+        public Iterable<Object> get(Object key) {
+            return null;
+        }
+
+        @Override
+        public void put(Object key, Iterable<Object> result) {
+            // Do nothing
+        }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -66,9 +66,6 @@ import java.util.stream.Collectors;
  * </pre>
  * Implementor must assume that {@link DataStoreTransaction} will never keep reference to any internal state of a
  * {@link QueryEngine} object. This ensures the plugability of various {@link QueryEngine} implementations.
- * <p>
- * This is a {@link java.util.function functional interface} whose functional method is
- * {@link #executeQuery(Query, boolean)}.
  */
 public abstract class QueryEngine {
     @Getter

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Cache.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Cache.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.query;
+
+/**
+ * A cache for Query results.
+ */
+public interface Cache {
+    /**
+     * Load Query result from cache. Exceptions should be passed through.
+     *
+     * @param key    a key to look up in the cache.
+     * @return query results from cache, or null if not found.
+     */
+    Iterable<Object> get(Object key);
+
+    /**
+     * Insert results into cache.
+     *
+     * @param key    the key to associate with the query
+     * @param result the result to cache with the key
+     */
+    void put(Object key, Iterable<Object> result);
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * {@link AbstractEntityHydrator} hydrates the entity loaded by {@link QueryEngine#executeQuery(Query)}.
+ * {@link AbstractEntityHydrator} hydrates the entity loaded by {@link QueryEngine#executeQuery(Query, boolean)}.
  * <p>
  * {@link AbstractEntityHydrator} is not thread-safe and should be accessed by only 1 thread in this application,
  * because it uses {@link StitchList}. See {@link StitchList} for more details.
@@ -49,8 +49,8 @@ public abstract class AbstractEntityHydrator {
     /**
      * Constructor.
      *
-     * @param results The loaded objects from {@link QueryEngine#executeQuery(Query)}
-     * @param query  The query passed to {@link QueryEngine#executeQuery(Query)} to load the objects
+     * @param results The loaded objects from {@link QueryEngine#executeQuery(Query, boolean)}
+     * @param query  The query passed to {@link QueryEngine#executeQuery(Query, boolean)} to load the objects
      * @param entityDictionary  An object that sets entity instance values and provides entity metadata info
      */
     public AbstractEntityHydrator(List<Object> results, Query query, EntityDictionary entityDictionary) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLEntityHydrator.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 
 /**
- * {@link SQLEntityHydrator} hydrates the entity loaded by {@link SQLQueryEngine#executeQuery(Query)}.
+ * {@link SQLEntityHydrator} hydrates the entity loaded by {@link SQLQueryEngine#executeQuery(Query, boolean)}.
  */
 public class SQLEntityHydrator extends AbstractEntityHydrator {
 
@@ -32,8 +32,8 @@ public class SQLEntityHydrator extends AbstractEntityHydrator {
     /**
      * Constructor.
      *
-     * @param results The loaded objects from {@link SQLQueryEngine#executeQuery(Query)}
-     * @param query  The query passed to {@link SQLQueryEngine#executeQuery(Query)} to load the objects
+     * @param results The loaded objects from {@link SQLQueryEngine#executeQuery(Query, boolean)}
+     * @param query  The query passed to {@link SQLQueryEngine#executeQuery(Query, boolean)} to load the objects
      * @param entityDictionary  An object that sets entity instance values and provides entity metadata info
      * @param entityManager  An service that issues JPQL queries to load relationship objects
      */

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
+import com.yahoo.elide.datastores.aggregation.query.Cache;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
@@ -61,8 +62,8 @@ public class SQLQueryEngine extends QueryEngine {
 
     private final SQLReferenceTable referenceTable;
 
-    public SQLQueryEngine(MetaDataStore metaDataStore, EntityManagerFactory entityManagerFactory) {
-        super(metaDataStore);
+    public SQLQueryEngine(MetaDataStore metaDataStore, EntityManagerFactory entityManagerFactory, Cache cache) {
+        super(metaDataStore, cache);
         this.entityManagerFactory = entityManagerFactory;
         this.referenceTable = new SQLReferenceTable(metaDataStore);
     }
@@ -114,7 +115,7 @@ public class SQLQueryEngine extends QueryEngine {
     }
 
     @Override
-    public Iterable<Object> executeQuery(Query query) {
+    public Iterable<Object> executeQuery(Query query, boolean useCache) {
         EntityManager entityManager = null;
         EntityTransaction transaction = null;
         try {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/annotation/dimensionformula/DimensionFormulaTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/annotation/dimensionformula/DimensionFormulaTest.java
@@ -24,7 +24,7 @@ public class DimensionFormulaTest {
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> new SQLQueryEngine(metaDataStore, null));
+                () -> new SQLQueryEngine(metaDataStore, null, null));
         assertEquals(
                 "Formula reference loop found: loop.playerLevel->loop.playerLevel",
                 exception.getMessage());
@@ -36,7 +36,7 @@ public class DimensionFormulaTest {
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> new SQLQueryEngine(metaDataStore, null));
+                () -> new SQLQueryEngine(metaDataStore, null, null));
         assertEquals(
                 "Formula reference loop found: joinToLoop.playerLevel->joinToLoop.playerLevel",
                 exception.getMessage());
@@ -49,7 +49,7 @@ public class DimensionFormulaTest {
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> new SQLQueryEngine(metaDataStore, null));
+                () -> new SQLQueryEngine(metaDataStore, null, null));
 
         String exception1 = "Formula reference loop found: loopCountryA.inUsa->loopCountryB.inUsa->loopCountryA.inUsa";
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/annotation/metricformula/MetricFormulaTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/annotation/metricformula/MetricFormulaTest.java
@@ -21,7 +21,7 @@ public class MetricFormulaTest {
 
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> new SQLQueryEngine(metaDataStore, null));
+                () -> new SQLQueryEngine(metaDataStore, null, null));
         assertEquals(
                 "Formula reference loop found: loop.highScore->loop.highScore",
                 exception.getMessage());

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
@@ -28,7 +28,7 @@ public class AggregationDataStoreTestHarness implements DataStoreTestHarness {
     public DataStore getDataStore() {
         MetaDataStore metaDataStore = new MetaDataStore();
 
-        QueryEngine sqlQueryEngine = new SQLQueryEngine(metaDataStore, entityManagerFactory);
+        QueryEngine sqlQueryEngine = new SQLQueryEngine(metaDataStore, entityManagerFactory, null);
 
         AggregationDataStore aggregationDataStore = new AggregationDataStore(sqlQueryEngine);
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -67,7 +67,7 @@ public abstract class SQLUnitTest {
 
         metaDataStore.populateEntityDictionary(dictionary);
 
-        engine = new SQLQueryEngine(metaDataStore, emf);
+        engine = new SQLQueryEngine(metaDataStore, emf, null);
         playerStatsTable = engine.getTable("playerStats");
 
         ASIA.setName("Asia");

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
@@ -54,7 +54,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.DAY))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -91,7 +91,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .metric(invoke(playerStatsViewTable.getMetric("highScore")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -123,7 +123,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -151,7 +151,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -178,7 +178,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStatsView.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -201,7 +201,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -235,7 +235,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -285,7 +285,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .pagination(pagination)
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         //Jon Doe,1234,72,Good,840,2019-07-12 00:00:00
@@ -315,7 +315,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         // Only "Good" rating would have total high score less than 2400
@@ -344,7 +344,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -381,7 +381,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -419,7 +419,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryIsoCode")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -452,7 +452,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -487,7 +487,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -525,7 +525,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.MONTH))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -554,7 +554,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .whereFilter(predicate)
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -579,7 +579,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -614,7 +614,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryNickName")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -640,7 +640,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryUnSeats")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
@@ -54,7 +54,7 @@ public class SubselectTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("subCountryIsoCode")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -87,7 +87,7 @@ public class SubselectTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -124,7 +124,7 @@ public class SubselectTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
@@ -46,7 +46,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -80,7 +80,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -115,7 +115,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -150,7 +150,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -185,7 +185,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -220,7 +220,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -103,7 +103,7 @@ public class ElideAutoConfiguration {
     public QueryEngine buildQueryEngine(EntityManagerFactory entityManagerFactory) {
         MetaDataStore metaDataStore = new MetaDataStore();
 
-        return new SQLQueryEngine(metaDataStore, entityManagerFactory);
+        return new SQLQueryEngine(metaDataStore, entityManagerFactory, null);
     }
 
     /**


### PR DESCRIPTION
## Description
Create an API for caching results of `QueryEngine.executeQuery`. The user will provide a `Cache` object (via bean for `buildQueryEngine` or otherwise) that implements a trivial API. Then QueryEngine implementations can use that cache for caching results. The `executeQuery` is given an additional argument to allow for cache bypass.

It is the responsibility of the QueryEngine implementation to generate a cache key from the given query. For example, SQLQueryEngine could use the SQL query string, combined with a table versioning token, as the key. To ensure a good hit rate implementations must ensure that they normalize the data used as the key, so that variations in the query that don't affect the results don't change the key.

Originally I was planning to use the Query object directly in key objects, but on further investigation, this didn't seem very workable. The problem is Query can't be provided upon to support `equals()`/`hashCode` properly, since even though its own fields are final and it implements those methods itself, it transitively includes many other fields and classes, many of which are mutable or don't implement `equals()/hashCode()`. Even if they were made to have the correct semantics now, it would be hard to guarantee that in perpetuity, with so many classes involved, some of which will be supplied by the various QueryEngine implementations.

Also, I originally intended it for the Cache API to have 'loading' semantics, where there would be only a single function `Iterable<Object> get(Object key, Supplier<Iterable<Object>> loader)` where the Cache would call the loader when the item was missing from cache. However that approach seemed difficult to integrate with SQLQueryEngine cleanly (largely due to use of transactions.)

## Motivation and Context
Not all QueryEngine data sources will have their own result caches available. So we can increase query performance by having our own result cache at the QueryEngine layer.

## How Has This Been Tested?
This is just an abstract API change currently. I'm planning to add abstract test cases for QueryEngine that can be used to test the QueryEngine implementations.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
