### PR TITLE
bump JUEL 2.2.7 to Jakarta EL 3.0.3

### DIFF
--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -128,14 +128,9 @@
         </dependency>
 
         <dependency>
-            <groupId>de.odysseus.juel</groupId>
-            <artifactId>juel-impl</artifactId>
-            <version>2.2.7</version>
-        </dependency>
-        <dependency>
-            <groupId>de.odysseus.juel</groupId>
-            <artifactId>juel-api</artifactId>
-            <version>2.2.7</version>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.fusesource.jansi</groupId>


### PR DESCRIPTION
## Description
Replace hard coded JUEL with Jakarta EL while maintaining support for JUEL 2.7.
Uses interfaces instead of requiring JUEL classes.

## Motivation and Context
Product may need later version of EL.

## How Has This Been Tested?
Unit testing.  Local testing.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.