### PR TITLE
Allow customizing the handling of ReadPermission for filter joins

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitor.java
@@ -97,9 +97,20 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
         return resource.getRelationChecked(fieldName, Optional.empty(), Optional.empty(), Optional.empty()).stream();
     }
 
+    /**
+     * Scan the Path for user checks.
+     * <ol>
+     * <li>If all are PASS, return PASS
+     * <li>If any FAIL, return FAIL
+     * <li>Otherwise return DEFERRED
+     * </ol>
+     * @param filterPredicate
+     * @return ExpressionResult
+     */
     private ExpressionResult evaluateUserChecks(FilterPredicate filterPredicate) {
         PermissionExecutor executor = resource.getRequestScope().getPermissionExecutor();
 
+        ExpressionResult ret = ExpressionResult.PASS;
         for (PathElement element : filterPredicate.getPath().getPathElements()) {
             ExpressionResult result;
             try {
@@ -111,11 +122,15 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
                 return ExpressionResult.FAIL;
             }
 
+            if (result == ExpressionResult.FAIL) {
+                return ExpressionResult.FAIL;
+            }
+
             if (result != ExpressionResult.PASS) {
-                return result;
+                ret = ExpressionResult.DEFERRED;
             }
         }
-        return ExpressionResult.PASS;
+        return ret;
     }
 
     @Override

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -78,7 +78,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
- * Tests the invocation & sequencing of DataStoreTransaction method invocations and life cycle events.
+ * Tests the invocation &amp; sequencing of DataStoreTransaction method invocations and life cycle events.
  */
 public class LifeCycleTest {
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.core.Path.PathElement;
 import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.InPredicate;
@@ -24,8 +26,8 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.NotFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.security.PermissionExecutor;
-
 import com.yahoo.elide.security.permissions.ExpressionResult;
+
 import example.Author;
 import example.Book;
 
@@ -37,6 +39,7 @@ import java.util.Collections;
 
 public class VerifyFieldAccessFilterExpressionVisitorTest {
 
+    private static final String AUTHORS = "authors";
     private static final String GENRE = "genre";
     private static final String HOME = "homeAddress";
     private static final String NAME = "name";
@@ -56,29 +59,31 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         when(scope.getDictionary()).thenReturn(dictionary);
         when(scope.getPermissionExecutor()).thenReturn(permissionExecutor);
         when(scope.getTransaction()).thenReturn(transaction);
+        when(permissionExecutor.evaluateFilterJoinUserChecks(any(), any())).thenCallRealMethod();
+        when(permissionExecutor.handleFilterJoinReject(any(), any(), any())).thenCallRealMethod();
     }
 
     @Test
     public void testAccept() throws Exception {
         Path p1Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, Author.class, "authors"),
-                new Path.PathElement(Author.class, String.class, NAME)
+                new PathElement(Book.class, Author.class, AUTHORS),
+                new PathElement(Author.class, String.class, NAME)
         ));
         FilterPredicate p1 = new InPredicate(p1Path, "foo", "bar");
 
         Path p2Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, String.class, NAME)
+                new PathElement(Book.class, String.class, NAME)
         ));
         FilterPredicate p2 = new InPredicate(p2Path, "blah");
 
         Path p3Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, String.class, GENRE)
+                new PathElement(Book.class, String.class, GENRE)
         ));
         FilterPredicate p3 = new InPredicate(p3Path, SCIFI);
 
         //P4 is a duplicate of P3
         Path p4Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, String.class, GENRE)
+                new PathElement(Book.class, String.class, GENRE)
         ));
         FilterPredicate p4 = new InPredicate(p4Path, SCIFI);
 
@@ -106,30 +111,32 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         assertTrue(p4.accept(visitor));
 
         PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
+        verify(permissionExecutor, times(17)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, NAME);
+        verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
     }
 
     @Test
     public void testReject() throws Exception {
         Path p1Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, Author.class, "authors"),
-                new Path.PathElement(Author.class, String.class, NAME)
+                new PathElement(Book.class, Author.class, AUTHORS),
+                new PathElement(Author.class, String.class, NAME)
         ));
         FilterPredicate p1 = new InPredicate(p1Path, "foo", "bar");
 
         Path p2Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, String.class, HOME)
+                new PathElement(Book.class, String.class, HOME)
         ));
         FilterPredicate p2 = new InPredicate(p2Path, "blah");
 
         Path p3Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, String.class, GENRE)
+                new PathElement(Book.class, String.class, GENRE)
         ));
         FilterPredicate p3 = new InPredicate(p3Path, SCIFI);
 
         //P4 is a duplicate of P3
         Path p4Path = new Path(Arrays.asList(
-                new Path.PathElement(Book.class, String.class, GENRE)
+                new PathElement(Book.class, String.class, GENRE)
         ));
         FilterPredicate p4 = new InPredicate(p4Path, SCIFI);
 
@@ -161,7 +168,9 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         assertTrue(p3.accept(visitor));
         assertTrue(p4.accept(visitor));
 
+        verify(permissionExecutor, times(8)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, HOME);
+        verify(permissionExecutor, times(5)).handleFilterJoinReject(any(), any(), any());
     }
 
     @Test
@@ -182,8 +191,10 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         // restricted HOME field
         assertFalse(expression.accept(visitor));
 
+        verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(Book.class, ReadPermission.class, GENRE);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
+        verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
     }
 
     @Test
@@ -206,8 +217,10 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         // restricted HOME field
         assertFalse(expression.accept(visitor));
 
+        verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(Book.class, ReadPermission.class, GENRE);
         verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
+        verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
     }
 
     @Test
@@ -222,7 +235,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
         DataStoreTransaction tx = scope.getTransaction();
 
-        when(permissionExecutor.checkUserPermissions(Book.class, ReadPermission.class, "authors"))
+        when(permissionExecutor.checkUserPermissions(Book.class, ReadPermission.class, AUTHORS))
                 .thenReturn(ExpressionResult.PASS);
         when(permissionExecutor.checkUserPermissions(Author.class, ReadPermission.class, NAME))
                 .thenReturn(ExpressionResult.PASS);
@@ -231,9 +244,82 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         // restricted HOME field
         assertTrue(expression.accept(visitor));
 
-        verify(permissionExecutor, times(1)).checkUserPermissions(Book.class, ReadPermission.class, "authors");
-        verify(permissionExecutor, times(1)).checkUserPermissions(Author.class, ReadPermission.class, "name");
+        verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
+        verify(permissionExecutor, times(1)).checkUserPermissions(Book.class, ReadPermission.class, AUTHORS);
+        verify(permissionExecutor, times(1)).checkUserPermissions(Author.class, ReadPermission.class, NAME);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
+        verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
+        verify(tx, never()).getRelation(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testBypassReadonlyFilterRestriction() throws Exception {
+        RSQLFilterDialect dialect = new RSQLFilterDialect(scope.getDictionary());
+        FilterExpression expression =
+                dialect.parseFilterExpression("authors.name==foo", Book.class, true);
+
+        Book book = new Book();
+        PersistentResource<Book> resource = new PersistentResource<>(book, null, "", scope);
+
+        PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
+        DataStoreTransaction tx = scope.getTransaction();
+
+        when(permissionExecutor.evaluateFilterJoinUserChecks(any(), any())).thenReturn(ExpressionResult.PASS);
+
+        VerifyFieldAccessFilterExpressionVisitor visitor = new VerifyFieldAccessFilterExpressionVisitor(resource);
+        // restricted HOME field
+        assertTrue(expression.accept(visitor));
+
+        verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
+        verify(permissionExecutor, never()).checkUserPermissions(Book.class, ReadPermission.class, AUTHORS);
+        verify(permissionExecutor, never()).checkUserPermissions(Author.class, ReadPermission.class, NAME);
+        verify(permissionExecutor, never()).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
+        verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
+        verify(tx, never()).getRelation(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void testCustomFilterJoin() throws Exception {
+        RSQLFilterDialect dialect = new RSQLFilterDialect(scope.getDictionary());
+        FilterExpression expression =
+                dialect.parseFilterExpression("genre==foo", Book.class, true);
+
+        Book book = new Book();
+        PersistentResource<Book> resource = new PersistentResource<>(book, null, "", scope);
+
+        PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
+        DataStoreTransaction tx = scope.getTransaction();
+
+        when(permissionExecutor.checkUserPermissions(Book.class, ReadPermission.class, GENRE))
+                .thenReturn(ExpressionResult.DEFERRED);
+        when(permissionExecutor.checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE))
+                .thenThrow(new ForbiddenAccessException("check expression"));
+
+        when(permissionExecutor.evaluateFilterJoinUserChecks(any(), any())).thenReturn(ExpressionResult.DEFERRED);
+        when(permissionExecutor.handleFilterJoinReject(any(), any(), any())).thenAnswer(invocation -> {
+            FilterPredicate filterPredicate = invocation.getArgument(0);
+            PathElement pathElement = invocation.getArgument(1);
+            ForbiddenAccessException reason = invocation.getArgument(2);
+
+            assertEquals("Book", pathElement.getType().getSimpleName());
+            assertEquals(GENRE, filterPredicate.getField());
+            assertEquals("book.genre IN_INSENSITIVE [foo]", filterPredicate.toString());
+
+            // custom processing
+            return "Book".equals(pathElement.getType().getSimpleName())
+                    && filterPredicate.toString().matches("book.genre IN_INSENSITIVE \\[\\w+\\]")
+                    && reason.getLoggedMessage().matches(".*Message=check expression.*")
+                            ? ExpressionResult.DEFERRED
+                            : ExpressionResult.FAIL;
+        });
+
+        VerifyFieldAccessFilterExpressionVisitor visitor = new VerifyFieldAccessFilterExpressionVisitor(resource);
+        // restricted HOME field
+        assertTrue(expression.accept(visitor));
+
+        verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
+        verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
+        verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
## Description
Allow customizing the enforcement of ReadPermission for filter joins added with:
`Enforce ReadPermission for filter joins` #1236

Provides the ability to allow special handling of the permission enforcement with a customized PermissionExecutor.  This can also disable enforcement for optimizing the queries.

To customize, create a custom PermissionExecutor and implement the new methods:
* **evaluateFilterJoinUserChecks**: customize processing checks in the filterexpression
* **handleFilterJoinReject**: customize handling of a rejected field in a filter

Also fixed a bug in the user check shortcut optimization.  If any check was deferred, it stopped looking for a failing user check and fell through to scanning the objects.  Now if any fails, the short cut fails.  If all are pass, the short cut passes.

## Motivation and Context
We have limited ability to filter on some fields for which the user does not have read access.  By evaluating the failed filter expression and the ForbiddenAccess, we can decide if the filter can be allowed, and return PASS.

## How Has This Been Tested?
Unit testing and locally with our own Elide project.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.