### PR TITLE
Fix: Check for null super in `getInheritedTypes`

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -672,10 +672,10 @@ public class EntityBinding {
         return hasConstructor;
     }
 
-    private List<Class<?>> getInheritedTypes(Class<?> entityClass) {
+    private List<Class<?>> getInheritedTypes(Class<?> entityCls) {
         ArrayList<Class<?>> results = new ArrayList<>();
 
-        for (Class<?> cls = entityClass.getSuperclass(); cls != Object.class; cls = cls.getSuperclass()) {
+        for (Class<?> cls = entityCls.getSuperclass(); null != cls && Object.class != cls; cls = cls.getSuperclass()) {
             results.add(cls);
         }
 


### PR DESCRIPTION

## Description

Fix: Check for null super in `getInheritedTypes`

## Motivation and Context

NPE

## How Has This Been Tested?

At application level

## Screenshots (if appropriate):

n/a

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
