### PR TITLE
Introduce QueryResult class for QueryEngine caching

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
@@ -64,17 +64,18 @@ public class PaginationImpl implements Pagination {
     private static final String PAGE_KEYS_CSV = PAGE_KEYS.keySet().stream().collect(Collectors.joining(", "));
 
     @Getter
-    private Integer offset;
+    private final int offset;
 
     @Getter
-    private Integer limit;
+    private final int limit;
 
-    private Boolean generateTotals;
-
-    private Boolean isDefault;
+    private final boolean generateTotals;
 
     @Getter
-    private Class<?> entityClass;
+    private final boolean defaultInstance;
+
+    @Getter
+    private final Class<?> entityClass;
 
     /**
      * Constructor.
@@ -95,7 +96,7 @@ public class PaginationImpl implements Pagination {
                            Boolean pageByPages) {
 
         this.entityClass = entityClass;
-        this.isDefault = (clientOffset == null && clientLimit == null && generateTotals == null);
+        this.defaultInstance = (clientOffset == null && clientLimit == null && generateTotals == null);
 
         Paginate paginate = entityClass != null ? (Paginate) entityClass.getAnnotation(Paginate.class) : null;
 
@@ -107,7 +108,7 @@ public class PaginationImpl implements Pagination {
 
         String pageSizeLabel = pageByPages ? "size" : "limit";
 
-        if (limit > maxLimit && !isDefault) {
+        if (limit > maxLimit && !defaultInstance) {
             throw new InvalidValueException("Pagination "
                     + pageSizeLabel + " must be less than or equal to " + maxLimit);
         }
@@ -138,17 +139,8 @@ public class PaginationImpl implements Pagination {
      * @return true if page totals should be returned.
      */
     @Override
-    public Boolean returnPageTotals() {
+    public boolean returnPageTotals() {
         return generateTotals;
-    }
-
-    /**
-     * Whether or not the client requested pagination or the system defaults are in effect.
-     * @return True if the system defaults are in effect.
-     */
-    @Override
-    public Boolean isDefaultInstance() {
-        return isDefault;
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/request/Pagination.java
+++ b/elide-core/src/main/java/com/yahoo/elide/request/Pagination.java
@@ -14,35 +14,35 @@ public interface Pagination {
     /**
      * Default offset (in records) it client does not provide one.
      */
-    public static final int DEFAULT_OFFSET = 0;
+    int DEFAULT_OFFSET = 0;
 
     /**
      * Default page limit (in records) it client does not provide one.
      */
-    public static final int DEFAULT_PAGE_LIMIT = 500;
+    int DEFAULT_PAGE_LIMIT = 500;
 
     /**
      * Maximum allowable page limit (in records).
      */
-    public static final int MAX_PAGE_LIMIT = 10000;
+    int MAX_PAGE_LIMIT = 10000;
 
     /**
      * Get the page offset.
      * @return record offset.
      */
-    Integer getOffset();
+    int getOffset();
 
     /**
      * Get the page limit.
      * @return record limit.
      */
-    Integer getLimit();
+    int getLimit();
 
     /**
      * Whether or not to fetch the collection size or not.
      * @return true if the client wants the total size of the collection.
      */
-    Boolean returnPageTotals();
+    boolean returnPageTotals();
 
     /**
      * Get the total size of the collection
@@ -60,5 +60,5 @@ public interface Pagination {
      * Is this the default instance (not present).
      * @return true if pagination wasn't requested.  False otherwise.
      */
-    public Boolean isDefaultInstance();
+    boolean isDefaultInstance();
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -53,7 +53,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
     @Override
     public Iterable<Object> loadObjects(EntityProjection entityProjection, RequestScope scope) {
         Query query = buildQuery(entityProjection, scope);
-        return queryEngine.executeQuery(query, true);
+        return queryEngine.executeQuery(query);
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -53,7 +53,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
     @Override
     public Iterable<Object> loadObjects(EntityProjection entityProjection, RequestScope scope) {
         Query query = buildQuery(entityProjection, scope);
-        return queryEngine.executeQuery(query);
+        return queryEngine.executeQuery(query).getData();
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.query.Query;
+import com.yahoo.elide.datastores.aggregation.query.QueryResult;
 import com.yahoo.elide.request.EntityProjection;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -53,7 +54,11 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
     @Override
     public Iterable<Object> loadObjects(EntityProjection entityProjection, RequestScope scope) {
         Query query = buildQuery(entityProjection, scope);
-        return queryEngine.executeQuery(query).getData();
+        QueryResult result = queryEngine.executeQuery(query);
+        if (entityProjection.getPagination() != null && entityProjection.getPagination().returnPageTotals()) {
+            entityProjection.getPagination().setPageTotals(result.getPageTotals());
+        }
+        return result.getData();
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslator.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+import com.yahoo.elide.datastores.aggregation.query.ImmutablePagination;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
@@ -72,7 +73,7 @@ public class EntityProjectionTranslator {
                 .whereFilter(whereFilter)
                 .havingFilter(havingFilter)
                 .sorting(entityProjection.getSorting())
-                .pagination(entityProjection.getPagination())
+                .pagination(ImmutablePagination.from(entityProjection.getPagination()))
                 .build();
         QueryValidator validator = new QueryValidator(query, getAllFields(), dictionary);
         validator.validate();

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -163,11 +163,10 @@ public abstract class QueryEngine {
      * Executes the specified {@link Query} against a specific persistent storage, which understand the provided
      * {@link Query}. Results may be taken from a cache, if configured.
      *
-     * @param query    The query customized for a particular persistent storage or storage client
-     * @param useCache Whether to use the cache, if configured
+     * @param query The query customized for a particular persistent storage or storage client
      * @return query results
      */
-    public abstract Iterable<Object> executeQuery(Query query, boolean useCache);
+    public abstract Iterable<Object> executeQuery(Query query);
 
     /**
      * Returns the schema for a given entity class.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -91,11 +91,7 @@ public abstract class QueryEngine {
         populateMetaData(metaDataStore);
         this.tables = metaDataStore.getMetaData(Table.class).stream()
                 .collect(Collectors.toMap(Table::getId, Functions.identity()));
-        if (cache != null) {
-            this.cache = cache;
-        } else {
-            this.cache = new NoCache();
-        }
+        this.cache = cache;
     }
 
     /**
@@ -175,17 +171,5 @@ public abstract class QueryEngine {
      */
     public Table getTable(String classAlias) {
         return tables.get(classAlias);
-    }
-
-    private static class NoCache implements Cache {
-        @Override
-        public Iterable<Object> get(Object key) {
-            return null;
-        }
-
-        @Override
-        public void put(Object key, Iterable<Object> result) {
-            // Do nothing
-        }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.datastores.aggregation.query.Cache;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
+import com.yahoo.elide.datastores.aggregation.query.QueryResult;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.request.Argument;
 
@@ -162,7 +163,7 @@ public abstract class QueryEngine {
      * @param query The query customized for a particular persistent storage or storage client
      * @return query results
      */
-    public abstract Iterable<Object> executeQuery(Query query);
+    public abstract QueryResult executeQuery(Query query);
 
     /**
      * Returns the schema for a given entity class.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Cache.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Cache.java
@@ -6,16 +6,16 @@
 package com.yahoo.elide.datastores.aggregation.query;
 
 /**
- * A cache for Query results.
+ * A cache for {@link QueryResult}s.
  */
 public interface Cache {
     /**
-     * Load Query result from cache. Exceptions should be passed through.
+     * Load QueryResult from cache. Exceptions should be passed through.
      *
      * @param key    a key to look up in the cache.
      * @return query results from cache, or null if not found.
      */
-    Iterable<Object> get(Object key);
+    QueryResult get(Object key);
 
     /**
      * Insert results into cache.
@@ -23,5 +23,5 @@ public interface Cache {
      * @param key    the key to associate with the query
      * @param result the result to cache with the key
      */
-    void put(Object key, Iterable<Object> result);
+    void put(Object key, QueryResult result);
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
@@ -16,10 +16,10 @@ import lombok.Value;
 @Value
 public class ImmutablePagination implements Pagination {
 
-    int offset;
-    int limit;
-    boolean defaultInstance;
-    boolean returnPageTotals;
+    private int offset;
+    private int limit;
+    private boolean defaultInstance;
+    private boolean returnPageTotals;
 
     public static ImmutablePagination from(Pagination src) {
         if (src instanceof ImmutablePagination) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.query;
+
+import com.yahoo.elide.request.Pagination;
+
+import lombok.Value;
+
+/**
+ * An immutable Pagination. Doesn't support getPageTotals/setPageTotals; page totals must be returned via QueryResult.
+ */
+@Value
+public class ImmutablePagination implements Pagination {
+
+    int offset;
+    int limit;
+    boolean defaultInstance;
+    boolean returnPageTotals;
+
+    public static ImmutablePagination from(Pagination src) {
+        if (src instanceof ImmutablePagination) {
+            return (ImmutablePagination) src;
+        } else if (src != null) {
+            return new ImmutablePagination(
+                    src.getOffset(), src.getLimit(), src.isDefaultInstance(), src.returnPageTotals());
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean returnPageTotals() {
+        return returnPageTotals;
+    }
+
+    @Override
+    public Long getPageTotals() {
+        return null;
+    }
+
+    @Override
+    public void setPageTotals(Long pageTotals) {
+        throw new UnsupportedOperationException("ImmutablePagination does not support setPageTotals");
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -9,9 +9,9 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.datastores.aggregation.QueryEngine;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
-import com.yahoo.elide.request.Pagination;
 import com.yahoo.elide.request.Sorting;
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
 
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 @Value
 @Builder
 public class Query {
+    @NonNull
     Table table;
 
     @Singular
@@ -41,7 +42,7 @@ public class Query {
     FilterExpression whereFilter;
     FilterExpression havingFilter;
     Sorting sorting;
-    Pagination pagination;
+    ImmutablePagination pagination;
     RequestScope scope;
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -45,6 +45,11 @@ public class Query {
     RequestScope scope;
 
     /**
+     * Whether to bypass the {@link QueryEngine} cache for this query.
+     */
+    boolean bypassingCache;
+
+    /**
      * Returns all the dimensions regardless of type.
      * @return All the dimensions.
      */

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -28,27 +28,27 @@ import java.util.stream.Stream;
 @Builder
 public class Query {
     @NonNull
-    Table table;
+    private Table table;
 
     @Singular
-    List<MetricProjection> metrics;
+    private List<MetricProjection> metrics;
 
     @Singular
-    Set<ColumnProjection> groupByDimensions;
+    private Set<ColumnProjection> groupByDimensions;
 
     @Singular
-    Set<TimeDimensionProjection> timeDimensions;
+    private Set<TimeDimensionProjection> timeDimensions;
 
-    FilterExpression whereFilter;
-    FilterExpression havingFilter;
-    Sorting sorting;
-    ImmutablePagination pagination;
-    RequestScope scope;
+    private FilterExpression whereFilter;
+    private FilterExpression havingFilter;
+    private Sorting sorting;
+    private ImmutablePagination pagination;
+    private RequestScope scope;
 
     /**
      * Whether to bypass the {@link QueryEngine} cache for this query.
      */
-    boolean bypassingCache;
+    private boolean bypassingCache;
 
     /**
      * Returns all the dimensions regardless of type.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryResult.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryResult.java
@@ -19,10 +19,10 @@ import lombok.Value;
 @Builder
 public class QueryResult {
     @NonNull
-    Iterable<Object> data;
+    private Iterable<Object> data;
 
     /**
      * Total record count. Null unless Query had Pagination with {@link Pagination#returnPageTotals()} set.
      */
-    Long pageTotals;
+    private Long pageTotals;
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryResult.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryResult.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.query;
+
+import com.yahoo.elide.datastores.aggregation.QueryEngine;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * A {@link QueryResult} contains the results from {@link QueryEngine#executeQuery(Query)}.
+ */
+@Value
+@Builder
+public class QueryResult {
+    @NonNull
+    Iterable<Object> data;
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryResult.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryResult.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.datastores.aggregation.query;
 
 import com.yahoo.elide.datastores.aggregation.QueryEngine;
+import com.yahoo.elide.request.Pagination;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -19,4 +20,9 @@ import lombok.Value;
 public class QueryResult {
     @NonNull
     Iterable<Object> data;
+
+    /**
+     * Total record count. Null unless Query had Pagination with {@link Pagination#returnPageTotals()} set.
+     */
+    Long pageTotals;
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/AbstractEntityHydrator.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * {@link AbstractEntityHydrator} hydrates the entity loaded by {@link QueryEngine#executeQuery(Query, boolean)}.
+ * {@link AbstractEntityHydrator} hydrates the entity loaded by {@link QueryEngine#executeQuery(Query)}.
  * <p>
  * {@link AbstractEntityHydrator} is not thread-safe and should be accessed by only 1 thread in this application,
  * because it uses {@link StitchList}. See {@link StitchList} for more details.
@@ -49,8 +49,8 @@ public abstract class AbstractEntityHydrator {
     /**
      * Constructor.
      *
-     * @param results The loaded objects from {@link QueryEngine#executeQuery(Query, boolean)}
-     * @param query  The query passed to {@link QueryEngine#executeQuery(Query, boolean)} to load the objects
+     * @param results The loaded objects from {@link QueryEngine#executeQuery(Query)}
+     * @param query  The query passed to {@link QueryEngine#executeQuery(Query)} to load the objects
      * @param entityDictionary  An object that sets entity instance values and provides entity metadata info
      */
     public AbstractEntityHydrator(List<Object> results, Query query, EntityDictionary entityDictionary) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLEntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLEntityHydrator.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql;
 
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.datastores.aggregation.QueryEngine;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.queryengines.AbstractEntityHydrator;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 
 /**
- * {@link SQLEntityHydrator} hydrates the entity loaded by {@link SQLQueryEngine#executeQuery(Query, boolean)}.
+ * {@link SQLEntityHydrator} hydrates the entity loaded by {@link QueryEngine#executeQuery(Query)}.
  */
 public class SQLEntityHydrator extends AbstractEntityHydrator {
 
@@ -32,8 +33,8 @@ public class SQLEntityHydrator extends AbstractEntityHydrator {
     /**
      * Constructor.
      *
-     * @param results The loaded objects from {@link SQLQueryEngine#executeQuery(Query, boolean)}
-     * @param query  The query passed to {@link SQLQueryEngine#executeQuery(Query, boolean)} to load the objects
+     * @param results The loaded objects from {@link QueryEngine#executeQuery(Query)}
+     * @param query  The query passed to {@link QueryEngine#executeQuery(Query)} to load the objects
      * @param entityDictionary  An object that sets entity instance values and provides entity metadata info
      * @param entityManager  An service that issues JPQL queries to load relationship objects
      */

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -115,7 +115,7 @@ public class SQLQueryEngine extends QueryEngine {
     }
 
     @Override
-    public Iterable<Object> executeQuery(Query query, boolean useCache) {
+    public Iterable<Object> executeQuery(Query query) {
         EntityManager entityManager = null;
         EntityTransaction transaction = null;
         try {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -156,7 +156,7 @@ public class SQLQueryEngine extends QueryEngine {
                             "Running Query: " + paginationSQL
                     ).get();
 
-                    pagination.setPageTotals(total);
+                    resultBuilder.pageTotals(total);
                 }
             }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -23,6 +23,7 @@ import com.yahoo.elide.datastores.aggregation.query.Cache;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
+import com.yahoo.elide.datastores.aggregation.query.QueryResult;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLMetric;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
@@ -115,7 +116,7 @@ public class SQLQueryEngine extends QueryEngine {
     }
 
     @Override
-    public Iterable<Object> executeQuery(Query query) {
+    public QueryResult executeQuery(Query query) {
         EntityManager entityManager = null;
         EntityTransaction transaction = null;
         try {
@@ -133,6 +134,7 @@ public class SQLQueryEngine extends QueryEngine {
 
             javax.persistence.Query jpaQuery = entityManager.createNativeQuery(sql.toString());
 
+            QueryResult.QueryResultBuilder resultBuilder = QueryResult.builder();
             Pagination pagination = query.getPagination();
             if (pagination != null) {
                 jpaQuery.setFirstResult(pagination.getOffset());
@@ -166,7 +168,8 @@ public class SQLQueryEngine extends QueryEngine {
                     () -> jpaQuery.setHint(QueryHints.HINT_READONLY, true).getResultList(),
                     "Running Query: " + sql).get();
 
-            return new SQLEntityHydrator(results, query, getMetadataDictionary(), entityManager).hydrate();
+            resultBuilder.data(new SQLEntityHydrator(results, query, getMetadataDictionary(), entityManager).hydrate());
+            return resultBuilder.build();
         } finally {
             if (transaction != null && transaction.isActive()) {
                 transaction.commit();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
@@ -54,7 +54,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.DAY))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -91,7 +91,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .metric(invoke(playerStatsViewTable.getMetric("highScore")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -123,7 +123,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -151,7 +151,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -178,7 +178,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStatsView.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -201,7 +201,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -235,7 +235,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -285,7 +285,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .pagination(pagination)
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         //Jon Doe,1234,72,Good,840,2019-07-12 00:00:00
@@ -315,7 +315,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         // Only "Good" rating would have total high score less than 2400
@@ -344,7 +344,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -381,7 +381,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -419,7 +419,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryIsoCode")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -452,7 +452,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -487,7 +487,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -525,7 +525,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.MONTH))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -554,7 +554,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .whereFilter(predicate)
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -579,7 +579,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -614,7 +614,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryNickName")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -640,7 +640,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryUnSeats")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
@@ -10,14 +10,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.Operator;
-import com.yahoo.elide.core.pagination.PaginationImpl;
 import com.yahoo.elide.core.sort.SortingImpl;
 import com.yahoo.elide.datastores.aggregation.example.PlayerStats;
 import com.yahoo.elide.datastores.aggregation.example.PlayerStatsView;
 import com.yahoo.elide.datastores.aggregation.framework.SQLUnitTest;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
+import com.yahoo.elide.datastores.aggregation.query.ImmutablePagination;
 import com.yahoo.elide.datastores.aggregation.query.Query;
+import com.yahoo.elide.datastores.aggregation.query.QueryResult;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.request.Sorting;
 
@@ -267,25 +268,16 @@ public class QueryEngineTest extends SQLUnitTest {
      */
     @Test
     public void testPagination() {
-        PaginationImpl pagination = new PaginationImpl(
-                PlayerStats.class,
-                0,
-                1,
-                PaginationImpl.DEFAULT_PAGE_LIMIT,
-                PaginationImpl.MAX_PAGE_LIMIT,
-                true,
-                false
-        );
-
         Query query = Query.builder()
                 .table(playerStatsTable)
                 .metric(invoke(playerStatsTable.getMetric("lowScore")))
                 .groupByDimension(toProjection(playerStatsTable.getDimension("overallRating")))
                 .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.DAY))
-                .pagination(pagination)
+                .pagination(new ImmutablePagination(0, 1, false, true))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
+        QueryResult result = engine.executeQuery(query);
+        List<Object> data = StreamSupport.stream(result.getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         //Jon Doe,1234,72,Good,840,2019-07-12 00:00:00
@@ -295,9 +287,9 @@ public class QueryEngineTest extends SQLUnitTest {
         stats1.setOverallRating("Good");
         stats1.setRecordedDate(Timestamp.valueOf("2019-07-12 00:00:00"));
 
-        assertEquals(results.size(), 1, "Number of records returned does not match");
-        assertEquals(results.get(0), stats1, "Returned record does not match");
-        assertEquals(pagination.getPageTotals(), 3, "Page totals does not match");
+        assertEquals(data.size(), 1, "Number of records returned does not match");
+        assertEquals(data.get(0), stats1, "Returned record does not match");
+        assertEquals(result.getPageTotals(), 3, "Page totals does not match");
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
@@ -54,7 +54,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.DAY))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -91,7 +91,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .metric(invoke(playerStatsViewTable.getMetric("highScore")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -123,7 +123,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -151,7 +151,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -178,7 +178,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStatsView.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsView stats2 = new PlayerStatsView();
@@ -201,7 +201,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -235,7 +235,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -285,7 +285,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .pagination(pagination)
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         //Jon Doe,1234,72,Good,840,2019-07-12 00:00:00
@@ -315,7 +315,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         // Only "Good" rating would have total high score less than 2400
@@ -344,7 +344,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -381,7 +381,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -419,7 +419,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryIsoCode")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -452,7 +452,7 @@ public class QueryEngineTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -487,7 +487,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -525,7 +525,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.MONTH))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -554,7 +554,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .whereFilter(predicate)
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -579,7 +579,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats0 = new PlayerStats();
@@ -614,7 +614,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryNickName")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -640,7 +640,7 @@ public class QueryEngineTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("countryUnSeats")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
@@ -54,7 +54,7 @@ public class SubselectTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("subCountryIsoCode")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -87,7 +87,7 @@ public class SubselectTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -124,7 +124,7 @@ public class SubselectTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
@@ -54,7 +54,7 @@ public class SubselectTest extends SQLUnitTest {
                 .groupByDimension(toProjection(playerStatsTable.getDimension("subCountryIsoCode")))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -87,7 +87,7 @@ public class SubselectTest extends SQLUnitTest {
                         PlayerStats.class, false))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();
@@ -124,7 +124,7 @@ public class SubselectTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStats stats1 = new PlayerStats();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
@@ -46,7 +46,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -80,7 +80,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -115,7 +115,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -150,7 +150,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -185,7 +185,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -220,7 +220,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query, true).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
@@ -46,7 +46,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -80,7 +80,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -115,7 +115,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -150,7 +150,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -185,7 +185,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();
@@ -220,7 +220,7 @@ public class ViewTest extends SQLUnitTest {
                 .sorting(new SortingImpl(sortMap, PlayerStatsWithView.class, dictionary))
                 .build();
 
-        List<Object> results = StreamSupport.stream(engine.executeQuery(query).spliterator(), false)
+        List<Object> results = StreamSupport.stream(engine.executeQuery(query).getData().spliterator(), false)
                 .collect(Collectors.toList());
 
         PlayerStatsWithView usa0 = new PlayerStatsWithView();


### PR DESCRIPTION
## Description
Currently QueryEngine.execute takes a Query as input and returns an iterable list of results as output. However, the Query can contain a mutable Pagination object which may be modified by `execute` to contain the page total. This complicates caching, since we want a single result object to cache. So for the purposes of QueryEngine, we make the Pagination used by Query immutable, and `execute` now returns a QueryResult which contains both the result data and the page total metadata.

Other caching-related changes:
 - Polish Pagination/PaginationImpl - many fields do not need to be nullable or non-final, and they were not making full use of Lombok.
- Consolidate the bypassCache flag into the Query object
- Don't use a stub cache implementation when caching is disabled. When caching is not enabled, we should skip caching code entirely to avoid overhead of forming cache keys.

## Motivation and Context
Current design of Query/QueryEngine is not ideal when caching is supported. This PR is a prerequisite for implementing the cache.

## How Has This Been Tested?
UTs pass. No UTs added.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
