### PR TITLE
add explicit join

### DIFF
--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
@@ -51,6 +51,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
 
             //Build the JOIN clause
             String joinClause =  getJoinClauseFromFilters(filterExpression.get())
+                    + getJoinClauseFromSort(sorting)
                     + extractToOneMergeJoins(entityClass, entityAlias);
 
             boolean requiresDistinct = pagination.isPresent() && containsOneToMany(filterExpression.get());
@@ -75,7 +76,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                         + SPACE
                         + filterClause
                         + SPACE
-                        + getSortClause(sorting, entityClass, USE_ALIAS)
+                        + getSortClause(sorting)
             );
 
             //Fill in the query parameters
@@ -88,9 +89,10 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                     + AS
                     + entityAlias
                     + SPACE
+                    + getJoinClauseFromSort(sorting)
                     + extractToOneMergeJoins(entityClass, entityAlias)
                     + SPACE
-                    + getSortClause(sorting, entityClass, USE_ALIAS));
+                    + getSortClause(sorting));
         }
 
         addPaginationToQuery(query);

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -74,6 +74,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
             String filterClause = new FilterTranslator().apply(fe, USE_ALIAS);
 
             String joinClause =  getJoinClauseFromFilters(filterExpression.get())
+                    + getJoinClauseFromSort(sorting)
                     + extractToOneMergeJoins(relationship.getChildType(), childAlias);
 
             //SELECT parent_children from Parent parent JOIN parent.children parent_children
@@ -88,7 +89,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                             + filterClause
                             + " AND " + parentAlias + "=:" + parentAlias
                             + SPACE
-                            + getSortClause(sorting, relationship.getChildType(), USE_ALIAS)
+                            + getSortClause(sorting)
             );
 
             supplyFilterQueryParameters(q, predicates);
@@ -99,9 +100,10 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                             + parentName + SPACE + parentAlias
                             + JOIN
                             + parentAlias + PERIOD + relationshipName + SPACE + childAlias
+                            + getJoinClauseFromSort(sorting)
                             + extractToOneMergeJoins(relationship.getChildType(), childAlias)
                             + " WHERE " + parentAlias + "=:" + parentAlias
-                            + getSortClause(sorting, relationship.getChildType(), USE_ALIAS)
+                            + getSortClause(sorting)
         ));
 
         query.setParameter(parentAlias, relationship.getParent());

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
@@ -121,9 +121,9 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
         sorting.put(TITLE, Sorting.SortOrder.asc);
         sorting.put(GENRE, Sorting.SortOrder.desc);
 
-        String actual = getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary)), Book.class, NO_ALIAS);
+        String actual = getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary)));
 
-        String expected = " order by title asc,genre desc";
+        String expected = " order by example_Book.title asc,example_Book.genre desc";
         assertEquals(expected, actual);
     }
 
@@ -133,7 +133,7 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
         sorting.put(TITLE, Sorting.SortOrder.asc);
         sorting.put(GENRE, Sorting.SortOrder.desc);
 
-        String actual = getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary)), Book.class, USE_ALIAS);
+        String actual = getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary)));
 
         String expected = " order by example_Book.title asc,example_Book.genre desc";
         assertEquals(expected, actual);
@@ -144,9 +144,9 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
         Map<String, Sorting.SortOrder> sorting = new LinkedHashMap<>();
         sorting.put(PUBLISHER + PERIOD + NAME, Sorting.SortOrder.asc);
 
-        String actual = getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary)), Book.class, NO_ALIAS);
+        String actual = getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary)));
 
-        String expected = " order by publisher.name asc";
+        String expected = " order by example_Book_publisher.name asc";
         assertEquals(expected, actual);
     }
 
@@ -155,7 +155,7 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
         Map<String, Sorting.SortOrder> sorting = new LinkedHashMap<>();
         sorting.put(AUTHORS + PERIOD + NAME, Sorting.SortOrder.asc);
 
-        assertThrows(InvalidValueException.class, () -> getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary)), Book.class, NO_ALIAS));
+        assertThrows(InvalidValueException.class, () -> getSortClause(Optional.of(new SortingImpl(sorting, Book.class, dictionary))));
     }
 
     @Test


### PR DESCRIPTION
Resolves #920  (if appropriate)

## Description
Query with Sorting clause should have an explicit join clause and use its alias in order by clause. 

## Motivation and Context
The implicit JPA join uses an inner join to fetch the relationship entity. We want JPA to perform left join to preserve all response records.

## How Has This Been Tested?
Unit test
IT test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
