### PR TITLE
CARBON-212 TimeZone Serde

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeSerde.java
@@ -8,6 +8,9 @@ package com.yahoo.elide.utils.coerce.converters;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
+/**
+ * Serde class for bidirectional conversion from OffsetDateTime type to String.
+ */
 @ElideTypeConverter(type = OffsetDateTime.class, name = "OffsetDateTime")
 public class OffsetDateTimeSerde implements Serde<String, OffsetDateTime> {
 

--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/TimeZoneSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/TimeZoneSerde.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.utils.coerce.converters;
+
+import java.util.TimeZone;
+
+@ElideTypeConverter(type = TimeZone.class, name = "TimeZone")
+public class TimeZoneSerde implements Serde<String, TimeZone> {
+
+    @Override
+    public TimeZone deserialize(String val) {
+        System.out.println("**************DeSerialize Timezone");
+        TimeZone timezone = TimeZone.getTimeZone(val);
+        return timezone;
+    }
+
+    @Override
+    public String serialize(TimeZone val) {
+        System.out.println("**************Serialize Timezone");
+        return val.getDisplayName(false, TimeZone.SHORT);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/TimeZoneSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/TimeZoneSerde.java
@@ -12,14 +12,12 @@ public class TimeZoneSerde implements Serde<String, TimeZone> {
 
     @Override
     public TimeZone deserialize(String val) {
-        System.out.println("**************DeSerialize Timezone");
         TimeZone timezone = TimeZone.getTimeZone(val);
         return timezone;
     }
 
     @Override
     public String serialize(TimeZone val) {
-        System.out.println("**************Serialize Timezone");
         return val.getDisplayName(false, TimeZone.SHORT);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/TimeZoneSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/TimeZoneSerde.java
@@ -7,6 +7,9 @@ package com.yahoo.elide.utils.coerce.converters;
 
 import java.util.TimeZone;
 
+/**
+ * Serde class for bidirectional conversion from TimeZone type to String.
+ */
 @ElideTypeConverter(type = TimeZone.class, name = "TimeZone")
 public class TimeZoneSerde implements Serde<String, TimeZone> {
 

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/TimeZoneTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/TimeZoneTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.utils.coerce.converters;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.TimeZone;
+
+public class TimeZoneTest {
+
+    @Test
+    public void testGraphQLTimeZoneSerialize() {
+
+        TimeZone timezone = TimeZone.getTimeZone("EST");
+        System.out.println("testGraphQLTimeZoneSerialize " + timezone);
+        String expected = "EST";
+        TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
+        Object actualTimeZone = timeZoneScalar.serialize(timezone);
+        assertEquals(expected, actualTimeZone);
+    }
+
+    @Test
+    public void testGraphQLTimeZoneDeserialize() {
+        TimeZone actualTimeZone = TimeZone.getTimeZone("EST");
+        System.out.println(actualTimeZone);
+        String actual = "EST";
+        TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
+        Object expected = timeZoneScalar.deserialize(actual);
+        System.out.println(expected);
+        assertEquals(expected, actualTimeZone);
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/TimeZoneTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/TimeZoneTest.java
@@ -17,21 +17,18 @@ public class TimeZoneTest {
     public void testGraphQLTimeZoneSerialize() {
 
         TimeZone timezone = TimeZone.getTimeZone("EST");
-        System.out.println("testGraphQLTimeZoneSerialize " + timezone);
         String expected = "EST";
         TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
-        Object actualTimeZone = timeZoneScalar.serialize(timezone);
-        assertEquals(expected, actualTimeZone);
+        Object actual = timeZoneScalar.serialize(timezone);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void testGraphQLTimeZoneDeserialize() {
-        TimeZone actualTimeZone = TimeZone.getTimeZone("EST");
-        System.out.println(actualTimeZone);
+        TimeZone expectedTimeZone = TimeZone.getTimeZone("EST");
         String actual = "EST";
         TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
-        Object expected = timeZoneScalar.deserialize(actual);
-        System.out.println(expected);
-        assertEquals(expected, actualTimeZone);
+        Object actualTimeZone = timeZoneScalar.deserialize(actual);
+        assertEquals(expectedTimeZone, actualTimeZone);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/TimeZoneTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/TimeZoneTest.java
@@ -14,21 +14,21 @@ import java.util.TimeZone;
 public class TimeZoneTest {
 
     @Test
-    public void testGraphQLTimeZoneSerialize() {
+    public void testTimeZoneSerialize() {
 
         TimeZone timezone = TimeZone.getTimeZone("EST");
         String expected = "EST";
-        TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
-        Object actual = timeZoneScalar.serialize(timezone);
+        TimeZoneSerde timeZoneSerde = new TimeZoneSerde();
+        Object actual = timeZoneSerde.serialize(timezone);
         assertEquals(expected, actual);
     }
 
     @Test
-    public void testGraphQLTimeZoneDeserialize() {
+    public void testTimeZoneDeserialize() {
         TimeZone expectedTimeZone = TimeZone.getTimeZone("EST");
         String actual = "EST";
-        TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
-        Object actualTimeZone = timeZoneScalar.deserialize(actual);
+        TimeZoneSerde timeZoneSerde = new TimeZoneSerde();
+        Object actualTimeZone = timeZoneSerde.deserialize(actual);
         assertEquals(expectedTimeZone, actualTimeZone);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
@@ -36,7 +36,8 @@ public class TimeDimension extends Dimension {
 
     public TimeDimension(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);
-        timezone = null;
+        System.out.println("**********Setting timezone to null");
+        timezone = TimeZone.getTimeZone("UTC");
 
         Temporal temporal = dictionary.getAttributeOrRelationAnnotation(
                 dictionary.getEntityClass(table.getName(), table.getVersion()),

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TimeDimension.java
@@ -36,7 +36,6 @@ public class TimeDimension extends Dimension {
 
     public TimeDimension(Table table, String fieldName, EntityDictionary dictionary) {
         super(table, fieldName, dictionary);
-        System.out.println("**********Setting timezone to null");
         timezone = TimeZone.getTimeZone("UTC");
 
         Temporal temporal = dictionary.getAttributeOrRelationAnnotation(

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLConversionUtilsTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLConversionUtilsTest.java
@@ -24,17 +24,22 @@ import java.util.TimeZone;
 public class GraphQLConversionUtilsTest {
 
     @Test
-    public void testGraphQLConversionUtilsClassToScalarType() {
+    public void testGraphQLConversionUtilsOffsetDateTimeToScalarType() {
         CoerceUtil.register(OffsetDateTime.class, new OffsetDateTimeSerde());
-        CoerceUtil.register(TimeZone.class, new TimeZoneSerde());
         GraphQLConversionUtils graphQLConversionUtils =
                 new GraphQLConversionUtils(new EntityDictionary(new HashMap<>()), new NonEntityDictionary());
         GraphQLScalarType offsetDateTimeType = graphQLConversionUtils.classToScalarType(OffsetDateTime.class);
-        GraphQLScalarType timeZoneType = graphQLConversionUtils.classToScalarType(TimeZone.class);
         assertNotNull(offsetDateTimeType);
-        assertNotNull(timeZoneType);
         String expected = "OffsetDateTime";
         assertEquals(expected, offsetDateTimeType.getName());
+    }
+    @Test
+    public void testGraphQLConversionUtilsTimeZoneToScalarType() {
+        CoerceUtil.register(TimeZone.class, new TimeZoneSerde());
+        GraphQLConversionUtils graphQLConversionUtils =
+                new GraphQLConversionUtils(new EntityDictionary(new HashMap<>()), new NonEntityDictionary());
+        GraphQLScalarType timeZoneType = graphQLConversionUtils.classToScalarType(TimeZone.class);
+        assertNotNull(timeZoneType);
         String expectedTimezone = "TimeZone";
         assertEquals(expectedTimezone, timeZoneType.getName());
     }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLConversionUtilsTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLConversionUtilsTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 import com.yahoo.elide.utils.coerce.converters.OffsetDateTimeSerde;
+import com.yahoo.elide.utils.coerce.converters.TimeZoneSerde;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,17 +19,23 @@ import graphql.schema.GraphQLScalarType;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.TimeZone;
 
 public class GraphQLConversionUtilsTest {
 
     @Test
     public void testGraphQLConversionUtilsClassToScalarType() {
         CoerceUtil.register(OffsetDateTime.class, new OffsetDateTimeSerde());
+        CoerceUtil.register(TimeZone.class, new TimeZoneSerde());
         GraphQLConversionUtils graphQLConversionUtils =
                 new GraphQLConversionUtils(new EntityDictionary(new HashMap<>()), new NonEntityDictionary());
-        GraphQLScalarType type = graphQLConversionUtils.classToScalarType(OffsetDateTime.class);
-        assertNotNull(type);
+        GraphQLScalarType offsetDateTimeType = graphQLConversionUtils.classToScalarType(OffsetDateTime.class);
+        GraphQLScalarType timeZoneType = graphQLConversionUtils.classToScalarType(TimeZone.class);
+        assertNotNull(offsetDateTimeType);
+        assertNotNull(timeZoneType);
         String expected = "OffsetDateTime";
-        assertEquals(expected, type.getName());
+        assertEquals(expected, offsetDateTimeType.getName());
+        String expectedTimezone = "TimeZone";
+        assertEquals(expectedTimezone, timeZoneType.getName());
     }
 }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLScalarsTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLScalarsTest.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.utils.coerce.CoerceUtil;
 import com.yahoo.elide.utils.coerce.converters.ISO8601DateSerde;
 import com.yahoo.elide.utils.coerce.converters.OffsetDateTimeSerde;
 import com.yahoo.elide.utils.coerce.converters.Serde;
+import com.yahoo.elide.utils.coerce.converters.TimeZoneSerde;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -84,6 +85,16 @@ public class GraphQLScalarsTest {
         assertEquals(expectedDate, actualDate);
     }
 
+    @Test
+    public void testGraphQLTimeZoneDeserialize() {
+        TimeZone expectedTz = TimeZone.getTimeZone("EST");
+        String input = "EST";
+        TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
+        SerdeCoercing timeZoneSerde =
+                new SerdeCoercing("", timeZoneScalar);
+        Object actualTz = timeZoneSerde.parseLiteral(new StringValue(input));
+        assertEquals(expectedTz, actualTz);
+    }
     @Test
     public void testGraphQLDeferredIdSerialize() {
         assertEquals(123L, GraphQLScalars.GRAPHQL_DEFERRED_ID.getCoercing().serialize(123L));

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLScalarsTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLScalarsTest.java
@@ -78,10 +78,10 @@ public class GraphQLScalarsTest {
                         16, 45, 4, 56,
                         ZoneOffset.ofHoursMinutes(5, 30));
         String input = "1995-11-02T16:45:04.000000056+05:30";
-        OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
-        SerdeCoercing offsetDateTimeSerde =
-                new SerdeCoercing("", offsetDateTimeScalar);
-        Object actualDate = offsetDateTimeSerde.parseLiteral(new StringValue(input));
+        OffsetDateTimeSerde offsetDateTimeSerde = new OffsetDateTimeSerde();
+        SerdeCoercing serdeCoercing =
+                new SerdeCoercing("", offsetDateTimeSerde);
+        Object actualDate = serdeCoercing.parseLiteral(new StringValue(input));
         assertEquals(expectedDate, actualDate);
     }
 
@@ -89,10 +89,10 @@ public class GraphQLScalarsTest {
     public void testGraphQLTimeZoneDeserialize() {
         TimeZone expectedTz = TimeZone.getTimeZone("EST");
         String input = "EST";
-        TimeZoneSerde timeZoneScalar = new TimeZoneSerde();
-        SerdeCoercing timeZoneSerde =
-                new SerdeCoercing("", timeZoneScalar);
-        Object actualTz = timeZoneSerde.parseLiteral(new StringValue(input));
+        TimeZoneSerde timeZoneSerde = new TimeZoneSerde();
+        SerdeCoercing serdeCoercing =
+                new SerdeCoercing("", timeZoneSerde);
+        Object actualTz = serdeCoercing.parseLiteral(new StringValue(input));
         assertEquals(expectedTz, actualTz);
     }
     @Test


### PR DESCRIPTION
Resolves #<issue number> (if appropriate)

## Description
Add Serde for TimeZone that converts TimeZone into a scalar type (instead of a Java object) 
## Motivation and Context
TimeZone shows up as an object in swagger and we want it to show as a scalar value

## How Has This Been Tested?
Tested in Spring boot example project

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
