### PR TITLE
update package whose cvss score raised above 7.0

### DIFF
--- a/elide-example/elide-blog-example-resteasy/pom.xml
+++ b/elide-example/elide-blog-example-resteasy/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <mysql.data.directory>${project.build.directory}/mysql-data</mysql.data.directory>
-        <resteasy.version>3.11.2.Final</resteasy.version>
+        <resteasy.version>3.12.0.Final</resteasy.version>
     </properties>
 
     <dependencies>

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <spring.boot.version>2.3.0.RELEASE</spring.boot.version>
-        <tomcat.version>9.0.34</tomcat.version>
+        <tomcat.version>9.0.35</tomcat.version>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <min_jdk_version>1.8</min_jdk_version>
         <max_jdk_version>1.8</max_jdk_version>


### PR DESCRIPTION
maven build failed due to the below package not meeting CVSS score requirement. 
* resteasy-jaxrs
* tomcat-embed-core


After update, the local maven build succeeds. 


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
