### PR TITLE
Add version support

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/annotation/ApiVersion.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/annotation/ApiVersion.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Versions API Models.
+ */
+@Target({PACKAGE})
+@Retention(RUNTIME)
+public @interface ApiVersion {
+
+    /**
+     * Models in this package are tied to this API version.
+     * @return the string (default = "")
+     */
+    String version() default "";
+}

--- a/elide-annotations/src/main/java/com/yahoo/elide/security/RequestScope.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/security/RequestScope.java
@@ -10,4 +10,5 @@ package com.yahoo.elide.security;
  */
 public interface RequestScope {
     User getUser();
+    String getApiVersion();
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
@@ -23,6 +23,6 @@ public class ExecuteQueryHook implements LifeCycleHook<AsyncQuery> {
     @Override
     public void execute(LifeCycleHookBinding.Operation operation, AsyncQuery query,
                         RequestScope requestScope, Optional<ChangeSpec> changes) {
-        asyncExecutorService.executeQuery(query, requestScope.getUser());
+        asyncExecutorService.executeQuery(query, requestScope.getUser(), requestScope.getApiVersion());
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.async.models;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRESECURITY;
+import static com.yahoo.elide.core.EntityDictionary.ASYNC_QUERY;
 
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Exclude;
@@ -32,7 +33,7 @@ import javax.persistence.PrePersist;
  * Model for Async Query.
  */
 @Entity
-@Include(type = "asyncQuery", rootLevel = true)
+@Include(type = ASYNC_QUERY, rootLevel = true)
 @ReadPermission(expression = "Principal is Owner")
 @UpdatePermission(expression = "Prefab.Role.None")
 @DeletePermission(expression = "Prefab.Role.None")

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.async.models;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRESECURITY;
-import static com.yahoo.elide.core.EntityDictionary.ASYNC_QUERY;
 
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Exclude;
@@ -33,7 +32,7 @@ import javax.persistence.PrePersist;
  * Model for Async Query.
  */
 @Entity
-@Include(type = ASYNC_QUERY, rootLevel = true)
+@Include(type = "asyncQuery", rootLevel = true)
 @ReadPermission(expression = "Principal is Owner")
 @UpdatePermission(expression = "Prefab.Role.None")
 @DeletePermission(expression = "Prefab.Role.None")

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -5,8 +5,6 @@
  */
 package com.yahoo.elide.async.models;
 
-import static com.yahoo.elide.core.EntityDictionary.ASYNC_QUERY_RESULT;
-
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Exclude;
@@ -27,7 +25,7 @@ import javax.persistence.OneToOne;
  * Model for Async Query Result.
  */
 @Entity
-@Include(type = ASYNC_QUERY_RESULT)
+@Include(type = "asyncQueryResult")
 @ReadPermission(expression = "Principal is Owner")
 @UpdatePermission(expression = "Prefab.Role.None")
 @CreatePermission(expression = "Prefab.Role.None")

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -21,11 +21,13 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
+import static com.yahoo.elide.core.EntityDictionary.ASYNC_QUERY_RESULT;
+
 /**
  * Model for Async Query Result.
  */
 @Entity
-@Include(type = "asyncQueryResult")
+@Include(type = ASYNC_QUERY_RESULT)
 @ReadPermission(expression = "Principal is Owner")
 @UpdatePermission(expression = "Prefab.Role.None")
 @CreatePermission(expression = "Prefab.Role.None")

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.async.models;
 
+import static com.yahoo.elide.core.EntityDictionary.ASYNC_QUERY_RESULT;
+
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Exclude;
@@ -20,8 +22,6 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
-
-import static com.yahoo.elide.core.EntityDictionary.ASYNC_QUERY_RESULT;
 
 /**
  * Model for Async Query Result.

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
@@ -40,7 +40,7 @@ public class AsyncExecutorService {
     @Inject
     private AsyncExecutorService(Elide elide, Integer threadPoolSize, Integer maxRunTime, AsyncQueryDAO asyncQueryDao) {
         this.elide = elide;
-        this.runner = new QueryRunner(elide);
+        this.runner = new QueryRunner(elide, "");
         this.maxRunTime = maxRunTime;
         executor = Executors.newFixedThreadPool(threadPoolSize == null ? defaultThreadpoolSize : threadPoolSize);
         interruptor = Executors.newFixedThreadPool(threadPoolSize == null ? defaultThreadpoolSize : threadPoolSize);
@@ -76,8 +76,8 @@ public class AsyncExecutorService {
      * @param queryObj Query Object
      * @param user User
      */
-    public void executeQuery(AsyncQuery queryObj, User user) {
-        AsyncQueryThread queryWorker = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao);
+    public void executeQuery(AsyncQuery queryObj, User user, String apiVersion) {
+        AsyncQueryThread queryWorker = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, apiVersion);
 
         AsyncQueryInterruptThread queryInterruptWorker = new AsyncQueryInterruptThread(elide,
                executor.submit(queryWorker), queryObj, new Date(), maxRunTime, asyncQueryDao);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
@@ -7,12 +7,15 @@ package com.yahoo.elide.async.service;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.security.User;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -30,7 +33,7 @@ public class AsyncExecutorService {
     private final int defaultThreadpoolSize = 6;
 
     private Elide elide;
-    private QueryRunner runner;
+    private Map<String, QueryRunner> runners;
     private ExecutorService executor;
     private ExecutorService interruptor;
     private int maxRunTime;
@@ -40,7 +43,12 @@ public class AsyncExecutorService {
     @Inject
     private AsyncExecutorService(Elide elide, Integer threadPoolSize, Integer maxRunTime, AsyncQueryDAO asyncQueryDao) {
         this.elide = elide;
-        this.runner = new QueryRunner(elide, "");
+        runners = new HashMap();
+
+        for (String apiVersion : elide.getElideSettings().getDictionary().getApiVersions()) {
+            runners.put(apiVersion, new QueryRunner(elide, apiVersion));
+        }
+
         this.maxRunTime = maxRunTime;
         executor = Executors.newFixedThreadPool(threadPoolSize == null ? defaultThreadpoolSize : threadPoolSize);
         interruptor = Executors.newFixedThreadPool(threadPoolSize == null ? defaultThreadpoolSize : threadPoolSize);
@@ -77,6 +85,11 @@ public class AsyncExecutorService {
      * @param user User
      */
     public void executeQuery(AsyncQuery queryObj, User user, String apiVersion) {
+        QueryRunner runner = runners.get(apiVersion);
+        if (runner == null) {
+            throw new InvalidOperationException("Invalid API Version");
+        }
+
         AsyncQueryThread queryWorker = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, apiVersion);
 
         AsyncQueryInterruptThread queryInterruptWorker = new AsyncQueryInterruptThread(elide,

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -60,12 +60,12 @@ public class AsyncQueryThread implements Runnable {
             if (queryObj.getQueryType().equals(QueryType.JSONAPI_V1_0)) {
                 MultivaluedMap<String, String> queryParams = getQueryParams(queryObj.getQuery());
                 log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
-                response = elide.get(getPath(queryObj.getQuery()), queryParams, user);
+                response = elide.get(getPath(queryObj.getQuery()), queryParams, user, "");
                 log.debug("JSONAPI_V1_0 getResponseCode: {}, JSONAPI_V1_0 getBody: {}",
                         response.getResponseCode(), response.getBody());
             }
             else if (queryObj.getQueryType().equals(QueryType.GRAPHQL_V1_0)) {
-                response = runner.run(queryObj.getQuery(), user);
+                response = runner.run(queryObj.getQuery(), user, "");
                 log.debug("GRAPHQL_V1_0 getResponseCode: {}, GRAPHQL_V1_0 getBody: {}",
                         response.getResponseCode(), response.getBody());
             }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -41,6 +41,7 @@ public class AsyncQueryThread implements Runnable {
     private Elide elide;
     private QueryRunner runner;
     private AsyncQueryDAO asyncQueryDao;
+    private String apiVersion;
 
     @Override
     public void run() {
@@ -60,12 +61,12 @@ public class AsyncQueryThread implements Runnable {
             if (queryObj.getQueryType().equals(QueryType.JSONAPI_V1_0)) {
                 MultivaluedMap<String, String> queryParams = getQueryParams(queryObj.getQuery());
                 log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
-                response = elide.get(getPath(queryObj.getQuery()), queryParams, user, "");
+                response = elide.get(getPath(queryObj.getQuery()), queryParams, user, apiVersion);
                 log.debug("JSONAPI_V1_0 getResponseCode: {}, JSONAPI_V1_0 getBody: {}",
                         response.getResponseCode(), response.getBody());
             }
             else if (queryObj.getQueryType().equals(QueryType.GRAPHQL_V1_0)) {
-                response = runner.run(queryObj.getQuery(), user, "");
+                response = runner.run(queryObj.getQuery(), user);
                 log.debug("GRAPHQL_V1_0 getResponseCode: {}, GRAPHQL_V1_0 getBody: {}",
                         response.getResponseCode(), response.getBody());
             }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -39,7 +39,7 @@ public class AsyncQueryThread implements Runnable {
     private AsyncQuery queryObj;
     private User user;
     private Elide elide;
-    private QueryRunner runner;
+    private final QueryRunner runner;
     private AsyncQueryDAO asyncQueryDao;
     private String apiVersion;
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -189,7 +189,8 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
         try (DataStoreTransaction tx = dataStore.beginTransaction()) {
             JsonApiDocument jsonApiDoc = new JsonApiDocument();
             MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
-            RequestScope scope = new RequestScope("query", jsonApiDoc, tx, null, queryParams, elide.getElideSettings());
+            RequestScope scope = new RequestScope("query", "", jsonApiDoc,
+                    tx, null, queryParams, elide.getElideSettings());
             result = action.execute(tx, scope);
             tx.commit(scope);
             tx.flush(scope);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.async.service;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
@@ -189,7 +191,7 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
         try (DataStoreTransaction tx = dataStore.beginTransaction()) {
             JsonApiDocument jsonApiDoc = new JsonApiDocument();
             MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
-            RequestScope scope = new RequestScope("query", "", jsonApiDoc,
+            RequestScope scope = new RequestScope("query", NO_VERSION, jsonApiDoc,
                     tx, null, queryParams, elide.getElideSettings());
             result = action.execute(tx, scope);
             tx.commit(scope);

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolver.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolver.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Swagger ModelResolvers map POJO classes to Swagger com.yahoo.elide.contrib.swagger.models.
+ * Swagger ModelResolvers map POJO classes to Swagger example.models.
  * This resolver maps the POJO to a JSON-API Resource.
  */
 public class JsonApiModelResolver extends ModelResolver {

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/SwaggerBuilder.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/SwaggerBuilder.java
@@ -676,10 +676,15 @@ public class SwaggerBuilder {
         ModelConverters converters = ModelConverters.getInstance();
         converters.addConverter(new JsonApiModelResolver(dictionary));
 
+        String apiVersion = swagger.getInfo().getVersion();
+        if (apiVersion == null) {
+            apiVersion = "";
+        }
+
         if (allClasses.isEmpty()) {
-            allClasses = dictionary.getBoundClasses();
+            allClasses = dictionary.getBoundClassesByVersion(apiVersion);
         } else {
-            allClasses = Sets.intersection(dictionary.getBoundClasses(), allClasses);
+            allClasses = Sets.intersection(dictionary.getBoundClassesByVersion(apiVersion), allClasses);
             if (allClasses.isEmpty()) {
                 throw new IllegalArgumentException("None of the provided classes are exported by Elide");
             }

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/SwaggerBuilder.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/SwaggerBuilder.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.contrib.swagger;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+
 import com.yahoo.elide.contrib.swagger.model.Data;
 import com.yahoo.elide.contrib.swagger.model.Datum;
 import com.yahoo.elide.contrib.swagger.property.Relationship;
@@ -678,7 +680,7 @@ public class SwaggerBuilder {
 
         String apiVersion = swagger.getInfo().getVersion();
         if (apiVersion == null) {
-            apiVersion = "";
+            apiVersion = NO_VERSION;
         }
 
         if (allClasses.isEmpty()) {

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/resources/DocEndpoint.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/resources/DocEndpoint.java
@@ -36,6 +36,8 @@ import javax.ws.rs.core.Response;
 @Path("/doc")
 @Produces("application/json")
 public class DocEndpoint {
+    //Maps api version & path to a swagger document.
+    protected Map<Pair<String, String>, String> documents;
 
     @Data
     @AllArgsConstructor
@@ -43,9 +45,6 @@ public class DocEndpoint {
         private String path;
         private Swagger document;
     }
-
-    //Maps api version & path to a swagger document.
-    protected Map<Pair<String, String>, String> documents;
 
     /**
      * Constructs the resource.

--- a/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/resources/DocEndpoint.java
+++ b/elide-contrib/elide-swagger/src/main/java/com/yahoo/elide/contrib/swagger/resources/DocEndpoint.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.contrib.swagger.resources;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -56,7 +58,7 @@ public class DocEndpoint {
 
         docs.forEach((doc) -> {
             String apiVersion = doc.document.getInfo().getVersion();
-            apiVersion = apiVersion == null ? "" : apiVersion;
+            apiVersion = apiVersion == null ? NO_VERSION : apiVersion;
             String apiPath = doc.path;
 
             documents.put(Pair.of(apiVersion, apiPath), SwaggerBuilder.getDocument(doc.document));
@@ -66,7 +68,7 @@ public class DocEndpoint {
     @GET
     @Path("/")
     public Response list(@HeaderParam("ApiVersion") String apiVersion) {
-        String safeApiVersion = apiVersion == null ? "" : apiVersion;
+        String safeApiVersion = apiVersion == null ? NO_VERSION : apiVersion;
 
         List<String> documentPaths = documents.keySet().stream()
                 .filter(key -> key.getLeft().equals(safeApiVersion))
@@ -89,7 +91,7 @@ public class DocEndpoint {
     @GET
     @Path("/{name}")
     public Response get(@HeaderParam("ApiVersion") String apiVersion, @PathParam("name") String name) {
-        String safeApiVersion = apiVersion == null ? "" : apiVersion;
+        String safeApiVersion = apiVersion == null ? NO_VERSION : apiVersion;
         Pair<String, String> lookupKey = Pair.of(safeApiVersion, name);
         if (documents.containsKey(lookupKey)) {
             return Response.ok(documents.get(lookupKey)).build();

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/JsonApiModelResolverTest.java
@@ -11,13 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.yahoo.elide.contrib.swagger.model.Resource;
-import com.yahoo.elide.contrib.swagger.models.Author;
-import com.yahoo.elide.contrib.swagger.models.Book;
-import com.yahoo.elide.contrib.swagger.models.Publisher;
 import com.yahoo.elide.core.EntityDictionary;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import example.models.Author;
+import example.models.Book;
+import example.models.Publisher;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
@@ -13,15 +13,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.contrib.swagger.model.Resource;
-import com.yahoo.elide.contrib.swagger.models.Author;
-import com.yahoo.elide.contrib.swagger.models.Book;
-import com.yahoo.elide.contrib.swagger.models.Publisher;
 import com.yahoo.elide.contrib.swagger.property.Data;
 import com.yahoo.elide.contrib.swagger.property.Datum;
 import com.yahoo.elide.contrib.swagger.property.Relationship;
 import com.yahoo.elide.core.EntityDictionary;
 
 import com.google.common.collect.Maps;
+import example.models.Author;
+import example.models.Book;
+import example.models.Publisher;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
@@ -66,7 +66,7 @@ public class SwaggerBuilderTest {
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Publisher.class);
-        Info info = new Info().title("Test Service").version("1.0");
+        Info info = new Info().title("Test Service").version("");
 
         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
         swagger = builder.build();
@@ -533,7 +533,7 @@ public class SwaggerBuilderTest {
     public void testGlobalErrorResponses() throws Exception {
         Info info = new Info()
                 .title("Test Service")
-                .version("1.0");
+                .version("");
 
         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
 
@@ -582,7 +582,7 @@ public class SwaggerBuilderTest {
         EntityDictionary entityDictionary = new EntityDictionary(Maps.newHashMap());
 
         entityDictionary.bindEntity(NothingToSort.class);
-        Info info = new Info().title("Test Service").version("1.0");
+        Info info = new Info().title("Test Service").version("");
 
         SwaggerBuilder builder = new SwaggerBuilder(entityDictionary, info);
         Swagger testSwagger = builder.build();

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerBuilderTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.contrib.swagger;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -66,7 +67,7 @@ public class SwaggerBuilderTest {
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Publisher.class);
-        Info info = new Info().title("Test Service").version("");
+        Info info = new Info().title("Test Service").version(NO_VERSION);
 
         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
         swagger = builder.build();
@@ -533,7 +534,7 @@ public class SwaggerBuilderTest {
     public void testGlobalErrorResponses() throws Exception {
         Info info = new Info()
                 .title("Test Service")
-                .version("");
+                .version(NO_VERSION);
 
         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
 
@@ -582,7 +583,7 @@ public class SwaggerBuilderTest {
         EntityDictionary entityDictionary = new EntityDictionary(Maps.newHashMap());
 
         entityDictionary.bindEntity(NothingToSort.class);
-        Info info = new Info().title("Test Service").version("");
+        Info info = new Info().title("Test Service").version(NO_VERSION);
 
         SwaggerBuilder builder = new SwaggerBuilder(entityDictionary, info);
         Swagger testSwagger = builder.build();

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerIT.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerIT.java
@@ -6,7 +6,10 @@
 package com.yahoo.elide.contrib.swagger;
 
 import static io.restassured.RestAssured.get;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.initialization.AbstractApiResourceInitializer;
@@ -25,6 +28,17 @@ public class SwaggerIT extends AbstractApiResourceInitializer {
     void testDocumentFetch() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(get("/doc/test").asString());
+        assertTrue(node.get("paths").size() > 1);
         assertNotNull(node.get("paths").get("/book"));
+        assertNotNull(node.get("paths").get("/publisher"));
+    }
+
+    @Test
+    void testVersion2DocumentFetch() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(given().header("ApiVersion", "1.0").get("/doc/test").asString());
+        assertEquals(2, node.get("paths").size());
+        assertNotNull(node.get("paths").get("/book"));
+        assertNotNull(node.get("paths").get("/book/{bookId}"));
     }
 }

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerResourceConfig.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerResourceConfig.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.contrib.swagger;
 import com.yahoo.elide.contrib.swagger.models.Author;
 import com.yahoo.elide.contrib.swagger.models.Book;
 import com.yahoo.elide.contrib.swagger.models.Publisher;
+import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.core.EntityDictionary;
 
 import com.google.common.collect.Maps;
@@ -20,8 +21,8 @@ import org.glassfish.jersey.server.ResourceConfig;
 import io.swagger.models.Info;
 import io.swagger.models.Swagger;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SwaggerResourceConfig extends ResourceConfig {
 
@@ -29,30 +30,30 @@ public class SwaggerResourceConfig extends ResourceConfig {
         register(new AbstractBinder() {
             @Override
             protected void configure() {
-                bindFactory(new Factory<Map<String, Swagger>>() {
+                bindFactory(new Factory<List<DocEndpoint.SwaggerRegistration>>() {
 
                     @Override
-                    public Map<String, Swagger> provide() {
+                    public List<DocEndpoint.SwaggerRegistration> provide() {
                         EntityDictionary dictionary = new EntityDictionary(Maps.newHashMap());
 
                         dictionary.bindEntity(Book.class);
                         dictionary.bindEntity(Author.class);
                         dictionary.bindEntity(Publisher.class);
-                        Info info = new Info().title("Test Service").version("1.0");
+                        Info info = new Info().title("Test Service");
 
                         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
                         Swagger swagger = builder.build();
 
-                        Map<String, Swagger> docs = new HashMap<>();
-                        docs.put("test", swagger);
+                        List<DocEndpoint.SwaggerRegistration> docs = new ArrayList<>();
+                        docs.add(new DocEndpoint.SwaggerRegistration("test", swagger));
                         return docs;
                     }
 
                     @Override
-                    public void dispose(Map<String, Swagger> instance) {
+                    public void dispose(List<DocEndpoint.SwaggerRegistration> instance) {
                         //NOP
                     }
-                }).to(new TypeLiteral<Map<String, Swagger>>() {
+                }).to(new TypeLiteral<List<DocEndpoint.SwaggerRegistration>>() {
                 }).named("swagger");
             }
         });

--- a/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerResourceConfig.java
+++ b/elide-contrib/elide-swagger/src/test/java/com/yahoo/elide/contrib/swagger/SwaggerResourceConfig.java
@@ -5,13 +5,16 @@
  */
 package com.yahoo.elide.contrib.swagger;
 
-import com.yahoo.elide.contrib.swagger.models.Author;
-import com.yahoo.elide.contrib.swagger.models.Book;
-import com.yahoo.elide.contrib.swagger.models.Publisher;
+
 import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.core.EntityDictionary;
 
 import com.google.common.collect.Maps;
+
+import example.models.Author;
+import example.models.Book;
+import example.models.Publisher;
+import example.models.versioned.BookV2;
 
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.TypeLiteral;
@@ -37,15 +40,21 @@ public class SwaggerResourceConfig extends ResourceConfig {
                         EntityDictionary dictionary = new EntityDictionary(Maps.newHashMap());
 
                         dictionary.bindEntity(Book.class);
+                        dictionary.bindEntity(BookV2.class);
                         dictionary.bindEntity(Author.class);
                         dictionary.bindEntity(Publisher.class);
-                        Info info = new Info().title("Test Service");
+                        Info info1 = new Info().title("Test Service");
 
-                        SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
-                        Swagger swagger = builder.build();
+                        SwaggerBuilder builder1 = new SwaggerBuilder(dictionary, info1);
+                        Swagger swagger1 = builder1.build();
+
+                        Info info2 = new Info().title("Test Service").version("1.0");
+                        SwaggerBuilder builder2 = new SwaggerBuilder(dictionary, info2);
+                        Swagger swagger2 = builder2.build();
 
                         List<DocEndpoint.SwaggerRegistration> docs = new ArrayList<>();
-                        docs.add(new DocEndpoint.SwaggerRegistration("test", swagger));
+                        docs.add(new DocEndpoint.SwaggerRegistration("test", swagger1));
+                        docs.add(new DocEndpoint.SwaggerRegistration("test", swagger2));
                         return docs;
                     }
 

--- a/elide-contrib/elide-swagger/src/test/java/example/models/Author.java
+++ b/elide-contrib/elide-swagger/src/test/java/example/models/Author.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.contrib.swagger.models;
+package example.models;
 
 import com.yahoo.elide.annotation.Include;
 

--- a/elide-contrib/elide-swagger/src/test/java/example/models/AuthorType.java
+++ b/elide-contrib/elide-swagger/src/test/java/example/models/AuthorType.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.contrib.swagger.models;
+package example.models;
 
 public enum AuthorType {
     SIGNED,

--- a/elide-contrib/elide-swagger/src/test/java/example/models/Book.java
+++ b/elide-contrib/elide-swagger/src/test/java/example/models/Book.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.contrib.swagger.models;
+package example.models;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;

--- a/elide-contrib/elide-swagger/src/test/java/example/models/Publisher.java
+++ b/elide-contrib/elide-swagger/src/test/java/example/models/Publisher.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.contrib.swagger.models;
+package example.models;
 
 import com.yahoo.elide.annotation.Include;
 import io.swagger.annotations.ApiModelProperty;

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -162,7 +162,7 @@ public class Elide {
     public ElideResponse get(String path, MultivaluedMap<String, String> queryParams, User opaqueUser) {
         return handleRequest(true, opaqueUser, dataStore::beginReadTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = new JsonApiDocument();
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
+            RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, queryParams, elideSettings);
             requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                     requestScope).parsePath(path));
             BaseVisitor visitor = new GetVisitor(requestScope);
@@ -182,7 +182,7 @@ public class Elide {
     public ElideResponse post(String path, String jsonApiDocument, User opaqueUser) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, null, elideSettings);
+            RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, null, elideSettings);
             requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                     requestScope).parsePath(path));
             BaseVisitor visitor = new PostVisitor(requestScope);
@@ -206,7 +206,7 @@ public class Elide {
         Handler<DataStoreTransaction, User, HandlerResult> handler;
         if (JsonApiPatch.isPatchExtension(contentType) && JsonApiPatch.isPatchExtension(accept)) {
             handler = (tx, user) -> {
-                PatchRequestScope requestScope = new PatchRequestScope(path, tx, user, elideSettings);
+                PatchRequestScope requestScope = new PatchRequestScope(path, "", tx, user, elideSettings);
                 try {
                     Supplier<Pair<Integer, JsonNode>> responder =
                             JsonApiPatch.processJsonPatch(dataStore, path, jsonApiDocument, requestScope);
@@ -218,7 +218,7 @@ public class Elide {
         } else {
             handler = (tx, user) -> {
                 JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-                RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, null, elideSettings);
+                RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, null, elideSettings);
                 requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                         requestScope).parsePath(path));
                 BaseVisitor visitor = new PatchVisitor(requestScope);
@@ -242,7 +242,7 @@ public class Elide {
             JsonApiDocument jsonApiDoc = StringUtils.isEmpty(jsonApiDocument)
                     ? new JsonApiDocument()
                     : mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, null, elideSettings);
+            RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, null, elideSettings);
             requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                     requestScope).parsePath(path));
             BaseVisitor visitor = new DeleteVisitor(requestScope);

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -159,10 +159,12 @@ public class Elide {
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse get(String path, MultivaluedMap<String, String> queryParams, User opaqueUser) {
+    public ElideResponse get(String path, MultivaluedMap<String, String> queryParams,
+                             User opaqueUser, String apiVersion) {
         return handleRequest(true, opaqueUser, dataStore::beginReadTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = new JsonApiDocument();
-            RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, queryParams, elideSettings);
+            RequestScope requestScope = new RequestScope(path, apiVersion, jsonApiDoc,
+                    tx, user, queryParams, elideSettings);
             requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                     requestScope).parsePath(path));
             BaseVisitor visitor = new GetVisitor(requestScope);
@@ -179,10 +181,11 @@ public class Elide {
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse post(String path, String jsonApiDocument, User opaqueUser) {
+    public ElideResponse post(String path, String jsonApiDocument, User opaqueUser, String apiVersion) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, null, elideSettings);
+            RequestScope requestScope = new RequestScope(path, apiVersion,
+                    jsonApiDoc, tx, user, null, elideSettings);
             requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                     requestScope).parsePath(path));
             BaseVisitor visitor = new PostVisitor(requestScope);
@@ -201,12 +204,12 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse patch(String contentType, String accept,
-                               String path, String jsonApiDocument, User opaqueUser) {
+                               String path, String jsonApiDocument, User opaqueUser, String apiVersion) {
 
         Handler<DataStoreTransaction, User, HandlerResult> handler;
         if (JsonApiPatch.isPatchExtension(contentType) && JsonApiPatch.isPatchExtension(accept)) {
             handler = (tx, user) -> {
-                PatchRequestScope requestScope = new PatchRequestScope(path, "", tx, user, elideSettings);
+                PatchRequestScope requestScope = new PatchRequestScope(path, apiVersion, tx, user, elideSettings);
                 try {
                     Supplier<Pair<Integer, JsonNode>> responder =
                             JsonApiPatch.processJsonPatch(dataStore, path, jsonApiDocument, requestScope);
@@ -218,7 +221,8 @@ public class Elide {
         } else {
             handler = (tx, user) -> {
                 JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-                RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, null, elideSettings);
+                RequestScope requestScope = new RequestScope(path, apiVersion, jsonApiDoc,
+                        tx, user, null, elideSettings);
                 requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                         requestScope).parsePath(path));
                 BaseVisitor visitor = new PatchVisitor(requestScope);
@@ -237,12 +241,13 @@ public class Elide {
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse delete(String path, String jsonApiDocument, User opaqueUser) {
+    public ElideResponse delete(String path, String jsonApiDocument, User opaqueUser, String apiVersion) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = StringUtils.isEmpty(jsonApiDocument)
                     ? new JsonApiDocument()
                     : mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, "", jsonApiDoc, tx, user, null, elideSettings);
+            RequestScope requestScope = new RequestScope(path, apiVersion, jsonApiDoc,
+                    tx, user, null, elideSettings);
             requestScope.setEntityProjection(new EntityProjectionMaker(elideSettings.getDictionary(),
                     requestScope).parsePath(path));
             BaseVisitor visitor = new DeleteVisitor(requestScope);

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static com.yahoo.elide.core.EntityDictionary.REGULAR_ID_NAME;
 
 import com.yahoo.elide.Injector;
@@ -123,7 +124,7 @@ public class EntityBinding {
     private EntityBinding() {
         jsonApiType = null;
         entityName = null;
-        apiVersion = "";
+        apiVersion = NO_VERSION;
         apiAttributes = new ArrayList<>();
         apiRelationships = new ArrayList<>();
         inheritedTypes = new ArrayList<>();
@@ -147,7 +148,7 @@ public class EntityBinding {
                          Class<?> cls,
                          String type,
                          String name) {
-        this(dictionary, cls, type, name, "", new HashSet<>());
+        this(dictionary, cls, type, name, NO_VERSION, new HashSet<>());
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -73,6 +73,7 @@ public class EntityBinding {
             Arrays.asList(ManyToMany.class, ManyToOne.class, OneToMany.class, OneToOne.class,
                     ToOne.class, ToMany.class);
 
+    @Getter
     public final Class<?> entityClass;
     public final String jsonApiType;
     public final String entityName;
@@ -88,6 +89,9 @@ public class EntityBinding {
     private AccessType accessType;
 
     private EntityDictionary dictionary;
+
+    @Getter
+    private String apiVersion;
 
     public final EntityPermissions entityPermissions;
     public final List<String> apiAttributes;
@@ -119,6 +123,7 @@ public class EntityBinding {
     private EntityBinding() {
         jsonApiType = null;
         entityName = null;
+        apiVersion = "";
         apiAttributes = new ArrayList<>();
         apiRelationships = new ArrayList<>();
         inheritedTypes = new ArrayList<>();
@@ -142,7 +147,7 @@ public class EntityBinding {
                          Class<?> cls,
                          String type,
                          String name) {
-        this(dictionary, cls, type, name, new HashSet<>());
+        this(dictionary, cls, type, name, "", new HashSet<>());
     }
 
     /**
@@ -158,10 +163,12 @@ public class EntityBinding {
                          Class<?> cls,
                          String type,
                          String name,
+                         String apiVersion,
                          Set<Class<? extends Annotation>> hiddenAnnotations) {
         this.dictionary = dictionary;
         entityClass = cls;
         jsonApiType = type;
+        this.apiVersion = apiVersion;
         entityName = name;
         inheritedTypes = getInheritedTypes(cls);
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -82,6 +82,7 @@ import javax.ws.rs.WebApplicationException;
 public class EntityDictionary {
 
     public static final String ELIDE_PACKAGE_PREFIX = "com.yahoo.elide";
+    public static final String NO_VERSION = "";
 
     protected final ConcurrentHashMap<Pair<String, String>, Class<?>> bindJsonApiToEntity = new ConcurrentHashMap<>();
     protected final ConcurrentHashMap<Class<?>, EntityBinding> entityBindings = new ConcurrentHashMap<>();
@@ -1642,6 +1643,6 @@ public class EntityDictionary {
         ApiVersion apiVersionAnnotation =
                 (ApiVersion) getFirstPackageAnnotation(modelClass, Arrays.asList(ApiVersion.class));
 
-        return (apiVersionAnnotation == null) ? "" : apiVersionAnnotation.version();
+        return (apiVersionAnnotation == null) ? NO_VERSION : apiVersionAnnotation.version();
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -330,6 +330,20 @@ public class EntityDictionary {
     }
 
     /**
+     * Get a list of inherited entities from a particular entity.
+     * Namely, the list of entities inheriting from the provided class.
+     *
+     * @param entityClass Entity class
+     * @return  List of all inherited entity types
+     */
+     public List<Class<?>> getSubclassingEntities(Class entityClass) {
+         return subclassingEntities.computeIfAbsent(entityClass, unused -> entityBindings
+                            .keySet().stream()
+                            .filter(c -> c != entityClass && entityClass.isAssignableFrom(c))
+                            .collect(Collectors.toList()));
+     }
+
+    /**
      * Returns the friendly named mapped to this given check.
      * @param checkClass The class to lookup
      * @return the friendly name of the check.

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -81,6 +81,9 @@ import javax.ws.rs.WebApplicationException;
 @SuppressWarnings("static-method")
 public class EntityDictionary {
 
+    public static final String ASYNC_QUERY = "asyncQuery";
+    public static final String ASYNC_QUERY_RESULT = "asyncQueryResult";
+
     protected final ConcurrentHashMap<Pair<String, String>, Class<?>> bindJsonApiToEntity = new ConcurrentHashMap<>();
     protected final ConcurrentHashMap<Class<?>, EntityBinding> entityBindings = new ConcurrentHashMap<>();
     protected final CopyOnWriteArrayList<Class<?>> bindEntityRoots = new CopyOnWriteArrayList<>();
@@ -238,6 +241,15 @@ public class EntityDictionary {
      * @return binding class
      */
     public Class<?> getEntityClass(String entityName, String version) {
+
+        //Elide standard models transcend API versions.
+        if (entityName.equals(ASYNC_QUERY) || entityName.equals(ASYNC_QUERY_RESULT)) {
+            return entityBindings.values().stream()
+                    .filter(binding -> binding.entityName.equals(entityName))
+                    .map(EntityBinding::getEntityClass)
+                    .findFirst()
+                    .orElse(null);
+        }
         return bindJsonApiToEntity.get(Pair.of(entityName, version));
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -231,8 +231,7 @@ public class EntityDictionary {
      * @param entityName entity name
      * @return binding class
      */
-    public Class<?> getEntityClass(String entityName) {
-        String version = "";
+    public Class<?> getEntityClass(String entityName, String version) {
         return bindJsonApiToEntity.get(Pair.of(entityName, version));
     }
 
@@ -808,7 +807,7 @@ public class EntityDictionary {
             type = include.type();
         }
 
-        String version = "";
+        String version = getModelVersion(cls);
         bindJsonApiToEntity.put(Pair.of(type, version), declaredClass);
         entityBindings.put(declaredClass, new EntityBinding(this, declaredClass, type, name, hiddenAnnotations));
         if (include.rootLevel()) {
@@ -831,7 +830,7 @@ public class EntityDictionary {
 
         Include include = (Include) getFirstAnnotation(declaredClass, Collections.singletonList(Include.class));
 
-        String version = "";
+        String version = getModelVersion(declaredClass);
         bindJsonApiToEntity.put(Pair.of(entityBinding.jsonApiType, version), declaredClass);
         entityBindings.put(declaredClass, entityBinding);
         if (include.rootLevel()) {
@@ -1316,7 +1315,7 @@ public class EntityDictionary {
      * @return true if the class is bound.  False otherwise.
      */
     public boolean hasBinding(Class<?> cls) {
-        String version = "";
+        String version = getModelVersion(cls);
         String name = StringUtils.uncapitalize(cls.getSimpleName());
         return bindJsonApiToEntity.containsKey(Pair.of(name, version));
     }
@@ -1581,5 +1580,9 @@ public class EntityDictionary {
         } else {
             return column[0].name();
         }
+    }
+
+    public static String getModelVersion(Class<?> modelClass) {
+        return "";
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -1367,9 +1367,9 @@ public class EntityDictionary {
      * @return true if the class is bound.  False otherwise.
      */
     public boolean hasBinding(Class<?> cls) {
-        String version = getModelVersion(cls);
-        String name = StringUtils.uncapitalize(cls.getSimpleName());
-        return bindJsonApiToEntity.containsKey(Pair.of(name, version));
+        return entityBindings.values().stream()
+                .filter(binding -> binding.entityClass.equals(cls))
+                .findFirst().orElse(null) != null;
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -153,8 +153,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         requestScope.publishLifecycleEvent(newResource, CREATE);
 
-        String type = newResource.getType();
-        requestScope.setUUIDForObject(type, id, newResource.getObject());
+        requestScope.setUUIDForObject(newResource.getResourceClass(), id, newResource.getObject());
 
         // Initialize null ToMany collections
         requestScope.getDictionary().getRelationships(entityClass).stream()
@@ -234,7 +233,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         Class<?> loadClass = projection.getType();
 
         // Check the resource cache if exists
-        Object obj = requestScope.getObjectById(dictionary.getJsonAliasFor(loadClass), id);
+        Object obj = requestScope.getObjectById(loadClass, id);
         if (obj == null) {
             // try to load object
             Optional<FilterExpression> permissionFilter = getPermissionFilterExpression(loadClass,
@@ -934,10 +933,9 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             RequestScope scope) {
         Class<?> idType = dictionary.getIdType(entityType);
         String idField = dictionary.getIdFieldName(entityType);
-        String typeAlias = dictionary.getJsonAliasFor(entityType);
 
         List<Object> coercedIds = ids.stream()
-                .filter(id -> scope.getObjectById(typeAlias, id) == null) // these don't exist yet
+                .filter(id -> scope.getObjectById(entityType, id) == null) // these don't exist yet
                 .map(id -> CoerceUtil.coerce(id, idType))
                 .collect(Collectors.toList());
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -443,12 +443,14 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     }
 
     public Object getObjectById(Class<?> type, String id) {
-        Object result = objectEntityCache.get(type.getName(), id);
+        Class<?> boundType = dictionary.lookupBoundClass(type);
+
+        Object result = objectEntityCache.get(boundType.getName(), id);
 
         // Check inheritance too
-        Iterator<Class<?>> it = dictionary.getSuperClassEntities(type).iterator();
+        Iterator<Class<?>> it = dictionary.getSuperClassEntities(boundType).iterator();
         while (result == null && it.hasNext()) {
-            String newType = getInheritanceKey(it.next().getName(), type.getName());
+            String newType = getInheritanceKey(it.next().getName(), boundType.getName());
             result = objectEntityCache.get(newType, id);
         }
 
@@ -456,11 +458,13 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     }
 
     public void setUUIDForObject(Class<?> type, String id, Object object) {
-        objectEntityCache.put(type.getName(), id, object);
+        Class<?> boundType = dictionary.lookupBoundClass(type);
+
+        objectEntityCache.put(boundType.getName(), id, object);
 
         // Insert for all inherited entities as well
         dictionary.getSuperClassEntities(type).stream()
-                .map(i -> getInheritanceKey(type.getName(), i.getName()))
+                .map(i -> getInheritanceKey(boundType.getName(), i.getName()))
                 .forEach((newType) -> objectEntityCache.put(newType, id, object));
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -294,7 +294,8 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      */
     private boolean interfaceHasFilterExpression(Class<?> entityInterface) {
         for (String filterType : expressionsByType.keySet()) {
-            Class<?> polyMorphicClass = dictionary.getEntityClass(filterType);
+            String version = EntityDictionary.getModelVersion(entityInterface);
+            Class<?> polyMorphicClass = dictionary.getEntityClass(filterType, version);
             if (entityInterface.isAssignableFrom(polyMorphicClass)) {
                 return true;
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -62,6 +62,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     @Getter private final ElideSettings elideSettings;
     @Getter private final int updateStatusCode;
     @Getter private final MultipleFilterDialect filterDialect;
+    @Getter private final String apiVersion;
 
     //TODO - this ought to be read only and set in the constructor.
     @Getter @Setter private EntityProjection entityProjection;
@@ -79,6 +80,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      * Create a new RequestScope with specified update status code.
      *
      * @param path the URL path
+     * @param apiVersion the API version.
      * @param jsonApiDocument the document for this request
      * @param transaction the transaction for this request
      * @param user the user making this request
@@ -86,11 +88,13 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      * @param elideSettings Elide settings object
      */
     public RequestScope(String path,
+                        String apiVersion,
                         JsonApiDocument jsonApiDocument,
                         DataStoreTransaction transaction,
                         User user,
                         MultivaluedMap<String, String> queryParams,
                         ElideSettings elideSettings) {
+        this.apiVersion = apiVersion;
         this.lifecycleEvents = PublishSubject.create();
         this.distinctLifecycleEvents = lifecycleEvents.distinct();
         this.queuedLifecycleEvents = ReplaySubject.create();
@@ -136,14 +140,14 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
 
                 /* First check to see if there is a global, cross-type filter */
                 try {
-                    globalFilterExpression = filterDialect.parseGlobalExpression(path, filterParams);
+                    globalFilterExpression = filterDialect.parseGlobalExpression(path, filterParams, apiVersion);
                 } catch (ParseException e) {
                     errorMessage = e.getMessage();
                 }
 
                 /* Next check to see if there is are type specific filters */
                 try {
-                    expressionsByType.putAll(filterDialect.parseTypedExpression(path, filterParams));
+                    expressionsByType.putAll(filterDialect.parseTypedExpression(path, filterParams, apiVersion));
                 } catch (ParseException e) {
 
                     /* If neither dialect parsed, report the last error found */
@@ -172,11 +176,14 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      * Special copy constructor for use by PatchRequestScope.
      *
      * @param path the URL path
+     * @param apiVersion the API version
      * @param jsonApiDocument   the json api document
      * @param outerRequestScope the outer request scope
      */
-    protected RequestScope(String path, JsonApiDocument jsonApiDocument, RequestScope outerRequestScope) {
+    protected RequestScope(String path, String apiVersion,
+                           JsonApiDocument jsonApiDocument, RequestScope outerRequestScope) {
         this.jsonApiDocument = jsonApiDocument;
+        this.apiVersion = apiVersion;
         this.path = path;
         this.transaction = outerRequestScope.transaction;
         this.user = outerRequestScope.user;

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -442,25 +442,25 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         return objectEntityCache.getUUID(o);
     }
 
-    public Object getObjectById(String type, String id) {
-        Object result = objectEntityCache.get(type, id);
+    public Object getObjectById(Class<?> type, String id) {
+        Object result = objectEntityCache.get(type.getName(), id);
 
         // Check inheritance too
-        Iterator<String> it = dictionary.getSubclassingEntityNames(type).iterator();
+        Iterator<Class<?>> it = dictionary.getSuperClassEntities(type).iterator();
         while (result == null && it.hasNext()) {
-            String newType = getInheritanceKey(it.next(), type);
+            String newType = getInheritanceKey(it.next().getName(), type.getName());
             result = objectEntityCache.get(newType, id);
         }
 
         return result;
     }
 
-    public void setUUIDForObject(String type, String id, Object object) {
-        objectEntityCache.put(type, id, object);
+    public void setUUIDForObject(Class<?> type, String id, Object object) {
+        objectEntityCache.put(type.getName(), id, object);
 
         // Insert for all inherited entities as well
-        dictionary.getSuperClassEntityNames(type).stream()
-                .map(i -> getInheritanceKey(type, i))
+        dictionary.getSuperClassEntities(type).stream()
+                .map(i -> getInheritanceKey(type.getName(), i.getName()))
                 .forEach((newType) -> objectEntityCache.put(newType, id, object));
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -448,7 +448,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         Object result = objectEntityCache.get(boundType.getName(), id);
 
         // Check inheritance too
-        Iterator<Class<?>> it = dictionary.getSuperClassEntities(boundType).iterator();
+        Iterator<Class<?>> it = dictionary.getSubclassingEntities(boundType).iterator();
         while (result == null && it.hasNext()) {
             String newType = getInheritanceKey(it.next().getName(), boundType.getName());
             result = objectEntityCache.get(newType, id);

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.request.EntityProjection;
 import com.yahoo.elide.request.Pagination;
 import com.yahoo.elide.request.Relationship;
 import com.yahoo.elide.request.Sorting;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
 
 /**
  * Data Store Transaction that wraps another transaction and provides in-memory filtering, soring, and pagination

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
@@ -156,7 +156,9 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
 
         Class<?>[] types = new Class[keyParts.length];
         String type = keyParts[0];
-        types[0] = dictionary.getEntityClass(type);
+
+        //TODO - this needs to come from the API.
+        types[0] = dictionary.getEntityClass(type, "");
 
         if (types[0] == null) {
             throw new ParseException("Unknown entity in filter: " + type);

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
@@ -40,7 +40,8 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
      * @return a list of the predicates from the query params
      * @throws ParseException when a filter parameter cannot be parsed
      */
-    private List<FilterPredicate> extractPredicates(MultivaluedMap<String, String> queryParams) throws ParseException {
+    private List<FilterPredicate> extractPredicates(MultivaluedMap<String, String> queryParams,
+                                                    String apiVersion) throws ParseException {
         List<FilterPredicate> filterPredicates = new ArrayList<>();
 
         Pattern pattern = Pattern.compile("filter\\[([^\\]]+)\\](\\[([^\\]]+)\\])?");
@@ -64,7 +65,7 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
             final Operator operator = (matcher.group(3) == null) ? Operator.IN
                     : Operator.fromString(matcher.group(3));
 
-            Path path = getPath(keyParts);
+            Path path = getPath(keyParts, apiVersion);
             List<Path.PathElement> elements = path.getPathElements();
             Path.PathElement last = elements.get(elements.size() - 1);
 
@@ -86,10 +87,11 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
     }
 
     @Override
-    public FilterExpression parseGlobalExpression(String path, MultivaluedMap<String, String> filterParams)
+    public FilterExpression parseGlobalExpression(String path, MultivaluedMap<String, String> filterParams,
+                                                  String apiVersion)
             throws ParseException {
         List<FilterPredicate> filterPredicates;
-        filterPredicates = extractPredicates(filterParams);
+        filterPredicates = extractPredicates(filterParams, apiVersion);
 
         /* Extract the first collection in the URL */
         String normalizedPath = JsonApiParser.normalizePath(path);
@@ -121,10 +123,11 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
     }
 
     @Override
-    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams)
+    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams,
+                                                              String apiVersion)
             throws ParseException {
         Map<String, FilterExpression> expressionMap = new HashMap<>();
-        List<FilterPredicate> filterPredicates = extractPredicates(filterParams);
+        List<FilterPredicate> filterPredicates = extractPredicates(filterParams, apiVersion);
 
         for (FilterPredicate filterPredicate : filterPredicates) {
             validateFilterPredicate(filterPredicate);
@@ -144,10 +147,11 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
      * Parses [ author, books, publisher, name ] into [(author, books), (book, publisher), (publisher, name)].
      *
      * @param keyParts [ author, books, publisher, name ]
+     * @param apiVersion The client requested version.
      * @return [(author, books), (book, publisher), (publisher, name)]
      * @throws ParseException if the filter cannot be parsed
      */
-    private Path getPath(final String[] keyParts) throws ParseException {
+    private Path getPath(final String[] keyParts, String apiVersion) throws ParseException {
         if (keyParts == null || keyParts.length <= 0) {
             throw new ParseException("Invalid filter expression");
         }
@@ -157,8 +161,7 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
         Class<?>[] types = new Class[keyParts.length];
         String type = keyParts[0];
 
-        //TODO - this needs to come from the API.
-        types[0] = dictionary.getEntityClass(type, "");
+        types[0] = dictionary.getEntityClass(type, apiVersion);
 
         if (types[0] == null) {
             throw new ParseException("Unknown entity in filter: " + type);

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/JoinFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/JoinFilterDialect.java
@@ -24,10 +24,12 @@ public interface JoinFilterDialect {
      *
      * @param path the URL path
      * @param filterParams the subset of query parameters that start with 'filter'
+     * @param apiVersion the version of the API requested.
      * @return The root of an expression abstract syntax tree parsed from both the path and the query parameters.
      * @throws ParseException if the expression cannot be parsed.
      */
     public FilterExpression parseGlobalExpression(
             String path,
-            MultivaluedMap<String, String> filterParams) throws ParseException;
+            MultivaluedMap<String, String> filterParams,
+            String apiVersion) throws ParseException;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialect.java
@@ -38,24 +38,27 @@ public class MultipleFilterDialect implements JoinFilterDialect, SubqueryFilterD
 
     @Override
     public FilterExpression parseGlobalExpression(String path,
-                                                  MultivaluedMap<String, String> queryParams) throws ParseException {
+                                                  MultivaluedMap<String, String> queryParams,
+                                                  String apiVersion) throws ParseException {
         if (joinDialects.isEmpty()) {
             throw new ParseException("Heterogeneous type filtering not supported");
         }
 
-        return parseExpression(joinDialects, (dialect) -> dialect.parseGlobalExpression(path, queryParams));
+        return parseExpression(joinDialects, (dialect) -> dialect.parseGlobalExpression(path, queryParams, apiVersion));
     }
 
     @Override
     public Map<String, FilterExpression> parseTypedExpression(String path,
-                                                              MultivaluedMap<String, String> queryParams)
+                                                              MultivaluedMap<String, String> queryParams,
+                                                              String apiVersion)
             throws ParseException {
 
         if (subqueryDialects.isEmpty()) {
             throw new ParseException("Type filtering not supported");
         }
 
-        return parseExpression(subqueryDialects, (dialect) -> dialect.parseTypedExpression(path, queryParams));
+        return parseExpression(subqueryDialects, (dialect) -> dialect.parseTypedExpression(path,
+                queryParams, apiVersion));
     }
 
     private static <T, R> R parseExpression(List<T> dialects, ParseFunction<T, R> parseFunction) throws ParseException {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -126,7 +126,8 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
          * This works today by virtue that global filter expressions are only used for root collections
          * and NOT nested associations.
          */
-        Class entityType = dictionary.getEntityClass(lastPathComponent);
+        //TODO - this needs to come from the API.
+        Class entityType = dictionary.getEntityClass(lastPathComponent, "");
         if (entityType == null) {
             throw new ParseException("No such collection: " + lastPathComponent);
         }
@@ -152,7 +153,8 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
                     throw new ParseException("Exactly one RSQL expression must be defined for type : " + typeName);
                 }
 
-                Class entityType = dictionary.getEntityClass(typeName);
+                //TODO - this needs to come from the API
+                Class entityType = dictionary.getEntityClass(typeName, "");
                 if (entityType == null) {
                     throw new ParseException(INVALID_QUERY_PARAMETER + paramName);
                 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -94,7 +94,8 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
     }
 
     @Override
-    public FilterExpression parseGlobalExpression(String path, MultivaluedMap<String, String> filterParams)
+    public FilterExpression parseGlobalExpression(String path, MultivaluedMap<String, String> filterParams,
+                                                  String apiVersion)
             throws ParseException {
         if (filterParams.size() != 1) {
             throw new ParseException(SINGLE_PARAMETER_ONLY);
@@ -126,8 +127,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
          * This works today by virtue that global filter expressions are only used for root collections
          * and NOT nested associations.
          */
-        //TODO - this needs to come from the API.
-        Class entityType = dictionary.getEntityClass(lastPathComponent, "");
+        Class entityType = dictionary.getEntityClass(lastPathComponent, apiVersion);
         if (entityType == null) {
             throw new ParseException("No such collection: " + lastPathComponent);
         }
@@ -136,7 +136,8 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
     }
 
     @Override
-    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams)
+    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams,
+                                                              String apiVersion)
             throws ParseException {
 
         Map<String, FilterExpression> expressionByType = new HashMap<>();
@@ -153,8 +154,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
                     throw new ParseException("Exactly one RSQL expression must be defined for type : " + typeName);
                 }
 
-                //TODO - this needs to come from the API
-                Class entityType = dictionary.getEntityClass(typeName, "");
+                Class entityType = dictionary.getEntityClass(typeName, apiVersion);
                 if (entityType == null) {
                     throw new ParseException(INVALID_QUERY_PARAMETER + paramName);
                 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/SubqueryFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/SubqueryFilterDialect.java
@@ -33,9 +33,11 @@ public interface SubqueryFilterDialect {
      *
      * @param path The URL path
      * @param filterParams The subset of queryParams that start with 'filter'
+     * @param apiVersion The version of the API requested.
      * @return The root of an expression abstract syntax tree parsed from both the path and the query parameters.
      * @throws ParseException if unable to parse
      */
-    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams)
+    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams,
+                                                              String apiVersion)
             throws ParseException;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
@@ -23,17 +23,20 @@ public class PatchRequestScope extends RequestScope {
      * Outer RequestScope constructor for use by Patch Extension.
      *
      * @param path the URL path
+     * @param apiVersion client requested API version
      * @param transaction current database transaction
      * @param user        request user
      * @param elideSettings Elide settings object
      */
     public PatchRequestScope(
             String path,
+            String apiVersion,
             DataStoreTransaction transaction,
             User user,
             ElideSettings elideSettings) {
         super(
                 path,
+                apiVersion,
                 (JsonApiDocument) null,
                 transaction,
                 user,
@@ -50,7 +53,7 @@ public class PatchRequestScope extends RequestScope {
      * @param scope           outer request scope
      */
     public PatchRequestScope(String path, JsonApiDocument jsonApiDocument, PatchRequestScope scope) {
-        super(path, jsonApiDocument, scope);
+        super(path, scope.getApiVersion(), jsonApiDocument, scope);
         this.setEntityProjection(new EntityProjectionMaker(dictionary, this).parsePath(path));
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
@@ -292,8 +292,7 @@ public class EntityProjectionMaker
             //entityLabel represents a root collection.
             if (parentClass == null) {
 
-                //TODO - version needs to come from the API
-                Class<?> entityClass = dictionary.getEntityClass(entityLabel, "");
+                Class<?> entityClass = dictionary.getEntityClass(entityLabel, scope.getApiVersion());
 
                 if (entityClass != null) {
                     return entityClass;

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
@@ -291,7 +291,9 @@ public class EntityProjectionMaker
 
             //entityLabel represents a root collection.
             if (parentClass == null) {
-                Class<?> entityClass = dictionary.getEntityClass(entityLabel);
+
+                //TODO - version needs to come from the API
+                Class<?> entityClass = dictionary.getEntityClass(entityLabel, "");
 
                 if (entityClass != null) {
                     return entityClass;

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Resource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Resource.java
@@ -150,7 +150,9 @@ public class Resource {
     public PersistentResource<?> toPersistentResource(RequestScope requestScope)
         throws ForbiddenAccessException, InvalidObjectIdentifierException {
         EntityDictionary dictionary = requestScope.getDictionary();
-        Class<?> cls = dictionary.getEntityClass(type);
+
+        //Version needs to come from the request scope.
+        Class<?> cls = dictionary.getEntityClass(type, "");
 
         if (cls == null) {
             throw new UnknownEntityException(type);

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Resource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Resource.java
@@ -151,8 +151,7 @@ public class Resource {
         throws ForbiddenAccessException, InvalidObjectIdentifierException {
         EntityDictionary dictionary = requestScope.getDictionary();
 
-        //Version needs to come from the request scope.
-        Class<?> cls = dictionary.getEntityClass(type, "");
+        Class<?> cls = dictionary.getEntityClass(type, requestScope.getApiVersion());
 
         if (cls == null) {
             throw new UnknownEntityException(type);

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/ResourceIdentifier.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/ResourceIdentifier.java
@@ -38,7 +38,9 @@ public class ResourceIdentifier {
 
     public PersistentResource toPersistentResource(RequestScope requestScope)
         throws ForbiddenAccessException, InvalidObjectIdentifierException {
-        Class<?> cls = requestScope.getDictionary().getEntityClass(type);
+
+        //TODO - version needs to come from the request scope.
+        Class<?> cls = requestScope.getDictionary().getEntityClass(type, "");
         return PersistentResource.loadRecord(EntityProjection.builder()
                 .type(cls)
                 .build(), id, requestScope);

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/ResourceIdentifier.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/ResourceIdentifier.java
@@ -39,8 +39,7 @@ public class ResourceIdentifier {
     public PersistentResource toPersistentResource(RequestScope requestScope)
         throws ForbiddenAccessException, InvalidObjectIdentifierException {
 
-        //TODO - version needs to come from the request scope.
-        Class<?> cls = requestScope.getDictionary().getEntityClass(type, "");
+        Class<?> cls = requestScope.getDictionary().getEntityClass(type, requestScope.getApiVersion());
         return PersistentResource.loadRecord(EntityProjection.builder()
                 .type(cls)
                 .build(), id, requestScope);

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
@@ -168,8 +168,8 @@ public class CollectionTerminalState extends BaseState {
 
         String id = resource.getId();
 
-        //TODO - version needs to come from request scope.
-        Class<?> newObjectClass = requestScope.getDictionary().getEntityClass(resource.getType(), "");
+        Class<?> newObjectClass = requestScope.getDictionary().getEntityClass(resource.getType(),
+                requestScope.getApiVersion());
 
         if (newObjectClass == null) {
             throw new UnknownEntityException("Entity " + resource.getType() + " not found");

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/CollectionTerminalState.java
@@ -167,7 +167,9 @@ public class CollectionTerminalState extends BaseState {
         }
 
         String id = resource.getId();
-        Class<?> newObjectClass = requestScope.getDictionary().getEntityClass(resource.getType());
+
+        //TODO - version needs to come from request scope.
+        Class<?> newObjectClass = requestScope.getDictionary().getEntityClass(resource.getType(), "");
 
         if (newObjectClass == null) {
             throw new UnknownEntityException("Entity " + resource.getType() + " not found");

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
@@ -53,8 +53,7 @@ public class RecordState extends BaseState {
         } else {
             entityName = dictionary.getJsonAliasFor(paramType);
 
-            //TODO - this needs to come from the API.
-            entityClass = dictionary.getEntityClass(entityName, "");
+            entityClass = dictionary.getEntityClass(entityName, state.getRequestScope().getApiVersion());
         }
         if (entityClass == null) {
             throw new IllegalArgumentException("Unknown type " + entityName);

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/RecordState.java
@@ -52,7 +52,9 @@ public class RecordState extends BaseState {
             entityClass = paramType;
         } else {
             entityName = dictionary.getJsonAliasFor(paramType);
-            entityClass = dictionary.getEntityClass(entityName);
+
+            //TODO - this needs to come from the API.
+            entityClass = dictionary.getEntityClass(entityName, "");
         }
         if (entityClass == null) {
             throw new IllegalArgumentException("Unknown type " + entityName);

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
@@ -25,8 +25,7 @@ public class StartState extends BaseState {
         String entityName = ctx.term().getText();
         EntityDictionary dictionary = state.getRequestScope().getDictionary();
 
-        //TODO - this needs to come from the API
-        Class<?> entityClass = dictionary.getEntityClass(entityName, "");
+        Class<?> entityClass = dictionary.getEntityClass(entityName, state.getRequestScope().getApiVersion());
 
         state.setState(new CollectionTerminalState(entityClass, Optional.empty(), Optional.empty(),
                 state.getRequestScope().getEntityProjection()));

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
@@ -24,7 +24,9 @@ public class StartState extends BaseState {
     public void handle(StateContext state, RootCollectionLoadEntitiesContext ctx) {
         String entityName = ctx.term().getText();
         EntityDictionary dictionary = state.getRequestScope().getDictionary();
-        Class<?> entityClass = dictionary.getEntityClass(entityName);
+
+        //TODO - this needs to come from the API
+        Class<?> entityClass = dictionary.getEntityClass(entityName, "");
 
         state.setState(new CollectionTerminalState(entityClass, Optional.empty(), Optional.empty(),
                 state.getRequestScope().getEntityProjection()));

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -60,7 +60,7 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
         User user = new SecurityContextUser(securityContext);
-        return build(elide.post(path, jsonapiDocument, user));
+        return build(elide.post(path, jsonapiDocument, user, ""));
     }
 
     /**
@@ -79,7 +79,7 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         User user = new SecurityContextUser(securityContext);
-        return build(elide.get(path, queryParams, user));
+        return build(elide.get(path, queryParams, user, ""));
     }
 
     /**
@@ -102,7 +102,7 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
         User user = new SecurityContextUser(securityContext);
-        return build(elide.patch(contentType, accept, path, jsonapiDocument, user));
+        return build(elide.patch(contentType, accept, path, jsonapiDocument, user, ""));
     }
 
     /**
@@ -121,7 +121,7 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
         User user = new SecurityContextUser(securityContext);
-        return build(elide.delete(path, jsonApiDocument, user));
+        return build(elide.delete(path, jsonApiDocument, user, ""));
     }
 
     private static Response build(ElideResponse response) {

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.resources;
 
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
@@ -61,7 +62,7 @@ public class JsonApiEndpoint {
         @HeaderParam("ApiVersion") String apiVersion,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
-        String safeApiVersion = apiVersion == null ? "" : apiVersion;
+        String safeApiVersion = apiVersion == null ? NO_VERSION : apiVersion;
         User user = new SecurityContextUser(securityContext);
         return build(elide.post(path, jsonapiDocument, user, safeApiVersion));
     }
@@ -82,7 +83,7 @@ public class JsonApiEndpoint {
         @HeaderParam("ApiVersion") String apiVersion,
         @Context UriInfo uriInfo,
         @Context SecurityContext securityContext) {
-        String safeApiVersion = apiVersion == null ? "" : apiVersion;
+        String safeApiVersion = apiVersion == null ? NO_VERSION : apiVersion;
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         User user = new SecurityContextUser(securityContext);
         return build(elide.get(path, queryParams, user, safeApiVersion));
@@ -109,7 +110,7 @@ public class JsonApiEndpoint {
         @PathParam("path") String path,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
-        String safeApiVersion = apiVersion == null ? "" : apiVersion;
+        String safeApiVersion = apiVersion == null ? NO_VERSION : apiVersion;
         User user = new SecurityContextUser(securityContext);
         return build(elide.patch(contentType, accept, path, jsonapiDocument, user, safeApiVersion));
     }
@@ -131,7 +132,7 @@ public class JsonApiEndpoint {
         @HeaderParam("ApiVersion") String apiVersion,
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
-        String safeApiVersion = apiVersion == null ? "" : apiVersion;
+        String safeApiVersion = apiVersion == null ? NO_VERSION : apiVersion;
         User user = new SecurityContextUser(securityContext);
         return build(elide.delete(path, jsonApiDocument, user, safeApiVersion));
     }

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -48,6 +48,7 @@ public class JsonApiEndpoint {
      * Create handler.
      *
      * @param path request path
+     * @param apiVersion The api version
      * @param securityContext security context
      * @param jsonapiDocument post data as jsonapi document
      * @return response
@@ -57,16 +58,19 @@ public class JsonApiEndpoint {
     @Consumes(JSONAPI_CONTENT_TYPE)
     public Response post(
         @PathParam("path") String path,
+        @HeaderParam("ApiVersion") String apiVersion,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
+        String safeApiVersion = apiVersion == null ? "" : apiVersion;
         User user = new SecurityContextUser(securityContext);
-        return build(elide.post(path, jsonapiDocument, user, ""));
+        return build(elide.post(path, jsonapiDocument, user, safeApiVersion));
     }
 
     /**
      * Read handler.
      *
      * @param path request path
+     * @param apiVersion The API version
      * @param uriInfo URI info
      * @param securityContext security context
      * @return response
@@ -75,17 +79,20 @@ public class JsonApiEndpoint {
     @Path("{path:.*}")
     public Response get(
         @PathParam("path") String path,
+        @HeaderParam("ApiVersion") String apiVersion,
         @Context UriInfo uriInfo,
         @Context SecurityContext securityContext) {
+        String safeApiVersion = apiVersion == null ? "" : apiVersion;
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         User user = new SecurityContextUser(securityContext);
-        return build(elide.get(path, queryParams, user, ""));
+        return build(elide.get(path, queryParams, user, safeApiVersion));
     }
 
     /**
      * Update handler.
      *
      * @param contentType document MIME type
+     * @param apiVersion the API version
      * @param accept response MIME type
      * @param path request path
      * @param securityContext security context
@@ -97,18 +104,21 @@ public class JsonApiEndpoint {
     @Consumes(JSONAPI_CONTENT_TYPE)
     public Response patch(
         @HeaderParam("Content-Type") String contentType,
+        @HeaderParam("ApiVersion") String apiVersion,
         @HeaderParam("accept") String accept,
         @PathParam("path") String path,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
+        String safeApiVersion = apiVersion == null ? "" : apiVersion;
         User user = new SecurityContextUser(securityContext);
-        return build(elide.patch(contentType, accept, path, jsonapiDocument, user, ""));
+        return build(elide.patch(contentType, accept, path, jsonapiDocument, user, safeApiVersion));
     }
 
     /**
      * Delete relationship handler (expects body with resource ids and types).
      *
      * @param path request path
+     * @param apiVersion the API version.
      * @param securityContext security context
      * @param jsonApiDocument DELETE document
      * @return response
@@ -118,10 +128,12 @@ public class JsonApiEndpoint {
     @Consumes(JSONAPI_CONTENT_TYPE)
     public Response delete(
         @PathParam("path") String path,
+        @HeaderParam("ApiVersion") String apiVersion,
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
+        String safeApiVersion = apiVersion == null ? "" : apiVersion;
         User user = new SecurityContextUser(securityContext);
-        return build(elide.delete(path, jsonApiDocument, user, ""));
+        return build(elide.delete(path, jsonApiDocument, user, safeApiVersion));
     }
 
     private static Response build(ElideResponse response) {

--- a/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageImplTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageImplTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.audit;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,7 +53,7 @@ public class LogMessageImplTest {
         friend.setId(9);
         child.setFriends(Sets.newHashSet(friend));
 
-        final RequestScope requestScope = new RequestScope(null, "", null, null,
+        final RequestScope requestScope = new RequestScope(null, NO_VERSION, null, null,
                 new TestUser("aaron"), null,
                 new ElideSettingsBuilder(null)
                         .withAuditLogger(new TestAuditLogger())

--- a/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageImplTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageImplTest.java
@@ -52,7 +52,7 @@ public class LogMessageImplTest {
         friend.setId(9);
         child.setFriends(Sets.newHashSet(friend));
 
-        final RequestScope requestScope = new RequestScope(null, null, null,
+        final RequestScope requestScope = new RequestScope(null, "", null, null,
                 new TestUser("aaron"), null,
                 new ElideSettingsBuilder(null)
                         .withAuditLogger(new TestAuditLogger())

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -551,8 +551,8 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertEquals("superclassBinding", getEntityFor(SubclassBinding.class));
         assertEquals("superclassBinding", getEntityFor(SuperclassBinding.class));
 
-        assertNull(getEntityClass("subclassBinding"));
-        assertEquals(SuperclassBinding.class, getEntityClass("superclassBinding"));
+        assertNull(getEntityClass("subclassBinding", ""));
+        assertEquals(SuperclassBinding.class, getEntityClass("superclassBinding", ""));
 
         assertEquals("superclassBinding", getJsonAliasFor(SubclassBinding.class));
         assertEquals("superclassBinding", getJsonAliasFor(SuperclassBinding.class));

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -557,8 +557,8 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertEquals("superclassBinding", getEntityFor(SubclassBinding.class));
         assertEquals("superclassBinding", getEntityFor(SuperclassBinding.class));
 
-        assertNull(getEntityClass("subclassBinding", ""));
-        assertEquals(SuperclassBinding.class, getEntityClass("superclassBinding", ""));
+        assertNull(getEntityClass("subclassBinding", NO_VERSION));
+        assertEquals(SuperclassBinding.class, getEntityClass("superclassBinding", NO_VERSION));
 
         assertEquals("superclassBinding", getJsonAliasFor(SubclassBinding.class));
         assertEquals("superclassBinding", getJsonAliasFor(SuperclassBinding.class));
@@ -867,13 +867,13 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertTrue(models.contains(BookV2.class));
 
 
-        models = getBoundClassesByVersion("");
+        models = getBoundClassesByVersion(NO_VERSION);
         assertEquals(14, models.size());
     }
 
     @Test
     public void testGetEntityClassByVersion() {
-        Class<?> model = getEntityClass("book", "");
+        Class<?> model = getEntityClass("book", NO_VERSION);
         assertEquals(Book.class, model);
 
         model = getEntityClass("book", "1.0");
@@ -883,6 +883,6 @@ public class EntityDictionaryTest extends EntityDictionary {
     @Test
     public void tetGetModelVersion() {
         assertEquals("1.0", getModelVersion(BookV2.class));
-        assertEquals("", getModelVersion(Book.class));
+        assertEquals(NO_VERSION, getModelVersion(Book.class));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -881,8 +881,27 @@ public class EntityDictionaryTest extends EntityDictionary {
     }
 
     @Test
-    public void tetGetModelVersion() {
+    public void testGetModelVersion() {
         assertEquals("1.0", getModelVersion(BookV2.class));
         assertEquals(NO_VERSION, getModelVersion(Book.class));
+    }
+
+    @Test
+    public void testHasBinding() {
+        assertTrue(hasBinding(FunWithPermissions.class));
+        assertTrue(hasBinding(Parent.class));
+        assertTrue(hasBinding(Child.class));
+        assertTrue(hasBinding(User.class));
+        assertTrue(hasBinding(Left.class));
+        assertTrue(hasBinding(Right.class));
+        assertTrue(hasBinding(StringId.class));
+        assertTrue(hasBinding(Friend.class));
+        assertTrue(hasBinding(FieldAnnotations.class));
+        assertTrue(hasBinding(Manager.class));
+        assertTrue(hasBinding(Employee.class));
+        assertTrue(hasBinding(Job.class));
+        assertTrue(hasBinding(NoId.class));
+        assertTrue(hasBinding(BookV2.class));
+        assertTrue(hasBinding(Book.class));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -1068,7 +1068,7 @@ public class LifeCycleTest {
     private RequestScope buildRequestScope(EntityDictionary dict, DataStoreTransaction tx) {
         User user = new TestUser("1");
 
-        return new RequestScope(null, null, tx, user, null,
+        return new RequestScope(null, "", null, tx, user, null,
                 getElideSettings(null, dict, MOCK_AUDIT_LOGGER));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -317,7 +317,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
 
-        ElideResponse response = elide.post("/testModel", body, null);
+        ElideResponse response = elide.post("/testModel", body, null, "");
         assertEquals(HttpStatus.SC_CREATED, response.getResponseCode());
 
         verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
@@ -371,7 +371,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
 
-        ElideResponse response = elide.post("/testModel", body, null);
+        ElideResponse response = elide.post("/testModel", body, null, "");
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getResponseCode());
         assertEquals(
                 "{\"errors\":[{\"detail\":\"Unexpected exception caught\"}]}",
@@ -402,7 +402,7 @@ public class LifeCycleTest {
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
-        ElideResponse response = elide.get("/testModel/1", headers, null);
+        ElideResponse response = elide.get("/testModel/1", headers, null, "");
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -447,7 +447,7 @@ public class LifeCycleTest {
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.putSingle("fields[testModel]", "field");
-        ElideResponse response = elide.get("/testModel/1", headers, null);
+        ElideResponse response = elide.get("/testModel/1", headers, null, "");
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -489,7 +489,7 @@ public class LifeCycleTest {
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
-        ElideResponse response = elide.get("/testModel/1/relationships/models", headers, null);
+        ElideResponse response = elide.get("/testModel/1/relationships/models", headers, null, "");
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -536,7 +536,7 @@ public class LifeCycleTest {
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
         String contentType = JSONAPI_CONTENT_TYPE;
-        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null);
+        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null, "");
         assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -579,7 +579,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
-        ElideResponse response = elide.delete("/testModel/1", "", null);
+        ElideResponse response = elide.delete("/testModel/1", "", null, "");
         assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -629,7 +629,7 @@ public class LifeCycleTest {
         doThrow(ConstraintViolationException.class).when(tx).flush(any());
 
         String contentType = JSONAPI_CONTENT_TYPE;
-        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null);
+        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null, "");
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
         assertEquals(
                 "{\"errors\":[{\"detail\":\"Constraint violation\"}]}",

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -681,7 +681,7 @@ public class LifeCycleTest {
         when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", body, null);
+        ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
@@ -736,7 +736,7 @@ public class LifeCycleTest {
         when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", body, null);
+        ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
         assertEquals(
                 "[{\"errors\":[{\"detail\":\"Bad Request Body&#39;Patch extension requires all objects to have an assigned ID (temporary or permanent) when assigning relationships.&#39;\",\"status\":\"400\"}]}]",
@@ -764,7 +764,7 @@ public class LifeCycleTest {
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", body, null);
+        ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -811,7 +811,7 @@ public class LifeCycleTest {
                 + "\"type\":\"testModel\",\"id\":\"1\"}}]";
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", body, null);
+        ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -14,6 +14,7 @@ import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.P
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRESECURITY;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -317,7 +318,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
 
-        ElideResponse response = elide.post("/testModel", body, null, "");
+        ElideResponse response = elide.post("/testModel", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_CREATED, response.getResponseCode());
 
         verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
@@ -371,7 +372,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
 
-        ElideResponse response = elide.post("/testModel", body, null, "");
+        ElideResponse response = elide.post("/testModel", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getResponseCode());
         assertEquals(
                 "{\"errors\":[{\"detail\":\"Unexpected exception caught\"}]}",
@@ -402,7 +403,7 @@ public class LifeCycleTest {
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
-        ElideResponse response = elide.get("/testModel/1", headers, null, "");
+        ElideResponse response = elide.get("/testModel/1", headers, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -447,7 +448,7 @@ public class LifeCycleTest {
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.putSingle("fields[testModel]", "field");
-        ElideResponse response = elide.get("/testModel/1", headers, null, "");
+        ElideResponse response = elide.get("/testModel/1", headers, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -489,7 +490,7 @@ public class LifeCycleTest {
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
-        ElideResponse response = elide.get("/testModel/1/relationships/models", headers, null, "");
+        ElideResponse response = elide.get("/testModel/1/relationships/models", headers, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -536,7 +537,7 @@ public class LifeCycleTest {
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
         String contentType = JSONAPI_CONTENT_TYPE;
-        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null, "");
+        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -579,7 +580,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
-        ElideResponse response = elide.delete("/testModel/1", "", null, "");
+        ElideResponse response = elide.delete("/testModel/1", "", null, NO_VERSION);
         assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
 
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -629,7 +630,7 @@ public class LifeCycleTest {
         doThrow(ConstraintViolationException.class).when(tx).flush(any());
 
         String contentType = JSONAPI_CONTENT_TYPE;
-        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null, "");
+        ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null, NO_VERSION);
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
         assertEquals(
                 "{\"errors\":[{\"detail\":\"Constraint violation\"}]}",
@@ -1068,7 +1069,7 @@ public class LifeCycleTest {
     private RequestScope buildRequestScope(EntityDictionary dict, DataStoreTransaction tx) {
         User user = new TestUser("1");
 
-        return new RequestScope(null, "", null, tx, user, null,
+        return new RequestScope(null, NO_VERSION, null, tx, user, null,
                 getElideSettings(null, dict, MOCK_AUDIT_LOGGER));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PermissionAnnotationTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PermissionAnnotationTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.elide.ElideSettings;
@@ -55,9 +56,9 @@ public class PermissionAnnotationTest {
                 .withEntityDictionary(dictionary)
                 .build();
 
-        RequestScope goodScope = new RequestScope(null, "", null, null, GOOD_USER, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, NO_VERSION, null, null, GOOD_USER, null, elideSettings);
         funRecord = new PersistentResource<>(fun, null, goodScope.getUUIDFor(fun), goodScope);
-        RequestScope badScope = new RequestScope(null, "", null, null, BAD_USER, null, elideSettings);
+        RequestScope badScope = new RequestScope(null, NO_VERSION, null, null, BAD_USER, null, elideSettings);
         badRecord = new PersistentResource<>(fun, null, badScope.getUUIDFor(fun), badScope);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PermissionAnnotationTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PermissionAnnotationTest.java
@@ -55,9 +55,9 @@ public class PermissionAnnotationTest {
                 .withEntityDictionary(dictionary)
                 .build();
 
-        RequestScope goodScope = new RequestScope(null, null, null, GOOD_USER, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, "", null, null, GOOD_USER, null, elideSettings);
         funRecord = new PersistentResource<>(fun, null, goodScope.getUUIDFor(fun), goodScope);
-        RequestScope badScope = new RequestScope(null, null, null, BAD_USER, null, elideSettings);
+        RequestScope badScope = new RequestScope(null, "", null, null, BAD_USER, null, elideSettings);
         badRecord = new PersistentResource<>(fun, null, badScope.getUUIDFor(fun), badScope);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.mockito.Mockito.mock;
 
 import com.yahoo.elide.ElideSettings;
@@ -116,7 +117,7 @@ public class PersistenceResourceTestSetup extends PersistentResource {
                 new Child(),
                 null,
                 null, // new request scope + new Child == cannot possibly be a UUID for this object
-                new RequestScope(null, "", null, null, null, null,
+                new RequestScope(null, NO_VERSION, null, null, null, null,
                         initSettings()
                 )
         );
@@ -143,7 +144,7 @@ public class PersistenceResourceTestSetup extends PersistentResource {
     }
 
     protected RequestScope buildRequestScope(String path, DataStoreTransaction tx, User user, MultivaluedMap<String, String> queryParams) {
-        return new RequestScope(path, "", null, tx, user, queryParams, elideSettings);
+        return new RequestScope(path, NO_VERSION, null, tx, user, queryParams, elideSettings);
     }
 
     protected <T> PersistentResource<T> bootstrapPersistentResource(T obj) {
@@ -152,12 +153,12 @@ public class PersistenceResourceTestSetup extends PersistentResource {
 
     protected <T> PersistentResource<T> bootstrapPersistentResource(T obj, DataStoreTransaction tx) {
         User goodUser = new TestUser("1");
-        RequestScope requestScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
+        RequestScope requestScope = new RequestScope(null, NO_VERSION, null, tx, goodUser, null, elideSettings);
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 
     protected RequestScope getUserScope(User user, AuditLogger auditLogger) {
-        return new RequestScope(null, "", new JsonApiDocument(), null, user, null,
+        return new RequestScope(null, NO_VERSION, new JsonApiDocument(), null, user, null,
                 new ElideSettingsBuilder(null)
                     .withEntityDictionary(dictionary)
                     .withAuditLogger(auditLogger)

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -116,7 +116,7 @@ public class PersistenceResourceTestSetup extends PersistentResource {
                 new Child(),
                 null,
                 null, // new request scope + new Child == cannot possibly be a UUID for this object
-                new RequestScope(null, null, null, null, null,
+                new RequestScope(null, "", null, null, null, null,
                         initSettings()
                 )
         );
@@ -143,7 +143,7 @@ public class PersistenceResourceTestSetup extends PersistentResource {
     }
 
     protected RequestScope buildRequestScope(String path, DataStoreTransaction tx, User user, MultivaluedMap<String, String> queryParams) {
-        return new RequestScope(path, null, tx, user, queryParams, elideSettings);
+        return new RequestScope(path, "", null, tx, user, queryParams, elideSettings);
     }
 
     protected <T> PersistentResource<T> bootstrapPersistentResource(T obj) {
@@ -152,12 +152,12 @@ public class PersistenceResourceTestSetup extends PersistentResource {
 
     protected <T> PersistentResource<T> bootstrapPersistentResource(T obj, DataStoreTransaction tx) {
         User goodUser = new TestUser("1");
-        RequestScope requestScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope requestScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 
     protected RequestScope getUserScope(User user, AuditLogger auditLogger) {
-        return new RequestScope(null, new JsonApiDocument(), null, user, null,
+        return new RequestScope(null, "", new JsonApiDocument(), null, user, null,
                 new ElideSettingsBuilder(null)
                     .withEntityDictionary(dictionary)
                     .withAuditLogger(auditLogger)

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -27,7 +28,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
     private final User goodUser;
     PersistentResourceNoopUpdateTest() {
         goodUser = new TestUser("1");
-        goodUserScope = new RequestScope(null, "", null,
+        goodUserScope = new RequestScope(null, NO_VERSION, null,
                 mock(DataStoreTransaction.class), goodUser, null, elideSettings);
         initDictionary();
         reset(goodUserScope.getTransaction());
@@ -40,7 +41,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, NO_VERSION, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
         //We do not want the update to one method to be called when we add the existing entity to the relation
@@ -56,7 +57,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, NO_VERSION, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
         funResource.addRelation("relation3", childResource);
@@ -74,7 +75,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, NO_VERSION, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
         //We do not want the update to one method to be called when we add the existing entity to the relation
@@ -89,7 +90,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, NO_VERSION, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
         funResource.addRelation("relation1", childResource);

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
@@ -27,7 +27,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
     private final User goodUser;
     PersistentResourceNoopUpdateTest() {
         goodUser = new TestUser("1");
-        goodUserScope = new RequestScope(null, null,
+        goodUserScope = new RequestScope(null, "", null,
                 mock(DataStoreTransaction.class), goodUser, null, elideSettings);
         initDictionary();
         reset(goodUserScope.getTransaction());
@@ -40,7 +40,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
         //We do not want the update to one method to be called when we add the existing entity to the relation
@@ -56,7 +56,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
         funResource.addRelation("relation3", childResource);
@@ -74,7 +74,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
         //We do not want the update to one method to be called when we add the existing entity to the relation
@@ -89,7 +89,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
         funResource.addRelation("relation1", childResource);

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -704,7 +704,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         @SuppressWarnings("resource")
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
 
         // null resource in toMany relationship is not valid
         List<Resource> idList = new ArrayList<>();
@@ -2219,7 +2219,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     @Test
     public void testPatchRequestScope() {
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
-        PatchRequestScope parentScope = new PatchRequestScope("/book", tx, new TestUser("1"), elideSettings);
+        PatchRequestScope parentScope = new PatchRequestScope("/book", "", tx, new TestUser("1"), elideSettings);
         PatchRequestScope scope = new PatchRequestScope(
                 parentScope.getPath(), parentScope.getJsonApiDocument(), parentScope);
         // verify wrap works

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -704,7 +705,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         @SuppressWarnings("resource")
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, "", null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, NO_VERSION, null, tx, goodUser, null, elideSettings);
 
         // null resource in toMany relationship is not valid
         List<Resource> idList = new ArrayList<>();
@@ -2219,7 +2220,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     @Test
     public void testPatchRequestScope() {
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
-        PatchRequestScope parentScope = new PatchRequestScope("/book", "", tx, new TestUser("1"), elideSettings);
+        PatchRequestScope parentScope = new PatchRequestScope("/book", NO_VERSION, tx, new TestUser("1"), elideSettings);
         PatchRequestScope scope = new PatchRequestScope(
                 parentScope.getPath(), parentScope.getJsonApiDocument(), parentScope);
         // verify wrap works

--- a/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
@@ -65,7 +65,7 @@ public class RequestScopeTest {
         dictionary.bindEntity(MyBaseClass.class);
         dictionary.bindEntity(MyInheritedClass.class);
 
-        RequestScope requestScope = new RequestScope("/", null, null, null, null,
+        RequestScope requestScope = new RequestScope("/", "", null, null, null, null,
                 new ElideSettingsBuilder(null)
                         .withEntityDictionary(dictionary)
                         .build());

--- a/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
@@ -72,7 +72,7 @@ public class RequestScopeTest {
 
         String myId = "myId";
         // Test that a new inherited class is counted for base type
-        requestScope.setUUIDForObject(dictionary.getJsonAliasFor(MyInheritedClass.class), myId, new MyInheritedClass());
-        assertNotNull(requestScope.getObjectById(dictionary.getJsonAliasFor(MyBaseClass.class), myId));
+        requestScope.setUUIDForObject(MyInheritedClass.class, myId, new MyInheritedClass());
+        assertNotNull(requestScope.getObjectById(MyBaseClass.class, myId));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,7 +66,7 @@ public class RequestScopeTest {
         dictionary.bindEntity(MyBaseClass.class);
         dictionary.bindEntity(MyInheritedClass.class);
 
-        RequestScope requestScope = new RequestScope("/", "", null, null, null, null,
+        RequestScope requestScope = new RequestScope("/", NO_VERSION, null, null, null, null,
                 new ElideSettingsBuilder(null)
                         .withEntityDictionary(dictionary)
                         .build());

--- a/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.core;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.security.User;
@@ -23,7 +24,7 @@ public class TestRequestScope extends RequestScope {
     public TestRequestScope(DataStoreTransaction transaction,
                         User user,
                         EntityDictionary dictionary) {
-        super(null, "", new JsonApiDocument(), transaction, user, null,
+        super(null, NO_VERSION, new JsonApiDocument(), transaction, user, null,
                 new ElideSettingsBuilder(null)
                 .withEntityDictionary(dictionary)
                 .build());
@@ -32,7 +33,7 @@ public class TestRequestScope extends RequestScope {
     public TestRequestScope(EntityDictionary dictionary,
                             String path,
                             MultivaluedMap<String, String> queryParams) {
-        super(path, "", new JsonApiDocument(), null, null, queryParams,
+        super(path, NO_VERSION, new JsonApiDocument(), null, null, queryParams,
                 new ElideSettingsBuilder(null)
                         .withEntityDictionary(dictionary)
                         .build());

--- a/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
@@ -23,7 +23,7 @@ public class TestRequestScope extends RequestScope {
     public TestRequestScope(DataStoreTransaction transaction,
                         User user,
                         EntityDictionary dictionary) {
-        super(null, new JsonApiDocument(), transaction, user, null,
+        super(null, "", new JsonApiDocument(), transaction, user, null,
                 new ElideSettingsBuilder(null)
                 .withEntityDictionary(dictionary)
                 .build());
@@ -32,7 +32,7 @@ public class TestRequestScope extends RequestScope {
     public TestRequestScope(EntityDictionary dictionary,
                             String path,
                             MultivaluedMap<String, String> queryParams) {
-        super(path, new JsonApiDocument(), null, null, queryParams,
+        super(path, "", new JsonApiDocument(), null, null, queryParams,
                 new ElideSettingsBuilder(null)
                         .withEntityDictionary(dictionary)
                         .build());

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
@@ -49,8 +49,8 @@ public class FilterPredicateTest {
         when(entityDictionary.getJsonAliasFor(Book.class)).thenReturn("book");
         when(entityDictionary.getJsonAliasFor(Author.class)).thenReturn("author");
 
-        doReturn(Book.class).when(entityDictionary).getEntityClass("book");
-        doReturn(Author.class).when(entityDictionary).getEntityClass("author");
+        doReturn(Book.class).when(entityDictionary).getEntityClass("book", "");
+        doReturn(Author.class).when(entityDictionary).getEntityClass("author", "");
         doReturn(String.class).when(entityDictionary).getParameterizedType(Book.class, "title");
         doReturn(String.class).when(entityDictionary).getParameterizedType(Book.class, "genre");
         doReturn(Integer.class).when(entityDictionary).getIdType(Book.class);

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
@@ -67,7 +67,7 @@ public class FilterPredicateTest {
 
         Map<String, FilterExpression> expressionMap;
         try {
-            expressionMap = strategy.parseTypedExpression("/book", queryParams);
+            expressionMap = strategy.parseTypedExpression("/book", queryParams, "");
         } catch (ParseException e) {
             throw new InvalidPredicateException(e.getMessage());
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core.filter;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,8 +50,8 @@ public class FilterPredicateTest {
         when(entityDictionary.getJsonAliasFor(Book.class)).thenReturn("book");
         when(entityDictionary.getJsonAliasFor(Author.class)).thenReturn("author");
 
-        doReturn(Book.class).when(entityDictionary).getEntityClass("book", "");
-        doReturn(Author.class).when(entityDictionary).getEntityClass("author", "");
+        doReturn(Book.class).when(entityDictionary).getEntityClass("book", NO_VERSION);
+        doReturn(Author.class).when(entityDictionary).getEntityClass("author", NO_VERSION);
         doReturn(String.class).when(entityDictionary).getParameterizedType(Book.class, "title");
         doReturn(String.class).when(entityDictionary).getParameterizedType(Book.class, "genre");
         doReturn(Integer.class).when(entityDictionary).getIdType(Book.class);
@@ -67,7 +68,7 @@ public class FilterPredicateTest {
 
         Map<String, FilterExpression> expressionMap;
         try {
-            expressionMap = strategy.parseTypedExpression("/book", queryParams, "");
+            expressionMap = strategy.parseTypedExpression("/book", queryParams, NO_VERSION);
         } catch (ParseException e) {
             throw new InvalidPredicateException(e.getMessage());
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -51,7 +51,7 @@ public class DefaultFilterDialectTest {
                 "Hemingway"
         );
 
-        FilterExpression filterExpression = dialect.parseGlobalExpression("/author", queryParams);
+        FilterExpression filterExpression = dialect.parseGlobalExpression("/author", queryParams, "");
 
         assertEquals(
                 "(author.books.title IN [foo, bar, baz] AND author.name INFIX [Hemingway])",
@@ -79,7 +79,7 @@ public class DefaultFilterDialectTest {
                 "Hemingway"
         );
 
-        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, "");
 
         assertEquals(2, expressionMap.size());
         assertEquals(expressionMap.get("book").toString(),
@@ -97,7 +97,7 @@ public class DefaultFilterDialectTest {
                 "foo,bar,baz"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/invalid", queryParams));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/invalid", queryParams, ""));
     }
 
     @Test
@@ -109,7 +109,7 @@ public class DefaultFilterDialectTest {
                 "foo,bar,baz"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/book", queryParams));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/book", queryParams, ""));
     }
 
     @Test
@@ -122,7 +122,7 @@ public class DefaultFilterDialectTest {
                 "foo,bar,baz"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams, ""));
     }
 
     @Test
@@ -135,6 +135,6 @@ public class DefaultFilterDialectTest {
         );
 
         assertThrows(ParseException.class,
-                () -> dialect.parseTypedExpression("/book", queryParams));
+                () -> dialect.parseTypedExpression("/book", queryParams, ""));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core.filter.dialect;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -51,7 +52,7 @@ public class DefaultFilterDialectTest {
                 "Hemingway"
         );
 
-        FilterExpression filterExpression = dialect.parseGlobalExpression("/author", queryParams, "");
+        FilterExpression filterExpression = dialect.parseGlobalExpression("/author", queryParams, NO_VERSION);
 
         assertEquals(
                 "(author.books.title IN [foo, bar, baz] AND author.name INFIX [Hemingway])",
@@ -79,7 +80,7 @@ public class DefaultFilterDialectTest {
                 "Hemingway"
         );
 
-        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, "");
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, NO_VERSION);
 
         assertEquals(2, expressionMap.size());
         assertEquals(expressionMap.get("book").toString(),
@@ -97,7 +98,7 @@ public class DefaultFilterDialectTest {
                 "foo,bar,baz"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/invalid", queryParams, ""));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/invalid", queryParams, NO_VERSION));
     }
 
     @Test
@@ -109,7 +110,7 @@ public class DefaultFilterDialectTest {
                 "foo,bar,baz"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/book", queryParams, ""));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/book", queryParams, NO_VERSION));
     }
 
     @Test
@@ -122,7 +123,7 @@ public class DefaultFilterDialectTest {
                 "foo,bar,baz"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams, ""));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams, NO_VERSION));
     }
 
     @Test
@@ -135,6 +136,6 @@ public class DefaultFilterDialectTest {
         );
 
         assertThrows(ParseException.class,
-                () -> dialect.parseTypedExpression("/book", queryParams, ""));
+                () -> dialect.parseTypedExpression("/book", queryParams, NO_VERSION));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialectTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core.filter.dialect;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -53,13 +54,13 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseGlobalExpression("/author", queryParams, "")).thenThrow(new ParseException(""));
-        when(dialect2.parseGlobalExpression("/author", queryParams, "")).thenReturn(filterExpression);
+        when(dialect1.parseGlobalExpression("/author", queryParams, NO_VERSION)).thenThrow(new ParseException(""));
+        when(dialect2.parseGlobalExpression("/author", queryParams, NO_VERSION)).thenReturn(filterExpression);
 
-        FilterExpression returnExpression = dialect.parseGlobalExpression("/author", queryParams, "");
+        FilterExpression returnExpression = dialect.parseGlobalExpression("/author", queryParams, NO_VERSION);
 
-        verify(dialect1, times(1)).parseGlobalExpression("/author", queryParams, "");
-        verify(dialect2, times(1)).parseGlobalExpression("/author", queryParams, "");
+        verify(dialect1, times(1)).parseGlobalExpression("/author", queryParams, NO_VERSION);
+        verify(dialect2, times(1)).parseGlobalExpression("/author", queryParams, NO_VERSION);
 
         assertEquals(returnExpression, filterExpression);
     }
@@ -90,13 +91,13 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseTypedExpression("/author", queryParams, "")).thenThrow(new ParseException(""));
-        when(dialect2.parseTypedExpression("/author", queryParams, "")).thenReturn(expressionMap);
+        when(dialect1.parseTypedExpression("/author", queryParams, NO_VERSION)).thenThrow(new ParseException(""));
+        when(dialect2.parseTypedExpression("/author", queryParams, NO_VERSION)).thenReturn(expressionMap);
 
-        Map<String, FilterExpression> returnMap = dialect.parseTypedExpression("/author", queryParams, "");
+        Map<String, FilterExpression> returnMap = dialect.parseTypedExpression("/author", queryParams, NO_VERSION);
 
-        verify(dialect1, times(1)).parseTypedExpression("/author", queryParams, "");
-        verify(dialect2, times(1)).parseTypedExpression("/author", queryParams, "");
+        verify(dialect1, times(1)).parseTypedExpression("/author", queryParams, NO_VERSION);
+        verify(dialect2, times(1)).parseTypedExpression("/author", queryParams, NO_VERSION);
 
         assertEquals(returnMap, expressionMap);
     }
@@ -124,7 +125,7 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams, ""));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams, NO_VERSION));
     }
 
     /**
@@ -150,7 +151,7 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseGlobalExpression("/author", queryParams, ""));
+        assertThrows(ParseException.class, () -> dialect.parseGlobalExpression("/author", queryParams, NO_VERSION));
     }
 
     /**
@@ -178,11 +179,11 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseGlobalExpression("/author", queryParams, "")).thenThrow(new ParseException("one"));
-        when(dialect2.parseGlobalExpression("/author", queryParams, "")).thenThrow(new ParseException("two"));
+        when(dialect1.parseGlobalExpression("/author", queryParams, NO_VERSION)).thenThrow(new ParseException("one"));
+        when(dialect2.parseGlobalExpression("/author", queryParams, NO_VERSION)).thenThrow(new ParseException("two"));
 
         try {
-            dialect.parseGlobalExpression("/author", queryParams, "");
+            dialect.parseGlobalExpression("/author", queryParams, NO_VERSION);
         } catch (ParseException e) {
             assertEquals("two\none", e.getMessage());
         }
@@ -213,11 +214,11 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseTypedExpression("/author", queryParams, "")).thenThrow(new ParseException("one"));
-        when(dialect2.parseTypedExpression("/author", queryParams, "")).thenThrow(new ParseException("two"));
+        when(dialect1.parseTypedExpression("/author", queryParams, NO_VERSION)).thenThrow(new ParseException("one"));
+        when(dialect2.parseTypedExpression("/author", queryParams, NO_VERSION)).thenThrow(new ParseException("two"));
 
         try {
-            dialect.parseTypedExpression("/author", queryParams, "");
+            dialect.parseTypedExpression("/author", queryParams, NO_VERSION);
         } catch (ParseException e) {
             assertEquals("two\none", e.getMessage());
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialectTest.java
@@ -53,13 +53,13 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseGlobalExpression("/author", queryParams)).thenThrow(new ParseException(""));
-        when(dialect2.parseGlobalExpression("/author", queryParams)).thenReturn(filterExpression);
+        when(dialect1.parseGlobalExpression("/author", queryParams, "")).thenThrow(new ParseException(""));
+        when(dialect2.parseGlobalExpression("/author", queryParams, "")).thenReturn(filterExpression);
 
-        FilterExpression returnExpression = dialect.parseGlobalExpression("/author", queryParams);
+        FilterExpression returnExpression = dialect.parseGlobalExpression("/author", queryParams, "");
 
-        verify(dialect1, times(1)).parseGlobalExpression("/author", queryParams);
-        verify(dialect2, times(1)).parseGlobalExpression("/author", queryParams);
+        verify(dialect1, times(1)).parseGlobalExpression("/author", queryParams, "");
+        verify(dialect2, times(1)).parseGlobalExpression("/author", queryParams, "");
 
         assertEquals(returnExpression, filterExpression);
     }
@@ -90,13 +90,13 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseTypedExpression("/author", queryParams)).thenThrow(new ParseException(""));
-        when(dialect2.parseTypedExpression("/author", queryParams)).thenReturn(expressionMap);
+        when(dialect1.parseTypedExpression("/author", queryParams, "")).thenThrow(new ParseException(""));
+        when(dialect2.parseTypedExpression("/author", queryParams, "")).thenReturn(expressionMap);
 
-        Map<String, FilterExpression> returnMap = dialect.parseTypedExpression("/author", queryParams);
+        Map<String, FilterExpression> returnMap = dialect.parseTypedExpression("/author", queryParams, "");
 
-        verify(dialect1, times(1)).parseTypedExpression("/author", queryParams);
-        verify(dialect2, times(1)).parseTypedExpression("/author", queryParams);
+        verify(dialect1, times(1)).parseTypedExpression("/author", queryParams, "");
+        verify(dialect2, times(1)).parseTypedExpression("/author", queryParams, "");
 
         assertEquals(returnMap, expressionMap);
     }
@@ -124,7 +124,7 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams));
+        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams, ""));
     }
 
     /**
@@ -150,7 +150,7 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseGlobalExpression("/author", queryParams));
+        assertThrows(ParseException.class, () -> dialect.parseGlobalExpression("/author", queryParams, ""));
     }
 
     /**
@@ -178,11 +178,11 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseGlobalExpression("/author", queryParams)).thenThrow(new ParseException("one"));
-        when(dialect2.parseGlobalExpression("/author", queryParams)).thenThrow(new ParseException("two"));
+        when(dialect1.parseGlobalExpression("/author", queryParams, "")).thenThrow(new ParseException("one"));
+        when(dialect2.parseGlobalExpression("/author", queryParams, "")).thenThrow(new ParseException("two"));
 
         try {
-            dialect.parseGlobalExpression("/author", queryParams);
+            dialect.parseGlobalExpression("/author", queryParams, "");
         } catch (ParseException e) {
             assertEquals("two\none", e.getMessage());
         }
@@ -213,11 +213,11 @@ public class MultipleFilterDialectTest {
                 "Hemingway"
         );
 
-        when(dialect1.parseTypedExpression("/author", queryParams)).thenThrow(new ParseException("one"));
-        when(dialect2.parseTypedExpression("/author", queryParams)).thenThrow(new ParseException("two"));
+        when(dialect1.parseTypedExpression("/author", queryParams, "")).thenThrow(new ParseException("one"));
+        when(dialect2.parseTypedExpression("/author", queryParams, "")).thenThrow(new ParseException("two"));
 
         try {
-            dialect.parseTypedExpression("/author", queryParams);
+            dialect.parseTypedExpression("/author", queryParams, "");
         } catch (ParseException e) {
             assertEquals("two\none", e.getMessage());
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core.filter.dialect;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -53,7 +54,7 @@ public class RSQLFilterDialectTest {
                 "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
         );
 
-        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, "");
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, NO_VERSION);
 
         assertEquals(1, expressionMap.size());
         assertEquals(
@@ -72,7 +73,7 @@ public class RSQLFilterDialectTest {
                 "title==*foo*;authors.name==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals(
                 "(book.title INFIX_CASE_INSENSITIVE [foo] AND book.authors.name IN_INSENSITIVE [Hemingway])",
@@ -89,7 +90,7 @@ public class RSQLFilterDialectTest {
                 "title==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title IN_INSENSITIVE [Hemingway]", expression.toString());
     }
@@ -103,7 +104,7 @@ public class RSQLFilterDialectTest {
                 "title!=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("NOT (book.title IN_INSENSITIVE [Hemingway])", expression.toString());
     }
@@ -117,7 +118,7 @@ public class RSQLFilterDialectTest {
                 "title=in=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title IN_INSENSITIVE [Hemingway]", expression.toString());
     }
@@ -131,7 +132,7 @@ public class RSQLFilterDialectTest {
                 "title=out=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("NOT (book.title IN_INSENSITIVE [Hemingway])", expression.toString());
     }
@@ -147,7 +148,7 @@ public class RSQLFilterDialectTest {
 
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals(
                 "((((book.publishDate GT [5] OR book.publishDate GE [5]) "
@@ -167,7 +168,7 @@ public class RSQLFilterDialectTest {
                 "title==*Hemingway*,title==*Hemingway,title==Hemingway*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals(
                 "((book.title INFIX_CASE_INSENSITIVE [Hemingway] "
@@ -186,7 +187,7 @@ public class RSQLFilterDialectTest {
                 "title==foo;(title==bar;title==baz)"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals(
                 "(book.title IN_INSENSITIVE [foo] AND (book.title IN_INSENSITIVE [bar] "
@@ -204,7 +205,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=true"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -218,7 +219,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -232,7 +233,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=false"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }
@@ -246,7 +247,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=0"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }
@@ -276,7 +277,7 @@ public class RSQLFilterDialectTest {
                 "id==1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/job", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/job", queryParams, NO_VERSION);
 
         assertEquals("job.jobId IN [1]", expression.toString());
     }
@@ -290,7 +291,7 @@ public class RSQLFilterDialectTest {
                 "id==*identifier*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/stringForId", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/stringForId", queryParams, NO_VERSION);
 
         assertEquals("stringId.surrogateKey INFIX_CASE_INSENSITIVE [identifier]", expression.toString());
     }
@@ -304,7 +305,7 @@ public class RSQLFilterDialectTest {
                 "id==*1*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/primitiveTypeId", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/primitiveTypeId", queryParams, NO_VERSION);
 
         assertEquals(expression.toString(),
                 "primitiveId.primitiveId INFIX_CASE_INSENSITIVE [1]"
@@ -322,7 +323,7 @@ public class RSQLFilterDialectTest {
                 "title=isempty=true"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title ISEMPTY []", expression.toString());
     }
@@ -336,7 +337,7 @@ public class RSQLFilterDialectTest {
                 "authors=isempty=1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.authors ISEMPTY []", expression.toString());
     }
@@ -350,7 +351,7 @@ public class RSQLFilterDialectTest {
                 "authors=isempty=false"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.authors NOTEMPTY []", expression.toString());
     }
@@ -364,7 +365,7 @@ public class RSQLFilterDialectTest {
                 "title=isempty=0"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title NOTEMPTY []", expression.toString());
     }
@@ -379,6 +380,6 @@ public class RSQLFilterDialectTest {
         );
 
         assertThrows(ParseException.class,
-                () -> dialect.parseTypedExpression("/book", queryParams, ""));
+                () -> dialect.parseTypedExpression("/book", queryParams, NO_VERSION));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -53,7 +53,7 @@ public class RSQLFilterDialectTest {
                 "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
         );
 
-        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, "");
 
         assertEquals(1, expressionMap.size());
         assertEquals(
@@ -72,7 +72,7 @@ public class RSQLFilterDialectTest {
                 "title==*foo*;authors.name==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals(
                 "(book.title INFIX_CASE_INSENSITIVE [foo] AND book.authors.name IN_INSENSITIVE [Hemingway])",
@@ -89,7 +89,7 @@ public class RSQLFilterDialectTest {
                 "title==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title IN_INSENSITIVE [Hemingway]", expression.toString());
     }
@@ -103,7 +103,7 @@ public class RSQLFilterDialectTest {
                 "title!=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("NOT (book.title IN_INSENSITIVE [Hemingway])", expression.toString());
     }
@@ -117,7 +117,7 @@ public class RSQLFilterDialectTest {
                 "title=in=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title IN_INSENSITIVE [Hemingway]", expression.toString());
     }
@@ -131,7 +131,7 @@ public class RSQLFilterDialectTest {
                 "title=out=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("NOT (book.title IN_INSENSITIVE [Hemingway])", expression.toString());
     }
@@ -147,7 +147,7 @@ public class RSQLFilterDialectTest {
 
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals(
                 "((((book.publishDate GT [5] OR book.publishDate GE [5]) "
@@ -167,7 +167,7 @@ public class RSQLFilterDialectTest {
                 "title==*Hemingway*,title==*Hemingway,title==Hemingway*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals(
                 "((book.title INFIX_CASE_INSENSITIVE [Hemingway] "
@@ -186,7 +186,7 @@ public class RSQLFilterDialectTest {
                 "title==foo;(title==bar;title==baz)"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals(
                 "(book.title IN_INSENSITIVE [foo] AND (book.title IN_INSENSITIVE [bar] "
@@ -204,7 +204,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=true"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -218,7 +218,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -232,7 +232,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=false"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }
@@ -246,7 +246,7 @@ public class RSQLFilterDialectTest {
                 "title=isnull=0"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }
@@ -276,7 +276,7 @@ public class RSQLFilterDialectTest {
                 "id==1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/job", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/job", queryParams, "");
 
         assertEquals("job.jobId IN [1]", expression.toString());
     }
@@ -290,7 +290,7 @@ public class RSQLFilterDialectTest {
                 "id==*identifier*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/stringForId", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/stringForId", queryParams, "");
 
         assertEquals("stringId.surrogateKey INFIX_CASE_INSENSITIVE [identifier]", expression.toString());
     }
@@ -304,7 +304,7 @@ public class RSQLFilterDialectTest {
                 "id==*1*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/primitiveTypeId", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/primitiveTypeId", queryParams, "");
 
         assertEquals(expression.toString(),
                 "primitiveId.primitiveId INFIX_CASE_INSENSITIVE [1]"
@@ -322,7 +322,7 @@ public class RSQLFilterDialectTest {
                 "title=isempty=true"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title ISEMPTY []", expression.toString());
     }
@@ -336,7 +336,7 @@ public class RSQLFilterDialectTest {
                 "authors=isempty=1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.authors ISEMPTY []", expression.toString());
     }
@@ -350,7 +350,7 @@ public class RSQLFilterDialectTest {
                 "authors=isempty=false"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.authors NOTEMPTY []", expression.toString());
     }
@@ -364,7 +364,7 @@ public class RSQLFilterDialectTest {
                 "title=isempty=0"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title NOTEMPTY []", expression.toString());
     }
@@ -379,6 +379,6 @@ public class RSQLFilterDialectTest {
         );
 
         assertThrows(ParseException.class,
-                () -> dialect.parseTypedExpression("/book", queryParams));
+                () -> dialect.parseTypedExpression("/book", queryParams, ""));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core.filter.dialect;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.core.EntityDictionary;
@@ -44,7 +45,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
         );
 
-        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, "");
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, NO_VERSION);
 
         assertEquals(1, expressionMap.size());
         assertEquals(
@@ -63,7 +64,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==*foo*;authors.name==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("(book.title INFIX [foo] AND book.authors.name IN [Hemingway])", expression.toString());
     }
@@ -77,7 +78,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title IN [Hemingway]", expression.toString());
     }
@@ -91,7 +92,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title!=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("NOT (book.title IN [Hemingway])", expression.toString());
     }
@@ -105,7 +106,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=in=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title IN [Hemingway]", expression.toString());
     }
@@ -119,7 +120,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=out=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("NOT (book.title IN [Hemingway])", expression.toString());
     }
@@ -135,7 +136,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals(
                 "((((book.publishDate GT [5] OR book.publishDate GE [5]) "
@@ -155,7 +156,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==*Hemingway*,title==*Hemingway,title==Hemingway*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals(
                 "((book.title INFIX [Hemingway] OR book.title POSTFIX [Hemingway]) OR book.title PREFIX [Hemingway])",
@@ -172,7 +173,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==foo;(title==bar;title==baz)"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("(book.title IN [foo] AND (book.title IN [bar] AND book.title IN [baz]))", expression.toString());
     }
@@ -186,7 +187,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=true"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -200,7 +201,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -214,7 +215,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=false"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }
@@ -228,7 +229,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=0"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithColumnCollationStrategyTest.java
@@ -44,7 +44,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
         );
 
-        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, "");
 
         assertEquals(1, expressionMap.size());
         assertEquals(
@@ -63,7 +63,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==*foo*;authors.name==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("(book.title INFIX [foo] AND book.authors.name IN [Hemingway])", expression.toString());
     }
@@ -77,7 +77,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title IN [Hemingway]", expression.toString());
     }
@@ -91,7 +91,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title!=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("NOT (book.title IN [Hemingway])", expression.toString());
     }
@@ -105,7 +105,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=in=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title IN [Hemingway]", expression.toString());
     }
@@ -119,7 +119,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=out=Hemingway"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("NOT (book.title IN [Hemingway])", expression.toString());
     }
@@ -135,7 +135,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals(
                 "((((book.publishDate GT [5] OR book.publishDate GE [5]) "
@@ -155,7 +155,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==*Hemingway*,title==*Hemingway,title==Hemingway*"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals(
                 "((book.title INFIX [Hemingway] OR book.title POSTFIX [Hemingway]) OR book.title PREFIX [Hemingway])",
@@ -172,7 +172,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title==foo;(title==bar;title==baz)"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("(book.title IN [foo] AND (book.title IN [bar] AND book.title IN [baz]))", expression.toString());
     }
@@ -186,7 +186,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=true"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -200,7 +200,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=1"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title ISNULL []", expression.toString());
     }
@@ -214,7 +214,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=false"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }
@@ -228,7 +228,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
                 "title=isnull=0"
         );
 
-        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams);
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, "");
 
         assertEquals("book.title NOTNULL []", expression.toString());
     }

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -230,7 +230,7 @@ public class PermissionToFilterExpressionVisitorTest {
     //
     public RequestScope newRequestScope() {
         User john = new TestUser("John");
-        return requestScope = new RequestScope(null, null, null, john, null, elideSettings);
+        return requestScope = new RequestScope(null, "", null, null, john, null, elideSettings);
     }
 
     private FilterExpression filterExpressionForPermissions(String permission) {

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.parsers.expression;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.FALSE_USER_CHECK_EXPRESSION;
 import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.NO_EVALUATION_EXPRESSION;
 import static com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor.TRUE_USER_CHECK_EXPRESSION;
@@ -230,7 +231,7 @@ public class PermissionToFilterExpressionVisitorTest {
     //
     public RequestScope newRequestScope() {
         User john = new TestUser("John");
-        return requestScope = new RequestScope(null, "", null, null, john, null, elideSettings);
+        return requestScope = new RequestScope(null, NO_VERSION, null, null, john, null, elideSettings);
     }
 
     private FilterExpression filterExpressionForPermissions(String permission) {

--- a/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.security;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -448,7 +449,7 @@ public class PermissionExecutorTest {
     public <T> PersistentResource<T> newResource(T obj, Class<T> cls, boolean markNew) {
         EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(cls);
-        RequestScope requestScope = new RequestScope(null, "", null, null, null, null, getElideSettings(dictionary));
+        RequestScope requestScope = new RequestScope(null, NO_VERSION, null, null, null, null, getElideSettings(dictionary));
         PersistentResource resource = new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
         if (markNew) {
             requestScope.getNewPersistentResources().add(resource);

--- a/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
@@ -448,7 +448,7 @@ public class PermissionExecutorTest {
     public <T> PersistentResource<T> newResource(T obj, Class<T> cls, boolean markNew) {
         EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(cls);
-        RequestScope requestScope = new RequestScope(null, null, null, null, null, getElideSettings(dictionary));
+        RequestScope requestScope = new RequestScope(null, "", null, null, null, null, getElideSettings(dictionary));
         PersistentResource resource = new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
         if (markNew) {
             requestScope.getNewPersistentResources().add(resource);

--- a/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
@@ -128,7 +128,7 @@ public class PermissionExpressionBuilderTest {
      }
 
     public <T> PersistentResource newResource(T obj, Class<T> cls) {
-        RequestScope requestScope = new RequestScope(null, null, null, null, null, elideSettings);
+        RequestScope requestScope = new RequestScope(null, "", null, null, null, null, elideSettings);
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.security.permissions;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.ElideSettings;
@@ -128,7 +129,7 @@ public class PermissionExpressionBuilderTest {
      }
 
     public <T> PersistentResource newResource(T obj, Class<T> cls) {
-        RequestScope requestScope = new RequestScope(null, "", null, null, null, null, elideSettings);
+        RequestScope requestScope = new RequestScope(null, NO_VERSION, null, null, null, null, elideSettings);
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
@@ -53,7 +53,7 @@ public class AggregationDataStore implements DataStore {
         for (Table table : queryEngine.getMetaDataStore().getMetaData(Table.class)) {
             for (TimeDimension timeDim : table.getColumns(TimeDimension.class)) {
                 dictionary.addArgumentToAttribute(
-                        dictionary.getEntityClass(table.getId(), table.getVersion()),
+                        dictionary.getEntityClass(table.getName(), table.getVersion()),
                         timeDim.getName(),
                         new ArgumentType("grain", String.class));
             }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
@@ -53,7 +53,7 @@ public class AggregationDataStore implements DataStore {
         for (Table table : queryEngine.getMetaDataStore().getMetaData(Table.class)) {
             for (TimeDimension timeDim : table.getColumns(TimeDimension.class)) {
                 dictionary.addArgumentToAttribute(
-                        dictionary.getEntityClass(table.getId()),
+                        dictionary.getEntityClass(table.getId(), table.getVersion()),
                         timeDim.getName(),
                         new ArgumentType("grain", String.class));
             }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
@@ -72,7 +72,7 @@ public class QueryValidator {
             Class<?> cls = last.getType();
             String fieldName = last.getFieldName();
 
-            Class<?> tableClass = dictionary.getEntityClass(queriedTable.getId(), queriedTable.getVersion());
+            Class<?> tableClass = dictionary.getEntityClass(queriedTable.getName(), queriedTable.getVersion());
 
             if (cls != tableClass) {
                 throw new InvalidOperationException(

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
@@ -72,7 +72,7 @@ public class QueryValidator {
             Class<?> cls = last.getType();
             String fieldName = last.getFieldName();
 
-            Class<?> tableClass = dictionary.getEntityClass(queriedTable.getId());
+            Class<?> tableClass = dictionary.getEntityClass(queriedTable.getId(), queriedTable.getVersion());
 
             if (cls != tableClass) {
                 throw new InvalidOperationException(

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/FormulaValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/FormulaValidator.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 
 import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
@@ -71,7 +72,8 @@ public class FormulaValidator extends ColumnVisitor<Void> {
             throw new IllegalArgumentException(referenceLoopMessage(visited, dimension));
         }
 
-        Class<?> tableClass = dictionary.getEntityClass(dimension.getTable().getId());
+        Table table = dimension.getTable();
+        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
 
         JoinPath joinToPath = new JoinPath(
                 tableClass,
@@ -96,7 +98,8 @@ public class FormulaValidator extends ColumnVisitor<Void> {
             throw new IllegalArgumentException(referenceLoopMessage(visited, column));
         }
 
-        Class<?> tableClass = dictionary.getEntityClass(column.getTable().getId());
+        Table table = column.getTable();
+        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
 
         visited.add(column);
         for (String reference : resolveFormulaReferences(column.getExpression())) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/FormulaValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/FormulaValidator.java
@@ -73,7 +73,7 @@ public class FormulaValidator extends ColumnVisitor<Void> {
         }
 
         Table table = dimension.getTable();
-        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
 
         JoinPath joinToPath = new JoinPath(
                 tableClass,
@@ -99,7 +99,7 @@ public class FormulaValidator extends ColumnVisitor<Void> {
         }
 
         Table table = column.getTable();
-        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
 
         visited.add(column);
         for (String reference : resolveFormulaReferences(column.getExpression())) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -85,7 +85,7 @@ public class MetaDataStore extends HashMapDataStore {
      * @param table table metadata
      */
     public void addTable(Table table) {
-        tables.put(dictionary.getEntityClass(table.getId()), table);
+        tables.put(dictionary.getEntityClass(table.getId(), table.getVersion()), table);
         addMetaData(table);
         table.getColumns().forEach(this::addColumn);
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -68,10 +68,9 @@ public class MetaDataStore extends HashMapDataStore {
         // bind meta data models to dictionary
         ClassScanner.getAllClasses(Table.class.getPackage().getName()).forEach(dictionary::bindEntity);
 
-        // bind external data models in the package.  Versioned models are not currently supported.
-        this.modelsToBind = modelsToBind.stream()
-                .filter(model -> EntityDictionary.getModelVersion(model).equals(""))
-                .collect(Collectors.toSet());
+        // bind external data models in the package.
+        this.modelsToBind = modelsToBind;
+
         this.modelsToBind.forEach(cls -> dictionary.bindEntity(cls, Collections.singleton(Join.class)));
     }
 
@@ -87,7 +86,7 @@ public class MetaDataStore extends HashMapDataStore {
      * @param table table metadata
      */
     public void addTable(Table table) {
-        tables.put(dictionary.getEntityClass(table.getId(), table.getVersion()), table);
+        tables.put(dictionary.getEntityClass(table.getName(), table.getVersion()), table);
         addMetaData(table);
         table.getColumns().forEach(this::addColumn);
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -68,8 +68,10 @@ public class MetaDataStore extends HashMapDataStore {
         // bind meta data models to dictionary
         ClassScanner.getAllClasses(Table.class.getPackage().getName()).forEach(dictionary::bindEntity);
 
-        // bind external data models in the package
-        this.modelsToBind = modelsToBind;
+        // bind external data models in the package.  Versioned models are not currently supported.
+        this.modelsToBind = modelsToBind.stream()
+                .filter(model -> EntityDictionary.getModelVersion(model).equals(""))
+                .collect(Collectors.toSet());
         this.modelsToBind.forEach(cls -> dictionary.bindEntity(cls, Collections.singleton(Join.class)));
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -62,7 +62,7 @@ public abstract class Column {
 
     protected Column(Table table, String fieldName, EntityDictionary dictionary) {
         this.table = table;
-        Class<?> tableClass = dictionary.getEntityClass(table.getId());
+        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
 
         this.id = constructColumnName(tableClass, fieldName, dictionary);
         this.name = fieldName;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -62,7 +62,7 @@ public abstract class Column {
 
     protected Column(Table table, String fieldName, EntityDictionary dictionary) {
         this.table = table;
-        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
 
         this.id = constructColumnName(tableClass, fieldName, dictionary);
         this.name = fieldName;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Metric.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Metric.java
@@ -35,7 +35,7 @@ public class Metric extends Column {
 
     public Metric(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);
-        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
 
         MetricAggregation aggregation = dictionary.getAttributeOrRelationAnnotation(
                 tableClass,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Metric.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Metric.java
@@ -35,7 +35,7 @@ public class Metric extends Column {
 
     public Metric(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);
-        Class<?> tableClass = dictionary.getEntityClass(table.getId());
+        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
 
         MetricAggregation aggregation = dictionary.getAttributeOrRelationAnnotation(
                 tableClass,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -77,8 +77,14 @@ public class Table {
                     String.format("Table class {%s} is not defined in dictionary.", cls));
         }
 
-        this.id = dictionary.getJsonAliasFor(cls);
+        this.name = dictionary.getJsonAliasFor(cls);
+        this.id = this.name;
         this.version = EntityDictionary.getModelVersion(cls);
+
+        if (this.version != null && ! this.version.isEmpty()) {
+            this.id = this.name + "." + this.version;
+        }
+
         this.tableTags = new HashSet<>();
 
         this.columns = constructColumns(cls, dictionary);
@@ -99,7 +105,6 @@ public class Table {
 
         Meta meta = cls.getAnnotation(Meta.class);
         if (meta != null) {
-            this.name = meta.longName();
             this.description = meta.description();
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -39,6 +39,9 @@ public class Table {
 
     private String name;
 
+    @Exclude
+    private String version;
+
     private String description;
 
     private String category;
@@ -75,6 +78,7 @@ public class Table {
         }
 
         this.id = dictionary.getJsonAliasFor(cls);
+        this.version = EntityDictionary.getModelVersion(cls);
         this.tableTags = new HashSet<>();
 
         this.columns = constructColumns(cls, dictionary);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
@@ -38,7 +38,7 @@ public class TimeDimension extends Dimension {
         super(table, fieldName, dictionary);
 
         Temporal temporal = dictionary.getAttributeOrRelationAnnotation(
-                dictionary.getEntityClass(table.getId(), table.getVersion()),
+                dictionary.getEntityClass(table.getName(), table.getVersion()),
                 Temporal.class,
                 fieldName);
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
@@ -38,7 +38,7 @@ public class TimeDimension extends Dimension {
         super(table, fieldName, dictionary);
 
         Temporal temporal = dictionary.getAttributeOrRelationAnnotation(
-                dictionary.getEntityClass(table.getId()),
+                dictionary.getEntityClass(table.getId(), table.getVersion()),
                 Temporal.class,
                 fieldName);
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.datastores.aggregation.QueryEngine;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
@@ -151,7 +152,8 @@ public abstract class AbstractEntityHydrator {
      * @return A hydrated entity object.
      */
     protected Object coerceObjectToEntity(Map<String, Object> result, MutableInt counter) {
-        Class<?> entityClass = entityDictionary.getEntityClass(query.getTable().getId());
+        Table table = query.getTable();
+        Class<?> entityClass = entityDictionary.getEntityClass(table.getId(), table.getVersion());
 
         //Construct the object.
         Object entityInstance;
@@ -193,8 +195,9 @@ public abstract class AbstractEntityHydrator {
         for (Map.Entry<String, List<Object>> entry : hydrationIdsByRelationship.entrySet()) {
             String joinField = entry.getKey();
             List<Object> joinFieldIds = entry.getValue();
+            Table table = getQuery().getTable();
             Class<?> relationshipType = getEntityDictionary().getParameterizedType(
-                    entityDictionary.getEntityClass(getQuery().getTable().getId()),
+                    entityDictionary.getEntityClass(table.getId(), table.getVersion()),
                     joinField);
 
             getStitchList().populateLookup(relationshipType, getRelationshipValues(relationshipType, joinFieldIds));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
@@ -153,7 +153,7 @@ public abstract class AbstractEntityHydrator {
      */
     protected Object coerceObjectToEntity(Map<String, Object> result, MutableInt counter) {
         Table table = query.getTable();
-        Class<?> entityClass = entityDictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> entityClass = entityDictionary.getEntityClass(table.getName(), table.getVersion());
 
         //Construct the object.
         Object entityInstance;
@@ -197,7 +197,7 @@ public abstract class AbstractEntityHydrator {
             List<Object> joinFieldIds = entry.getValue();
             Table table = getQuery().getTable();
             Class<?> relationshipType = getEntityDictionary().getParameterizedType(
-                    entityDictionary.getEntityClass(table.getId(), table.getVersion()),
+                    entityDictionary.getEntityClass(table.getName(), table.getVersion()),
                     joinField);
 
             getStitchList().populateLookup(relationshipType, getRelationshipValues(relationshipType, joinFieldIds));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoinVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoinVisitor.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -101,8 +102,9 @@ public class SQLJoinVisitor extends ColumnVisitor<Set<JoinPath>> {
     private Set<JoinPath> visitJoinToReference(Column column, String joinToPath) {
         Set<JoinPath> joinPaths = new HashSet<>();
 
+        Table table = column.getTable();
         JoinPath joinPath = froms.empty()
-                ? new JoinPath(dictionary.getEntityClass(column.getTable().getId()), dictionary, joinToPath)
+                ? new JoinPath(dictionary.getEntityClass(table.getId(), table.getVersion()), dictionary, joinToPath)
                 : froms.peek().extend(joinToPath, dictionary);
         joinPaths.add(joinPath);
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoinVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoinVisitor.java
@@ -104,7 +104,7 @@ public class SQLJoinVisitor extends ColumnVisitor<Set<JoinPath>> {
 
         Table table = column.getTable();
         JoinPath joinPath = froms.empty()
-                ? new JoinPath(dictionary.getEntityClass(table.getId(), table.getVersion()), dictionary, joinToPath)
+                ? new JoinPath(dictionary.getEntityClass(table.getName(), table.getVersion()), dictionary, joinToPath)
                 : froms.peek().extend(joinToPath, dictionary);
         joinPaths.add(joinPath);
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -47,7 +47,7 @@ public class SQLReferenceTable {
      * @return resolved reference
      */
     public String getResolvedReference(Table table, String fieldName) {
-        return resolvedReferences.get(dictionary.getEntityClass(table.getId())).get(fieldName);
+        return resolvedReferences.get(dictionary.getEntityClass(table.getId(), table.getVersion())).get(fieldName);
     }
 
     /**
@@ -58,7 +58,7 @@ public class SQLReferenceTable {
      * @return resolved reference
      */
     public Set<JoinPath> getResolvedJoinPaths(Table table, String fieldName) {
-        return resolvedJoinPaths.get(dictionary.getEntityClass(table.getId())).get(fieldName);
+        return resolvedJoinPaths.get(dictionary.getEntityClass(table.getId(), table.getVersion())).get(fieldName);
     }
 
     /**
@@ -67,7 +67,7 @@ public class SQLReferenceTable {
      * @param table meta data table
      */
     private void resolveAndStoreAllReferencesAndJoins(Table table) {
-        Class<?> tableClass = dictionary.getEntityClass(table.getId());
+        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
         if (!resolvedReferences.containsKey(tableClass)) {
             resolvedReferences.put(tableClass, new HashMap<>());
         }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -47,7 +47,7 @@ public class SQLReferenceTable {
      * @return resolved reference
      */
     public String getResolvedReference(Table table, String fieldName) {
-        return resolvedReferences.get(dictionary.getEntityClass(table.getId(), table.getVersion())).get(fieldName);
+        return resolvedReferences.get(dictionary.getEntityClass(table.getName(), table.getVersion())).get(fieldName);
     }
 
     /**
@@ -58,7 +58,7 @@ public class SQLReferenceTable {
      * @return resolved reference
      */
     public Set<JoinPath> getResolvedJoinPaths(Table table, String fieldName) {
-        return resolvedJoinPaths.get(dictionary.getEntityClass(table.getId(), table.getVersion())).get(fieldName);
+        return resolvedJoinPaths.get(dictionary.getEntityClass(table.getName(), table.getVersion())).get(fieldName);
     }
 
     /**
@@ -67,7 +67,7 @@ public class SQLReferenceTable {
      * @param table meta data table
      */
     private void resolveAndStoreAllReferencesAndJoins(Table table) {
-        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
         if (!resolvedReferences.containsKey(tableClass)) {
             resolvedReferences.put(tableClass, new HashMap<>());
         }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceVisitor.java
@@ -55,7 +55,7 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
                 getFieldAlias(
                         tableAliases.peek(),
                         dictionary.getAnnotatedColumnName(
-                                dictionary.getEntityClass(table.getId(), table.getVersion()),
+                                dictionary.getEntityClass(table.getName(), table.getVersion()),
                                 metric.getName())));
     }
 
@@ -76,7 +76,7 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
         return getFieldAlias(
                 tableAliases.peek(),
                 dictionary.getAnnotatedColumnName(
-                        dictionary.getEntityClass(table.getId(), table.getVersion()),
+                        dictionary.getEntityClass(table.getName(), table.getVersion()),
                         dimension.getName()));
     }
 
@@ -91,7 +91,7 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
     protected String visitReferenceDimension(Dimension dimension) {
         Table table = dimension.getTable();
         return visitTableJoinToReference(
-                dictionary.getEntityClass(table.getId(), table.getVersion()),
+                dictionary.getEntityClass(table.getName(), table.getVersion()),
                 dimension.getExpression());
     }
 
@@ -108,7 +108,7 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
      */
     private String visitFormulaColumn(Column column) {
         Table table = column.getTable();
-        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
 
         String expr = column.getExpression();
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceVisitor.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 
 import java.util.Stack;
 
@@ -48,12 +49,13 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
      */
     @Override
     protected String visitFieldMetric(Metric metric) {
+        Table table = metric.getTable();
         return String.format(
                 metric.getMetricFunction().getExpression(),
                 getFieldAlias(
                         tableAliases.peek(),
                         dictionary.getAnnotatedColumnName(
-                                dictionary.getEntityClass(metric.getTable().getId()),
+                                dictionary.getEntityClass(table.getId(), table.getVersion()),
                                 metric.getName())));
     }
 
@@ -70,10 +72,11 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
      */
     @Override
     protected String visitFieldDimension(Dimension dimension) {
+        Table table = dimension.getTable();
         return getFieldAlias(
                 tableAliases.peek(),
                 dictionary.getAnnotatedColumnName(
-                        dictionary.getEntityClass(dimension.getTable().getId()),
+                        dictionary.getEntityClass(table.getId(), table.getVersion()),
                         dimension.getName()));
     }
 
@@ -86,8 +89,9 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
      */
     @Override
     protected String visitReferenceDimension(Dimension dimension) {
+        Table table = dimension.getTable();
         return visitTableJoinToReference(
-                dictionary.getEntityClass(dimension.getTable().getId()),
+                dictionary.getEntityClass(table.getId(), table.getVersion()),
                 dimension.getExpression());
     }
 
@@ -103,7 +107,8 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
      * @return
      */
     private String visitFormulaColumn(Column column) {
-        Class<?> tableClass = dictionary.getEntityClass(column.getTable().getId());
+        Table table = column.getTable();
+        Class<?> tableClass = dictionary.getEntityClass(table.getId(), table.getVersion());
 
         String expr = column.getExpression();
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
@@ -72,7 +72,7 @@ public class SQLQueryConstructor {
                                     FilterExpression whereClause,
                                     FilterExpression havingClause) {
         Table table = template.getTable();
-        Class<?> tableCls = dictionary.getEntityClass(table.getId());
+        Class<?> tableCls = dictionary.getEntityClass(table.getId(), table.getVersion());
         String tableAlias = getClassAlias(tableCls);
 
         SQLQuery.SQLQueryBuilder builder = SQLQuery.builder().clientQuery(clientQuery);
@@ -141,7 +141,8 @@ public class SQLQueryConstructor {
         Class<?> lastClass = last.getType();
         String fieldName = last.getFieldName();
 
-        if (!lastClass.equals(dictionary.getEntityClass(template.getTable().getId()))) {
+        Table table = template.getTable();
+        if (!lastClass.equals(dictionary.getEntityClass(table.getId(), table.getVersion()))) {
             throw new InvalidPredicateException("The having clause can only reference fact table aggregations.");
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
@@ -72,7 +72,7 @@ public class SQLQueryConstructor {
                                     FilterExpression whereClause,
                                     FilterExpression havingClause) {
         Table table = template.getTable();
-        Class<?> tableCls = dictionary.getEntityClass(table.getId(), table.getVersion());
+        Class<?> tableCls = dictionary.getEntityClass(table.getName(), table.getVersion());
         String tableAlias = getClassAlias(tableCls);
 
         SQLQuery.SQLQueryBuilder builder = SQLQuery.builder().clientQuery(clientQuery);
@@ -83,7 +83,7 @@ public class SQLQueryConstructor {
                 ? "(" + tableCls.getAnnotation(FromSubquery.class).sql() + ")"
                 : tableCls.isAnnotationPresent(FromTable.class)
                 ? tableCls.getAnnotation(FromTable.class).name()
-                : table.getId();
+                : table.getName();
 
         builder.fromClause(String.format("%s AS %s", tableStatement, tableAlias));
 
@@ -142,7 +142,7 @@ public class SQLQueryConstructor {
         String fieldName = last.getFieldName();
 
         Table table = template.getTable();
-        if (!lastClass.equals(dictionary.getEntityClass(table.getId(), table.getVersion()))) {
+        if (!lastClass.equals(dictionary.getEntityClass(table.getName(), table.getVersion()))) {
             throw new InvalidPredicateException("The having clause can only reference fact table aggregations.");
         }
 

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/datastores/hibernate3/HibernateDataStoreHarness.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/datastores/hibernate3/HibernateDataStoreHarness.java
@@ -7,10 +7,11 @@ package com.yahoo.elide.datastores.hibernate3;
 
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.datastore.test.DataStoreTestHarness;
-import com.yahoo.elide.models.generics.Manager;
-import com.yahoo.elide.models.triggers.Invoice;
 import com.yahoo.elide.utils.ClassScanner;
 import example.Parent;
+import example.models.generics.Manager;
+import example.models.triggers.Invoice;
+import example.models.versioned.BookV2;
 import org.hibernate.MappingException;
 import org.hibernate.ScrollMode;
 import org.hibernate.SessionFactory;
@@ -37,6 +38,8 @@ public class HibernateDataStoreHarness implements DataStoreTestHarness {
             ClassScanner.getAnnotatedClasses(Manager.class.getPackage(), Entity.class)
                     .forEach(configuration::addAnnotatedClass);
             ClassScanner.getAnnotatedClasses(Invoice.class.getPackage(), Entity.class)
+                    .forEach(configuration::addAnnotatedClass);
+            ClassScanner.getAnnotatedClasses(BookV2.class.getPackage(), Entity.class)
                     .forEach(configuration::addAnnotatedClass);
         } catch (MappingException e) {
             throw new IllegalStateException(e);

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -9,6 +9,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.Elide;
@@ -129,7 +130,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testRootEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/book", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -146,7 +147,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testSubcollectionEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -164,7 +165,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/book", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -178,7 +179,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -192,7 +193,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/book", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -210,7 +211,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -231,7 +232,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser, "");
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser, NO_VERSION);
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(data.toJSON(), response.getBody());
     }
@@ -243,7 +244,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser, "");
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals(data.toJSON(), response.getBody());
     }

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -129,7 +129,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testRootEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser);
+        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -146,7 +146,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testSubcollectionEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser);
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -164,7 +164,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser);
+        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -178,7 +178,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser);
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -192,7 +192,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser);
+        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -210,7 +210,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser);
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -231,7 +231,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser);
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser, "");
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(data.toJSON(), response.getBody());
     }
@@ -243,7 +243,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser);
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser, "");
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals(data.toJSON(), response.getBody());
     }

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateDataStoreHarness.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateDataStoreHarness.java
@@ -7,10 +7,11 @@ package com.yahoo.elide.datastores.hibernate5;
 
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.datastore.test.DataStoreTestHarness;
-import com.yahoo.elide.models.generics.Manager;
-import com.yahoo.elide.models.triggers.Invoice;
 import com.yahoo.elide.utils.ClassScanner;
 import example.Parent;
+import example.models.generics.Manager;
+import example.models.triggers.Invoice;
+import example.models.versioned.BookV2;
 import org.hibernate.MappingException;
 import org.hibernate.ScrollMode;
 import org.hibernate.boot.MetadataSources;
@@ -49,6 +50,8 @@ public class HibernateDataStoreHarness implements DataStoreTestHarness {
             ClassScanner.getAnnotatedClasses(Manager.class.getPackage(), Entity.class)
                     .forEach(metadataSources::addAnnotatedClass);
             ClassScanner.getAnnotatedClasses(Invoice.class.getPackage(), Entity.class)
+                    .forEach(metadataSources::addAnnotatedClass);
+            ClassScanner.getAnnotatedClasses(BookV2.class.getPackage(), Entity.class)
                     .forEach(metadataSources::addAnnotatedClass);
         } catch (MappingException e) {
             throw new IllegalStateException(e);

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreHarness.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreHarness.java
@@ -7,14 +7,13 @@ package com.yahoo.elide.datastores.hibernate5;
 
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.datastore.test.DataStoreTestHarness;
-import com.yahoo.elide.models.generics.Manager;
-import com.yahoo.elide.models.triggers.Invoice;
 import com.yahoo.elide.utils.ClassScanner;
-
 import example.Filtered;
 import example.Parent;
 import example.TestCheckMappings;
-
+import example.models.generics.Manager;
+import example.models.triggers.Invoice;
+import example.models.versioned.BookV2;
 import org.hibernate.MappingException;
 import org.hibernate.ScrollMode;
 import org.hibernate.boot.MetadataSources;
@@ -58,6 +57,7 @@ public class HibernateEntityManagerDataStoreHarness implements DataStoreTestHarn
             bindClasses.addAll(ClassScanner.getAnnotatedClasses(Parent.class.getPackage(), Entity.class));
             bindClasses.addAll(ClassScanner.getAnnotatedClasses(Manager.class.getPackage(), Entity.class));
             bindClasses.addAll(ClassScanner.getAnnotatedClasses(Invoice.class.getPackage(), Entity.class));
+            bindClasses.addAll(ClassScanner.getAnnotatedClasses(BookV2.class.getPackage(), Entity.class));
         } catch (MappingException e) {
             throw new IllegalStateException(e);
         }

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -9,6 +9,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.Elide;
@@ -129,7 +130,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testRootEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/book", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -146,7 +147,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testSubcollectionEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -164,7 +165,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/book", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -178,7 +179,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -192,7 +193,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/book", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -210,7 +211,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, NO_VERSION);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -231,7 +232,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser, "");
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser, NO_VERSION);
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(data.toJSON(), response.getBody());
     }
@@ -243,7 +244,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser, "");
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals(data.toJSON(), response.getBody());
     }

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -129,7 +129,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testRootEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser);
+        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -146,7 +146,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testSubcollectionEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser);
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -164,7 +164,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser);
+        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -178,7 +178,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser);
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -192,7 +192,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, goodUser);
+        ElideResponse response = elide.get("/book", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -210,7 +210,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser);
+        ElideResponse response = elide.get("/author/1/books", queryParams, goodUser, "");
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -231,7 +231,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser);
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), goodUser, "");
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(data.toJSON(), response.getBody());
     }
@@ -243,7 +243,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser);
+        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), badUser, "");
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals(data.toJSON(), response.getBody());
     }

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreHarness.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreHarness.java
@@ -9,10 +9,11 @@ package com.yahoo.elide.datastores.jpa;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.datastore.test.DataStoreTestHarness;
 import com.yahoo.elide.datastores.jpa.transaction.NonJtaTransaction;
-import com.yahoo.elide.models.generics.Manager;
-import com.yahoo.elide.models.triggers.Invoice;
 import com.yahoo.elide.utils.ClassScanner;
 import example.Parent;
+import example.models.generics.Manager;
+import example.models.triggers.Invoice;
+import example.models.versioned.BookV2;
 import org.hibernate.MappingException;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
@@ -49,6 +50,7 @@ public class JpaDataStoreHarness implements DataStoreTestHarness {
             bindClasses.addAll(ClassScanner.getAnnotatedClasses(Parent.class.getPackage(), Entity.class));
             bindClasses.addAll(ClassScanner.getAnnotatedClasses(Manager.class.getPackage(), Entity.class));
             bindClasses.addAll(ClassScanner.getAnnotatedClasses(Invoice.class.getPackage(), Entity.class));
+            bindClasses.addAll(ClassScanner.getAnnotatedClasses(BookV2.class.getPackage(), Entity.class));
         } catch (MappingException e) {
             throw new IllegalStateException(e);
         }

--- a/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopDataStoreTest.java
+++ b/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopDataStoreTest.java
@@ -25,7 +25,7 @@ public class NoopDataStoreTest {
         DataStore store = new NoopDataStore(Arrays.asList(NoopBean.class));
         EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
         store.populateEntityDictionary(dictionary);
-        assertEquals(NoopBean.class, dictionary.getEntityClass("theNoopBean", ""));
+        assertEquals(NoopBean.class, dictionary.getEntityClass("theNoopBean", EntityDictionary.NO_VERSION));
     }
 
     @Test

--- a/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopDataStoreTest.java
+++ b/elide-datastore/elide-datastore-noop/src/test/java/com/yahoo/elide/datastores/noop/NoopDataStoreTest.java
@@ -25,7 +25,7 @@ public class NoopDataStoreTest {
         DataStore store = new NoopDataStore(Arrays.asList(NoopBean.class));
         EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
         store.populateEntityDictionary(dictionary);
-        assertEquals(NoopBean.class, dictionary.getEntityClass("theNoopBean"));
+        assertEquals(NoopBean.class, dictionary.getEntityClass("theNoopBean", ""));
     }
 
     @Test

--- a/elide-example-models/src/main/java/example/models/BaseId.java
+++ b/elide-example-models/src/main/java/example/models/BaseId.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.models;
+package example.models;
 
 import com.yahoo.elide.annotation.Exclude;
 
@@ -23,6 +23,8 @@ public abstract class BaseId {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected long id;
+
+    @Exclude
     protected String naturalKey = UUID.randomUUID().toString();
 
     @Exclude

--- a/elide-example-models/src/main/java/example/models/generics/Employee.java
+++ b/elide-example-models/src/main/java/example/models/generics/Employee.java
@@ -4,16 +4,16 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.generics;
+package example.models.generics;
 
 import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
 
 /**
- * Tests a parameterized superclass.
+ * Helper class to test parameterized subclass/superclass hierarchies.
  */
 @Include(rootLevel = true)
 @Entity
-public class Manager extends Overlord<Employee> {
+public class Employee extends Peon<Manager> {
 }

--- a/elide-example-models/src/main/java/example/models/generics/Manager.java
+++ b/elide-example-models/src/main/java/example/models/generics/Manager.java
@@ -4,16 +4,16 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.generics;
+package example.models.generics;
 
 import com.yahoo.elide.annotation.Include;
 
 import javax.persistence.Entity;
 
 /**
- * Helper class to test parameterized subclass/superclass hierarchies.
+ * Tests a parameterized superclass.
  */
 @Include(rootLevel = true)
 @Entity
-public class Employee extends Peon<Manager> {
+public class Manager extends Overlord<Employee> {
 }

--- a/elide-example-models/src/main/java/example/models/generics/Overlord.java
+++ b/elide-example-models/src/main/java/example/models/generics/Overlord.java
@@ -4,21 +4,23 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.generics;
+package example.models.generics;
 
-import com.yahoo.elide.models.BaseId;
+import example.models.BaseId;
+
+import java.util.Set;
 
 import javax.persistence.MappedSuperclass;
-import javax.persistence.OneToOne;
+import javax.persistence.OneToMany;
 
 
 /**
  * Parameterized base class for testing.
- * @param <T> Boss Type
+ * @param <T> Minion type
  */
 @MappedSuperclass
-public class Peon<T> extends BaseId {
+public class Overlord<T> extends BaseId {
 
-    @OneToOne
-    private T boss;
+    @OneToMany
+    private Set<T> minions;
 }

--- a/elide-example-models/src/main/java/example/models/generics/Peon.java
+++ b/elide-example-models/src/main/java/example/models/generics/Peon.java
@@ -4,23 +4,21 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.generics;
+package example.models.generics;
 
-import com.yahoo.elide.models.BaseId;
-
-import java.util.Set;
+import example.models.BaseId;
 
 import javax.persistence.MappedSuperclass;
-import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 
 
 /**
  * Parameterized base class for testing.
- * @param <T> Minion type
+ * @param <T> Boss Type
  */
 @MappedSuperclass
-public class Overlord<T> extends BaseId {
+public class Peon<T> extends BaseId {
 
-    @OneToMany
-    private Set<T> minions;
+    @OneToOne
+    private T boss;
 }

--- a/elide-example-models/src/main/java/example/models/generics/package-info.java
+++ b/elide-example-models/src/main/java/example/models/generics/package-info.java
@@ -4,4 +4,4 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.generics;
+package example.models.generics;

--- a/elide-example-models/src/main/java/example/models/triggers/Invoice.java
+++ b/elide-example-models/src/main/java/example/models/triggers/Invoice.java
@@ -4,13 +4,13 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.triggers;
+package example.models.triggers;
 
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
-import com.yahoo.elide.models.BaseId;
-import com.yahoo.elide.models.triggers.services.BillingService;
+import example.models.BaseId;
+import example.models.triggers.services.BillingService;
 
 import lombok.Data;
 

--- a/elide-example-models/src/main/java/example/models/triggers/InvoiceCompletionHook.java
+++ b/elide-example-models/src/main/java/example/models/triggers/InvoiceCompletionHook.java
@@ -4,13 +4,14 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.triggers;
+package example.models.triggers;
 
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.functions.LifeCycleHook;
-import com.yahoo.elide.models.triggers.services.BillingService;
 import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.RequestScope;
+
+import example.models.triggers.services.BillingService;
 
 import java.util.Optional;
 import javax.inject.Inject;

--- a/elide-example-models/src/main/java/example/models/triggers/services/BillingService.java
+++ b/elide-example-models/src/main/java/example/models/triggers/services/BillingService.java
@@ -4,9 +4,9 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.models.triggers.services;
+package example.models.triggers.services;
 
-import com.yahoo.elide.models.triggers.Invoice;
+import example.models.triggers.Invoice;
 
 /**
  * Interface to make a financial transaction based on an Invoice.

--- a/elide-example-models/src/main/java/example/models/versioned/BookV2.java
+++ b/elide-example-models/src/main/java/example/models/versioned/BookV2.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package example.models.versioned;
+
+import com.yahoo.elide.annotation.Include;
+import example.models.BaseId;
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Include(rootLevel = true, type = "book")
+@Entity
+@Data
+@Table(name = "book")
+public class BookV2 extends BaseId {
+
+    @Column(name = "title")
+    private String name;
+}

--- a/elide-example-models/src/main/java/example/models/versioned/BookV2.java
+++ b/elide-example-models/src/main/java/example/models/versioned/BookV2.java
@@ -22,4 +22,6 @@ public class BookV2 extends BaseId {
 
     @Column(name = "title")
     private String name;
+
+    private long publishDate = 0;
 }

--- a/elide-example-models/src/main/java/example/models/versioned/package-info.java
+++ b/elide-example-models/src/main/java/example/models/versioned/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+@ApiVersion(version = "1.0")
+package example.models.versioned;
+
+import com.yahoo.elide.annotation.ApiVersion;

--- a/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/CommonElideSettings.java
+++ b/elide-example/elide-blog-example/src/main/java/com/yahoo/elide/example/CommonElideSettings.java
@@ -7,6 +7,7 @@
 package com.yahoo.elide.example;
 
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
+import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.example.models.Comment;
 import com.yahoo.elide.example.models.Post;
@@ -15,8 +16,9 @@ import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import io.swagger.models.Info;
 import io.swagger.models.Swagger;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -33,7 +35,7 @@ public abstract class CommonElideSettings implements ElideStandaloneSettings {
     }
 
     @Override
-    public Map<String, Swagger> enableSwagger() {
+    public List<DocEndpoint.SwaggerRegistration> enableSwagger() {
         EntityDictionary dictionary = new EntityDictionary(new HashMap());
 
         dictionary.bindEntity(User.class);
@@ -44,8 +46,8 @@ public abstract class CommonElideSettings implements ElideStandaloneSettings {
         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
         Swagger swagger = builder.build();
 
-        Map<String, Swagger> docs = new HashMap<>();
-        docs.put("test", swagger);
+        List<DocEndpoint.SwaggerRegistration> docs = new ArrayList<>();
+        docs.add(new DocEndpoint.SwaggerRegistration("test", swagger));
         return docs;
     }
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -65,7 +65,7 @@ public class GraphQLEndpoint {
 
         ElideResponse response;
         if (runner == null) {
-            response = runner.buildErrorResponse(new InvalidOperationException("Invalid API Header"), false);
+            response = runner.buildErrorResponse(new InvalidOperationException("Invalid API Version"), false);
         } else {
             response = runner.run(graphQLDocument, user);
         }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -52,7 +52,7 @@ public class GraphQLEndpoint {
             @Context SecurityContext securityContext,
             String graphQLDocument) {
         User user = new SecurityContextUser(securityContext);
-        ElideResponse response = runner.run(graphQLDocument, user);
+        ElideResponse response = runner.run(graphQLDocument, user, "");
         return Response.status(response.getResponseCode()).entity(response.getBody()).build();
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.graphql;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
@@ -59,7 +61,7 @@ public class GraphQLEndpoint {
     public Response post(
             @HeaderParam("ApiVersion") String apiVersion,
             @Context SecurityContext securityContext, String graphQLDocument) {
-        String safeApiVersion = apiVersion == null ? "" : apiVersion;
+        String safeApiVersion = apiVersion == null ? NO_VERSION : apiVersion;
         User user = new SecurityContextUser(securityContext);
         QueryRunner runner = runners.getOrDefault(safeApiVersion, null);
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.graphql;
 
 import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+import static com.yahoo.elide.graphql.QueryRunner.buildErrorResponse;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
@@ -39,10 +40,12 @@ import javax.ws.rs.core.SecurityContext;
 @Path("/")
 public class GraphQLEndpoint {
     private final Map<String, QueryRunner> runners;
+    private final Elide elide;
 
     @Inject
     public GraphQLEndpoint(@Named("elide") Elide elide) {
         log.debug("Started ~~");
+        this.elide = elide;
         this.runners = new HashMap<>();
         for (String apiVersion : elide.getElideSettings().getDictionary().getApiVersions()) {
             runners.put(apiVersion, new QueryRunner(elide, apiVersion));
@@ -67,7 +70,7 @@ public class GraphQLEndpoint {
 
         ElideResponse response;
         if (runner == null) {
-            response = runner.buildErrorResponse(new InvalidOperationException("Invalid API Version"), false);
+            response = buildErrorResponse(elide, new InvalidOperationException("Invalid API Version"), false);
         } else {
             response = runner.run(graphQLDocument, user);
         }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
@@ -35,7 +35,8 @@ public class GraphQLRequestScope extends RequestScope {
         // we should have a GraphQLRequestScope and a JSONAPIRequestScope.
         // TODO: What should mutate multiple entity value be? There is a problem with this setting in practice.
         // Namely, we don't filter or paginate in the data store.
-        super("/", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
+        //TODO - Set API Version
+        super("/", "", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
         this.projectionInfo = projectionInfo;
 
         // Entity Projection is retrieved from projectionInfo.

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
@@ -28,6 +28,7 @@ public class GraphQLRequestScope extends RequestScope {
     public GraphQLRequestScope(
             DataStoreTransaction transaction,
             User user,
+            String apiVersion,
             ElideSettings elideSettings,
             GraphQLProjectionInfo projectionInfo
     ) {
@@ -35,8 +36,7 @@ public class GraphQLRequestScope extends RequestScope {
         // we should have a GraphQLRequestScope and a JSONAPIRequestScope.
         // TODO: What should mutate multiple entity value be? There is a problem with this setting in practice.
         // Namely, we don't filter or paginate in the data store.
-        //TODO - Set API Version
-        super("/", "", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
+        super("/", apiVersion, null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
         this.projectionInfo = projectionInfo;
 
         // Entity Projection is retrieved from projectionInfo.

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -62,6 +62,7 @@ public class ModelBuilder {
     private GraphQLConversionUtils generator;
     private GraphQLNameUtils nameUtils;
     private GraphQLObjectType pageInfoObject;
+    private final String apiVersion;
 
     private Map<Class<?>, MutableGraphQLInputObjectType> inputObjectRegistry;
     private Map<Class<?>, GraphQLObjectType> queryObjectRegistry;
@@ -75,11 +76,12 @@ public class ModelBuilder {
      * @param dictionary elide entity dictionary
      * @param dataFetcher graphQL data fetcher
      */
-    public ModelBuilder(EntityDictionary dictionary, DataFetcher dataFetcher) {
+    public ModelBuilder(EntityDictionary dictionary, DataFetcher dataFetcher, String apiVersion) {
         this.generator = new GraphQLConversionUtils(dictionary);
         this.nameUtils = new GraphQLNameUtils(dictionary);
         this.dictionary = dictionary;
         this.dataFetcher = dataFetcher;
+        this.apiVersion = apiVersion;
 
         relationshipOpArg = newArgument()
                 .name(ARGUMENT_OPERATION)
@@ -147,7 +149,7 @@ public class ModelBuilder {
      * @return The built schema.
      */
     public GraphQLSchema build() {
-        Set<Class<?>> allClasses = dictionary.getBoundClasses();
+        Set<Class<?>> allClasses = dictionary.getBoundClassesByVersion(apiVersion);
 
         if (allClasses.isEmpty()) {
             throw new IllegalArgumentException("None of the provided classes are exported by Elide");

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
@@ -35,8 +35,7 @@ public class NonEntityDictionary extends EntityDictionary {
     public void bindEntity(Class<?> cls) {
         String type = WordUtils.uncapitalize(cls.getSimpleName());
 
-        String version = "";
-        Class<?> duplicate = bindJsonApiToEntity.put(Pair.of(type, ""), cls);
+        Class<?> duplicate = bindJsonApiToEntity.put(Pair.of(type, NO_VERSION), cls);
 
         if (duplicate != null && !duplicate.equals(cls)) {
             log.error("Duplicate binding {} for {}, {}", type, cls, duplicate);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.exceptions.DuplicateMappingException;
 
 import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,7 +35,8 @@ public class NonEntityDictionary extends EntityDictionary {
     public void bindEntity(Class<?> cls) {
         String type = WordUtils.uncapitalize(cls.getSimpleName());
 
-        Class<?> duplicate = bindJsonApiToEntity.put(type, cls);
+        String version = "";
+        Class<?> duplicate = bindJsonApiToEntity.put(Pair.of(type, ""), cls);
 
         if (duplicate != null && !duplicate.equals(cls)) {
             log.error("Duplicate binding {} for {}, {}", type, cls, duplicate);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -237,8 +237,7 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
         Class<?> entityClass;
         EntityDictionary dictionary = context.requestScope.getDictionary();
         if (context.isRoot()) {
-            //TODO - Version needs to come from the API
-            entityClass = dictionary.getEntityClass(context.field.getName(), "");
+            entityClass = dictionary.getEntityClass(context.field.getName(), context.requestScope.getApiVersion());
         } else {
             assert context.parentResource != null;
             entityClass = dictionary.getParameterizedType(

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -237,7 +237,8 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
         Class<?> entityClass;
         EntityDictionary dictionary = context.requestScope.getDictionary();
         if (context.isRoot()) {
-            entityClass = dictionary.getEntityClass(context.field.getName());
+            //TODO - Version needs to come from the API
+            entityClass = dictionary.getEntityClass(context.field.getName(), "");
         } else {
             assert context.parentResource != null;
             entityClass = dictionary.getParameterizedType(

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -98,7 +98,7 @@ public class QueryRunner {
             log.debug("Invalid json body provided to GraphQL", e);
             // NOTE: Can't get at isVerbose setting here for hardcoding to false. If necessary, we can refactor
             // so this can be set appropriately.
-            return buildErrorResponse(new InvalidEntityBodyException(graphQLDocument), false);
+            return buildErrorResponse(elide, new InvalidEntityBodyException(graphQLDocument), false);
         }
 
         Function<JsonNode, ElideResponse> executeRequest =
@@ -217,10 +217,10 @@ public class QueryRunner {
                     .build();
         } catch (JsonProcessingException e) {
             log.debug("Invalid json body provided to GraphQL", e);
-            return buildErrorResponse(new InvalidEntityBodyException(graphQLDocument), isVerbose);
+            return buildErrorResponse(elide, new InvalidEntityBodyException(graphQLDocument), isVerbose);
         } catch (IOException e) {
             log.error("Uncaught IO Exception by Elide in GraphQL", e);
-            return buildErrorResponse(new TransactionException(e), isVerbose);
+            return buildErrorResponse(elide, new TransactionException(e), isVerbose);
         } catch (WebApplicationException e) {
             log.debug("WebApplicationException", e);
             return ElideResponse.builder()
@@ -234,7 +234,7 @@ public class QueryRunner {
             } else {
                 log.debug("Caught HTTP status exception {}", e.getStatus(), e);
             }
-            return buildErrorResponse(new HttpStatusException(200, e.getMessage()) {
+            return buildErrorResponse(elide, new HttpStatusException(200, e.getMessage()) {
                 @Override
                 public int getStatus() {
                     return 200;
@@ -268,7 +268,7 @@ public class QueryRunner {
         }
     }
 
-    public ElideResponse buildErrorResponse(HttpStatusException error, boolean isVerbose) {
+    public static ElideResponse buildErrorResponse(Elide elide, HttpStatusException error, boolean isVerbose) {
         ObjectMapper mapper = elide.getMapper().getObjectMapper();
         JsonNode errorNode;
         if (!(error instanceof CustomErrorException)) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -157,8 +157,9 @@ public class QueryRunner {
                 variables = mapper.convertValue(jsonDocument.get(VARIABLES), Map.class);
             }
 
+            //TODO - get API version.
             GraphQLProjectionInfo projectionInfo =
-                    new GraphQLEntityProjectionMaker(elide.getElideSettings(), variables).make(query);
+                    new GraphQLEntityProjectionMaker(elide.getElideSettings(), variables, "").make(query);
             GraphQLRequestScope requestScope =
                     new GraphQLRequestScope(tx, principal, elide.getElideSettings(), projectionInfo);
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -163,7 +163,8 @@ public class GraphQLEntityProjectionMaker {
                 // '__schema' and '__type' would not be handled by entity projection
                 return;
             }
-            Class<?> entityType = entityDictionary.getEntityClass(rootSelectionField.getName());
+            //TODO - Version needs to come from the API.
+            Class<?> entityType = entityDictionary.getEntityClass(rootSelectionField.getName(), "");
             if (entityType == null) {
                 throw new InvalidEntityBodyException(String.format("Unknown entity {%s}.",
                         rootSelectionField.getName()));

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.graphql.parser;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static com.yahoo.elide.graphql.KeyWord.EDGES;
 import static com.yahoo.elide.graphql.KeyWord.NODE;
 import static com.yahoo.elide.graphql.KeyWord.PAGE_INFO;
@@ -102,7 +103,7 @@ public class GraphQLEntityProjectionMaker {
      * @param elideSettings settings of current Elide instance
      */
     public GraphQLEntityProjectionMaker(ElideSettings elideSettings) {
-        this(elideSettings, new HashMap<>(), "");
+        this(elideSettings, new HashMap<>(), NO_VERSION);
     }
 
     /**

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -228,7 +228,7 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     @Test
     public void testTypeIntrospection() {
         String graphQLRequest = "{"
-            + "__type(name: \"author\") {"
+            + "__type(name: \"Author\") {"
             + "   name"
             + "   fields {"
             + "     name"

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -208,7 +208,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -261,7 +261,7 @@ public class GraphQLEndpointTest {
 
         Map<String, String> variables = new HashMap<>();
         variables.put("bookId", "1");
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest, variables));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest, variables));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -289,7 +289,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -306,7 +306,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -331,7 +331,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -361,7 +361,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
 
         graphQLRequest = document(
@@ -388,7 +388,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -432,7 +432,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
 
         assertHasErrors(response);
 
@@ -479,7 +479,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -524,7 +524,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         String expectedLog = "On Title Update Pre Security\nOn Title Update Pre Commit\nOn Title Update Post Commit\n";
@@ -557,7 +557,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
 
         Mockito.verify(audit, Mockito.times(1)).log(Mockito.any());
         Mockito.verify(audit, Mockito.times(1)).commit();
@@ -606,7 +606,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         graphQLRequest = document(
@@ -659,7 +659,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -688,7 +688,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user3, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user3, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -742,7 +742,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -767,7 +767,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -844,7 +844,7 @@ public class GraphQLEndpointTest {
         ).toResponse();
 
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -910,7 +910,7 @@ public class GraphQLEndpointTest {
         ).toResponse();
 
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -994,7 +994,7 @@ public class GraphQLEndpointTest {
         variables.put("author1", "1");
         variables.put("author2", "2");
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest, variables));
+        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest, variables));
         assert200EqualBody(response, graphQLResponse);
     }
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -17,6 +17,7 @@ import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selections;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.toJson;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.variableDefinition;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.variableDefinitions;
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -208,7 +209,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -261,7 +262,7 @@ public class GraphQLEndpointTest {
 
         Map<String, String> variables = new HashMap<>();
         variables.put("bookId", "1");
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest, variables));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest, variables));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -289,7 +290,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -306,7 +307,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -331,7 +332,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -361,7 +362,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
 
         graphQLRequest = document(
@@ -388,7 +389,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post("", user2, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post(NO_VERSION, user2, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -432,7 +433,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
 
         assertHasErrors(response);
 
@@ -479,7 +480,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -524,7 +525,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post("", user, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         String expectedLog = "On Title Update Pre Security\nOn Title Update Pre Commit\nOn Title Update Post Commit\n";
@@ -557,7 +558,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
 
         Mockito.verify(audit, Mockito.times(1)).log(Mockito.any());
         Mockito.verify(audit, Mockito.times(1)).commit();
@@ -606,7 +607,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         graphQLRequest = document(
@@ -659,7 +660,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -688,7 +689,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post("", user3, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user3, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -742,7 +743,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -767,7 +768,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -844,7 +845,7 @@ public class GraphQLEndpointTest {
         ).toResponse();
 
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -910,7 +911,7 @@ public class GraphQLEndpointTest {
         ).toResponse();
 
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -994,7 +995,7 @@ public class GraphQLEndpointTest {
         variables.put("author1", "1");
         variables.put("author2", "2");
 
-        Response response = endpoint.post("", user1, graphQLRequestToJSON(graphQLRequest, variables));
+        Response response = endpoint.post(NO_VERSION, user1, graphQLRequestToJSON(graphQLRequest, variables));
         assert200EqualBody(response, graphQLResponse);
     }
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -96,7 +96,7 @@ public class ModelBuilderTest {
     @Test
     public void testPageInfoObject() {
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher);
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
 
         GraphQLSchema schema = builder.build();
 
@@ -107,7 +107,7 @@ public class ModelBuilderTest {
     @Test
     public void testRelationshipParameters() {
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher);
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
 
         GraphQLSchema schema = builder.build();
         GraphQLObjectType root = schema.getQueryType();
@@ -143,7 +143,7 @@ public class ModelBuilderTest {
     @Test
     public void testBuild() {
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher);
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
 
         GraphQLSchema schema = builder.build();
 
@@ -206,7 +206,7 @@ public class ModelBuilderTest {
         dictionary.addArgumentsToAttribute(Book.class, FIELD_PUBLISH_DATE, arguments);
 
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher);
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
 
         GraphQLSchema schema = builder.build();
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.graphql;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static graphql.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -96,7 +97,7 @@ public class ModelBuilderTest {
     @Test
     public void testPageInfoObject() {
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 
@@ -107,7 +108,7 @@ public class ModelBuilderTest {
     @Test
     public void testRelationshipParameters() {
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
         GraphQLObjectType root = schema.getQueryType();
@@ -143,7 +144,7 @@ public class ModelBuilderTest {
     @Test
     public void testBuild() {
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 
@@ -206,7 +207,7 @@ public class ModelBuilderTest {
         dictionary.addArgumentsToAttribute(Book.class, FIELD_PUBLISH_DATE, arguments);
 
         DataFetcher fetcher = mock(DataFetcher.class);
-        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, "");
+        ModelBuilder builder = new ModelBuilder(dictionary, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -172,7 +172,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
 
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
         GraphQLProjectionInfo projectionInfo =
-                new GraphQLEntityProjectionMaker(settings, variables).make(graphQLRequest);
+                new GraphQLEntityProjectionMaker(settings, variables, "").make(graphQLRequest);
         GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, settings, projectionInfo);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope, variables);

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.graphql;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -85,7 +86,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
 
         inMemoryDataStore.populateEntityDictionary(dictionary);
 
-        ModelBuilder builder = new ModelBuilder(dictionary, new PersistentResourceFetcher(), "");
+        ModelBuilder builder = new ModelBuilder(dictionary, new PersistentResourceFetcher(), NO_VERSION);
 
         api = new GraphQL(builder.build());
 
@@ -172,8 +173,8 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
 
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
         GraphQLProjectionInfo projectionInfo =
-                new GraphQLEntityProjectionMaker(settings, variables, "").make(graphQLRequest);
-        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, "", settings, projectionInfo);
+                new GraphQLEntityProjectionMaker(settings, variables, NO_VERSION).make(graphQLRequest);
+        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, NO_VERSION, settings, projectionInfo);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope, variables);
         // NOTE: We're forcing commit even in case of failures. GraphQLEndpoint tests should ensure we do not commit on
@@ -199,7 +200,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
 
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
         GraphQLProjectionInfo projectionInfo = new GraphQLEntityProjectionMaker(settings).make(graphQLRequest);
-        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, "", settings, projectionInfo);
+        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, NO_VERSION, settings, projectionInfo);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope);
         if (isMutation) {
@@ -232,7 +233,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
     protected ExecutionResult runGraphQLRequest(String graphQLRequest, Map<String, Object> variables) {
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
         GraphQLProjectionInfo projectionInfo = new GraphQLEntityProjectionMaker(settings).make(graphQLRequest);
-        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, "", settings, projectionInfo);
+        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, NO_VERSION, settings, projectionInfo);
 
         return api.execute(graphQLRequest, requestScope, variables);
     }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -85,7 +85,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
 
         inMemoryDataStore.populateEntityDictionary(dictionary);
 
-        ModelBuilder builder = new ModelBuilder(dictionary, new PersistentResourceFetcher());
+        ModelBuilder builder = new ModelBuilder(dictionary, new PersistentResourceFetcher(), "");
 
         api = new GraphQL(builder.build());
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -173,7 +173,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
         GraphQLProjectionInfo projectionInfo =
                 new GraphQLEntityProjectionMaker(settings, variables, "").make(graphQLRequest);
-        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, settings, projectionInfo);
+        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, "", settings, projectionInfo);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope, variables);
         // NOTE: We're forcing commit even in case of failures. GraphQLEndpoint tests should ensure we do not commit on
@@ -199,7 +199,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
 
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
         GraphQLProjectionInfo projectionInfo = new GraphQLEntityProjectionMaker(settings).make(graphQLRequest);
-        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, settings, projectionInfo);
+        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, "", settings, projectionInfo);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope);
         if (isMutation) {
@@ -232,7 +232,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
     protected ExecutionResult runGraphQLRequest(String graphQLRequest, Map<String, Object> variables) {
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
         GraphQLProjectionInfo projectionInfo = new GraphQLEntityProjectionMaker(settings).make(graphQLRequest);
-        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, settings, projectionInfo);
+        GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, null, "", settings, projectionInfo);
 
         return api.execute(graphQLRequest, requestScope, variables);
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/InMemoryDataStoreHarness.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/InMemoryDataStoreHarness.java
@@ -10,12 +10,13 @@ import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.datastore.inmemory.HashMapDataStore;
 import com.yahoo.elide.core.datastore.inmemory.InMemoryDataStore;
 import com.yahoo.elide.core.datastore.test.DataStoreTestHarness;
-import com.yahoo.elide.models.generics.Manager;
-import com.yahoo.elide.models.triggers.Invoice;
 
 import com.google.common.collect.Sets;
 
 import example.Parent;
+import example.models.generics.Manager;
+import example.models.triggers.Invoice;
+import example.models.versioned.BookV2;
 
 import java.util.Set;
 
@@ -30,7 +31,8 @@ public class InMemoryDataStoreHarness implements DataStoreTestHarness {
         Set<Package> beanPackages = Sets.newHashSet(
                 Parent.class.getPackage(),
                 Invoice.class.getPackage(),
-                Manager.class.getPackage()
+                Manager.class.getPackage(),
+                BookV2.class.getPackage()
         );
 
         mapStore = new HashMapDataStore(beanPackages);

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/StandardTestBinder.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/StandardTestBinder.java
@@ -14,9 +14,9 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
-import com.yahoo.elide.models.triggers.services.BillingService;
 
 import example.TestCheckMappings;
+import example.models.triggers.services.BillingService;
 
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.ServiceLocator;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/VerboseErrorResponsesTestBinder.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/VerboseErrorResponsesTestBinder.java
@@ -15,9 +15,9 @@ import com.yahoo.elide.core.filter.dialect.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.dialect.MultipleFilterDialect;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 
-import com.yahoo.elide.models.triggers.Invoice;
-import com.yahoo.elide.models.triggers.services.BillingService;
 import example.TestCheckMappings;
+import example.models.triggers.Invoice;
+import example.models.triggers.services.BillingService;
 
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.ServiceLocator;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
@@ -427,7 +427,6 @@ public class GraphQLIT extends IntegrationTest {
             .body(query)
             .post("/graphQL")
             .then()
-            .log().all()
             .statusCode(HttpStatus.SC_OK)
             .body("data.__type.fields.name", containsInAnyOrder("id", "awards", "chapterCount",
                     "editorName", "genre", "language", "publishDate", "title", "authors", "chapters",
@@ -454,7 +453,6 @@ public class GraphQLIT extends IntegrationTest {
                 .body(query)
                 .post("/graphQL")
                 .then()
-                .log().all()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.__type.fields.name", containsInAnyOrder("id", "name", "publishDate"));
     }
@@ -489,6 +487,41 @@ public class GraphQLIT extends IntegrationTest {
         ).toResponse();
 
         runQueryWithExpectedResult(graphQLRequest, null, expected, "1.0");
+    }
+
+    @Test
+    public void testInvalidApiVersion() throws IOException {
+
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "book",
+                                selections(
+                                        field("id"),
+                                        field("name")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = "{\n"
+                + "    \"errors\": [\n"
+                + "        {\n"
+                + "            \"message\": \"Invalid operation: Invalid API Version\"\n"
+                + "        }\n"
+                + "    ]\n"
+                + "}";
+
+        String query = toJsonQuery(graphQLRequest, new HashMap<>());
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("ApiVersion", "2.0")
+                .body(query)
+                .post("/graphQL")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
     @Test

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
@@ -456,7 +456,7 @@ public class GraphQLIT extends IntegrationTest {
                 .then()
                 .log().all()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.__type.fields.name", containsInAnyOrder("id", "name"));
+                .body("data.__type.fields.name", containsInAnyOrder("id", "name", "publishDate"));
     }
 
     @Test

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
@@ -18,6 +18,7 @@ import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.variableDef
 import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.contrib.testhelpers.graphql.VariableFieldSerializer;
@@ -504,13 +505,7 @@ public class GraphQLIT extends IntegrationTest {
                 )
         ).toQuery();
 
-        String expected = "{\n"
-                + "    \"errors\": [\n"
-                + "        {\n"
-                + "            \"message\": \"Invalid operation: Invalid API Version\"\n"
-                + "        }\n"
-                + "    ]\n"
-                + "}";
+        String expected = "{\"errors\":[{\"message\":\"Invalid operation: Invalid API Version\"}]}";
 
         String query = toJsonQuery(graphQLRequest, new HashMap<>());
 
@@ -521,6 +516,7 @@ public class GraphQLIT extends IntegrationTest {
                 .body(query)
                 .post("/graphQL")
                 .then()
+                .body(equalTo(expected))
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -20,6 +20,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relationshi
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relation.TO_ONE;
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -2479,7 +2480,7 @@ public class ResourceIT extends IntegrationTest {
                 .build());
 
         com.yahoo.elide.security.User user = new com.yahoo.elide.security.User(() -> "-1");
-        ElideResponse response = elide.get("parent/1/children", new MultivaluedHashMap<>(), user, "");
+        ElideResponse response = elide.get("parent/1/children", new MultivaluedHashMap<>(), user, NO_VERSION);
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(response.getBody(), "{\"data\":[]}");
     }
@@ -2739,7 +2740,7 @@ public class ResourceIT extends IntegrationTest {
                 ));
 
         given()
-                .header("ApiVersion", "")
+                .header("ApiVersion", NO_VERSION)
                 .when()
                 .get("/book?fields[book]=title")
                 .then()

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -2708,4 +2708,69 @@ public class ResourceIT extends IntegrationTest {
     public void badChildCollectionId() {
         given().when().get("/user/1/oops/1").then().statusCode(Status.NOT_FOUND.getStatusCode());
     }
+
+    @Test
+    @Tag("skipInMemory") //Skipping because storage for in-memory store is
+                         //broken out by class instead of a common table.
+    public void testVersionedBook() throws Exception {
+        given()
+                .header("ApiVersion", "1.0")
+                .when()
+                .get("/book?fields[book]=name")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(
+                        data(
+                                resource(
+                                        type("book"),
+                                        id("1"),
+                                        attributes(
+                                                attr("name", "titlewith%percentage")
+                                        )
+                                ),
+                                resource(
+                                        type("book"),
+                                        id("2"),
+                                        attributes(
+                                                attr("name", "titlewithoutpercentage")
+                                        )
+                                )
+                        ).toJSON()
+                ));
+
+        given()
+                .header("ApiVersion", "")
+                .when()
+                .get("/book?fields[book]=title")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(
+                        data(
+                                resource(
+                                        type("book"),
+                                        id("1"),
+                                        attributes(
+                                                attr("title", "titlewith%percentage")
+                                        )
+                                ),
+                                resource(
+                                        type("book"),
+                                        id("2"),
+                                        attributes(
+                                                attr("title", "titlewithoutpercentage")
+                                        )
+                                )
+                        ).toJSON()
+                ));
+    }
+
+    @Test
+    public void testMissingVersionedModels() throws Exception {
+        given()
+                .header("ApiVersion", "1.0")
+                .when()
+                .get("/parent")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -2479,7 +2479,7 @@ public class ResourceIT extends IntegrationTest {
                 .build());
 
         com.yahoo.elide.security.User user = new com.yahoo.elide.security.User(() -> "-1");
-        ElideResponse response = elide.get("parent/1/children", new MultivaluedHashMap<>(), user);
+        ElideResponse response = elide.get("parent/1/children", new MultivaluedHashMap<>(), user, "");
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(response.getBody(), "{\"data\":[]}");
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -2713,7 +2713,7 @@ public class ResourceIT extends IntegrationTest {
     @Test
     @Tag("skipInMemory") //Skipping because storage for in-memory store is
                          //broken out by class instead of a common table.
-    public void testVersionedBook() throws Exception {
+    public void testVersionedBookFetch() throws Exception {
         given()
                 .header("ApiVersion", "1.0")
                 .when()
@@ -2764,6 +2764,81 @@ public class ResourceIT extends IntegrationTest {
                         ).toJSON()
                 ));
     }
+
+    @Test
+    @Tag("skipInMemory") //Skipping because storage for in-memory store is
+    //broken out by class instead of a common table.
+    public void testVersionedBookCreate() throws Exception {
+        given()
+                .header("ApiVersion", "1.0")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(
+                        data(
+                                resource(
+                                        type("book"),
+                                        attributes(
+                                                attr("name", "A new book."),
+                                                attr("publishDate", 1123)
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .post("/book")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(equalTo(
+                        datum(
+                                resource(
+                                        type("book"),
+                                        id("3"),
+                                        attributes(
+                                                attr("name", "A new book."),
+                                                attr("publishDate", 1123)
+                                        )
+                                )
+                        ).toJSON()
+                ));
+    }
+
+    @Test
+    @Tag("skipInMemory") //Skipping because storage for in-memory store is
+    //broken out by class instead of a common table.
+    public void testVersionedBookPatch() throws Exception {
+        given()
+                .header("ApiVersion", "1.0")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("book"),
+                                        id("2"),
+                                        attributes(
+                                                attr("name", "A new book.")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .patch("/book/2")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    @Tag("skipInMemory") //Skipping because storage for in-memory store is
+    //broken out by class instead of a common table.
+    public void testVersionedBookDelete() throws Exception {
+        given()
+                .header("ApiVersion", "1.0")
+                .when()
+                .delete("/book/2")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
 
     @Test
     public void testMissingVersionedModels() throws Exception {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -2830,6 +2830,24 @@ public class ResourceIT extends IntegrationTest {
     @Test
     @Tag("skipInMemory") //Skipping because storage for in-memory store is
     //broken out by class instead of a common table.
+    public void testVersionedPatchExtension() {
+        String req = jsonParser.getJson("/ResourceIT/versionedPatchExtension.req.json");
+        String expected = jsonParser.getJson("/ResourceIT/versionedPatchExtension.resp.json");
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .accept(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
+                .header("ApiVersion", "1.0")
+                .body(req)
+                .patch("/book")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(expected));
+    }
+
+    @Test
+    @Tag("skipInMemory") //Skipping because storage for in-memory store is
+    //broken out by class instead of a common table.
     public void testVersionedBookDelete() throws Exception {
         given()
                 .header("ApiVersion", "1.0")

--- a/elide-integration-tests/src/test/resources/ResourceIT/versionedPatchExtension.req.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/versionedPatchExtension.req.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "add",
+    "path": "/-",
+    "value": {
+      "type": "book",
+      "id": "12345678-1234-1234-1234-123456789ab1",
+      "attributes": {
+        "name": "A new book.",
+        "publishDate" : 1234
+      }
+    }
+  }
+]

--- a/elide-integration-tests/src/test/resources/ResourceIT/versionedPatchExtension.resp.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/versionedPatchExtension.resp.json
@@ -1,0 +1,12 @@
+[
+  {
+    "data": {
+      "type": "book",
+      "id": "3",
+      "attributes": {
+        "name": "A new book.",
+        "publishDate": 1234
+      }
+    }
+  }
+]

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/SwaggerControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/SwaggerControllerProperties.java
@@ -21,5 +21,5 @@ public class SwaggerControllerProperties extends ControllerProperties {
     /**
      * Swagger needs a version for the service.
      */
-    private String version = "1.0";
+    private String version = "";
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -70,7 +70,7 @@ public class GraphqlController {
                                        @RequestBody String graphQLDocument, Authentication principal) {
         User user = new AuthenticationUser(principal);
 
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
         QueryRunner runner = runners.get(apiVersion);
 
         ElideResponse response;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -57,7 +57,7 @@ public class GraphqlController {
     public ResponseEntity<String> post(@RequestBody String graphQLDocument, Authentication principal) {
         User user = new AuthenticationUser(principal);
 
-        ElideResponse response = runner.run(graphQLDocument, user);
+        ElideResponse response = runner.run(graphQLDocument, user, "");
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -71,7 +71,7 @@ public class GraphqlController {
 
         ElideResponse response;
         if (runner == null) {
-            response = runner.buildErrorResponse(new InvalidOperationException("Invalid API Header"), false);
+            response = runner.buildErrorResponse(new InvalidOperationException("Invalid API Version"), false);
         } else {
             response = runner.run(graphQLDocument, user);
         }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -21,8 +21,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.extern.slf4j.Slf4j;
@@ -62,11 +62,11 @@ public class GraphqlController {
      * @return response
      */
     @PostMapping(value = {"/**", ""}, consumes = JSON_CONTENT_TYPE, produces = JSON_CONTENT_TYPE)
-    public ResponseEntity<String> post(@RequestParam Map<String, String> allRequestParams,
+    public ResponseEntity<String> post(@RequestHeader Map<String, String> requestHeaders,
                                        @RequestBody String graphQLDocument, Authentication principal) {
         User user = new AuthenticationUser(principal);
 
-        String apiVersion = Util.getApiVersion(allRequestParams);
+        String apiVersion = Util.getApiVersion(requestHeaders);
         QueryRunner runner = runners.get(apiVersion);
 
         ElideResponse response;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.spring.controllers;
 
+import static com.yahoo.elide.graphql.QueryRunner.buildErrorResponse;
+
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
@@ -29,8 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.yahoo.elide.graphql.QueryRunner.buildErrorResponse;
 
 /**
  * Spring rest controller for Elide GraphQL.

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -30,6 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.yahoo.elide.graphql.QueryRunner.buildErrorResponse;
+
 /**
  * Spring rest controller for Elide GraphQL.
  */
@@ -42,12 +44,14 @@ import java.util.Map;
 public class GraphqlController {
 
     private final Map<String, QueryRunner> runners;
+    private final Elide elide;
 
     private static final String JSON_CONTENT_TYPE = "application/json";
 
     @Autowired
     public GraphqlController(Elide elide) {
         log.debug("Started ~~");
+        this.elide = elide;
         this.runners = new HashMap<>();
         for (String apiVersion : elide.getElideSettings().getDictionary().getApiVersions()) {
             runners.put(apiVersion, new QueryRunner(elide, apiVersion));
@@ -71,7 +75,7 @@ public class GraphqlController {
 
         ElideResponse response;
         if (runner == null) {
-            response = runner.buildErrorResponse(new InvalidOperationException("Invalid API Version"), false);
+            response = buildErrorResponse(elide, new InvalidOperationException("Invalid API Version"), false);
         } else {
             response = runner.run(graphQLDocument, user);
         }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -63,7 +63,7 @@ public class JsonApiController {
                                            @RequestParam Map<String, String> allRequestParams,
                                            HttpServletRequest request, Authentication authentication) {
 
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -75,7 +75,7 @@ public class JsonApiController {
     public ResponseEntity<String> elidePost(@RequestHeader Map<String, String> requestHeaders,
                                             @RequestBody String body,
                                             HttpServletRequest request, Authentication authentication) {
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -88,7 +88,7 @@ public class JsonApiController {
     public ResponseEntity<String> elidePatch(@RequestHeader Map<String, String> requestHeaders,
                                              @RequestBody String body,
                                              HttpServletRequest request, Authentication authentication) {
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -101,7 +101,7 @@ public class JsonApiController {
     public ResponseEntity<String> elideDelete(@RequestHeader Map<String, String> requestHeaders,
                                               HttpServletRequest request,
                                               Authentication authentication) {
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -114,7 +114,7 @@ public class JsonApiController {
     public ResponseEntity<String> elideDeleteRelationship(@RequestHeader Map<String, String> requestHeaders,
                                                           @RequestBody String body,
                                                           HttpServletRequest request, Authentication authentication) {
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -63,7 +63,7 @@ public class JsonApiController {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
-        ElideResponse response = elide.get(pathname, new MultivaluedHashMap<>(allRequestParams), user);
+        ElideResponse response = elide.get(pathname, new MultivaluedHashMap<>(allRequestParams), user, "");
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
@@ -74,7 +74,7 @@ public class JsonApiController {
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .post(pathname, body, user);
+                .post(pathname, body, user, "");
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
@@ -85,7 +85,7 @@ public class JsonApiController {
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .patch(request.getContentType(), request.getContentType(), pathname, body, user);
+                .patch(request.getContentType(), request.getContentType(), pathname, body, user, "");
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
@@ -96,7 +96,7 @@ public class JsonApiController {
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .delete(pathname, null, user);
+                .delete(pathname, null, user, "");
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
@@ -107,7 +107,7 @@ public class JsonApiController {
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .delete(pathname, body, user);
+                .delete(pathname, body, user, "");
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -58,10 +59,11 @@ public class JsonApiController {
     }
 
     @GetMapping(value = "/**", produces = JSON_API_CONTENT_TYPE)
-    public ResponseEntity<String> elideGet(@RequestParam Map<String, String> allRequestParams,
+    public ResponseEntity<String> elideGet(@RequestHeader Map<String, String> requestHeaders,
+                                           @RequestParam Map<String, String> allRequestParams,
                                            HttpServletRequest request, Authentication authentication) {
 
-        String apiVersion = Util.getApiVersion(allRequestParams);
+        String apiVersion = Util.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -70,10 +72,10 @@ public class JsonApiController {
     }
 
     @PostMapping(value = "/**", consumes = JSON_API_CONTENT_TYPE, produces = JSON_API_CONTENT_TYPE)
-    public ResponseEntity<String> elidePost(@RequestParam Map<String, String> allRequestParams,
+    public ResponseEntity<String> elidePost(@RequestHeader Map<String, String> requestHeaders,
                                             @RequestBody String body,
                                             HttpServletRequest request, Authentication authentication) {
-        String apiVersion = Util.getApiVersion(allRequestParams);
+        String apiVersion = Util.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -83,10 +85,10 @@ public class JsonApiController {
     }
 
     @PatchMapping(value = "/**", consumes = { JSON_API_CONTENT_TYPE, JSON_API_PATCH_CONTENT_TYPE})
-    public ResponseEntity<String> elidePatch(@RequestParam Map<String, String> allRequestParams,
+    public ResponseEntity<String> elidePatch(@RequestHeader Map<String, String> requestHeaders,
                                              @RequestBody String body,
                                              HttpServletRequest request, Authentication authentication) {
-        String apiVersion = Util.getApiVersion(allRequestParams);
+        String apiVersion = Util.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -96,10 +98,10 @@ public class JsonApiController {
     }
 
     @DeleteMapping(value = "/**")
-    public ResponseEntity<String> elideDelete(@RequestParam Map<String, String> allRequestParams,
+    public ResponseEntity<String> elideDelete(@RequestHeader Map<String, String> requestHeaders,
                                               HttpServletRequest request,
                                               Authentication authentication) {
-        String apiVersion = Util.getApiVersion(allRequestParams);
+        String apiVersion = Util.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
@@ -109,10 +111,10 @@ public class JsonApiController {
     }
 
     @DeleteMapping(value = "/**", consumes = JSON_API_CONTENT_TYPE)
-    public ResponseEntity<String> elideDeleteRelationship(@RequestParam Map<String, String> allRequestParams,
+    public ResponseEntity<String> elideDeleteRelationship(@RequestHeader Map<String, String> requestHeaders,
                                                           @RequestBody String body,
                                                           HttpServletRequest request, Authentication authentication) {
-        String apiVersion = Util.getApiVersion(allRequestParams);
+        String apiVersion = Util.getApiVersion(requestHeaders);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -60,54 +60,64 @@ public class JsonApiController {
     @GetMapping(value = "/**", produces = JSON_API_CONTENT_TYPE)
     public ResponseEntity<String> elideGet(@RequestParam Map<String, String> allRequestParams,
                                            HttpServletRequest request, Authentication authentication) {
+
+        String apiVersion = Util.getApiVersion(allRequestParams);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
-        ElideResponse response = elide.get(pathname, new MultivaluedHashMap<>(allRequestParams), user, "");
+        ElideResponse response = elide.get(pathname, new MultivaluedHashMap<>(allRequestParams), user, apiVersion);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
     @PostMapping(value = "/**", consumes = JSON_API_CONTENT_TYPE, produces = JSON_API_CONTENT_TYPE)
-    public ResponseEntity<String> elidePost(@RequestBody String body,
+    public ResponseEntity<String> elidePost(@RequestParam Map<String, String> allRequestParams,
+                                            @RequestBody String body,
                                             HttpServletRequest request, Authentication authentication) {
+        String apiVersion = Util.getApiVersion(allRequestParams);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .post(pathname, body, user, "");
+                .post(pathname, body, user, apiVersion);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
     @PatchMapping(value = "/**", consumes = { JSON_API_CONTENT_TYPE, JSON_API_PATCH_CONTENT_TYPE})
-    public ResponseEntity<String> elidePatch(@RequestBody String body,
+    public ResponseEntity<String> elidePatch(@RequestParam Map<String, String> allRequestParams,
+                                             @RequestBody String body,
                                              HttpServletRequest request, Authentication authentication) {
+        String apiVersion = Util.getApiVersion(allRequestParams);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .patch(request.getContentType(), request.getContentType(), pathname, body, user, "");
+                .patch(request.getContentType(), request.getContentType(), pathname, body, user, apiVersion);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
     @DeleteMapping(value = "/**")
-    public ResponseEntity<String> elideDelete(HttpServletRequest request,
+    public ResponseEntity<String> elideDelete(@RequestParam Map<String, String> allRequestParams,
+                                              HttpServletRequest request,
                                               Authentication authentication) {
+        String apiVersion = Util.getApiVersion(allRequestParams);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .delete(pathname, null, user, "");
+                .delete(pathname, null, user, apiVersion);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
     @DeleteMapping(value = "/**", consumes = JSON_API_CONTENT_TYPE)
-    public ResponseEntity<String> elideDeleteRelationship(@RequestBody String body,
+    public ResponseEntity<String> elideDeleteRelationship(@RequestParam Map<String, String> allRequestParams,
+                                                          @RequestBody String body,
                                                           HttpServletRequest request, Authentication authentication) {
+        String apiVersion = Util.getApiVersion(allRequestParams);
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         User user = new AuthenticationUser(authentication);
         ElideResponse response = elide
-                .delete(pathname, body, user, "");
+                .delete(pathname, body, user, apiVersion);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
@@ -84,16 +84,16 @@ public class SwaggerController {
     public ResponseEntity<String> list(@RequestHeader Map<String, String> requestHeaders) {
         String apiVersion = Util.getApiVersion(requestHeaders);
 
-        if (documents.size() == 1) {
-            return ResponseEntity
-                    .status(HttpStatus.OK)
-                    .body(documents.values().stream().findFirst().get());
-        }
-
         List<String> documentPaths = documents.keySet().stream()
                 .filter(key -> key.getLeft().equals(apiVersion))
                 .map(key -> key.getRight())
                 .collect(Collectors.toList());
+
+        if (documentPaths.size() == 1) {
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(documents.values().iterator().next());
+        }
 
         String body = "[" + documentPaths.stream()
                 .map(key -> '"' + key + '"')

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
@@ -18,8 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.models.Swagger;
@@ -81,8 +81,8 @@ public class SwaggerController {
     }
 
     @GetMapping(value = {"/", ""}, produces = JSON_CONTENT_TYPE)
-    public ResponseEntity<String> list(@RequestParam Map<String, String> allRequestParams) {
-        String apiVersion = Util.getApiVersion(allRequestParams);
+    public ResponseEntity<String> list(@RequestHeader Map<String, String> requestHeaders) {
+        String apiVersion = Util.getApiVersion(requestHeaders);
 
         if (documents.size() == 1) {
             return ResponseEntity
@@ -109,10 +109,10 @@ public class SwaggerController {
      * @return response The Swagger JSON document
      */
     @GetMapping(value = "/{name}", produces = JSON_CONTENT_TYPE)
-    public ResponseEntity<String> list(@RequestParam Map<String, String> allRequestParams,
+    public ResponseEntity<String> list(@RequestHeader Map<String, String> requestHeaders,
                                        @PathVariable("name") String name) {
 
-        String apiVersion = Util.getApiVersion(allRequestParams);
+        String apiVersion = Util.getApiVersion(requestHeaders);
         String encodedName = Encode.forHtml(name);
 
         Pair<String, String> lookupKey = Pair.of(apiVersion, encodedName);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.spring.controllers;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -63,7 +65,7 @@ public class SwaggerController {
 
         docs.forEach((doc) -> {
             String apiVersion = doc.document.getInfo().getVersion();
-            apiVersion = apiVersion == null ? "" : apiVersion;
+            apiVersion = apiVersion == null ? NO_VERSION : apiVersion;
             String apiPath = doc.path;
 
             documents.put(Pair.of(apiVersion, apiPath), SwaggerBuilder.getDocument(doc.document));
@@ -75,7 +77,7 @@ public class SwaggerController {
         log.debug("Started ~~");
         documents = new HashMap<>();
 
-        documents.put(Pair.of("", ""), SwaggerBuilder.getDocument(doc));
+        documents.put(Pair.of(NO_VERSION, ""), SwaggerBuilder.getDocument(doc));
     }
 
     @GetMapping(value = {"/", ""}, produces = JSON_CONTENT_TYPE)

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
@@ -42,16 +42,16 @@ import java.util.stream.Collectors;
 @ConditionalOnExpression("${elide.swagger.enabled:false}")
 public class SwaggerController {
 
+    //Maps api version & path to swagger document.
+    protected Map<Pair<String, String>, String> documents;
+    private static final String JSON_CONTENT_TYPE = "application/json";
+
     @Data
     @AllArgsConstructor
     public static class SwaggerRegistration {
         private String path;
         private Swagger document;
     }
-
-    //Maps api version & path to swagger document.
-    protected Map<Pair<String, String>, String> documents;
-    private static final String JSON_CONTENT_TYPE = "application/json";
 
     /**
      * Constructs the resource.
@@ -82,7 +82,7 @@ public class SwaggerController {
 
     @GetMapping(value = {"/", ""}, produces = JSON_CONTENT_TYPE)
     public ResponseEntity<String> list(@RequestHeader Map<String, String> requestHeaders) {
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
 
         List<String> documentPaths = documents.keySet().stream()
                 .filter(key -> key.getLeft().equals(apiVersion))
@@ -112,7 +112,7 @@ public class SwaggerController {
     public ResponseEntity<String> list(@RequestHeader Map<String, String> requestHeaders,
                                        @PathVariable("name") String name) {
 
-        String apiVersion = Util.getApiVersion(requestHeaders);
+        String apiVersion = Utils.getApiVersion(requestHeaders);
         String encodedName = Encode.forHtml(name);
 
         Pair<String, String> lookupKey = Pair.of(apiVersion, encodedName);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Util.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Util.java
@@ -6,10 +6,11 @@
 
 package com.yahoo.elide.spring.controllers;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import java.util.Map;
 
 public class Util {
     public static String getApiVersion(Map<String, String> requestHeaders) {
-        return requestHeaders.getOrDefault("ApiVersion", "");
+        return requestHeaders.getOrDefault("ApiVersion", NO_VERSION);
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Util.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Util.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public class Util {
     public static String getApiVersion(Map<String, String> requestHeaders) {
-        return requestHeaders.getOrDefault("ApiVersion", NO_VERSION);
+        return requestHeaders.getOrDefault("ApiVersion",
+                requestHeaders.getOrDefault("apiversion", NO_VERSION));  //For tomcat
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Util.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Util.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.spring.controllers;
+
+import java.util.Map;
+
+public class Util {
+    public static String getApiVersion(Map<String, String> requestHeaders) {
+        return requestHeaders.getOrDefault("ApiVersion", "");
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Utils.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/Utils.java
@@ -9,7 +9,7 @@ package com.yahoo.elide.spring.controllers;
 import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import java.util.Map;
 
-public class Util {
+public class Utils {
     public static String getApiVersion(Map<String, String> requestHeaders) {
         return requestHeaders.getOrDefault("ApiVersion",
                 requestHeaders.getOrDefault("apiversion", NO_VERSION));  //For tomcat

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/App.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/App.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring;
+package example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/SecurityConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/SecurityConfiguration.java
@@ -4,7 +4,7 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.spring;
+package example;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/checks/AdminCheck.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/checks/AdminCheck.java
@@ -4,7 +4,7 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.spring.checks;
+package example.checks;
 
 import com.yahoo.elide.annotation.SecurityCheck;
 import com.yahoo.elide.security.RequestScope;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/aggregation/Stats.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/aggregation/Stats.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring.models.aggregation;
+package example.models.aggregation;
 
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.datastores.aggregation.annotation.Cardinality;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactGroup.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactGroup.java
@@ -3,12 +3,12 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring.models.jpa;
+package example.models.jpa;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
-import com.yahoo.elide.spring.checks.AdminCheck;
+import example.checks.AdminCheck;
 import lombok.Data;
 
 import java.util.ArrayList;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactProduct.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactProduct.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring.models.jpa;
+package example.models.jpa;
 
 import com.yahoo.elide.annotation.Include;
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactVersion.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactVersion.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring.models.jpa;
+package example.models.jpa;
 
 import com.yahoo.elide.annotation.Include;
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/v2/ArtifactGroupV2.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/v2/ArtifactGroupV2.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package example.models.jpa.v2;
+
+import com.yahoo.elide.annotation.Include;
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Include(rootLevel = true, type = "group")
+@Entity
+@Data
+@Table(name = "ArtifactGroup")
+public class ArtifactGroupV2 {
+    @Id
+    private String name = "";
+
+    @Column(name = "commonName")
+    private String title = "";
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/v2/package-info.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/v2/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+@ApiVersion(version = "1.0")
+package example.models.jpa.v2;
+
+import com.yahoo.elide.annotation.ApiVersion;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AggregationStoreTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AggregationStoreTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring.tests;
+package example.tests;
 
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -7,6 +7,7 @@ package example.tests;
 
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.argument;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.arguments;
+import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.document;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.field;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.query;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selection;
@@ -40,6 +41,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
 import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 /**
  * Example functional test.
@@ -286,6 +288,33 @@ public class ControllerTest extends IntegrationTest {
                 )
             ).toResponse()))
             .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void testInvalidApiVersion() throws IOException {
+
+        String graphQLRequest = GraphQLDSL.document(
+                selection(
+                        field(
+                                "group",
+                                selections(
+                                        field("name")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = "{\"errors\":[{\"message\":\"Invalid operation: Invalid API Version\"}]}";
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("ApiVersion", "2.0")
+                .body("{ \"query\" : \"" + graphQLRequest + "\" }")
+                .post("/graphql")
+                .then()
+                .body(equalTo(expected))
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring.tests;
+package example.tests;
 
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.argument;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.arguments;
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.spring.controllers.JsonApiController;
-import com.yahoo.elide.spring.models.jpa.ArtifactGroup;
+import example.models.jpa.ArtifactGroup;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
@@ -70,6 +70,27 @@ public class ControllerTest extends IntegrationTest {
                                         ),
                                         relationships(
                                                 relation("products")
+                                        )
+                                )
+                        ).toJSON())
+                )
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void versionedJsonApiGetTest() {
+        given()
+                .header("ApiVersion", "1.0")
+                .when()
+                .get("/json/group")
+                .then()
+                .body(equalTo(
+                        data(
+                                resource(
+                                        type("group"),
+                                        id("com.example.repository"),
+                                        attributes(
+                                                attr("title", "Example Repository")
                                         )
                                 )
                         ).toJSON())

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -287,6 +287,45 @@ public class ControllerTest extends IntegrationTest {
             .statusCode(HttpStatus.SC_OK);
     }
 
+    /**
+     * This test demonstrates an example test using the GraphQL DSL.
+     */
+    @Test
+    public void versionedGraphqlTest() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("ApiVersion", "1.0")
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        query(
+                                selection(
+                                        field("group",
+                                                selections(
+                                                        field("name"),
+                                                        field("title")
+                                                )
+                                        )
+                                )
+                        )
+                        ).toQuery() + "\" }"
+                )
+                .when()
+                .post("/graphql")
+                .then()
+                .body(equalTo(GraphQLDSL.document(
+                        selection(
+                                field(
+                                        "group",
+                                        selections(
+                                                field("name", "com.example.repository"),
+                                                field("title", "Example Repository")
+                                        )
+                                )
+                        )
+                ).toResponse()))
+                .statusCode(HttpStatus.SC_OK);
+    }
+
     @Test
     public void swaggerDocumentTest() {
         when()

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -7,7 +7,6 @@ package example.tests;
 
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.argument;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.arguments;
-import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.document;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.field;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.query;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selection;
@@ -40,8 +39,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
-import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import javax.ws.rs.core.MediaType;
 
 /**
  * Example functional test.

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -27,6 +27,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperatio
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL;
@@ -331,7 +332,21 @@ public class ControllerTest extends IntegrationTest {
         when()
                 .get("/doc")
                 .then()
-                .statusCode(HttpStatus.SC_OK);
+                .statusCode(HttpStatus.SC_OK)
+                .body("tags.name", containsInAnyOrder("group", "functionArgument", "metric",
+                        "metricFunction", "dimension", "column", "table", "asyncQuery", "asyncQueryResult",
+                        "timeDimensionGrain", "timeDimension"));
+    }
+
+    @Test
+    public void versionedSwaggerDocumentTest() {
+        given()
+                .header("ApiVersion", "1.0")
+        .when()
+                .get("/doc")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo("[]"));
     }
 
     @Test

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.spring.tests;
+package example.tests;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -2,7 +2,7 @@ server:
   port: 4001
 
 elide:
-  modelPackage: 'com.yahoo.elide.spring.models'
+  modelPackage: 'example.models'
   json-api:
     path: /json
     enabled: true

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.standalone.config;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.standalone.Util;
@@ -112,7 +113,7 @@ public class ElideResourceConfig extends ResourceConfig {
         register(new org.glassfish.hk2.utilities.binding.AbstractBinder() {
             @Override
             protected void configure() {
-                Map<String, Swagger> swaggerDocs = settings.enableSwagger();
+                List<DocEndpoint.SwaggerRegistration> swaggerDocs = settings.enableSwagger();
                 if (!swaggerDocs.isEmpty()) {
                     // Include the async models in swagger docs
                     if(settings.enableAsync()) {
@@ -120,7 +121,7 @@ public class ElideResourceConfig extends ResourceConfig {
                         dictionary.bindEntity(AsyncQuery.class);
                         dictionary.bindEntity(AsyncQueryResult.class);
                          
-                        Info info = new Info().title("Async Service").version("1.0");
+                        Info info = new Info().title("Async Service");
 
                         SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
                         
@@ -129,10 +130,10 @@ public class ElideResourceConfig extends ResourceConfig {
 
                         Swagger swagger = builder.build().basePath(asyncBasePath);
 
-                        swaggerDocs.put("async", swagger);
+                        swaggerDocs.add(new DocEndpoint.SwaggerRegistration("async", swagger));
                     }
 
-                    bind(swaggerDocs).named("swagger").to(new TypeLiteral<Map<String, Swagger>>() { });
+                    bind(swaggerDocs).named("swagger").to(new TypeLiteral<List<DocEndpoint.SwaggerRegistration>>() { });
                 }
             }
         });

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.Injector;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.audit.Slf4jLogger;
+import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
@@ -26,6 +27,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 
 import io.swagger.models.Swagger;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -240,11 +242,11 @@ public interface ElideStandaloneSettings {
     }
 
     /**
-     * Enable swagger documentation by returning non empty map object.
-     * @return Map object that maps document name to swagger object.
+     * Enable swagger documentation by returning non empty list.
+     * @return list of swagger registration objects.
      */
-    default Map<String, Swagger> enableSwagger() {
-        return new HashMap<>();
+    default List<DocEndpoint.SwaggerRegistration> enableSwagger() {
+        return new ArrayList<>();
     }
 
     /**

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.hasKey;
 
 import com.google.common.collect.Maps;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
+import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import com.yahoo.elide.standalone.models.Post;
@@ -28,8 +29,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -66,17 +67,17 @@ public class ElideStandaloneTest {
             }
 
             @Override
-            public Map<String, Swagger> enableSwagger() {
+            public List<DocEndpoint.SwaggerRegistration> enableSwagger() {
                 EntityDictionary dictionary = new EntityDictionary(Maps.newHashMap());
 
                 dictionary.bindEntity(Post.class);
-                Info info = new Info().title("Test Service").version("1.0");
+                Info info = new Info().title("Test Service");
 
                 SwaggerBuilder builder = new SwaggerBuilder(dictionary, info);
                 Swagger swagger = builder.build();
 
-                Map<String, Swagger> docs = new HashMap<>();
-                docs.put("test", swagger);
+                List<DocEndpoint.SwaggerRegistration> docs = new ArrayList<>();
+                docs.add(new DocEndpoint.SwaggerRegistration("test", swagger));
                 return docs;
             }
 

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.standalone;
+package example;
 
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
@@ -19,8 +19,9 @@ import com.google.common.collect.Maps;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 import com.yahoo.elide.contrib.swagger.resources.DocEndpoint;
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.standalone.ElideStandalone;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
-import com.yahoo.elide.standalone.models.Post;
+import example.models.Post;
 import io.swagger.models.Info;
 import io.swagger.models.Swagger;
 import org.apache.http.HttpStatus;
@@ -111,6 +112,30 @@ public class ElideStandaloneTest {
             .then()
             .statusCode(HttpStatus.SC_CREATED)
             .extract().body().asString();
+    }
+
+    @Test
+    public void testVersionedJsonAPIPost() {
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .header("ApiVersion", "1.0")
+                .body(
+                        datum(
+                                resource(
+                                        type("post"),
+                                        id("2"),
+                                        attributes(
+                                                attr("text", "This is my first post. woot."),
+                                                attr("date", "2019-01-01T00:00Z")
+                                        )
+                                )
+                        )
+                )
+                .post("/api/v1/post")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .extract().body().asString();
     }
 
     @Test

--- a/elide-standalone/src/test/java/example/checks/AdminCheck.java
+++ b/elide-standalone/src/test/java/example/checks/AdminCheck.java
@@ -4,7 +4,7 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.standalone.checks;
+package example.checks;
 
 import com.yahoo.elide.annotation.SecurityCheck;
 import com.yahoo.elide.security.RequestScope;

--- a/elide-standalone/src/test/java/example/models/Post.java
+++ b/elide-standalone/src/test/java/example/models/Post.java
@@ -4,12 +4,12 @@
  * See LICENSE file in project root for terms.
  */
 
-package com.yahoo.elide.standalone.models;
+package example.models;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
-import com.yahoo.elide.standalone.checks.AdminCheck;
+import example.checks.AdminCheck;
 import lombok.Data;
 
 import java.util.Date;

--- a/elide-standalone/src/test/java/example/models/v2/PostV2.java
+++ b/elide-standalone/src/test/java/example/models/v2/PostV2.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package example.models.v2;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.UpdatePermission;
+import example.checks.AdminCheck;
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
+
+@Entity
+@Include(rootLevel = true, type = "post")
+@Data
+@Table(name = "Post")
+public class PostV2 {
+    @Id
+    private long id;
+
+    @Column(nullable = false, name = "content")
+    private String text;
+
+    @Temporal( TemporalType.TIMESTAMP )
+    private Date date;
+
+    @CreatePermission(expression = AdminCheck.USER_IS_ADMIN)
+    @UpdatePermission(expression = AdminCheck.USER_IS_ADMIN)
+    private boolean abusiveContent;
+}

--- a/elide-standalone/src/test/java/example/models/v2/package-info.java
+++ b/elide-standalone/src/test/java/example/models/v2/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+@ApiVersion(version = "1.0")
+package example.models.v2;
+
+import com.yahoo.elide.annotation.ApiVersion;


### PR DESCRIPTION
Resolves #1274 

## Description
This PR adds plumbing to support distinct sets of entity models that be selected at query time by API version.

All of the default JAX-RS and Spring controller endpoints support selecting version by a new header (ApiVersion).  Alternatives schemes (content type, path parameters, etc) for api versioning can be supported by creating a customized JAX-RS endpoint or Spring controller.

To version a collection of models, the following must be done:
1.  Each model must have a unique class name if working with a JPA backed data store (`@Entity` requires the class name to be unique).  However, the models can share the same API name and underlying physical SQL table.
2. A new annotation (`ApiVersion`) marks that a collection of models (at the package level) are only accessible for a particular version of the API.

## Motivation and Context
While simple model changes are relatively easy to support (adding new fields) - more complex changes like removing fields or modifying relationships are difficult.

## How Has This Been Tested?
New entity dictionary UTs and a bunch of new ITs.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
