### PR TITLE
Changes elide to only inject models annotated with @Inject

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -651,7 +651,7 @@ public class EntityBinding {
         return annotation == NO_ANNOTATION ? null : annotationClass.cast(annotation);
     }
 
-    boolean shouldInject() {
+    private boolean shouldInject() {
         boolean hasField = getAllFields().stream()
                 .anyMatch(accessibleObject -> accessibleObject.isAnnotationPresent(Inject.class));
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.inject.Inject;
 import javax.persistence.AccessType;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -89,6 +90,9 @@ public class EntityBinding {
     @Getter
     private AccessType accessType;
 
+    @Getter
+    private final boolean injected;
+
     private EntityDictionary dictionary;
 
     @Getter
@@ -122,6 +126,7 @@ public class EntityBinding {
 
     /* empty binding constructor */
     private EntityBinding() {
+        injected = false;
         jsonApiType = null;
         entityName = null;
         apiVersion = NO_VERSION;
@@ -175,6 +180,7 @@ public class EntityBinding {
 
         // Map id's, attributes, and relationships
         List<AccessibleObject> fieldOrMethodList = getAllFields();
+        injected = shouldInject();
 
         if (fieldOrMethodList.stream().anyMatch(field -> field.isAnnotationPresent(Id.class))) {
             accessType = AccessType.FIELD;
@@ -250,6 +256,17 @@ public class EntityBinding {
         }
 
         return fields;
+    }
+
+    private List<AccessibleObject> getAllMethods() {
+        List<AccessibleObject> methods = new ArrayList<>();
+
+        methods.addAll(getInstanceMembers(entityClass.getDeclaredMethods(), (method) -> !method.isSynthetic()));
+        for (Class<?> type : inheritedTypes) {
+            methods.addAll(getInstanceMembers(type.getDeclaredMethods(), (method) -> !method.isSynthetic()));
+        }
+
+        return methods;
     }
 
     /**
@@ -632,6 +649,27 @@ public class EntityBinding {
             }
         });
         return annotation == NO_ANNOTATION ? null : annotationClass.cast(annotation);
+    }
+
+    boolean shouldInject() {
+        boolean hasField = getAllFields().stream()
+                .anyMatch(accessibleObject -> accessibleObject.isAnnotationPresent(Inject.class));
+
+        if (hasField) {
+            return true;
+        }
+
+        boolean hasMethod = getAllMethods().stream()
+                .anyMatch(accessibleObject -> accessibleObject.isAnnotationPresent(Inject.class));
+
+        if (hasMethod) {
+            return true;
+        }
+
+        boolean hasConstructor = Arrays.stream(entityClass.getConstructors())
+                .anyMatch(ctor -> ctor.getAnnotation(Inject.class) != null);
+
+        return hasConstructor;
     }
 
     private List<Class<?>> getInheritedTypes(Class<?> entityClass) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -781,7 +781,11 @@ public class EntityDictionary {
      */
     public <T> void initializeEntity(T entity) {
         if (entity != null) {
-            injector.inject(entity);
+            EntityBinding binding = getEntityBinding(entity.getClass());
+
+            if (binding.isInjected()) {
+                injector.inject(entity);
+            }
         }
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -744,6 +744,93 @@ public class EntityDictionaryTest extends EntityDictionary {
     }
 
     @Test
+    public void testFieldIsInjected() {
+        EntityDictionary testDictionary = new EntityDictionary(new HashMap<>());
+
+        @Include
+        class FieldInject {
+            @Inject
+            private String field;
+        }
+
+        testDictionary.bindEntity(FieldInject.class);
+
+        assertTrue(testDictionary.getEntityBinding(FieldInject.class).isInjected());
+    }
+
+    @Test
+    public void testInheritedFieldIsInjected() {
+        EntityDictionary testDictionary = new EntityDictionary(new HashMap<>());
+        class BaseClass {
+            @Inject
+            private String field;
+        }
+
+        @Include
+        class SubClass extends BaseClass {
+            private String anotherField;
+        }
+
+        testDictionary.bindEntity(SubClass.class);
+
+        assertTrue(testDictionary.getEntityBinding(SubClass.class).isInjected());
+    }
+
+    @Test
+    public void testMethodIsInjected() {
+        EntityDictionary testDictionary = new EntityDictionary(new HashMap<>());
+
+        @Include
+        class MethodInject {
+            @Inject
+            private void setField(String field) {
+                //NOOP
+            }
+        }
+
+        testDictionary.bindEntity(MethodInject.class);
+
+        assertTrue(testDictionary.getEntityBinding(MethodInject.class).isInjected());
+    }
+
+    @Test
+    public void testInhertedMethodIsInjected() {
+        EntityDictionary testDictionary = new EntityDictionary(new HashMap<>());
+        class BaseClass {
+            @Inject
+            private void setField(String field) {
+                //NOOP
+            }
+        }
+
+        @Include
+        class SubClass extends BaseClass {
+            private String anotherField;
+        }
+
+        testDictionary.bindEntity(SubClass.class);
+
+        assertTrue(testDictionary.getEntityBinding(SubClass.class).isInjected());
+    }
+
+    @Test
+    public void testConstructorIsInjected() {
+        EntityDictionary testDictionary = new EntityDictionary(new HashMap<>());
+
+        @Include
+        class ConstructorInject {
+            @Inject
+            public ConstructorInject(String field) {
+                //NOOP
+            }
+        }
+
+        testDictionary.bindEntity(ConstructorInject.class);
+
+        assertTrue(testDictionary.getEntityBinding(ConstructorInject.class).isInjected());
+    }
+
+    @Test
     public void testFieldLookup() throws Exception {
         bindEntity(Book.class);
         bindEntity(Editor.class);


### PR DESCRIPTION
## Description
Elide currently injects every model it manages.  This can be costly for large collections loaded from a database - especially if those models don't actually require injection.

This PR changes Elide to only inject models that are decorated with `@Inject`.

## Motivation and Context
Performance improvement for loading large collections.

## How Has This Been Tested?
UT tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
