### PR TITLE
Fix QueryKeyExtractorTest.testTimeDimensionsOrdered

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/PlayerStats.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/PlayerStats.java
@@ -106,6 +106,8 @@ public class PlayerStats {
 
     private Date recordedDate;
 
+    private Date updatedDate;
+
     @Setter
     private int playerLevel;
 
@@ -261,6 +263,23 @@ public class PlayerStats {
 
     public void setRecordedDate(final Date recordedDate) {
         this.recordedDate = recordedDate;
+    }
+
+    /**
+     * <b>DO NOT put {@link Cardinality} annotation on this field</b>. See
+     *
+     * @return the date of the player session.
+     */
+    @Temporal(grains = {
+            @TimeGrainDefinition(grain = TimeGrain.DAY, expression = DAY_FORMAT),
+            @TimeGrainDefinition(grain = TimeGrain.MONTH, expression = MONTH_FORMAT)
+    }, timeZone = "UTC")
+    public Date getUpdatedDate() {
+        return updatedDate;
+    }
+
+    public void setUpdatedDate(final Date updatedDate) {
+        this.updatedDate = updatedDate;
     }
 
     @DimensionFormula("CASE WHEN {{country.inUsa}} THEN 'true' ELSE 'false' END")

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/query/QueryKeyExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/query/QueryKeyExtractorTest.java
@@ -118,12 +118,14 @@ public class QueryKeyExtractorTest {
                 QueryKeyExtractor.extractKey(Query.builder()
                         .table(playerStatsTable)
                         .metric(invoke(playerStatsTable.getMetric("highScore")))
+                        .timeDimension(toProjection(playerStatsTable.getTimeDimension("updatedDate"), TimeGrain.DAY))
                         .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.DAY))
                         .build()),
                 QueryKeyExtractor.extractKey(Query.builder()
                         .table(playerStatsTable)
                         .metric(invoke(playerStatsTable.getMetric("highScore")))
                         .timeDimension(toProjection(playerStatsTable.getTimeDimension("recordedDate"), TimeGrain.DAY))
+                        .timeDimension(toProjection(playerStatsTable.getTimeDimension("updatedDate"), TimeGrain.DAY))
                         .build()));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/create_tables.sql
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/create_tables.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS playerStats
       sub_country_id VARCHAR(255),
       player_id BIGINT,
       player2_id BIGINT,
-      recordedDate DATETIME
+      recordedDate DATETIME,
+      updatedDate DATETIME
     ) AS SELECT * FROM CSVREAD('classpath:player_stats.csv');
 
 CREATE TABLE IF NOT EXISTS countries

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/player_stats.csv
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/player_stats.csv
@@ -1,4 +1,4 @@
-highScore,lowScore,overallRating,country_id,sub_country_id,player_id,player2_id,recordedDate
-1234,35,Good,840,840,1,2,2019-07-12 00:00:00
-2412,241,Great,840,840,2,3,2019-07-11 00:00:00
-1000,72,Good,344,344,3,1,2019-07-13 00:00:00
+highScore,lowScore,overallRating,country_id,sub_country_id,player_id,player2_id,recordedDate,updatedDate
+1234,35,Good,840,840,1,2,2019-07-12 00:00:00,2019-08-12 00:00:00
+2412,241,Great,840,840,2,3,2019-07-11 00:00:00,2019-08-12 00:00:00
+1000,72,Good,344,344,3,1,2019-07-13 00:00:00,2019-08-12 00:00:00


### PR DESCRIPTION

## Description
Fix QueryKeyExtractorTest.testTimeDimensionsOrdered to actually test handling of multiple time dimensions.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
