### PR TITLE
Miscellanous fix

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryInterruptThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryInterruptThread.java
@@ -47,7 +47,8 @@ public class AsyncQueryInterruptThread implements Runnable {
     protected void interruptQuery() {
         try {
             long interruptTimeMillies = calculateTimeOut(maxRunTimeMinutes, submittedOn);
-
+            log.info("Waiting on the future with the given timeout for {}", interruptTimeMillies);
+            System.out.println("Waiting on the future with the given timeout for " + interruptTimeMillies);
             if (interruptTimeMillies > 0) {
                log.debug("Waiting on the future with the given timeout for {}", interruptTimeMillies);
                task.get(interruptTimeMillies, TimeUnit.MILLISECONDS);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -201,7 +201,7 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
             tx.commit(scope);
         } catch (IOException e) {
             log.error("IOException: {}", e);
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
         return result;
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -201,8 +201,12 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
             tx.commit(scope);
         } catch (IOException e) {
             log.error("IOException: {}", e);
+            log.info("IOException: {}", e);
+            e.printStackTrace();
         } catch (Exception e) {
             log.error("Exception: {}", e);
+            log.info("Exception: {}", e);
+            e.printStackTrace();
         }
         return result;
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -201,12 +201,7 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
             tx.commit(scope);
         } catch (IOException e) {
             log.error("IOException: {}", e);
-            log.info("IOException: {}", e);
-            e.printStackTrace();
-        } catch (Exception e) {
-            log.error("Exception: {}", e);
-            log.info("Exception: {}", e);
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
         return result;
     }

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryThreadTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryThreadTest.java
@@ -102,4 +102,18 @@ public class AsyncQueryThreadTest {
         verify(asyncQueryDao, times(1)).updateStatus(queryObj, QueryStatus.PROCESSING);
         verify(asyncQueryDao, times(1)).updateStatus(queryObj, QueryStatus.FAILURE);
     }
+
+    @Test
+    public void testAsyncQueryResultNullException() {
+        String query = "/group?sort=commonName&fields%5Bgroup%5D=commonName,description";
+
+        when(queryObj.getQuery()).thenReturn(query);
+        when(queryObj.getQueryType()).thenReturn(QueryType.JSONAPI_V1_0);
+        when(asyncQueryDao.createAsyncQueryResult(any(), any(), any(), any())).thenThrow(RuntimeException.class);
+
+        queryThread.processQuery();
+
+        verify(asyncQueryDao, times(1)).updateStatus(queryObj, QueryStatus.PROCESSING);
+        verify(asyncQueryDao, times(1)).updateStatus(queryObj, QueryStatus.FAILURE);
+    }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideDynamicConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideDynamicConfiguration.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.utils.ClassScanner;
 import org.hibernate.cfg.AvailableSettings;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties.Naming;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
@@ -60,6 +61,7 @@ public class ElideDynamicConfiguration {
      * @return LocalContainerEntityManagerFactoryBean bean
      */
     @Bean
+    @ConditionalOnMissingBean
     public LocalContainerEntityManagerFactoryBean entityManagerFactory (
             DataSource source,
             JpaProperties jpaProperties,

--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -143,7 +143,6 @@
             <version>${version.jetty}</version>
         </dependency>
 
-
         <!-- Let's use Jetty Instead -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Description
i) Added `@ConditionalOnMissingBean` to `entityManagerFactory` method in Dynamic Config Configuration to allow overriding of the bean. 
ii)  `executeInTransaction` will throw a RuntimeException when IOException happens and not ignore the other exceptions too. 

## Motivation and Context
i) If we want to override the entityManagerFactory Bean in one of our implementations, we need to have the annotation.
ii) The AsyncIT test fails intermittently with `Expected: asyncQueryResult Actual: null` error. The only possible scenario this could happen is if the AsyncQueryResult object was not persisted properly. 

## How Has This Been Tested?
Existing test case pass. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
