### PR TITLE
Elide dynamic config model verification

### DIFF
--- a/elide-contrib/elide-dynamic-config-helpers/pom.xml
+++ b/elide-contrib/elide-dynamic-config-helpers/pom.xml
@@ -70,6 +70,11 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.20</version>
+        </dependency>
+        <dependency>
         <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/elide-contrib/elide-dynamic-config-helpers/src/main/java/com/yahoo/elide/contrib/dynamicconfighelpers/verify/DynamicConfigVerifier.java
+++ b/elide-contrib/elide-dynamic-config-helpers/src/main/java/com/yahoo/elide/contrib/dynamicconfighelpers/verify/DynamicConfigVerifier.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.contrib.dynamicconfighelpers.verify;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+import java.util.Base64;
+
+@Slf4j
+public class DynamicConfigVerifier {
+
+    /**
+     * Main Methode to Verify Signature of Model Tar file.
+     * @param args : expects 3 arguments.
+     * @throws IllegalStateException
+     */
+    public static void main(String[] args) {
+        if (args == null || args.length != 3) {
+            usage();
+            throw new IllegalStateException("No Arguments provided!");
+        }
+        String modelTarFile = args[0];
+        String signatureFile = args[1];
+        String publicKeyName = args[2];
+
+        if (verify(tarContents(modelTarFile), signatureFile, getPublicKey(publicKeyName))) {
+            log.info("Successfully Validated " + modelTarFile);
+        }
+        else {
+            log.error("Could not verify " + modelTarFile + " with details provided");
+        }
+    }
+
+    private static PublicKey getPublicKey(String keyName) {
+        PublicKey publicKey = null;
+        try {
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            Certificate cert = keyStore.getCertificate(keyName);
+            publicKey = cert.getPublicKey();
+        } catch (KeyStoreException e) {
+            log.error(e.getMessage());
+            throw new IllegalArgumentException("Key " + keyName + " is not availabe in keystore");
+        }
+        return publicKey;
+    }
+
+    /**
+     * Verify signature of tar.gz.
+     * @param fileList
+     * @param signature
+     * @param publicKey
+     * @return whether the file can be verified by given key & signature.
+     * @throws Exception
+     */
+    public static boolean verify(String fileList, String signature, PublicKey publicKey) {
+        Signature publicSignature;
+        try {
+            publicSignature = Signature.getInstance("SHA256withRSA");
+            publicSignature.initVerify(publicKey);
+            publicSignature.update(fileList.getBytes(StandardCharsets.UTF_8));
+            byte[] signatureBytes = Base64.getDecoder().decode(signature);
+            return publicSignature.verify(signatureBytes);
+        } catch (NoSuchAlgorithmException e) {
+            log.error(e.getMessage());
+        } catch (InvalidKeyException e) {
+            log.error(e.getMessage());
+        } catch (SignatureException e) {
+            log.error(e.getMessage());
+        }
+        return false;
+    }
+
+    private static String tarContents(String archiveFile) {
+        StringBuffer sb = new StringBuffer();
+        try (TarArchiveInputStream archive = new TarArchiveInputStream(
+                new GzipCompressorInputStream(new BufferedInputStream(new FileInputStream(archiveFile))))) {
+            TarArchiveEntry entry;
+            while ((entry = archive.getNextTarEntry()) != null) {
+                sb.append(entry.getName());
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new IllegalArgumentException("archiveFile " + archiveFile + " is not available");
+        }
+        return sb.toString();
+    }
+
+    private static void usage() {
+        log.info("\n Usage: java -cp <Jar File Name>"
+                + " com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigVerifier\n"
+                + " <The name of the tar.gz file\n"
+                + " <The name of the file containing the signature \n"
+                + " <The name public key \n"
+                );
+    }
+}

--- a/elide-contrib/elide-dynamic-config-helpers/src/test/java/com/yahoo/elide/contrib/dynamicconfighelpers/verify/DynamicConfigVerifiesTest.java
+++ b/elide-contrib/elide-dynamic-config-helpers/src/test/java/com/yahoo/elide/contrib/dynamicconfighelpers/verify/DynamicConfigVerifiesTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.contrib.dynamicconfighelpers.verify;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.util.Base64;
+
+public class DynamicConfigVerifiesTest {
+
+    private KeyPair kp;
+    private String signature;
+
+    private static KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048, new SecureRandom());
+        KeyPair pair = generator.generateKeyPair();
+        return pair;
+    }
+
+    private static String sign(String data, PrivateKey privateKey) throws Exception {
+        Signature privateSignature = Signature.getInstance("SHA256withRSA");
+        privateSignature.initSign(privateKey);
+        privateSignature.update(data.getBytes(StandardCharsets.UTF_8));
+
+        byte[] signature = privateSignature.sign();
+
+        return Base64.getEncoder().encodeToString(signature);
+    }
+
+    private void setup() throws Exception {
+        kp = generateKeyPair();
+        signature = sign("testing-signature", kp.getPrivate());
+    }
+
+    @Test
+    public void testValidSignature() throws Exception {
+        setup();
+        assertTrue(DynamicConfigVerifier.verify("testing-signature", signature, kp.getPublic()));
+    }
+
+    @Test
+    public void testInvalidSignature() throws Exception {
+        setup();
+        assertFalse(DynamicConfigVerifier.verify("invalid-signature", signature, kp.getPublic()));
+    }
+
+    @Test
+    public void testFileSignature() throws Exception {
+        kp = generateKeyPair();
+        signature = sign("testing-signature", kp.getPrivate());
+
+        assertTrue(DynamicConfigVerifier.verify("testing-signature", signature, kp.getPublic()));
+    }
+}


### PR DESCRIPTION
Authored-by: AvaniMakwana

One of the multiple PRs that will resolve #1178 (if appropriate)

Description
Verify Dynamic Model Configuration tar.gz file with available public key and signature file.

Motivation and Context
Please refer #1178

How Has This Been Tested?
Unit tests have been included.

License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.