### PR TITLE
Async ID change from UUID to String and Dynamic Config FIx

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -13,13 +13,13 @@ import com.yahoo.elide.annotation.UpdatePermission;
 
 import lombok.Data;
 
-import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.PrePersist;
+import javax.validation.constraints.Pattern;
 
 /**
  * Model for Async Query.
@@ -35,7 +35,9 @@ import javax.persistence.PrePersist;
 public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     @Id
     @Column(columnDefinition = "varchar(36)")
-    private UUID id; //Provided.
+    @Pattern(regexp = "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+            message = "id not of pattern UUID")
+    private String id; //Provided.
 
     private String query;  //JSON-API PATH or GraphQL payload.
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -14,8 +14,6 @@ import com.yahoo.elide.annotation.UpdatePermission;
 
 import lombok.Data;
 
-import java.util.UUID;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -34,7 +32,7 @@ import javax.persistence.OneToOne;
 public class AsyncQueryResult extends AsyncBase implements PrincipalOwned {
     @Id
     @Column(columnDefinition = "varchar(36)")
-    private UUID id; //Matches UUID in query.
+    private String id; //Matches id in query.
 
     private Integer contentLength;
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryDAO.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryStatus;
 
 import java.util.Collection;
-import java.util.UUID;
 
 /**
  * Utility interface which uses the elide datastore to modify and create AsyncQuery and AsyncQueryResult Objects.
@@ -34,7 +33,7 @@ public interface AsyncQueryDAO {
      * @return AsyncQueryResult Object
      */
     public AsyncQueryResult createAsyncQueryResult(Integer status, String responseBody, AsyncQuery asyncQuery,
-            UUID asyncQueryId);
+            String asyncQueryId);
 
     /**
      * This method deletes a collection of AsyncQuery and its associated AsyncQueryResult objects from database and

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.UUID;
 
 import javax.inject.Singleton;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -165,7 +164,7 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
 
     @Override
     public AsyncQueryResult createAsyncQueryResult(Integer status, String responseBody,
-            AsyncQuery asyncQuery, UUID asyncQueryId) {
+            AsyncQuery asyncQuery, String asyncQueryId) {
         log.debug("createAsyncQueryResult");
         AsyncQueryResult queryResultObj = (AsyncQueryResult) executeInTransaction(dataStore, (tx, scope) -> {
             AsyncQueryResult asyncQueryResult = new AsyncQueryResult();

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
@@ -111,7 +111,7 @@ public class DefaultAsyncQueryDAOTest {
         Integer status = 200;
         String responseBody = "responseBody";
         String uuid = "ba31ca4e-ed8f-4be0-a0f3-12088fa9263e";
-        AsyncQueryResult result = asyncQueryDAO.createAsyncQueryResult(status, "responseBody", asyncQuery, "ba31ca4e-ed8f-4be0-a0f3-12088fa9263e");
+        AsyncQueryResult result = asyncQueryDAO.createAsyncQueryResult(status, "responseBody", asyncQuery, uuid);
 
         assertEquals(status, result.getStatus());
         assertEquals(responseBody, result.getResponseBody());

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.UUID;
 
 public class DefaultAsyncQueryDAOTest {
 
@@ -111,8 +110,8 @@ public class DefaultAsyncQueryDAOTest {
     public void testCreateAsyncQueryResult() {
         Integer status = 200;
         String responseBody = "responseBody";
-        UUID uuid = UUID.fromString("ba31ca4e-ed8f-4be0-a0f3-12088fa9263e");
-        AsyncQueryResult result = asyncQueryDAO.createAsyncQueryResult(status, "responseBody", asyncQuery, uuid);
+        String uuid = "ba31ca4e-ed8f-4be0-a0f3-12088fa9263e";
+        AsyncQueryResult result = asyncQueryDAO.createAsyncQueryResult(status, "responseBody", asyncQuery, "ba31ca4e-ed8f-4be0-a0f3-12088fa9263e");
 
         assertEquals(status, result.getStatus());
         assertEquals(responseBody, result.getResponseBody());

--- a/elide-contrib/elide-dynamic-config-helpers/pom.xml
+++ b/elide-contrib/elide-dynamic-config-helpers/pom.xml
@@ -44,7 +44,6 @@
         <handlebars.version>4.2.0</handlebars.version>
         <json-schema-validator.version>2.2.12</json-schema-validator.version>
         <mdkt.compiler.version>1.3.0</mdkt.compiler.version>
-        <google.collections.version>1.0</google.collections.version>
         <commons-io.version>2.6</commons-io.version>
     </properties>
 
@@ -116,10 +115,9 @@
             <version>${mdkt.compiler.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.collections</groupId>
-            <artifactId>google-collections</artifactId>
-            <version>${google.collections.version}</version>
-        </dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+         </dependency>
     </dependencies>
 
     <build>

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -62,7 +62,7 @@ public class ElideAutoConfiguration {
 
         ElideDynamicEntityCompiler compiler = null;
 
-        if (settings.getDynamicConfig().isEnabled()) {
+        if (isDynamicConfigEnabled(settings)) {
             compiler = new ElideDynamicEntityCompiler(settings.getDynamicConfig().getPath());
         }
         return compiler;
@@ -121,7 +121,7 @@ public class ElideAutoConfiguration {
 
         dictionary.scanForSecurityChecks();
 
-        if (settings.getDynamicConfig().isEnabled()) {
+        if (isDynamicConfigEnabled(settings)) {
             ElideDynamicEntityCompiler compiler = dynamicCompiler.getIfAvailable();
             Set<Class<?>> annotatedClass = compiler.findAnnotatedClasses(SecurityCheck.class);
             dictionary.addSecurityChecks(annotatedClass);
@@ -146,7 +146,7 @@ public class ElideAutoConfiguration {
 
         MetaDataStore metaDataStore = null;
 
-        if (settings.getDynamicConfig().isEnabled()) {
+        if (isDynamicConfigEnabled(settings)) {
             metaDataStore = new MetaDataStore(dynamicCompiler.getIfAvailable());
         } else {
             metaDataStore = new MetaDataStore();
@@ -171,7 +171,7 @@ public class ElideAutoConfiguration {
             throws ClassNotFoundException {
         AggregationDataStore aggregationDataStore = null;
 
-        if (settings.getDynamicConfig().isEnabled()) {
+        if (isDynamicConfigEnabled(settings)) {
             ElideDynamicEntityCompiler compiler = dynamicCompiler.getIfAvailable();
             Set<Class<?>> annotatedClass = compiler.findAnnotatedClasses(FromTable.class);
             annotatedClass.addAll(compiler.findAnnotatedClasses(FromSubquery.class));
@@ -206,5 +206,16 @@ public class ElideAutoConfiguration {
         Swagger swagger = builder.build().basePath(settings.getJsonApi().getPath());
 
         return swagger;
+    }
+
+    private boolean isDynamicConfigEnabled(ElideConfigProperties settings) {
+
+        boolean enabled = false;
+        if (settings.getDynamicConfig() != null) {
+            enabled = settings.getDynamicConfig().isEnabled();
+        }
+
+        return enabled;
+
     }
 }


### PR DESCRIPTION

## Description
Async ID change from UUID to String to avoid database incompatibility errors for casting UUID to string.
Fixes issue in Dynamic Model config

## Motivation and Context
Deployment errors with Postgres on heroku

## How Has This Been Tested?
Unit Test successful. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
