### PR TITLE
Add Eclipse import order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ When submitting a pull request (PR), please use the following guidelines:
 - Make sure your code respects existing formatting conventions. In general, follow
   the same coding style as the code that you are modifying. If you are using
   IntelliJ, you can import our code style settings xml:
-  [elide-intellij-codestyle.xml](https://github.com/yahoo/elide/raw/master/elide-intellij-codestyle.xml).
+  [elide-intellij-codestyle.xml](https://github.com/yahoo/elide/raw/master/elide-intellij-codestyle.xml)
+  or [elide-eclipse.importorder](https://github.com/yahoo/elide/raw/master/elide-eclipse.importorder).
 - Do add/update [documentation](https://github.com/yahoo/elide-doc) appropriately for the change you are making.
 - Bugfixes should include a unit test or integration test reproducing the issue.
 - Do not use author tags/information in the code.

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -6,7 +6,20 @@
 
 package com.yahoo.elide.contrib.testhelpers.jsonapi;
 
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.*;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.document;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.include;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchOperation;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchSet;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relation;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relationships;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperationType.add;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Relation.TO_ONE;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/LogMessage.java
@@ -10,8 +10,8 @@ import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.ResourceLineage;
 import com.yahoo.elide.security.ChangeSpec;
-
 import com.yahoo.elide.security.User;
+
 import de.odysseus.el.ExpressionFactoryImpl;
 import de.odysseus.el.util.SimpleContext;
 

--- a/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
@@ -21,8 +21,8 @@ import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
 import com.yahoo.elide.security.checks.CommitCheck;
 import com.yahoo.elide.security.checks.OperationCheck;
 import com.yahoo.elide.security.checks.UserCheck;
-
 import com.yahoo.elide.security.permissions.ExpressionResult;
+
 import example.TestCheckMappings;
 
 import org.junit.jupiter.api.Test;

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/AbstractHibernateStore.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/AbstractHibernateStore.java
@@ -7,8 +7,8 @@ package com.yahoo.elide.datastores.hibernate5;
 
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
-
 import com.yahoo.elide.core.datastore.JPQLDataStore;
+
 import org.hibernate.ScrollMode;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;

--- a/elide-eclipse.importorder
+++ b/elide-eclipse.importorder
@@ -1,0 +1,10 @@
+#Organize Import Order
+#Sat May 16 09:45:37 CDT 2020
+0=\#
+1=com.yahoo
+2=com
+3=example
+4=org
+5=
+6=java
+7=javax

--- a/elide-example/elide-blog-example/src/test/java/com/yahoo/elide/example/ExampleTest.java
+++ b/elide-example/elide-blog-example/src/test/java/com/yahoo/elide/example/ExampleTest.java
@@ -5,14 +5,6 @@
  */
 package com.yahoo.elide.example;
 
-import com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL;
-import com.yahoo.elide.core.HttpStatus;
-import org.junit.jupiter.api.Test;
-
-import javax.ws.rs.core.MediaType;
-
-import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.when;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.field;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.query;
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.selection;
@@ -23,7 +15,15 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.equalTo;
+
+import com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL;
+import com.yahoo.elide.core.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.MediaType;
 
 /**
  * Example functional test.

--- a/elide-example/elide-blog-example/src/test/java/com/yahoo/elide/example/IntegrationTest.java
+++ b/elide-example/elide-blog-example/src/test/java/com/yahoo/elide/example/IntegrationTest.java
@@ -6,14 +6,16 @@
 package com.yahoo.elide.example;
 
 import com.yahoo.elide.standalone.ElideStandalone;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestInstance;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.audit.AuditLogger;
-
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.datastore.inmemory.HashMapDataStore;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/GraphQLIT.java
@@ -37,7 +37,6 @@ import io.restassured.response.ValidatableResponse;
 import lombok.Getter;
 import lombok.Setter;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.standalone.config;
 
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
-
 import com.yahoo.elide.Injector;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.audit.Slf4jLogger;

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -15,18 +15,21 @@ import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.hasKey;
 
-import com.google.common.collect.Maps;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import com.yahoo.elide.standalone.models.Post;
-import io.swagger.models.Info;
-import io.swagger.models.Swagger;
+
+import com.google.common.collect.Maps;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+
+import io.swagger.models.Info;
+import io.swagger.models.Swagger;
 
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
## Description
Add Eclipse import order.

## Motivation and Context
To help maintain import order when using Eclipse IDE.

## How Has This Been Tested?
With Eclipse IDE ran Organize Imports on entire project.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.