### PR TITLE
Removed redundant fetch join for filters

### DIFF
--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -119,12 +119,7 @@ public abstract class AbstractHQLQueryBuilder {
      * @return an HQL join clause
      */
     protected String getJoinClauseFromFilters(FilterExpression filterExpression) {
-        PredicateExtractionVisitor visitor = new PredicateExtractionVisitor(new ArrayList<>());
-        Collection<FilterPredicate> predicates = filterExpression.accept(visitor);
-
-        return predicates.stream()
-            .map(predicate -> extractJoinClause(predicate, false))
-            .collect(Collectors.joining(SPACE));
+        return getJoinClauseFromFilters(filterExpression, false);
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
@@ -70,7 +70,7 @@ public class RootCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilde
             filterClause = new FilterTranslator().apply(filterExpression.get(), USE_ALIAS);
 
             //Build the JOIN clause
-            joinClause =  getJoinClauseFromFilters(filterExpression.get());
+            joinClause =  getJoinClauseFromFilters(filterExpression.get(), true);
 
         } else {
             predicates = new HashSet<>();

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
@@ -102,7 +102,7 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
             FilterExpression joinedExpression = new AndFilterExpression(scoped, idExpression);
 
             //Build the JOIN clause from the filter predicate
-            joinClause = getJoinClauseFromFilters(joinedExpression);
+            joinClause = getJoinClauseFromFilters(joinedExpression, true);
 
             //Build the WHERE clause
             filterClause = new FilterTranslator().apply(joinedExpression, USE_ALIAS);

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -142,7 +142,7 @@ public class SubCollectionFetchQueryBuilderTest {
 
         String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
                 + "JOIN example_Author__fetch.books example_Book "
-                + "LEFT JOIN example_Book.publisher example_Book_publisher  LEFT JOIN FETCH example_Book.publisher  "
+                + "LEFT JOIN FETCH example_Book.publisher example_Book_publisher  "
                 + "WHERE example_Book_publisher.name IN (:books_publisher_name_XXX) AND example_Author__fetch=:example_Author__fetch ";
         String actual = query.getQueryText();
         actual = actual.replaceFirst(":publisher_name_\\w+_\\w+", ":books_publisher_name_XXX");
@@ -188,7 +188,7 @@ public class SubCollectionFetchQueryBuilderTest {
 
         String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
                 + "JOIN example_Author__fetch.books example_Book "
-                + "LEFT JOIN example_Book.publisher example_Book_publisher  LEFT JOIN FETCH example_Book.publisher  "
+                + "LEFT JOIN FETCH example_Book.publisher example_Book_publisher  "
                 + "WHERE example_Book_publisher.name IN (:publisher_name_XXX) AND example_Author__fetch=:example_Author__fetch  order by example_Book.title asc";
 
         String actual = query.getQueryText();


### PR DESCRIPTION
When Elide fetch joins toOne relationships, it can overlap with a join because of a filter expression resulting in two joins.  This complicates the SQL and reduces performance.

## How Has This Been Tested?
Updated unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
