### PR TITLE
Slf4j multiple_bindings fix

### DIFF
--- a/elide-contrib/elide-dynamic-config-helpers/pom.xml
+++ b/elide-contrib/elide-dynamic-config-helpers/pom.xml
@@ -86,6 +86,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>elide-datastore-aggregation</artifactId>
             <version>5.0.0-pr13-SNAPSHOT</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -75,6 +75,12 @@
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-aggregation</artifactId>
             <version>5.0.0-pr13-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -62,6 +62,12 @@
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-aggregation</artifactId>
             <version>5.0.0-pr13-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <dependency>
@@ -89,6 +95,12 @@
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-dynamic-config-helpers</artifactId>
             <version>5.0.0-pr13-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- JPA -->


### PR DESCRIPTION
## Description
slf4j-simple was removed from dynamic-config-helpers to resolve multiple binding errors. This change adds it back and excludes from spring starter and standalone modules.

## How Has This Been Tested?
Existing test cases pass and spring example works.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
