### PR TITLE
Fixes for query cache spring integration

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/README.md
+++ b/elide-spring/elide-spring-boot-autoconfigure/README.md
@@ -23,6 +23,8 @@ The Elide spring autoconfigure package provides the core code needed to use Elid
 | elide.swagger.enabled      | No         | false           | Whether or not the Swagger document endpoint is exposed. |
 | elide.swagger.name         | No         | 'Elide Service' | Swagger documentation requires an API name.              |
 | elide.swagger.version      | No         | '1.0'           | Swagger documentation requires an API version.           |
+| elide.queryCacheMaximumEntries | No     | 1024            | Maximum number of entries inquery result cache.          |
+
 
 ## Entity Dictionary Override
 

--- a/elide-spring/elide-spring-boot-autoconfigure/README.md
+++ b/elide-spring/elide-spring-boot-autoconfigure/README.md
@@ -11,19 +11,19 @@ The Elide spring autoconfigure package provides the core code needed to use Elid
    
 ## Configuration Properties   
 
-| *Property*                 | *Required* |  *Default*      | *Description*                                            |
-| -------------------------- | -----------| --------------- | -------------------------------------------------------- |
-| elide.pageSize             | No         | 500             | Default pagination page size for collections             |
-| elide.maxPageSize          | No         | 10000           | Max pagination page size a client can request.           |
-| elide.json-api.path        | No         | '/'             | URL path prefix for JSON-API endpoint.                   |
-| elide.json-api.enabled     | No         | false           | Whether or not the JSON-API endpoint is exposed.         |
-| elide.graphql.path         | No         | '/'             | URL path prefix for GraphQL endpoint.                    |
-| elide.graphql.enabled      | No         | false           | Whether or not the GraphQL endpoint is exposed.          |
-| elide.swagger.path         | No         | '/'             | URL path prefix for Swagger document  endpoint.          |
-| elide.swagger.enabled      | No         | false           | Whether or not the Swagger document endpoint is exposed. |
-| elide.swagger.name         | No         | 'Elide Service' | Swagger documentation requires an API name.              |
-| elide.swagger.version      | No         | '1.0'           | Swagger documentation requires an API version.           |
-| elide.queryCacheMaximumEntries | No     | 1024            | Maximum number of entries inquery result cache.          |
+| *Property*                     | *Required* |  *Default*      | *Description*                                            |
+| ------------------------------ | -----------| --------------- | -------------------------------------------------------- |
+| elide.pageSize                 | No         | 500             | Default pagination page size for collections             |
+| elide.maxPageSize              | No         | 10000           | Max pagination page size a client can request.           |
+| elide.json-api.path            | No         | '/'             | URL path prefix for JSON-API endpoint.                   |
+| elide.json-api.enabled         | No         | false           | Whether or not the JSON-API endpoint is exposed.         |
+| elide.graphql.path             | No         | '/'             | URL path prefix for GraphQL endpoint.                    |
+| elide.graphql.enabled          | No         | false           | Whether or not the GraphQL endpoint is exposed.          |
+| elide.swagger.path             | No         | '/'             | URL path prefix for Swagger document  endpoint.          |
+| elide.swagger.enabled          | No         | false           | Whether or not the Swagger document endpoint is exposed. |
+| elide.swagger.name             | No         | 'Elide Service' | Swagger documentation requires an API name.              |
+| elide.swagger.version          | No         | '1.0'           | Swagger documentation requires an API version.           |
+| elide.queryCacheMaximumEntries | No         | 1024            | Maximum number of entries inquery result cache.          |
 
 
 ## Entity Dictionary Override

--- a/elide-spring/elide-spring-boot-autoconfigure/README.md
+++ b/elide-spring/elide-spring-boot-autoconfigure/README.md
@@ -23,7 +23,7 @@ The Elide spring autoconfigure package provides the core code needed to use Elid
 | elide.swagger.enabled          | No         | false           | Whether or not the Swagger document endpoint is exposed. |
 | elide.swagger.name             | No         | 'Elide Service' | Swagger documentation requires an API name.              |
 | elide.swagger.version          | No         | '1.0'           | Swagger documentation requires an API version.           |
-| elide.queryCacheMaximumEntries | No         | 1024            | Maximum number of entries inquery result cache.          |
+| elide.queryCacheMaximumEntries | No         | 1024            | Maximum number of entries in query result cache.         |
 
 
 ## Entity Dictionary Override

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -181,7 +181,8 @@ public class ElideAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public DataStore buildDataStore(EntityManagerFactory entityManagerFactory, QueryEngine queryEngine,
-            ObjectProvider<ElideDynamicEntityCompiler> dynamicCompiler, ElideConfigProperties settings, Cache cache)
+            ObjectProvider<ElideDynamicEntityCompiler> dynamicCompiler, ElideConfigProperties settings,
+            @Autowired(required = false) Cache cache)
             throws ClassNotFoundException {
         AggregationDataStore.AggregationDataStoreBuilder aggregationDataStoreBuilder = AggregationDataStore.builder()
                 .queryEngine(queryEngine);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/aggregation/Stats.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/aggregation/Stats.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.datastores.aggregation.annotation.Cardinality;
 import com.yahoo.elide.datastores.aggregation.annotation.CardinalitySize;
 import com.yahoo.elide.datastores.aggregation.annotation.MetricAggregation;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.VersionQuery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metric.functions.SqlSum;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -21,6 +22,7 @@ import javax.persistence.Id;
 @EqualsAndHashCode
 @ToString
 @FromTable(name = "stats")
+@VersionQuery(sql = "SELECT COUNT(*) FROM stats")
 public class Stats {
 
     /**


### PR DESCRIPTION
## Description
Add test for Spring integration, checking that default configuration enables the Caffeine query cache, which should then publish metrics.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
