### PR TITLE
test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <doclint>all,-missing</doclint>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description
Travis build exceeds number of log limit. Removing the java doc warning to reduce the log size. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
