### PR TITLE
Multiplex Transaction Lazy Initialize and Dynamic Config fixes

### DIFF
--- a/elide-contrib/elide-dynamic-config-helpers/src/main/java/com/yahoo/elide/contrib/dynamicconfighelpers/parser/handlebars/HandlebarsHydrator.java
+++ b/elide-contrib/elide-dynamic-config-helpers/src/main/java/com/yahoo/elide/contrib/dynamicconfighelpers/parser/handlebars/HandlebarsHydrator.java
@@ -30,11 +30,9 @@ public class HandlebarsHydrator {
     public static final String HANDLEBAR_START_DELIMITER = "<%";
     public static final String HANDLEBAR_END_DELIMITER = "%>";
     public static final EscapingStrategy MY_ESCAPING_STRATEGY = new Hbs(new String[][]{
-        {"<", "&lt;" },
-        {">", "&gt;" },
         {"\"", "&quot;" },
         {"`", "&#x60;" },
-        {"&", "&amp;" }
+        {"\n", " " }
     });
 
     /**

--- a/elide-contrib/elide-dynamic-config-helpers/src/main/resources/templates/table.hbs
+++ b/elide-contrib/elide-dynamic-config-helpers/src/main/resources/templates/table.hbs
@@ -26,6 +26,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Data;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Id;

--- a/elide-contrib/elide-dynamic-config-helpers/src/test/java/com/yahoo/elide/contrib/dynamicconfighelpers/parser/handlebars/HandlebarsHydratorTest.java
+++ b/elide-contrib/elide-dynamic-config-helpers/src/test/java/com/yahoo/elide/contrib/dynamicconfighelpers/parser/handlebars/HandlebarsHydratorTest.java
@@ -112,6 +112,7 @@ public class HandlebarsHydratorTest {
             + "import lombok.ToString;\n"
             + "import lombok.Data;\n"
             + "\n"
+            + "import java.math.BigDecimal;\n"
             + "import java.util.Date;\n"
             + "import javax.persistence.Column;\n"
             + "import javax.persistence.Id;\n"

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
@@ -34,9 +34,8 @@ import java.util.Set;
  * If any commit fails in process, reverse any commits already completed.
  */
 public abstract class MultiplexTransaction extends DataStoreTransactionImplementation {
-    protected final LinkedHashMap<DataStore, DataStoreTransaction> transactions;
+    protected LinkedHashMap<DataStore, DataStoreTransaction> transactions;
     protected final MultiplexManager multiplexManager;
-    protected final DataStoreTransaction lastDataStoreTransaction;
 
     /**
      * Multiplex transaction handler.
@@ -45,14 +44,6 @@ public abstract class MultiplexTransaction extends DataStoreTransactionImplement
     public MultiplexTransaction(MultiplexManager multiplexManager) {
         this.multiplexManager = multiplexManager;
         this.transactions = new LinkedHashMap<>(multiplexManager.dataStores.size());
-
-        // create each subordinate transaction
-        DataStoreTransaction transaction = null;
-        for (DataStore dataStore : multiplexManager.dataStores) {
-            transaction = beginTransaction(dataStore);
-            transactions.put(dataStore, transaction);
-        }
-        lastDataStoreTransaction = transaction;
     }
 
     protected abstract DataStoreTransaction beginTransaction(DataStore dataStore);
@@ -78,19 +69,25 @@ public abstract class MultiplexTransaction extends DataStoreTransactionImplement
 
     @Override
     public void flush(RequestScope requestScope) {
-        transactions.values().forEach(dataStoreTransaction -> dataStoreTransaction.flush(requestScope));
+        transactions.values().stream()
+                .filter(dataStoreTransaction -> dataStoreTransaction != null)
+                .forEach(dataStoreTransaction -> dataStoreTransaction.flush(requestScope));
     }
 
     @Override
     public void preCommit() {
-        transactions.values().forEach(DataStoreTransaction::preCommit);
+        transactions.values().stream()
+                .filter(dataStoreTransaction -> dataStoreTransaction != null)
+                .forEach(DataStoreTransaction::preCommit);
     }
 
     @Override
     public void commit(RequestScope scope) {
         // flush all before commit
         flush(scope);
-        transactions.values().forEach(dataStoreTransaction -> dataStoreTransaction.commit(scope));
+        transactions.values().stream()
+               .filter(dataStoreTransaction -> dataStoreTransaction != null)
+               .forEach(dataStoreTransaction -> dataStoreTransaction.commit(scope));
     }
 
     @Override
@@ -121,9 +118,20 @@ public abstract class MultiplexTransaction extends DataStoreTransactionImplement
     }
 
     protected DataStoreTransaction getTransaction(Class<?> cls) {
-        DataStoreTransaction transaction = transactions.get(this.multiplexManager.getSubManager(cls));
+        DataStore lookupDataStore = this.multiplexManager.getSubManager(cls);
+
+        DataStoreTransaction transaction = transactions.get(lookupDataStore);
         if (transaction == null) {
-            throw new InvalidCollectionException(cls.getName());
+            for (DataStore dataStore : multiplexManager.dataStores) {
+                if (dataStore.equals(lookupDataStore)) {
+                    transaction = beginTransaction(dataStore);
+                    transactions.put(dataStore, transaction);
+                    break;
+                }
+            }
+            if (transaction == null) {
+                throw new InvalidCollectionException(cls.getName());
+            }
         }
         return transaction;
     }

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexWriteTransaction.java
@@ -111,15 +111,12 @@ public class MultiplexWriteTransaction extends MultiplexTransaction {
     }
 
     private <T> Iterable<T> hold(DataStoreTransaction transaction, Iterable<T> list) {
-        if (transaction != lastDataStoreTransaction) {
-            ArrayList<T> newList = new ArrayList<>();
-            list.forEach(newList::add);
-            for (T object : newList) {
-                hold(transaction, object);
-            }
-            return newList;
+        ArrayList<T> newList = new ArrayList<>();
+        list.forEach(newList::add);
+        for (T object : newList) {
+            hold(transaction, object);
         }
-        return list;
+        return newList;
     }
 
     /**
@@ -129,9 +126,7 @@ public class MultiplexWriteTransaction extends MultiplexTransaction {
      * @return original object
      */
     private <T> T hold(DataStoreTransaction subTransaction, T object) {
-        if (subTransaction != lastDataStoreTransaction) {
-            clonedObjects.put(object, cloneObject(object));
-        }
+        clonedObjects.put(object, cloneObject(object));
         return object;
     }
 

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexTransactionTest.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexTransactionTest.java
@@ -5,13 +5,16 @@
  */
 package com.yahoo.elide.datastores.multiplex;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.DataStoreTransaction;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 /**
  * Tests MultiplexTransaction.
@@ -33,7 +36,18 @@ public class MultiplexTransactionTest {
 
         multiplexTx.preCommit();
 
-        verify(tx1).preCommit();
-        verify(tx2).preCommit();
+        // Since transactions are lazy initialized,
+        // preCommit will not be called on individual transactions.
+        verify(tx1, Mockito.times(0)).preCommit();
+        verify(tx2, Mockito.times(0)).preCommit();
+
+        MultiplexReadTransaction multiplexReadTx = (MultiplexReadTransaction) multiplexTx;
+
+        long countInitializedTransaction = multiplexReadTx.transactions.values().stream()
+                .filter(dataStoreTransaction -> dataStoreTransaction != null)
+                .count();
+
+        assertEquals(0, countInitializedTransaction);
+
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -68,7 +68,7 @@ public class ElideAutoConfiguration {
      * @throws Exception Exception thrown.
      */
 
-     private final Consumer<EntityManager> txCancel = (em) -> { em.unwrap(Session.class).cancelQuery(); };
+    private final Consumer<EntityManager> txCancel = (em) -> { em.unwrap(Session.class).cancelQuery(); };
 
     @Bean
     @ConditionalOnMissingBean


### PR DESCRIPTION
## Description
i) Lazy Initialization of transactions in Multiplex Transaction
ii) Handlebars escaping now limited to quotes, new line.  

## Motivation and Context
Multiplex Transaction was committing all the transactions since they were initialized even though they were not used. This resuled in transaction not in progress errors.
Sqls have < , > etc which can not be escaped

## How Has This Been Tested?
Existing test cases pass. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
