### PR TITLE
GraphQL Many-to-many filter Bug Fix

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -570,7 +570,6 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
                     filterKey += "[" + typeName + "]";
                 }
                 put(filterKey, Arrays.asList(filterStr));
-
             }
         };
     }
@@ -581,11 +580,12 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
         // TODO: Refactor FilterDialect interfaces to accept string or List<String> instead of (or in addition to?)
         // query params.
         return filter.map(filterStr -> {
+            String errorMessage = "";
             try {
                 return requestScope.getFilterDialect()
                         .parseGlobalExpression(typeName, getQueryParams(Optional.empty(), filterStr));
             } catch (ParseException e) {
-                log.debug(e.getMessage());
+                errorMessage = e.getMessage();
             }
 
             try {
@@ -593,8 +593,7 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
                         .parseTypedExpression(typeName, getQueryParams(Optional.of(typeName), filterStr))
                         .get(typeName);
             } catch (ParseException e) {
-                log.debug("Filter parse exception caught", e);
-                throw new InvalidPredicateException("Could not parse filter for type: " + typeName);
+                throw new InvalidPredicateException(errorMessage + "\n" + e.getMessage());
             }
         });
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Invoked by GraphQL Java to fetch/mutate data from Elide.
@@ -563,19 +562,36 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
         return sort.map(Sorting::parseSortRule);
     }
 
+    private MultivaluedHashMap<String, String> getQueryParams(Optional<String> typeName, String filterStr) {
+        return new MultivaluedHashMap<String, String>() {
+            {
+                String filterKey = "filter";
+                if (typeName.isPresent()) {
+                    filterKey += "[" + typeName + "]";
+                }
+                put(filterKey, Arrays.asList(filterStr));
+
+            }
+        };
+    }
+
     private Optional<FilterExpression> buildFilter(String typeName,
                                                    Optional<String> filter,
                                                    RequestScope requestScope) {
         // TODO: Refactor FilterDialect interfaces to accept string or List<String> instead of (or in addition to?)
         // query params.
         return filter.map(filterStr -> {
-            MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>() {
-                {
-                    put("filter[" + typeName + "]", Arrays.asList(filterStr));
-                }
-            };
             try {
-                return requestScope.getFilterDialect().parseTypedExpression(typeName, queryParams).get(typeName);
+                return requestScope.getFilterDialect()
+                        .parseGlobalExpression(typeName, getQueryParams(Optional.empty(), filterStr));
+            } catch (ParseException e) {
+                log.debug(e.getMessage());
+            }
+
+            try {
+                return requestScope.getFilterDialect()
+                        .parseTypedExpression(typeName, getQueryParams(Optional.of(typeName), filterStr))
+                        .get(typeName);
             } catch (ParseException e) {
                 log.debug("Filter parse exception caught", e);
                 throw new InvalidPredicateException("Could not parse filter for type: " + typeName);

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
@@ -34,6 +34,9 @@ import org.junit.jupiter.api.Test;
 import io.restassured.response.ValidatableResponse;
 import lombok.Getter;
 import lombok.Setter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -551,15 +554,19 @@ public class GraphQLIT extends IntegrationTest {
         runQueryWithExpectedResult(graphQLRequest, expectedResponse);
     }
 
-    @Test
-    public void runManyToManyFilter() throws IOException {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "\"books.title==\\\"1984\\\"\"",
+            "\"books.id=isnull=false\"",
+            "\"books.title=in=(\\\"1984\\\")\""})
+    public void runManyToManyFilter(String filter) throws IOException {
         String graphQLRequest = document(
             query(
                 selections(
                         field(
                                 "author",
                                 arguments(
-                                        argument("filter", "\"books.title==\\\"1984\\\"\"")
+                                        argument("filter", filter)
                                 ),
                                 selections(
                                         field("id"),

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
@@ -11,6 +11,7 @@ import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.arguments;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.document;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.field;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.mutation;
+import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.query;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selection;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selections;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.variableDefinition;
@@ -545,6 +546,54 @@ public class GraphQLIT extends IntegrationTest {
                                 )
                         )
                 )
+        ).toResponse();
+
+        runQueryWithExpectedResult(graphQLRequest, expectedResponse);
+    }
+
+    @Test
+    public void runManyToManyFilter() throws IOException {
+        String graphQLRequest = document(
+            query(
+                selections(
+                        field(
+                                "author",
+                                arguments(
+                                        argument("filter", "\"books.title==\\\"1984\\\"\"")
+                                ),
+                                selections(
+                                        field("id"),
+                                        field("name"),
+                                        field(
+                                                "books",
+                                                selections(
+                                                        field("id"),
+                                                        field("title")
+                                                )
+                                        )
+                                        )
+                        )
+                )
+            )
+        ).toQuery();
+
+        String expectedResponse = document(
+            selection(
+                    field(
+                            "author",
+                            selections(
+                                    field("id", "1"),
+                                    field("name", "George Orwell"),
+                                    field(
+                                            "books",
+                                            selections(
+                                                    field("id", "1"),
+                                                    field("title", "1984")
+                                            )
+                                    )
+                            )
+                    )
+            )
         ).toResponse();
 
         runQueryWithExpectedResult(graphQLRequest, expectedResponse);

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
@@ -30,12 +30,13 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.restassured.response.ValidatableResponse;
 import lombok.Getter;
 import lombok.Setter;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
Resolves - Could not find any related issues

## Description
The GraphQL interface has a bug related to filtering values through a many-to-many relationship. An example of a broken filter would be `books.title=="1984"` on a request for the author object from the UT and integration test model. The books set in the author entity is a many-to-many relationship to the book entity. The filter fails to parse due to type errors since the `MultipleFilterDialect. parseTypedExpression` method does not properly handle parsing the nested types. 

The solution is to attempt to parse with the `MultipleFilterDialect.parseGlobalExpression` similar to the existing solution in the JsonAPI interface in `RequestScope`.

## Motivation and Context
This bug unnecessarily limits how our UI can query the GraphQL endpoint.

## How Has This Been Tested?
I have added multiple integration tests in this PR to ensure that different filters work with this change. All existing test continue to pass unchanged.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
