### PR TITLE
Issue 683

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -209,7 +209,6 @@ public class Elide {
      * @param accept the accept
      * @param path the path
      * @param jsonApiDocument the json api document
-     * @param queryParams the query params
      * @param opaqueUser the opaque user
      * @return Elide response object
      */

--- a/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DataStoreTransaction.java
@@ -270,7 +270,8 @@ public interface DataStoreTransaction extends Closeable {
 
     /**
      * Whether or not the transaction can sort the provided class.
-     * @param entityClass
+     * @param entityClass The model type
+     * @param sorting Whether or not the store supports sorting for the given model
      * @return true if sorting is possible
      */
     default boolean supportsSorting(Class<?> entityClass, Sorting sorting) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -169,7 +169,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
                             errorMessage = errorMessage + "\n" + e.getMessage();
                         }
 
-                        throw new BadRequestException(errorMessage);
+                        throw new BadRequestException(errorMessage, e);
                     }
                 }
             }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/BadRequestException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/BadRequestException.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.core.exceptions;
 
 import com.yahoo.elide.core.HttpStatus;
+import com.yahoo.elide.core.filter.dialect.ParseException;
 
 /**
  * Invalid predicate exception.
@@ -13,5 +14,9 @@ import com.yahoo.elide.core.HttpStatus;
 public class BadRequestException extends HttpStatusException {
     public BadRequestException(String message) {
         super(HttpStatus.SC_BAD_REQUEST, message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(HttpStatus.SC_BAD_REQUEST, message, cause, null);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/BadRequestException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/BadRequestException.java
@@ -6,7 +6,6 @@
 package com.yahoo.elide.core.exceptions;
 
 import com.yahoo.elide.core.HttpStatus;
-import com.yahoo.elide.core.filter.dialect.ParseException;
 
 /**
  * Invalid predicate exception.

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -272,13 +272,14 @@ public enum Operator {
                 throw new BadRequestException("PREFIX can only take one argument");
             }
 
-            Object val = getFieldValue(entity, fieldPath, requestScope);
-            String valStr = CoerceUtil.coerce(val, String.class);
-            String filterStr = CoerceUtil.coerce(values.get(0), String.class);
+            BiPredicate predicate = (a, b) -> {
+                String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
+                String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
-            return valStr != null
-                    && filterStr != null
-                    && transform.apply(valStr).startsWith(transform.apply(filterStr));
+                return lhs != null && rhs != null && lhs.startsWith(rhs);
+            };
+
+            return evaluate(entity, fieldPath, values, predicate, requestScope);
         };
     }
 
@@ -291,13 +292,14 @@ public enum Operator {
                 throw new BadRequestException("POSTFIX can only take one argument");
             }
 
-            Object val = getFieldValue(entity, fieldPath, requestScope);
-            String valStr = CoerceUtil.coerce(val, String.class);
-            String filterStr = CoerceUtil.coerce(values.get(0), String.class);
+            BiPredicate predicate = (a, b) -> {
+                String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
+                String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
-            return valStr != null
-                    && filterStr != null
-                    && transform.apply(valStr).endsWith(transform.apply(filterStr));
+                return lhs != null && rhs != null && lhs.endsWith(rhs);
+            };
+
+            return evaluate(entity, fieldPath, values, predicate, requestScope);
         };
     }
 
@@ -310,13 +312,14 @@ public enum Operator {
                 throw new BadRequestException("INFIX can only take one argument");
             }
 
-            Object val = getFieldValue(entity, fieldPath, requestScope);
-            String valStr = CoerceUtil.coerce(val, String.class);
-            String filterStr = CoerceUtil.coerce(values.get(0), String.class);
+            BiPredicate predicate = (a, b) -> {
+                String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
+                String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
-            return valStr != null
-                    && filterStr != null
-                    && transform.apply(valStr).contains(transform.apply(filterStr));
+                return lhs != null && rhs != null && lhs.contains(rhs);
+            };
+
+            return evaluate(entity, fieldPath, values, predicate, requestScope);
         };
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -433,6 +433,16 @@ public enum Operator {
                 throw new BadRequestException("No value to compare");
             }
             Object fieldVal = getFieldValue(entity, fieldPath, requestScope);
+
+            if (fieldVal instanceof Collection) {
+                return ((Collection) fieldVal).stream()
+                        .anyMatch((fieldValueElement) -> {
+                            return fieldValueElement != null
+                                    && values.stream()
+                                    .anyMatch(testVal -> condition.test(compare(fieldValueElement, testVal)));
+                        });
+            }
+
             return fieldVal != null
                     && values.stream()
                     .anyMatch(testVal -> condition.test(compare(fieldVal, testVal)));

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialect.java
@@ -214,10 +214,6 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
             case HASNOMEMBER:
                 memberOfOperatorConditions(filterPredicate);
                 break;
-            default:
-                if (FilterPredicate.toManyInPath(dictionary, filterPredicate.getPath())) {
-                    throw new ParseException("Invalid toMany join: " + filterPredicate);
-                }
         }
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialect.java
@@ -68,7 +68,10 @@ public class MultipleFilterDialect implements JoinFilterDialect, SubqueryFilterD
                     log.trace("Parse Failure: {}", e.getMessage());
                 }
                 if (lastFailure != null) {
+                    ParseException prev = lastFailure;
                     lastFailure = new ParseException(e.getMessage() + "\n" + lastFailure.getMessage());
+                    lastFailure.addSuppressed(prev);
+                    lastFailure.addSuppressed(e);
                 } else {
                     lastFailure = e;
                 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -166,7 +166,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
 
                 String expressionText = paramValues.get(0);
 
-                FilterExpression filterExpression = parseFilterExpression(expressionText, entityType, false);
+                FilterExpression filterExpression = parseFilterExpression(expressionText, entityType, true);
                 expressionByType.put(typeName, filterExpression);
             } else {
                 throw new ParseException(INVALID_QUERY_PARAMETER + paramName);

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -300,8 +300,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
             //handles '=isempty=' op before coerce arguments
             // ToMany Association is allowed if the operation is IsEmpty
             if (op.equals(ISEMPTY_OP)) {
-                if (FilterPredicate.toManyInPathExceptLastPathElement(dictionary, path)
-                        && !allowNestedToManyAssociations) {
+                if (FilterPredicate.toManyInPathExceptLastPathElement(dictionary, path)) {
                     throw new RSQLParseException(
                             String.format("Invalid association %s. toMany association has to be the target collection.",
                                     relationship));

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import example.Author;
+import example.Book;
 import example.Child;
 import example.Color;
 import example.ComputedBean;
@@ -2231,6 +2232,27 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         assertEquals(Arrays.asList("Hemingway"), predicate.getValues());
         assertEquals("[Author].name", predicate.getPath().toString());
     }
+
+    @Test
+    public void testFilterExpressionCollection() {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter[book.authors.name][infix]",
+                "Hemingway"
+        );
+
+        RequestScope scope = buildRequestScope("/", mock(DataStoreTransaction.class), new User(1), queryParams);
+
+        Optional<FilterExpression> filter = scope.getLoadFilterExpression(Book.class);
+        FilterPredicate predicate = (FilterPredicate) filter.get();
+        assertEquals("name", predicate.getField());
+        assertEquals("authors.name", predicate.getFieldPath());
+        assertEquals(Operator.INFIX, predicate.getOperator());
+        assertEquals(Arrays.asList("Hemingway"), predicate.getValues());
+        assertEquals("[Book].authors/[Author].name", predicate.getPath().toString());
+    }
+
 
     @Test
     public void testSparseFields() {

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -205,6 +205,48 @@ public class OperatorTest {
     }
 
     @Test
+    public void lessThanOpTraversingToManyRelationshipTests() throws Exception {
+        Book book = new Book();
+        Author author1 = new Author();
+        author1.setName("Jon");
+        author1.setId(10L);
+        Author author2 = new Author();
+        author2.setName("Jane");
+        author2.setId(20L);
+        book.setAuthors(Arrays.asList(author1, author2));
+
+        // single value
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Collections.singletonList("11"), requestScope);
+        assertTrue(fn.test(book));
+
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Collections.singletonList("40"), requestScope);
+        assertTrue(fn.test(book));
+
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Collections.singletonList("5"), requestScope);
+        assertFalse(fn.test(book));
+
+        // multiple value
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Arrays.asList("5", "11"), requestScope);
+        assertTrue(fn.test(book));
+
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Arrays.asList("5", "4"), requestScope);
+        assertFalse(fn.test(book));
+
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Arrays.asList("11", "12"), requestScope);
+        assertTrue(fn.test(book));
+
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Arrays.asList("40", "50"), requestScope);
+        assertTrue(fn.test(book));
+
+        // when val is null
+        author1.setId(null);
+        author2.setId(null);
+
+        fn = Operator.LT.contextualize(constructPath(Book.class, "authors.id"), Collections.singletonList("11"), requestScope);
+        assertFalse(fn.test(book));
+    }
+
+    @Test
     public void memberOfTest() throws Exception {
         author = new Author();
         author.setId(1L);

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -56,6 +56,7 @@ public class OperatorTest {
     OperatorTest() {
         dictionary = new TestEntityDictionary(new HashMap<>());
         dictionary.bindEntity(Author.class);
+        dictionary.bindEntity(Book.class);
         requestScope = Mockito.mock(RequestScope.class);
         when(requestScope.getDictionary()).thenReturn(dictionary);
     }
@@ -167,6 +168,40 @@ public class OperatorTest {
         fn = Operator.NOTEMPTY.contextualize(constructPath(Author.class, "books"), null, requestScope);
         assertTrue(fn.test(author));
 
+    }
+
+    @Test
+    public void inOperatorTraversingToManyRelationshipTest() throws Exception {
+        Book book = new Book();
+        Author author1 = new Author();
+        author1.setName("Jon");
+        Author author2 = new Author();
+        author2.setName("Jane");
+        book.setAuthors(Arrays.asList(author1, author2));
+
+        fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Jon"), requestScope);
+        assertTrue(fn.test(book));
+
+        fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Nobody", "Jon"), requestScope);
+        assertTrue(fn.test(book));
+
+        fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Jane", "Jon"), requestScope);
+        assertTrue(fn.test(book));
+
+        fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Nobody1", "Nobody2"), requestScope);
+        assertFalse(fn.test(book));
+
+        fn = Operator.NOT.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Jon"), requestScope);
+        assertFalse(fn.test(book));
+
+        fn = Operator.NOT.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Nobody", "Jon"), requestScope);
+        assertFalse(fn.test(book));
+
+        fn = Operator.NOT.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Jane", "Jon"), requestScope);
+        assertFalse(fn.test(book));
+
+        fn = Operator.NOT.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Nobody1", "Nobody2"), requestScope);
+        assertTrue(fn.test(book));
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -82,9 +82,7 @@ public class DefaultFilterDialectTest {
         Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
 
         assertEquals(2, expressionMap.size());
-        assertEquals(expressionMap.get("book").toString(),
-                "(book.title IN [foo, bar, baz] AND book.genre IN [scifi])"
-        );
+        assertEquals("(book.title IN [foo, bar, baz] AND book.genre IN [scifi])", expressionMap.get("book").toString());
         assertEquals("author.name INFIX [Hemingway]", expressionMap.get("author").toString());
     }
 
@@ -116,13 +114,17 @@ public class DefaultFilterDialectTest {
     public void testInvalidTypeQualifier() throws ParseException {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 
-        /* This is OK for global but not OK for subqueries */
+        /* This is now OK for global and for subqueries */
         queryParams.add(
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        assertThrows(ParseException.class, () -> dialect.parseTypedExpression("/author", queryParams));
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
+
+        assertEquals(1, expressionMap.size());
+        assertEquals("author.books.title IN [foo, bar, baz]", expressionMap.get("author").toString());
+        assertEquals("author.name INFIX [Hemingway]", expressionMap.get("author").toString());
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -124,7 +124,6 @@ public class DefaultFilterDialectTest {
 
         assertEquals(1, expressionMap.size());
         assertEquals("author.books.title IN [foo, bar, baz]", expressionMap.get("author").toString());
-        assertEquals("author.name INFIX [Hemingway]", expressionMap.get("author").toString());
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -79,11 +79,17 @@ public class DefaultFilterDialectTest {
                 "Hemingway"
         );
 
+        queryParams.add(
+                "filter[author.books.title][in]",
+                "foo,bar,baz"
+        );
+
         Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
 
         assertEquals(2, expressionMap.size());
         assertEquals("(book.title IN [foo, bar, baz] AND book.genre IN [scifi])", expressionMap.get("book").toString());
-        assertEquals("author.name INFIX [Hemingway]", expressionMap.get("author").toString());
+        assertEquals("(author.books.title IN [foo, bar, baz] AND author.name INFIX [Hemingway])",
+                expressionMap.get("author").toString());
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -53,13 +53,23 @@ public class RSQLFilterDialectTest {
                 "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
         );
 
+        queryParams.add(
+                "filter[author]",
+                "books.title=in=(foo,bar,baz)"
+        );
+
         Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams);
 
-        assertEquals(1, expressionMap.size());
+        assertEquals(2, expressionMap.size());
         assertEquals(
                 "((book.title INFIX_CASE_INSENSITIVE [foo] AND NOT (book.title PREFIX_CASE_INSENSITIVE [bar])) "
                         + "AND (book.genre IN_INSENSITIVE [sci-fi, action] OR book.publishDate GT [123]))",
                 expressionMap.get("book").toString()
+        );
+
+        assertEquals(
+                "author.books.title IN_INSENSITIVE [foo, bar, baz]",
+                expressionMap.get("author").toString()
         );
     }
 

--- a/elide-core/src/test/java/example/Book.java
+++ b/elide-core/src/test/java/example/Book.java
@@ -30,12 +30,15 @@ import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.OperationCheck;
 
+import example.Author.AuthorType;
+
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
@@ -121,6 +124,12 @@ public class Book {
 
     public void setAuthors(Collection<Author> authors) {
         this.authors = authors;
+    }
+
+    @ElementCollection(targetClass = AuthorType.class)
+    @FilterExpressionPath("authors.type")
+    public Collection<AuthorType> getAuthorTypes() {
+        return getAuthors().stream().map(Author::getType).distinct().collect(Collectors.toList());
     }
 
 

--- a/elide-example/pom.xml
+++ b/elide-example/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
-        <version.log4j>2.13.2</version.log4j>
+        <version.log4j>2.13.3</version.log4j>
     </properties>
 
     <dependencyManagement>

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1353,21 +1353,35 @@ public class FilterIT extends IntegrationTest {
     void testFilterByAuthorBookByChapter() throws JsonProcessingException {
         /* Test default */
         given()
-                .get(String.format("/author/%s/books?filter[book.chapters.title]=doesn't matter", hemingwayId))
+                .get(String.format("/author/%s/books?filter[book.chapters.title]=Viva la Roma!", asimovId))
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK)
+                .body("data", hasSize(1));
+
+        /* Test RSQL */
+        given()
+                .get(String.format("/author/%s/books?filter[book]=chapters.title=='Viva la Roma!'", asimovId))
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK)
+                .body("data", hasSize(1));
+
+        /* Test default */
+        given()
+                .get(String.format("/author/%s/books?filter[book.chapters.title]=None", hemingwayId))
                 .then()
                 .statusCode(org.apache.http.HttpStatus.SC_OK)
                 .body("data", hasSize(0));
 
         /* Test RSQL */
         given()
-                .get(String.format("/author/%s/books?filter[book]=chapters.title=='Borked'", hemingwayId))
+                .get(String.format("/author/%s/books?filter[book]=chapters.title=='None'", hemingwayId))
                 .then()
                 .statusCode(org.apache.http.HttpStatus.SC_OK)
                 .body("data", hasSize(0));
     }
 
     @Test
-    void testFailFilterBookByAuthorAddress() throws JsonProcessingException {
+    void testFilterBookByAuthorAddress() throws JsonProcessingException {
         /* Test default */
         JsonNode result = getAsNode("book?filter[book.authors.homeAddress]=main&include=authors");
         JsonNode data = result.get("data");

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1652,6 +1652,30 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    void testExceptionOnEmptyOperator() throws JsonProcessingException {
+        JsonNode result;
+        // Typed Expression
+        result = getAsNode(String.format("/author/%s/books?filter[book.authors.name][notempty]", nullNedId), HttpStatus.SC_BAD_REQUEST);
+        assertEquals(
+                "BadRequestException: Invalid predicate: book.authors.name NOTEMPTY []\n"
+                        + "Invalid query parameter: filter[book.authors.name][notempty]\n"
+                        + "Invalid toMany join. toMany association has to be the target collection.book.authors.name NOTEMPTY []\n"
+                        + "Invalid query parameter: filter[book.authors.name][notempty]",
+                result.get("errors").get(0).asText()
+        );
+
+        //RSQL
+        result = getAsNode(String.format("/author/%s/books?filter[book]=authors.name=isempty=true", nullNedId), HttpStatus.SC_BAD_REQUEST);
+        assertEquals(
+                "BadRequestException: Invalid filter format: filter[book]\n"
+                        + "Invalid query parameter: filter[book]\n"
+                        + "Invalid filter format: filter[book]\n"
+                        + "Invalid association authors.name. toMany association has to be the target collection.",
+                result.get("errors").get(0).asText()
+        );
+    }
+
+    @Test
     @Tag("excludeOnHibernate3")
     void testMemberOfOnAttributes() {
         String filterString = "Booker Prize";

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -20,6 +20,7 @@ import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.initialization.IntegrationTest;
 import com.yahoo.elide.utils.JsonParser;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.AfterAll;
@@ -27,7 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
@@ -59,7 +59,7 @@ public class FilterIT extends IntegrationTest {
 
 
     @BeforeEach
-    void setup() throws IOException {
+    void setup() throws JsonProcessingException {
 
         given()
                 .contentType(JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION)
@@ -229,7 +229,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterImplicitSingle() throws IOException {
+    void testRootFilterImplicitSingle() throws JsonProcessingException {
         int scienceFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (node.get("attributes").get("genre").asText().equalsIgnoreCase("Science Fiction")) {
@@ -256,7 +256,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterInSingle() throws IOException {
+    void testRootFilterInSingle() throws JsonProcessingException {
         int literaryFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (node.get("attributes").get("genre").asText().equalsIgnoreCase("Literary Fiction")) {
@@ -283,7 +283,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterNotInSingle() throws IOException {
+    void testRootFilterNotInSingle() throws JsonProcessingException {
         int nonLiteraryFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (!node.get("attributes").get("genre").isNull()
@@ -311,7 +311,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterNotInMultiple() throws IOException {
+    void testRootFilterNotInMultiple() throws JsonProcessingException {
         int nonFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (!node.get("attributes").get("genre").isNull()
@@ -340,7 +340,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterInMultipleSingle() throws IOException {
+    void testRootFilterInMultipleSingle() throws JsonProcessingException {
         int literaryAndScienceFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (node.get("attributes").get("genre").asText().equalsIgnoreCase("Literary Fiction")
@@ -368,7 +368,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterPostfix() throws IOException {
+    void testRootFilterPostfix() throws JsonProcessingException {
         int genreEndsWithFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (node.get("attributes").get("genre").asText().toLowerCase(Locale.ENGLISH).endsWith("fiction")) {
@@ -395,7 +395,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterPrefix() throws IOException {
+    void testRootFilterPrefix() throws JsonProcessingException {
         int titleStartsWithTheBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (node.get("attributes").get("title").asText().toLowerCase(Locale.ENGLISH).startsWith("the")) {
@@ -422,7 +422,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterPrefixWithSpecialChars() throws IOException {
+    void testRootFilterPrefixWithSpecialChars() throws JsonProcessingException {
         int titleStartsWithTheBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (node.get("attributes").get("title").asText().toLowerCase(Locale.ENGLISH).startsWith("i'm")) {
@@ -449,7 +449,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterInfix() throws IOException {
+    void testRootFilterInfix() throws JsonProcessingException {
         int titleContainsTheBookCount = 0;
         for (JsonNode node : books.get("data")) {
             if (node.get("attributes").get("title").asText().toLowerCase(Locale.ENGLISH).contains("the")) {
@@ -476,7 +476,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterWithInclude() throws IOException {
+    void testRootFilterWithInclude() throws JsonProcessingException {
         Set<String> authorIdsOfLiteraryFiction = new HashSet<>();
 
         for (JsonNode book : books.get("data")) {
@@ -512,7 +512,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterIsNull() throws IOException {
+    void testRootFilterIsNull() throws JsonProcessingException {
         Set<JsonNode> bookIdsWithNullGenre = new HashSet<>();
 
         for (JsonNode book : books.get("data")) {
@@ -577,7 +577,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testRootFilterIsNotNull() throws IOException {
+    void testRootFilterIsNotNull() throws JsonProcessingException {
         Set<JsonNode> bookIdsWithNonNullGenre = new HashSet<>();
 
         for (JsonNode book : books.get("data")) {
@@ -642,7 +642,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterImplicitSingle() throws IOException {
+    void testNonRootFilterImplicitSingle() throws JsonProcessingException {
         int asimovScienceFictionBookCount = 0;
         for (JsonNode node : asimovBooks.get("data")) {
             if (node.get("attributes").get("genre").asText().equals("Science Fiction")) {
@@ -664,7 +664,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterInSingle() throws IOException {
+    void testNonRootFilterInSingle() throws JsonProcessingException {
         int asimovHistoryBookCount = 0;
         for (JsonNode node : asimovBooks.get("data")) {
             if (node.get("attributes").get("genre").asText().equals("History")) {
@@ -686,7 +686,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterNotInSingle() throws IOException {
+    void testNonRootFilterNotInSingle() throws JsonProcessingException {
         int nonHistoryBookCount = 0;
         for (JsonNode node : asimovBooks.get("data")) {
             if (!node.get("attributes").get("genre").isNull()
@@ -709,7 +709,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterPostfix() throws IOException {
+    void testNonRootFilterPostfix() throws JsonProcessingException {
         int genreEndsWithFictionBookCount = 0;
         for (JsonNode node : asimovBooks.get("data")) {
             if (node.get("attributes").get("genre").asText().endsWith("Fiction")) {
@@ -731,7 +731,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterPostfixInsensitive() throws IOException {
+    void testNonRootFilterPostfixInsensitive() throws JsonProcessingException {
         int editorEdBooks = 0;
         for (JsonNode node : nullNedBooks.get("data")) {
             if (node.get("attributes").get("editorName").asText().endsWith("d")) {
@@ -757,7 +757,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterPrefixInsensitive() throws IOException {
+    void testNonRootFilterPrefixInsensitive() throws JsonProcessingException {
         int editorEdBooks = 0;
         for (JsonNode node : nullNedBooks.get("data")) {
             if (node.get("attributes").get("editorName").asText().startsWith("E")) {
@@ -783,7 +783,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterInfixInsensitive() throws IOException {
+    void testNonRootFilterInfixInsensitive() throws JsonProcessingException {
         int editorEditBooks = 0;
         for (JsonNode node : nullNedBooks.get("data")) {
             if (node.get("attributes").get("editorName").asText().contains("Ed")) {
@@ -809,7 +809,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterPrefix() throws IOException {
+    void testNonRootFilterPrefix() throws JsonProcessingException {
         int titleStartsWithTheBookCount = 0;
         for (JsonNode node : asimovBooks.get("data")) {
             if (node.get("attributes").get("title").asText().startsWith("The")) {
@@ -831,7 +831,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterPrefixWithSpecialChars() throws IOException {
+    void testNonRootFilterPrefixWithSpecialChars() throws JsonProcessingException {
         int titleStartsWithTheBookCount = 0;
         for (JsonNode node : thomasHarrisBooks.get("data")) {
             if (node.get("attributes").get("title").asText().startsWith("I'm")) {
@@ -853,7 +853,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterInfix() throws IOException {
+    void testNonRootFilterInfix() throws JsonProcessingException {
         int titleContainsTheBookCount = 0;
         for (JsonNode node : asimovBooks.get("data")) {
             if (node.get("attributes").get("title").asText().toLowerCase(Locale.ENGLISH).contains("the")) {
@@ -875,7 +875,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterWithInclude() throws IOException {
+    void testNonRootFilterWithInclude() throws JsonProcessingException {
         Set<String> authorIdsOfScienceFiction = new HashSet<>();
 
         for (JsonNode book : asimovBooks.get("data")) {
@@ -904,7 +904,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterIsNull() throws IOException {
+    void testNonRootFilterIsNull() throws JsonProcessingException {
         Set<JsonNode> bookIdsWithNullGenre = new HashSet<>();
 
         for (JsonNode book : nullNedBooks.get("data")) {
@@ -948,7 +948,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNonRootFilterIsNotNull() throws IOException {
+    void testNonRootFilterIsNotNull() throws JsonProcessingException {
         Set<JsonNode> bookIdsWithNonNullGenre = new HashSet<>();
 
         for (JsonNode book : nullNedBooks.get("data")) {
@@ -992,7 +992,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testPublishDateGreaterThanFilter() throws IOException {
+    void testPublishDateGreaterThanFilter() throws JsonProcessingException {
         Set<JsonNode> bookIdsWithNonNullGenre = new HashSet<>();
         long publishDate;
 
@@ -1026,7 +1026,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testPublishDateGreaterThanFilterSubRecord() throws IOException {
+    void testPublishDateGreaterThanFilterSubRecord() throws JsonProcessingException {
         long publishDate;
 
         /* Test Default */
@@ -1051,7 +1051,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testPublishDateLessThanOrEqualsFilterSubRecord() throws IOException {
+    void testPublishDateLessThanOrEqualsFilterSubRecord() throws JsonProcessingException {
         long publishDate;
 
         /* Test Default */
@@ -1076,7 +1076,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testPublishDateLessThanOrEqual() throws IOException {
+    void testPublishDateLessThanOrEqual() throws JsonProcessingException {
         long publishDate;
 
         /* Test Default */
@@ -1111,7 +1111,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testPublishDateLessThanFilter() throws IOException {
+    void testPublishDateLessThanFilter() throws JsonProcessingException {
         long publishDate;
 
         /* Test Default */
@@ -1149,7 +1149,7 @@ public class FilterIT extends IntegrationTest {
      * Verifies that issue 508 is closed.
      */
     @Test
-    void testIssue508() throws IOException {
+    void testIssue508() throws JsonProcessingException {
         JsonNode result = getAsNode("book?filter=(authors.name=='Thomas Harris',publisher.name=='Default Publisher')&page[totals]");
 
         assertEquals(2, result.get("data").size());
@@ -1174,7 +1174,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testGetBadRelationshipNameWithNestedFieldFilter() throws IOException {
+    void testGetBadRelationshipNameWithNestedFieldFilter() throws JsonProcessingException {
         /* Test Default */
         JsonNode result = getAsNode(
                 "book?filter[book.author12.name]=Null Ned", HttpStatus.SC_BAD_REQUEST);
@@ -1194,7 +1194,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testGetBooksFilteredByAuthors() throws IOException {
+    void testGetBooksFilteredByAuthors() throws JsonProcessingException {
         /* Test Default */
         JsonNode result = getAsNode("book?filter[book.authors.name]=Null Ned");
 
@@ -1217,7 +1217,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testGetBooksFilteredByAuthorsId() throws IOException {
+    void testGetBooksFilteredByAuthorsId() throws JsonProcessingException {
         String nullNedIdStr = String.valueOf(nullNedId);
         /* Test Default */
         JsonNode result = getAsNode("book?filter[book.authors.id]=" + nullNedIdStr);
@@ -1241,7 +1241,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testGetBooksFilteredByAuthorAndTitle() throws IOException {
+    void testGetBooksFilteredByAuthorAndTitle() throws JsonProcessingException {
         /* Test Default */
         JsonNode result = getAsNode("book?filter[book.authors.name]=Null Ned&filter[book.title]=Life with Null Ned");
 
@@ -1262,7 +1262,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testFilterAuthorsByBookChapterTitle() throws IOException {
+    void testFilterAuthorsByBookChapterTitle() throws JsonProcessingException {
         /* Test Default */
         JsonNode result = getAsNode("/author?sort=-name&filter[author.books.chapters.title][in]=Viva la Roma!,Mamma mia I wantz some pizza!");
 
@@ -1285,7 +1285,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testFilterAuthorBookByPublisher() throws IOException {
+    void testFilterAuthorBookByPublisher() throws JsonProcessingException {
         /* Test default */
         JsonNode result = getAsNode(String.format("/author/%s/books?filter[book.publisher.name]=Default publisher", hemingwayId));
         JsonNode data = result.get("data");
@@ -1350,22 +1350,24 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testFailFilterAuthorBookByChapter() throws IOException {
+    void testFailFilterAuthorBookByChapter() throws JsonProcessingException {
         /* Test default */
-        JsonNode result = getAsNode(
-                String.format("/author/%s/books?filter[book.chapters.title]=doesn't matter", hemingwayId),
-                HttpStatus.SC_BAD_REQUEST);
-        assertNotNull(result.get("errors"));
+        given()
+                .get(String.format("/author/%s/books?filter[book.chapters.title]=doesn't matter", hemingwayId))
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK)
+                .body("data", hasSize(0));
 
         /* Test RSQL */
-        result = getAsNode(
-                String.format("/author/%s/books?filter[book]=chapters.title=='Borked'", hemingwayId),
-                HttpStatus.SC_BAD_REQUEST);
-        assertNotNull(result.get("errors"));
+        given()
+                .get(String.format("/author/%s/books?filter[book]=chapters.title=='Borked'", hemingwayId))
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK)
+                .body("data", hasSize(0));
     }
 
     @Test
-    void testFailFilterBookByAuthorAddress() throws IOException {
+    void testFailFilterBookByAuthorAddress() throws JsonProcessingException {
         /* Test default */
         JsonNode result = getAsNode("book?filter[book.authors.homeAddress]=main&include=authors");
         JsonNode data = result.get("data");
@@ -1379,7 +1381,7 @@ public class FilterIT extends IntegrationTest {
 
 
     @Test
-    void testGetBadRelationshipRoot() throws IOException {
+    void testGetBadRelationshipRoot() throws JsonProcessingException {
         /* Test Default */
         JsonNode result = getAsNode(
                 "/author?filter[idontexist.books.title][in]=Viva la Roma!,Mamma mia I wantz some pizza!",
@@ -1400,7 +1402,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testGetBadRelationshipIntermediate() throws IOException {
+    void testGetBadRelationshipIntermediate() throws JsonProcessingException {
         /* Test Default */
         JsonNode result = getAsNode(
                 "/author?filter[author.idontexist.title][in]=Viva la Roma!,Mamma mia I wantz some pizza!",
@@ -1421,7 +1423,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testGetBadRelationshipLeaf() throws IOException {
+    void testGetBadRelationshipLeaf() throws JsonProcessingException {
         /* Test Default */
         JsonNode result = getAsNode(
                 "/author?filter[author.books.idontexist][in]=Viva la Roma!,Mamma mia I wantz some pizza!",
@@ -1445,7 +1447,7 @@ public class FilterIT extends IntegrationTest {
      * Verify that a combination of filters and order by generate working SQL.
      */
     @Test
-    void testFilterWithSort() throws IOException {
+    void testFilterWithSort() throws JsonProcessingException {
         JsonNode result = getAsNode(String.format("/author/%s/books?filter[book.title][notnull]=true&sort=title", asimovId));
         JsonNode data = result.get("data");
         assertEquals(data.size(), 2);
@@ -1453,7 +1455,7 @@ public class FilterIT extends IntegrationTest {
 
 
     @Test
-    void testIsEmptyRelationshipOnRoot() throws IOException {
+    void testIsEmptyRelationshipOnRoot() throws JsonProcessingException {
         //Book has ToMany relationship with chapter
         Set<JsonNode> bookIdsWithEmptyChapters = new HashSet<>();
         JsonNode result;
@@ -1502,7 +1504,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testNotEmptyRelationshipOnNonRoot() throws IOException {
+    void testNotEmptyRelationshipOnNonRoot() throws JsonProcessingException {
         //Book has ToMany relationship with chapter
         Set<JsonNode> bookIdsWithNonEmptyChapters = new HashSet<>();
         JsonNode result;
@@ -1552,7 +1554,7 @@ public class FilterIT extends IntegrationTest {
     @Tag("excludeOnHibernate3")
     @Tag("excludeOnHibernate5")
     @Tag("excludeOnJPA")
-    void testNotEmptyAttributeOnRoot() throws IOException {
+    void testNotEmptyAttributeOnRoot() throws JsonProcessingException {
         Set<JsonNode> bookIdsWithNonEmptyAwards = new HashSet<>();
         JsonNode result;
 
@@ -1604,7 +1606,7 @@ public class FilterIT extends IntegrationTest {
     @Tag("excludeOnHibernate3")
     @Tag("excludeOnHibernate5")
     @Tag("excludeOnJPA")
-    void testIsEmptyAttributesOnNonRoot() throws IOException {
+    void testIsEmptyAttributesOnNonRoot() throws JsonProcessingException {
         Set<JsonNode> bookIdsWithEmptyAwards = new HashSet<>();
         JsonNode result;
         for (JsonNode book : nullNedBooks.get("data")) {
@@ -1650,7 +1652,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testExceptionOnEmptyOperator() throws IOException {
+    void testExceptionOnEmptyOperator() throws JsonProcessingException {
         JsonNode result;
         // Typed Expression
         result = getAsNode(String.format("/author/%s/books?filter[book.authors.name][notempty]", nullNedId), HttpStatus.SC_BAD_REQUEST);
@@ -1676,7 +1678,7 @@ public class FilterIT extends IntegrationTest {
 
     @Test
     @Tag("excludeOnHibernate3")
-    void testMemberOfOnAttributes() throws IOException {
+    void testMemberOfOnAttributes() {
         String filterString = "Booker Prize";
         Set<String> awardBook = new HashSet<>();
         Set<String> nullNedAwardBook = new HashSet<>();
@@ -1742,7 +1744,7 @@ public class FilterIT extends IntegrationTest {
 
     @Test
     @Tag("excludeOnHibernate3")
-    void testMembertoOneRelationships() throws IOException {
+    void testMembertoOneRelationships() {
         String phoneNumber = "987-654-3210";
         Set<String> publisherBook = new HashSet<>();
 
@@ -1775,7 +1777,7 @@ public class FilterIT extends IntegrationTest {
 
     @Test
     @Tag("excludeOnHibernate3")
-    void testExceptionOnMemberOfOperator() throws IOException {
+    void testExceptionOnMemberOfOperator() throws JsonProcessingException {
         JsonNode result;
         // Typed Expression
         result = getAsNode(String.format("/author/%s/books?filter[book.authors.name][hasmember]", nullNedId), HttpStatus.SC_BAD_REQUEST);

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1350,7 +1350,7 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
-    void testFailFilterAuthorBookByChapter() throws JsonProcessingException {
+    void testFilterByAuthorBookByChapter() throws JsonProcessingException {
         /* Test default */
         given()
                 .get(String.format("/author/%s/books?filter[book.chapters.title]=doesn't matter", hemingwayId))
@@ -1648,31 +1648,6 @@ public class FilterIT extends IntegrationTest {
             assertTrue(book.get("attributes").get("awards").isEmpty());
             assertTrue(bookIdsWithEmptyAwards.contains(book.get("id")));
         }
-
-    }
-
-    @Test
-    void testExceptionOnEmptyOperator() throws JsonProcessingException {
-        JsonNode result;
-        // Typed Expression
-        result = getAsNode(String.format("/author/%s/books?filter[book.authors.name][notempty]", nullNedId), HttpStatus.SC_BAD_REQUEST);
-        assertEquals(
-                "BadRequestException: Invalid predicate: book.authors.name NOTEMPTY []\n"
-                        + "Invalid query parameter: filter[book.authors.name][notempty]\n"
-                        + "Invalid toMany join. toMany association has to be the target collection.book.authors.name NOTEMPTY []\n"
-                        + "Invalid query parameter: filter[book.authors.name][notempty]",
-                result.get("errors").get(0).asText()
-        );
-
-        //RSQL
-        result = getAsNode(String.format("/author/%s/books?filter[book]=authors.name=isempty=true", nullNedId), HttpStatus.SC_BAD_REQUEST);
-        assertEquals(
-                "BadRequestException: Invalid filter format: filter[book]\n"
-                        + "Invalid query parameter: filter[book]\n"
-                        + "Invalid filter format: filter[book]\n"
-                        + "Invalid association authors.name. toMany association has to be the target collection.",
-                result.get("errors").get(0).asText()
-        );
 
     }
 


### PR DESCRIPTION
Resolves #683

## Description
Process collections in filter expression operator.

## Motivation and Context
FilterExpression handling when in memory did not properly handle a collection.

## How Has This Been Tested?
Unit testing.  Local testing with our Elide product.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.