### PR TITLE
Implement equals/hashCode and immutability where needed

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/request/Argument.java
+++ b/elide-core/src/main/java/com/yahoo/elide/request/Argument.java
@@ -7,13 +7,13 @@
 package com.yahoo.elide.request;
 
 import lombok.Builder;
-import lombok.Data;
 import lombok.NonNull;
+import lombok.Value;
 
 /**
  * Represents an argument passed to an attribute.
  */
-@Data
+@Value
 @Builder
 public class Argument {
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -19,8 +19,8 @@ import com.yahoo.elide.datastores.aggregation.annotation.MetricFormula;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ColumnType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 
 import java.util.Date;
@@ -32,33 +32,32 @@ import javax.persistence.Id;
  * Column is the super class of a field in a table, it can be either dimension or metric.
  */
 @Include(type = "column")
-@Data
+@Getter
+@EqualsAndHashCode
 @ToString
 public abstract class Column {
     @Id
-    private String id;
+    private final String id;
 
-    private String name;
+    private final String name;
 
-    private String longName;
+    private final String longName;
 
-    private String description;
-
-    private String category;
+    private final String description;
 
     @ToOne
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
-    private Table table;
+    private final Table table;
 
-    private ValueType valueType;
+    private final ValueType valueType;
 
-    private ColumnType columnType;
+    private final ColumnType columnType;
 
-    private String expression;
+    private final String expression;
 
     @ToString.Exclude
-    private Set<String> columnTags;
+    private final Set<String> columnTags;
 
     protected Column(Table table, String fieldName, EntityDictionary dictionary) {
         this.table = table;
@@ -72,6 +71,9 @@ public abstract class Column {
         if (meta != null) {
             this.longName = meta.longName();
             this.description = meta.description();
+        } else {
+            this.longName = null;
+            this.description = null;
         }
 
         valueType = getValueType(tableClass, fieldName, dictionary);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Dimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Dimension.java
@@ -8,15 +8,13 @@ package com.yahoo.elide.datastores.aggregation.metadata.models;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.core.EntityDictionary;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
  * Regular field in tables, can be grouped by.
  */
-@EqualsAndHashCode(callSuper = true)
 @Include(type = "dimension")
-@Data
+@EqualsAndHashCode(callSuper = true)
 public class Dimension extends Column {
     public Dimension(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Metric.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Metric.java
@@ -10,10 +10,9 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.datastores.aggregation.annotation.Meta;
 import com.yahoo.elide.datastores.aggregation.annotation.MetricAggregation;
 import com.yahoo.elide.datastores.aggregation.annotation.MetricFormula;
-import com.yahoo.elide.datastores.aggregation.metadata.enums.Format;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 
 import java.util.HashSet;
@@ -23,15 +22,14 @@ import javax.persistence.ManyToOne;
 /**
  * Column which supports aggregation.
  */
-@EqualsAndHashCode(callSuper = true)
 @Include(type = "metric")
-@Data
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString
 public class Metric extends Column {
-    private Format defaultFormat;
-
     @ManyToOne
     @ToString.Exclude
-    private MetricFunction metricFunction;
+    private final MetricFunction metricFunction;
 
     public Metric(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -16,7 +16,8 @@ import com.yahoo.elide.datastores.aggregation.annotation.CardinalitySize;
 import com.yahoo.elide.datastores.aggregation.annotation.Meta;
 import com.yahoo.elide.datastores.aggregation.annotation.Temporal;
 
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 
 import java.util.HashSet;
@@ -31,41 +32,40 @@ import javax.persistence.OneToMany;
  * Super class of all logical or physical tables.
  */
 @Include(rootLevel = true, type = "table")
-@Data
+@Getter
+@EqualsAndHashCode
 @ToString
 public class Table {
     @Id
-    private String id;
+    private final String id;
 
-    private String name;
+    private final String name;
 
     @Exclude
-    private String version;
+    private final String version;
 
-    private String description;
+    private final String description;
 
-    private String category;
-
-    private CardinalitySize cardinality;
+    private final CardinalitySize cardinality;
 
     @OneToMany
     @ToString.Exclude
-    private Set<Column> columns;
+    private final Set<Column> columns;
 
     @OneToMany
     @ToString.Exclude
-    private Set<Metric> metrics;
+    private final Set<Metric> metrics;
 
     @OneToMany
     @ToString.Exclude
-    private Set<Dimension> dimensions;
+    private final Set<Dimension> dimensions;
 
     @OneToMany
     @ToString.Exclude
-    private Set<TimeDimension> timeDimensions;
+    private final Set<TimeDimension> timeDimensions;
 
     @ToString.Exclude
-    private Set<String> tableTags;
+    private final Set<String> tableTags;
 
     @Exclude
     @ToString.Exclude
@@ -78,11 +78,12 @@ public class Table {
         }
 
         this.name = dictionary.getJsonAliasFor(cls);
-        this.id = this.name;
         this.version = EntityDictionary.getModelVersion(cls);
 
         if (this.version != null && ! this.version.isEmpty()) {
             this.id = this.name + "." + this.version;
+        } else {
+            this.id = this.name;
         }
 
         this.tableTags = new HashSet<>();
@@ -106,11 +107,15 @@ public class Table {
         Meta meta = cls.getAnnotation(Meta.class);
         if (meta != null) {
             this.description = meta.description();
+        } else {
+            this.description = null;
         }
 
         Cardinality cardinality = dictionary.getAnnotation(cls, Cardinality.class);
         if (cardinality != null) {
             this.cardinality = cardinality.size();
+        } else {
+            this.cardinality = null;
         }
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
@@ -9,9 +9,9 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.datastores.aggregation.annotation.Temporal;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import lombok.Value;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -26,16 +26,17 @@ import javax.persistence.ManyToMany;
  */
 @EqualsAndHashCode(callSuper = true)
 @Include(type = "timeDimension")
-@Data
+@Value
 public class TimeDimension extends Dimension {
     @ManyToMany
     @ToString.Exclude
     Set<TimeDimensionGrain> supportedGrains;
 
-    private TimeZone timezone;
+    TimeZone timezone;
 
     public TimeDimension(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);
+        timezone = null;
 
         Temporal temporal = dictionary.getAttributeOrRelationAnnotation(
                 dictionary.getEntityClass(table.getName(), table.getVersion()),

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimensionGrain.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimensionGrain.java
@@ -9,7 +9,7 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.datastores.aggregation.annotation.TimeGrainDefinition;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 
-import lombok.Data;
+import lombok.Value;
 
 import java.util.Locale;
 import javax.persistence.Id;
@@ -18,14 +18,11 @@ import javax.persistence.Id;
  * Defines how to extract a time dimension for a specific grain from a table.
  */
 @Include(type = "timeDimensionGrain")
-@Data
+@Value
 public class TimeDimensionGrain {
-    @Id
-    private String id;
-
-    private TimeGrain grain;
-
-    private String expression;
+    @Id String id;
+    TimeGrain grain;
+    String expression;
 
     public TimeDimensionGrain(String fieldName, TimeGrainDefinition definition) {
         this.id = fieldName + "." + definition.grain().name().toLowerCase(Locale.ENGLISH);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
@@ -36,4 +36,8 @@ public interface ColumnProjection<T extends Column> extends Serializable {
      * @return request arguments
      */
     Map<String, Argument> getArguments();
+
+    // force implementations to define equals/hashCode
+    boolean equals(Object other);
+    int hashCode();
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -12,8 +12,8 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.request.Pagination;
 import com.yahoo.elide.request.Sorting;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Singular;
+import lombok.Value;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -24,25 +24,25 @@ import java.util.stream.Stream;
 /**
  * A {@link Query} is an object representing a query executed by {@link QueryEngine}.
  */
-@Data
+@Value
 @Builder
 public class Query {
-    private final Table table;
+    Table table;
 
     @Singular
-    private final List<MetricProjection> metrics;
+    List<MetricProjection> metrics;
 
     @Singular
-    private final Set<ColumnProjection> groupByDimensions;
+    Set<ColumnProjection> groupByDimensions;
 
     @Singular
-    private final Set<TimeDimensionProjection> timeDimensions;
+    Set<TimeDimensionProjection> timeDimensions;
 
-    private final FilterExpression whereFilter;
-    private final FilterExpression havingFilter;
-    private final Sorting sorting;
-    private final Pagination pagination;
-    private final RequestScope scope;
+    FilterExpression whereFilter;
+    FilterExpression havingFilter;
+    Sorting sorting;
+    Pagination pagination;
+    RequestScope scope;
 
     /**
      * Returns all the dimensions regardless of type.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -11,50 +11,23 @@ import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.request.Argument;
 
+import lombok.Value;
+
 import java.util.Map;
 
 /**
  * Metric projection that can expand the metric into a SQL projection fragment.
  */
+@Value
 public class SQLMetricProjection implements MetricProjection, SQLColumnProjection<Metric> {
 
-    private Metric metric;
-    private SQLReferenceTable sqlReferenceTable;
-    private String alias;
-    private Map<String, Argument> arguments;
-
-    public SQLMetricProjection(Metric metric,
-                               SQLReferenceTable sqlReferenceTable,
-                               String alias,
-                               Map<String, Argument> arguments) {
-        this.metric = metric;
-        this.sqlReferenceTable = sqlReferenceTable;
-        this.arguments = arguments;
-        this.alias = alias;
-    }
-
-    @Override
-    public SQLReferenceTable getReferenceTable() {
-        return sqlReferenceTable;
-    }
-
-    @Override
-    public Metric getColumn() {
-        return metric;
-    }
+    Metric column;
+    SQLReferenceTable referenceTable;
+    String alias;
+    Map<String, Argument> arguments;
 
     @Override
     public String toSQL(SQLQueryTemplate queryTemplate) {
-        return sqlReferenceTable.getResolvedReference(metric.getTable(), metric.getName());
-    }
-
-    @Override
-    public String getAlias() {
-        return alias;
-    }
-
-    @Override
-    public Map<String, Argument> getArguments() {
-        return arguments;
+        return referenceTable.getResolvedReference(column.getTable(), column.getName());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -14,6 +14,8 @@ import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.request.Argument;
 
+import lombok.Value;
+
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -22,26 +24,27 @@ import java.util.TimeZone;
 /**
  * Column projection that can expand the column into a SQL projection fragment.
  */
+@Value
 public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimension>, TimeDimensionProjection {
 
-    private final TimeDimension column;
-    private final TimeDimensionGrain grain;
-    private final TimeZone timezone;
-    private final SQLReferenceTable sqlReferenceTable;
-    private final String alias;
-    private final Map<String, Argument> arguments;
+    TimeDimension column;
+    TimeDimensionGrain grain;
+    TimeZone timeZone;
+    SQLReferenceTable referenceTable;
+    String alias;
+    Map<String, Argument> arguments;
 
     /**
      * Default constructor for columns that are projected in filter and sorting clauses.
      * @param column The column in the filter/sorting clause.
-     * @param sqlReferenceTable The reference table.
+     * @param referenceTable The reference table.
      */
     public SQLTimeDimensionProjection(TimeDimension column,
-                                      SQLReferenceTable sqlReferenceTable) {
+                                      SQLReferenceTable referenceTable) {
         this(
                 column,
                 column.getTimezone(),
-                sqlReferenceTable,
+                referenceTable,
                 column.getName(),
                 new LinkedHashMap<>()
         );
@@ -50,14 +53,14 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
     /**
      * All argument constructor.
      * @param column The column being projected.
-     * @param timezone The selected time zone.
-     * @param sqlReferenceTable The reference table.
+     * @param timeZone The selected time zone.
+     * @param referenceTable The reference table.
      * @param alias The client provided alias.
      * @param arguments List of client provided arguments.
      */
     public SQLTimeDimensionProjection(TimeDimension column,
-                                      TimeZone timezone,
-                                      SQLReferenceTable sqlReferenceTable,
+                                      TimeZone timeZone,
+                                      SQLReferenceTable referenceTable,
                                       String alias,
                                       Map<String, Argument> arguments) {
 
@@ -83,21 +86,11 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
         }
 
         this.column = column;
-        this.sqlReferenceTable = sqlReferenceTable;
+        this.referenceTable = referenceTable;
         this.arguments = arguments;
         this.alias = alias;
         this.grain = resolvedGrain;
-        this.timezone = timezone;
-    }
-
-    @Override
-    public SQLReferenceTable getReferenceTable() {
-        return sqlReferenceTable;
-    }
-
-    @Override
-    public TimeDimension getColumn() {
-        return column;
+        this.timeZone = timeZone;
     }
 
     @Override
@@ -105,26 +98,11 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection<TimeDimen
         //TODO - We will likely migrate to a templating language when we support parameterized metrics.
         return String.format(
                 grain.getExpression(),
-                sqlReferenceTable.getResolvedReference(column.getTable(), column.getName()));
-    }
-
-    @Override
-    public String getAlias() {
-        return alias;
+                referenceTable.getResolvedReference(column.getTable(), column.getName()));
     }
 
     @Override
     public TimeGrain getGrain() {
         return grain.getGrain();
-    }
-
-    @Override
-    public TimeZone getTimeZone() {
-        return timezone;
-    }
-
-    @Override
-    public Map<String, Argument> getArguments() {
-        return arguments;
     }
 }


### PR DESCRIPTION
## Description
Make sure classes used in queries have correct equals/hashCode implementations, using Lombok if possible.

## Motivation and Context
`Query` has `Set<ColumnProjection>` and `Set<TimeDimensionProjection>` fields, but for those sets to work as expected, `ColumnProjection` and `TimeDimensionProjection` need to implement equals/hashCode correctly, as well as classes held by those classes and their superclasses.

## How Has This Been Tested?
UTs are passing.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
