### PR TITLE
Fix hibernate entity manager store threading issue.

### DIFF
--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/AbstractHibernateStore.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/AbstractHibernateStore.java
@@ -12,9 +12,9 @@ import com.yahoo.elide.core.datastore.JPQLDataStore;
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.jpa.HibernateEntityManager;
+import org.hibernate.jpa.HibernateEntityManagerFactory;
 
-import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 import javax.persistence.metamodel.EntityType;
 
 /**
@@ -63,30 +63,30 @@ public abstract class AbstractHibernateStore implements JPQLDataStore {
      */
     public static class Builder {
         private final SessionFactory sessionFactory;
-        private final EntityManager entityManager;
         private boolean isScrollEnabled;
         private ScrollMode scrollMode;
+        private EntityManagerFactory emf;
 
         public Builder(final SessionFactory sessionFactory) {
             this.sessionFactory = sessionFactory;
             this.isScrollEnabled = true;
             this.scrollMode = ScrollMode.FORWARD_ONLY;
-            this.entityManager = null;
+            this.emf = null;
         }
 
-        public Builder(final EntityManager entityManager) {
+        public Builder(final EntityManagerFactory entityManagerFactory) {
             this.sessionFactory = null;
             this.isScrollEnabled = true;
             this.scrollMode = ScrollMode.FORWARD_ONLY;
-            this.entityManager = entityManager;
+            this.emf = entityManagerFactory;
         }
 
         @Deprecated
-        public Builder(final HibernateEntityManager entityManager) {
+        public Builder(final HibernateEntityManagerFactory entityManagerFactory) {
             this.sessionFactory = null;
             this.isScrollEnabled = true;
             this.scrollMode = ScrollMode.FORWARD_ONLY;
-            this.entityManager = entityManager;
+            this.emf = entityManagerFactory;
         }
 
         public Builder withScrollEnabled(final boolean isScrollEnabled) {
@@ -102,8 +102,8 @@ public abstract class AbstractHibernateStore implements JPQLDataStore {
         public AbstractHibernateStore build() {
             if (sessionFactory != null) {
                 return new HibernateSessionFactoryStore(sessionFactory, isScrollEnabled, scrollMode);
-            } else if (entityManager != null) {
-                return new HibernateEntityManagerStore(entityManager, isScrollEnabled, scrollMode);
+            } else if (emf != null) {
+                return new HibernateEntityManagerStore(emf, isScrollEnabled, scrollMode);
             }
             throw new IllegalStateException("Either an EntityManager or SessionFactory is required!");
         }
@@ -122,13 +122,6 @@ public abstract class AbstractHibernateStore implements JPQLDataStore {
 
         bindEntityClass(mappedClass, dictionary);
     }
-
-    /**
-     * Get current Hibernate session.
-     *
-     * @return session
-     */
-    abstract public Session getSession();
 
     /**
      * Start Hibernate transaction.

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerStore.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerStore.java
@@ -10,40 +10,22 @@ import com.yahoo.elide.core.EntityDictionary;
 
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
-import org.hibernate.jpa.HibernateEntityManager;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 import javax.persistence.metamodel.EntityType;
 
 /**
  * Hibernate5 store supporting the EntityManager.
  */
 public class HibernateEntityManagerStore extends AbstractHibernateStore {
-    protected final EntityManager entityManager;
+    protected final EntityManagerFactory entityManagerFactory;
 
-    @Deprecated
-    public HibernateEntityManagerStore(HibernateEntityManager entityManager,
+    public HibernateEntityManagerStore(EntityManagerFactory entityManagerFactory,
                                        boolean isScrollEnabled,
                                        ScrollMode scrollMode) {
         super(null, isScrollEnabled, scrollMode);
-        this.entityManager = entityManager;
-    }
-
-    public HibernateEntityManagerStore(EntityManager entityManager,
-                                       boolean isScrollEnabled,
-                                       ScrollMode scrollMode) {
-        super(null, isScrollEnabled, scrollMode);
-        this.entityManager = entityManager;
-    }
-
-    /**
-     * Get current Hibernate session.
-     *
-     * @return session Hibernate session from EntityManager.
-     */
-    @Override
-    public Session getSession() {
-        return entityManager.unwrap(Session.class);
+        this.entityManagerFactory = entityManagerFactory;
     }
 
     /**
@@ -54,7 +36,8 @@ public class HibernateEntityManagerStore extends AbstractHibernateStore {
     @Override
     @SuppressWarnings("resource")
     public DataStoreTransaction beginTransaction() {
-        Session session = getSession();
+        EntityManager manager = entityManagerFactory.createEntityManager();
+        Session session = manager.unwrap(Session.class);
         session.beginTransaction();
         session.clear();
         return transactionSupplier.get(session, isScrollEnabled, scrollMode);
@@ -63,7 +46,7 @@ public class HibernateEntityManagerStore extends AbstractHibernateStore {
     @Override
     public void populateEntityDictionary(EntityDictionary dictionary) {
         /* bind all entities */
-        for (EntityType<?> type : entityManager.getEntityManagerFactory().getMetamodel().getEntities()) {
+        for (EntityType<?> type : entityManagerFactory.getMetamodel().getEntities()) {
             bindEntity(dictionary, type);
         }
     }

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateSessionFactoryStore.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/HibernateSessionFactoryStore.java
@@ -6,15 +6,12 @@
 package com.yahoo.elide.datastores.hibernate5;
 
 import com.yahoo.elide.core.DataStoreTransaction;
-import com.yahoo.elide.core.exceptions.TransactionException;
 
 import com.google.common.base.Preconditions;
 
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-
-import javax.persistence.PersistenceException;
 
 /**
  * Implementation for HibernateStore supporting SessionFactory.
@@ -25,23 +22,6 @@ public class HibernateSessionFactoryStore extends AbstractHibernateStore {
                                            boolean isScrollEnabled,
                                            ScrollMode scrollMode) {
         super(aSessionFactory, isScrollEnabled, scrollMode);
-    }
-
-    /**
-     * Get current Hibernate session.
-     *
-     * @return session
-     */
-    @Override
-    public Session getSession() {
-        try {
-            Session session = sessionFactory.getCurrentSession();
-            Preconditions.checkNotNull(session);
-            Preconditions.checkArgument(session.isConnected());
-            return session;
-        } catch (PersistenceException e) {
-            throw new TransactionException(e);
-        }
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreHarness.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/datastores/hibernate5/HibernateEntityManagerDataStoreHarness.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.persistence.Entity;
-import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
@@ -72,7 +71,6 @@ public class HibernateEntityManagerDataStoreHarness implements DataStoreTestHarn
         options.put(AvailableSettings.LOADED_CLASSES, bindClasses);
 
         EntityManagerFactory emf = Persistence.createEntityManagerFactory("elide-tests", options);
-        EntityManager em = emf.createEntityManager();
 
         // method to force class initialization
         MetadataSources metadataSources = new MetadataSources(
@@ -104,7 +102,7 @@ public class HibernateEntityManagerDataStoreHarness implements DataStoreTestHarn
             throw new IllegalStateException(schemaExport.getExceptions().toString());
         }
 
-        store = new AbstractHibernateStore.Builder(em)
+        store = new AbstractHibernateStore.Builder(emf)
                 .withScrollEnabled(true)
                 .withScrollMode(ScrollMode.FORWARD_ONLY)
                 .build();


### PR DESCRIPTION

## Description
Fixes ancient bug in legacy HIbernate 5 entity manager store.

## Motivation and Context
Hibernate entity manager store recycles the entity manager - which is not thread safe.

## How Has This Been Tested?
IT tests including async tests which catch this.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
