### PR TITLE
Data Export Changes

### DIFF
--- a/elide-annotations/src/main/java/com/yahoo/elide/security/RequestScope.java
+++ b/elide-annotations/src/main/java/com/yahoo/elide/security/RequestScope.java
@@ -11,4 +11,5 @@ package com.yahoo.elide.security;
 public interface RequestScope {
     User getUser();
     String getApiVersion();
+    String getBaseUrlEndPoint();
 }

--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -88,6 +88,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- H2 -->
         <dependency>
             <groupId>com.h2database</groupId>
@@ -112,6 +118,32 @@
             <artifactId>javax.el-api</artifactId>
             <version>3.0.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.opendevl</groupId>
+            <artifactId>json2flat</artifactId>
+            <version>1.0.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${version.jackson}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${version.jackson}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.4.0</version>
         </dependency>
     </dependencies>
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -27,6 +27,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /**
@@ -51,6 +52,8 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
 
     private QueryType queryType; //GRAPHQL, JSONAPI
 
+    private ResultFormatType resultFormatType = ResultFormatType.JSON;
+
     @Transient
     @Max(10)
     @ComputedAttribute
@@ -64,6 +67,10 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     @CreatePermission(expression = "value is Queued")
     @Enumerated(EnumType.STRING)
     private QueryStatus status = QueryStatus.QUEUED;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private ResultType resultType; //EMBEDDED, DOWNLOAD
 
     @Embedded
     private AsyncQueryResult result;

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -7,11 +7,10 @@ package com.yahoo.elide.async.models;
 
 import lombok.Data;
 
+import java.sql.Blob;
 import java.util.Date;
 
 import javax.persistence.Embeddable;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 
 /**
  * Model for Async Query Result.
@@ -23,13 +22,14 @@ public class AsyncQueryResult {
 
     private Integer contentLength;
 
+    private Integer recordCount;
+
     private String responseBody;  //URL or Response body
 
     private Integer httpStatus; // HTTP Status
 
-    @Enumerated(EnumType.STRING)
-    private ResultType resultType; //EMBEDDED, DOWNLOAD
-
     private Date completedOn = new Date();
+
+    private Blob attachment; // To allow expansion to XLSX?
 
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/BlobSerde.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/BlobSerde.java
@@ -23,8 +23,8 @@ public class BlobSerde implements Serde<String, Blob> {
     @Override
     public Blob deserialize(String val) {
         try {
-            val = val == null ? EMPTY_STRING : val;
-            return new SerialBlob(val.getBytes());
+            String newVal = val == null ? EMPTY_STRING : val;
+            return new SerialBlob(newVal.getBytes());
         } catch (SQLException e) {
             throw new IllegalArgumentException(e);
         }

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/BlobSerde.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/BlobSerde.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models;
+
+import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
+import com.yahoo.elide.utils.coerce.converters.Serde;
+
+import java.sql.Blob;
+import java.sql.SQLException;
+
+import javax.sql.rowset.serial.SerialBlob;
+
+/**
+ * Serde class for bidirectional conversion from Blob type to String.
+ */
+@ElideTypeConverter(type = Blob.class, name = "Blob")
+public class BlobSerde implements Serde<String, Blob> {
+    private static final String EMPTY_STRING = "";
+
+    @Override
+    public Blob deserialize(String val) {
+        try {
+            val = val == null ? EMPTY_STRING : val;
+            return new SerialBlob(val.getBytes());
+        } catch (SQLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public String serialize(Blob val) {
+        try {
+            return val == null ? EMPTY_STRING : new String(val.getBytes(1, (int) val.length()));
+        } catch (SQLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/ResultFormatType.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/ResultFormatType.java
@@ -3,12 +3,10 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
+
 package com.yahoo.elide.async.models;
 
-/**
- * ENUM of supported result types.
- */
-public enum ResultType {
-    EMBEDDED,
-    DOWNLOAD
+public enum ResultFormatType {
+    JSON,
+    CSV
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/resources/DownloadApiEndpoint.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/resources/DownloadApiEndpoint.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.resources;
+
+import com.yahoo.elide.async.service.ResultStorageEngine;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
+/**
+ * Default endpoint/servlet for using Elide and Async Download.
+ */
+@Singleton
+@Path("/")
+public class DownloadApiEndpoint {
+    protected final ResultStorageEngine resultStorageEngine;
+
+    @Inject
+    public DownloadApiEndpoint(
+            @Named("resultStorageEngine") ResultStorageEngine resultStorageEngine) {
+        this.resultStorageEngine = resultStorageEngine;
+    }
+
+    /**
+     * Read handler.
+     *
+     * @param asyncQueryId asyncQueryId to download results
+     * @return response Response
+     */
+    @GET
+    @Path("/{asyncQueryId}")
+    public Response get(
+        @PathParam("asyncQueryId") String asyncQueryId) {
+        ///************* Getresults from ResultStorageEngine
+        byte[] temp = resultStorageEngine.getResultsByID(asyncQueryId);
+        ResponseBuilder response;
+        if (temp == null) {
+            response = Response.noContent();
+        } else {
+            response = Response.ok(new String(temp), MediaType.APPLICATION_OCTET_STREAM);
+            response.header("Content-Disposition", "attachment; filename=" + asyncQueryId);
+        }
+        return response.build();
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/resources/DownloadApiEndpoint.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/resources/DownloadApiEndpoint.java
@@ -45,7 +45,7 @@ public class DownloadApiEndpoint {
         byte[] temp = resultStorageEngine.getResultsByID(asyncQueryId);
         ResponseBuilder response;
         if (temp == null) {
-            response = Response.noContent();
+            response = Response.status(Response.Status.NOT_FOUND).entity("Result not found");
         } else {
             response = Response.ok(new String(temp), MediaType.APPLICATION_OCTET_STREAM);
             response.header("Content-Disposition", "attachment; filename=" + asyncQueryId);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
@@ -30,7 +30,7 @@ public class AsyncCleanerService {
 
     @Inject
     private AsyncCleanerService(Elide elide, Integer maxRunTimeSeconds, Integer queryCleanupDays,
-            Integer cancelDelaySeconds, AsyncQueryDAO asyncQueryDao) {
+            Integer cancelDelaySeconds, AsyncQueryDAO asyncQueryDao,ResultStorageEngine resultStorageEngine) {
 
         //If query is still running for twice than maxRunTime, then interrupt did not work due to host/app crash.
         int queryRunTimeThresholdMinutes = Math.round((maxRunTimeSeconds * 2) / 60);
@@ -38,7 +38,7 @@ public class AsyncCleanerService {
         // Setting up query cleaner that marks long running query as TIMEDOUT.
         ScheduledExecutorService cleaner = Executors.newSingleThreadScheduledExecutor();
         AsyncQueryCleanerThread cleanUpTask = new AsyncQueryCleanerThread(queryRunTimeThresholdMinutes, elide,
-            queryCleanupDays, asyncQueryDao);
+            queryCleanupDays, asyncQueryDao, resultStorageEngine);
 
         // Since there will be multiple hosts running the elide service,
         // setting up random delays to avoid all of them trying to cleanup at the same time.
@@ -71,10 +71,10 @@ public class AsyncCleanerService {
      * @param asyncQueryDao DAO Object
      */
     public static void init(Elide elide, Integer maxRunTimeSeconds, Integer queryCleanupDays,
-            Integer cancelDelaySeconds, AsyncQueryDAO asyncQueryDao) {
+            Integer cancelDelaySeconds, AsyncQueryDAO asyncQueryDao, ResultStorageEngine resultStorageEngine) {
         if (asyncCleanerService == null) {
             asyncCleanerService = new AsyncCleanerService(elide, maxRunTimeSeconds, queryCleanupDays,
-                    cancelDelaySeconds, asyncQueryDao);
+                    cancelDelaySeconds, asyncQueryDao, resultStorageEngine);
         } else {
             log.debug("asyncCleanerService is already initialized.");
         }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
@@ -30,7 +30,7 @@ public class AsyncCleanerService {
 
     @Inject
     private AsyncCleanerService(Elide elide, Integer maxRunTimeSeconds, Integer queryCleanupDays,
-            Integer cancelDelaySeconds, AsyncQueryDAO asyncQueryDao,ResultStorageEngine resultStorageEngine) {
+            Integer cancelDelaySeconds, AsyncQueryDAO asyncQueryDao, ResultStorageEngine resultStorageEngine) {
 
         //If query is still running for twice than maxRunTime, then interrupt did not work due to host/app crash.
         int queryRunTimeThresholdMinutes = Math.round((maxRunTimeSeconds * 2) / 60);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCancelThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCancelThread.java
@@ -48,7 +48,7 @@ public class AsyncQueryCancelThread implements Runnable {
 
     private int maxRunTimeSeconds;
     private Elide elide;
-    AsyncQueryDAO asyncQueryDao;
+    private AsyncQueryDAO asyncQueryDao;
 
     @Override
     public void run() {

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryCleanerThread.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -39,6 +40,7 @@ public class AsyncQueryCleanerThread implements Runnable {
     private Elide elide;
     private int queryCleanupDays;
     private AsyncQueryDAO asyncQueryDao;
+    private ResultStorageEngine resultStorageEngine;
 
     @Override
     public void run() {
@@ -55,7 +57,8 @@ public class AsyncQueryCleanerThread implements Runnable {
             Date cleanupDate = DateUtil.calculateFilterDate(Calendar.DATE, queryCleanupDays);
             PathElement createdOnPathElement = new PathElement(AsyncQuery.class, Long.class, "createdOn");
             FilterExpression fltDeleteExp = new LEPredicate(createdOnPathElement, cleanupDate);
-            asyncQueryDao.deleteAsyncQueryAndResultCollection(fltDeleteExp);
+            Collection<AsyncQuery> asyncQueryList = asyncQueryDao.deleteAsyncQueryAndResultCollection(fltDeleteExp);
+            resultStorageEngine.deleteResultsCollection(asyncQueryList);
         } catch (Exception e) {
             log.error("Exception in scheduled cleanup: {}", e);
         }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -187,6 +187,7 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
         try {
             isError = (Integer) JsonPath.read(jsonStr, "$.errors.length()") >= 1;
         } catch (PathNotFoundException e) {
+            //ignore when not an error message
             log.error(e.getMessage());
         }
         return isError;

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -10,9 +10,14 @@ import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryType;
+import com.yahoo.elide.async.models.ResultFormatType;
 import com.yahoo.elide.async.models.ResultType;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.security.User;
+
+import com.github.opendevl.JFlat;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.NoHttpResponseException;
@@ -21,8 +26,11 @@ import org.apache.http.client.utils.URIBuilder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
@@ -36,7 +44,6 @@ import javax.ws.rs.core.MultivaluedMap;
  */
 @Slf4j
 @Data
-
 public class AsyncQueryThread implements Callable<AsyncQueryResult> {
 
     private AsyncQuery queryObj;
@@ -46,50 +53,79 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
     private final QueryRunner runner;
     private AsyncQueryDAO asyncQueryDao;
     private String apiVersion;
+    private ResultStorageEngine resultStorageEngine;
+    private String requestURL;
 
     @Override
-    public AsyncQueryResult call() throws NoHttpResponseException, URISyntaxException {
-         return processQuery();
+    public AsyncQueryResult call() throws URISyntaxException, IOException {
+        return processQuery();
     }
 
+    /**
+     * Constructor for AsyncQueryThread.
+     * @param queryObj AsyncQuery object
+     * @param user Elide User Object
+     * @param elide Elide Object
+     * @param runner QueryRunner Object for GraphQL executions
+     * @param asyncQueryDao AsyncQueryDAO implementation Object
+     * @param apiVersion Api Version
+     * @param resultStorageEngine ResultStorageEngine implementation Object
+     * @param requestURL URL of the AsyncRequest pulled from Request Scope
+     */
     public AsyncQueryThread(AsyncQuery queryObj, User user, Elide elide, QueryRunner runner,
-            AsyncQueryDAO asyncQueryDao, String apiVersion) {
+            AsyncQueryDAO asyncQueryDao, String apiVersion, ResultStorageEngine resultStorageEngine,
+            String requestURL) {
         this.queryObj = queryObj;
         this.user = user;
         this.elide = elide;
         this.runner = runner;
         this.asyncQueryDao = asyncQueryDao;
         this.apiVersion = apiVersion;
+        this.resultStorageEngine = resultStorageEngine;
+        this.requestURL = requestURL;
     }
 
-
-   /**
-    * This is the main method which processes the Async Query request, executes the query and updates
-    * values for AsyncQuery and AsyncQueryResult models accordingly.
-    * @return AsyncQueryResult
-    * @throws URISyntaxException
-    * @throws NoHttpResponseException
-    */
-    protected AsyncQueryResult processQuery() throws URISyntaxException, NoHttpResponseException {
+    /**
+     * This is the main method which processes the Async Query request, executes the query and updates
+     * values for AsyncQuery and AsyncQueryResult models accordingly.
+     * @return AsyncQueryResult
+     * @throws URISyntaxException URISyntaxException
+     * @throws IOException IOException
+     */
+    protected AsyncQueryResult processQuery() throws URISyntaxException, IOException {
         UUID requestId = UUID.fromString(queryObj.getRequestId());
 
         ElideResponse response = null;
+        Integer recCount = null;
+        String responseBody = null;
+        boolean isError = false;
         log.debug("AsyncQuery Object from request: {}", queryObj);
         if (queryObj.getQueryType().equals(QueryType.JSONAPI_V1_0)) {
             MultivaluedMap<String, String> queryParams = getQueryParams(queryObj.getQuery());
             log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
 
-            //TODO - we need to add the baseUrlEndpoint to the queryObject.
+            //TODO - we need to add the baseURLEndpoint to the queryObject.
             response = elide.get("", getPath(queryObj.getQuery()), queryParams, user, apiVersion, requestId);
+            responseBody = response.getBody();
+            isError = checkJsonStrErrorMessage(responseBody);
             log.debug("JSONAPI_V1_0 getResponseCode: {}, JSONAPI_V1_0 getBody: {}",
-                    response.getResponseCode(), response.getBody());
+                    response.getResponseCode(), responseBody);
+
+            if (response.getResponseCode() == 200 && !isError) {
+                recCount = calculateRecordsJSON(responseBody);
+            }
         }
         else if (queryObj.getQueryType().equals(QueryType.GRAPHQL_V1_0)) {
-            //TODO - we need to add the baseUrlEndpoint to the queryObject.
-
+            //TODO - we need to add the baseURLEndpoint to the queryObject.
             response = runner.run("", queryObj.getQuery(), user, requestId);
+            responseBody = response.getBody();
+            isError = checkJsonStrErrorMessage(responseBody);
             log.debug("GRAPHQL_V1_0 getResponseCode: {}, GRAPHQL_V1_0 getBody: {}",
-                    response.getResponseCode(), response.getBody());
+                    response.getResponseCode(), responseBody);
+
+            if (response.getResponseCode() == 200 && !isError) {
+                recCount = calculateRecordsGraphQL(responseBody);
+            }
         }
         if (response == null) {
             throw new NoHttpResponseException("Response for request returned as null");
@@ -99,16 +135,96 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
 
         queryResultObj = new AsyncQueryResult();
         queryResultObj.setHttpStatus(response.getResponseCode());
-        queryResultObj.setResponseBody(response.getBody());
-        queryResultObj.setContentLength(response.getBody().length());
-        queryResultObj.setResultType(ResultType.EMBEDDED);
+        queryResultObj.setContentLength(responseBody.length());
+        queryResultObj.setRecordCount(recCount);
         queryResultObj.setCompletedOn(new Date());
+
+        String tempResult = queryObj.getResultFormatType() == ResultFormatType.CSV && !isError
+                ? convertJsonToCSV(responseBody) : responseBody;
+
+        if (queryObj.getResultType() == ResultType.EMBEDDED || isError) {
+            queryResultObj.setResponseBody(tempResult);
+        } else if (queryObj.getResultType() == ResultType.DOWNLOAD) {
+            if (resultStorageEngine == null) {
+                throw new IllegalStateException("Unable to store async results for download");
+            }
+            queryResultObj = resultStorageEngine.storeResults(queryResultObj, tempResult, queryObj.getId());
+            queryResultObj.setResponseBody(resultStorageEngine.generateDownloadUrl(requestURL,
+                    queryObj.getId()).toString());
+        }
 
         return queryResultObj;
     }
 
     /**
-     * This method parses the url and gets the query params.
+     * This method calculates the number of records from the response with JSON API.
+     * @param jsonStr is the response.getBody() we get from the response
+     * @return rec is the recordCount
+     */
+    protected Integer calculateRecordsJSON(String jsonStr) {
+        return JsonPath.read(jsonStr, "$.data.length()");
+    }
+
+    /**
+     * This method calculates the number of records from the response with GRAPHQL API.
+     * @param jsonStr is the response.getBody() we get from the response
+     * @return rec is the recordCount
+     * @throws IOException Exception thrown by JsonPath
+     */
+    protected Integer calculateRecordsGraphQL(String jsonStr) throws IOException {
+        List<Integer> countList = JsonPath.read(jsonStr, "$..edges.length()");
+        return countList.get(0);
+    }
+
+    /**
+     * This method checks if the json string is error message.
+     * @param jsonStr is the response.getBody() we get from the response
+     * @return is the message an error message
+     */
+    protected boolean checkJsonStrErrorMessage(String jsonStr) {
+        boolean isError = false;
+        try {
+            isError = (Integer) JsonPath.read(jsonStr, "$.errors.length()") >= 1;
+        } catch (PathNotFoundException e) {
+            log.error(e.getMessage());
+        }
+        return isError;
+    }
+
+    /**
+     * This method converts the JSON response to a CSV response type.
+     * @param jsonStr is the response.getBody() of the query
+     * @return retuns a string which nis in CSV format
+     * @throws IllegalStateException Exception thrown
+     */
+    protected String convertJsonToCSV(String jsonStr) {
+        if (jsonStr == null) {
+            return null;
+        }
+        StringBuilder str = new StringBuilder();
+        JFlat flatMe = new JFlat(jsonStr);
+        List<Object[]> json2csv;
+        try {
+            json2csv = flatMe.json2Sheet().headerSeparator("_").getJsonAsSheet();
+            for (Object[] obj : json2csv) {
+                String objString = Arrays.toString(obj);
+                if (objString != null) {
+                    objString = objString.substring(1, objString.length() - 1);
+                }
+                str.append(objString);
+                str.append(System.getProperty("line.separator"));
+            }
+        } catch (Exception e) {
+            log.debug("Exception while converting to CSV: {}", e.getMessage());
+            throw new IllegalStateException(e);
+        }
+
+        return str.toString();
+
+    }
+
+    /**
+     * This method parses the URL and gets the query params.
      * And adds them into a MultivaluedMap to be used by underlying Elide.get method
      * @param query query from the Async request
      * @throws URISyntaxException URISyntaxException from malformed or incorrect URI
@@ -125,7 +241,7 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
     }
 
     /**
-     * This method parses the url and gets the query params.
+     * This method parses the URL and gets the query params.
      * And retrieves path to be used by underlying Elide.get method
      * @param query query from the Async request
      * @throws URISyntaxException URISyntaxException from malformed or incorrect URI

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -104,7 +104,7 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
             MultivaluedMap<String, String> queryParams = getQueryParams(queryObj.getQuery());
             log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
 
-            //TODO - we need to add the baseURLEndpoint to the queryObject.
+            //TODO - we need to add the baseUrlEndpoint to the queryObject.
             response = elide.get("", getPath(queryObj.getQuery()), queryParams, user, apiVersion, requestId);
             responseBody = response.getBody();
             isError = checkJsonStrErrorMessage(responseBody);
@@ -173,7 +173,8 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
      */
     protected Integer calculateRecordsGraphQL(String jsonStr) throws IOException {
         List<Integer> countList = JsonPath.read(jsonStr, "$..edges.length()");
-        return countList.get(0);
+        Integer count = countList.size() > 0 ? countList.get(0) : 0;
+        return count;
     }
 
     /**

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -188,7 +188,7 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
             isError = (Integer) JsonPath.read(jsonStr, "$.errors.length()") >= 1;
         } catch (PathNotFoundException e) {
             //ignore when not an error message
-            log.error(e.getMessage());
+            log.debug(e.getMessage());
         }
         return isError;
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DBUtil.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DBUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.async.service;
+
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.jsonapi.models.JsonApiDocument;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * Utility class which implements a static method executeInTransaction.
+ */
+@Slf4j
+public class DBUtil {
+
+    /**
+     * This method creates a transaction from the datastore, performs the DB action using
+     * a generic functional interface and closes the transaction.
+     * @param dataStore Elide datastore retrieved from Elide object
+     * @param action Functional interface to perform DB action
+     * @return Object Returns Entity Object (AsyncQueryResult or AsyncResult)
+     */
+    protected static Object executeInTransaction(ElideSettings elideSettings,
+        DataStore dataStore, Transactional action) {
+        log.debug("executeInTransaction");
+        Object result = null;
+        try (DataStoreTransaction tx = dataStore.beginTransaction()) {
+            JsonApiDocument jsonApiDoc = new JsonApiDocument();
+            MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
+            RequestScope scope = new RequestScope(null, "query", NO_VERSION, jsonApiDoc,
+                    tx, null, queryParams, UUID.randomUUID(), elideSettings);
+            result = action.execute(tx, scope);
+            tx.flush(scope);
+            tx.commit(scope);
+        } catch (IOException e) {
+            log.error("IOException: {}", e);
+            throw new IllegalStateException(e);
+        }
+        return result;
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -5,31 +5,30 @@
  */
 package com.yahoo.elide.async.service;
 
-import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
-
-import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryStatus;
 import com.yahoo.elide.core.DataStore;
+<<<<<<< HEAD
 import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.RequestScope;
+=======
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.ParseException;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+>>>>>>> Adding record count to AsyncQueryResult and related changes
 import com.yahoo.elide.core.filter.expression.FilterExpression;
-import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.request.EntityProjection;
 
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.UUID;
 
 import javax.inject.Singleton;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Utility class which implements AsyncQueryDAO.
@@ -39,21 +38,22 @@ import javax.ws.rs.core.MultivaluedMap;
 @Getter
 public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
 
-    @Setter private Elide elide;
+    @Setter private ElideSettings elideSettings;
     @Setter private DataStore dataStore;
 
     // Default constructor is needed for standalone implementation for override in getAsyncQueryDao
     public DefaultAsyncQueryDAO() {
     }
 
-    public DefaultAsyncQueryDAO(Elide elide, DataStore dataStore) {
-        this.elide = elide;
+    public DefaultAsyncQueryDAO(ElideSettings elideSettings, DataStore dataStore) {
+        this.elideSettings = elideSettings;
         this.dataStore = dataStore;
     }
 
     @Override
     public AsyncQuery updateStatus(String asyncQueryId, QueryStatus status) {
-        AsyncQuery queryObj = (AsyncQuery) executeInTransaction(dataStore, (tx, scope) -> {
+        AsyncQuery queryObj = (AsyncQuery) DBUtil.executeInTransaction(elideSettings,
+                dataStore, (tx, scope) -> {
             EntityProjection asyncQueryCollection = EntityProjection.builder()
                     .type(AsyncQuery.class)
                     .build();
@@ -70,7 +70,7 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
             QueryStatus status) {
         return updateAsyncQueryCollection(filterExpression, (asyncQuery) -> {
             asyncQuery.setStatus(status);
-            });
+        });
     }
 
     /**
@@ -86,23 +86,23 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
         log.debug("updateAsyncQueryCollection");
 
         Collection<AsyncQuery> asyncQueryList = null;
-         asyncQueryList = (Collection<AsyncQuery>) executeInTransaction(dataStore,
+        asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(dataStore,
                     (tx, scope) -> {
-             EntityProjection asyncQueryCollection = EntityProjection.builder()
-                     .type(AsyncQuery.class)
-                     .filterExpression(filterExpression)
-                     .build();
+            EntityProjection asyncQueryCollection = EntityProjection.builder()
+                    .type(AsyncQuery.class)
+                    .filterExpression(filterExpression)
+                    .build();
 
-             Iterable<Object> loaded = tx.loadObjects(asyncQueryCollection, scope);
-             Iterator<Object> itr = loaded.iterator();
+            Iterable<Object> loaded = tx.loadObjects(asyncQueryCollection, scope);
+            Iterator<Object> itr = loaded.iterator();
 
-             while (itr.hasNext()) {
-                 AsyncQuery query = (AsyncQuery) itr.next();
-                 updateFunction.update(query);
-                 tx.save(query, scope);
-             }
-             return loaded;
-         });
+            while (itr.hasNext()) {
+                AsyncQuery query = (AsyncQuery) itr.next();
+                updateFunction.update(query);
+                tx.save(query, scope);
+            }
+            return loaded;
+        });
         return asyncQueryList;
     }
 
@@ -111,7 +111,7 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
     public Collection<AsyncQuery> deleteAsyncQueryAndResultCollection(FilterExpression filterExpression) {
         log.debug("deleteAsyncQueryAndResultCollection");
         Collection<AsyncQuery> asyncQueryList = null;
-        asyncQueryList = (Collection<AsyncQuery>) executeInTransaction(dataStore, (tx, scope) -> {
+        asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(dataStore, (tx, scope) -> {
             EntityProjection asyncQueryCollection = EntityProjection.builder()
                     .type(AsyncQuery.class)
                     .filterExpression(filterExpression)
@@ -132,10 +132,10 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
     }
 
     @Override
-    public AsyncQuery updateAsyncQueryResult(AsyncQueryResult asyncQueryResult,
-            String asyncQueryId) {
+    public AsyncQuery updateAsyncQueryResult(AsyncQueryResult asyncQueryResult, String asyncQueryId) {
         log.debug("updateAsyncQueryResult");
-        AsyncQuery queryObj = (AsyncQuery) executeInTransaction(dataStore, (tx, scope) -> {
+        AsyncQuery queryObj = (AsyncQuery) DBUtil.executeInTransaction(elideSettings,
+                dataStore, (tx, scope) -> {
             EntityProjection asyncQueryCollection = EntityProjection.builder()
                     .type(AsyncQuery.class)
                     .build();
@@ -152,38 +152,13 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
         return queryObj;
     }
 
-    /**
-     * This method creates a transaction from the datastore, performs the DB action using
-     * a generic functional interface and closes the transaction.
-     * @param dataStore Elide datastore retrieved from Elide object
-     * @param action Functional interface to perform DB action
-     * @return Object Returns Entity Object (AsyncQueryResult or AsyncResult)
-     */
-    protected Object executeInTransaction(DataStore dataStore, Transactional action) {
-        log.debug("executeInTransaction");
-        Object result = null;
-        try (DataStoreTransaction tx = dataStore.beginTransaction()) {
-            JsonApiDocument jsonApiDoc = new JsonApiDocument();
-            MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<String, String>();
-            RequestScope scope = new RequestScope("", "query", NO_VERSION, jsonApiDoc,
-                    tx, null, queryParams, UUID.randomUUID(), elide.getElideSettings());
-            result = action.execute(tx, scope);
-            tx.flush(scope);
-            tx.commit(scope);
-        } catch (IOException e) {
-            log.error("IOException: {}", e);
-            throw new IllegalStateException(e);
-        }
-        return result;
-    }
-
     @Override
     @SuppressWarnings("unchecked")
     public Collection<AsyncQuery> loadAsyncQueryCollection(FilterExpression filterExpression) {
         Collection<AsyncQuery> asyncQueryList = null;
         log.debug("loadAsyncQueryCollection");
         try {
-            asyncQueryList = (Collection<AsyncQuery>) executeInTransaction(dataStore, (tx, scope) -> {
+            asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(dataStore, (tx, scope) -> {
 
                 EntityProjection asyncQueryCollection = EntityProjection.builder()
                         .type(AsyncQuery.class)

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAO.java
@@ -10,14 +10,6 @@ import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryStatus;
 import com.yahoo.elide.core.DataStore;
-<<<<<<< HEAD
-import com.yahoo.elide.core.DataStoreTransaction;
-import com.yahoo.elide.core.RequestScope;
-=======
-import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.filter.dialect.ParseException;
-import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
->>>>>>> Adding record count to AsyncQueryResult and related changes
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.request.EntityProjection;
 
@@ -86,7 +78,7 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
         log.debug("updateAsyncQueryCollection");
 
         Collection<AsyncQuery> asyncQueryList = null;
-        asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(dataStore,
+        asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(elideSettings, dataStore,
                     (tx, scope) -> {
             EntityProjection asyncQueryCollection = EntityProjection.builder()
                     .type(AsyncQuery.class)
@@ -111,7 +103,8 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
     public Collection<AsyncQuery> deleteAsyncQueryAndResultCollection(FilterExpression filterExpression) {
         log.debug("deleteAsyncQueryAndResultCollection");
         Collection<AsyncQuery> asyncQueryList = null;
-        asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(dataStore, (tx, scope) -> {
+        asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(elideSettings, dataStore,
+                (tx, scope) -> {
             EntityProjection asyncQueryCollection = EntityProjection.builder()
                     .type(AsyncQuery.class)
                     .filterExpression(filterExpression)
@@ -158,8 +151,8 @@ public class DefaultAsyncQueryDAO implements AsyncQueryDAO {
         Collection<AsyncQuery> asyncQueryList = null;
         log.debug("loadAsyncQueryCollection");
         try {
-            asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(dataStore, (tx, scope) -> {
-
+            asyncQueryList = (Collection<AsyncQuery>) DBUtil.executeInTransaction(elideSettings, dataStore,
+                    (tx, scope) -> {
                 EntityProjection asyncQueryCollection = EntityProjection.builder()
                         .type(AsyncQuery.class)
                         .filterExpression(filterExpression)

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultResultStorageEngine.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.async.service;
+
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.AsyncQueryResult;
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.request.EntityProjection;
+
+import org.apache.http.client.utils.URIBuilder;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.sql.Blob;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import javax.inject.Singleton;
+import javax.sql.rowset.serial.SerialBlob;
+
+/**
+ * Default implementation of ResultStorageEngine.
+ * It supports Async Module to store results with async query.
+ */
+@Singleton
+@Slf4j
+@Getter
+public class DefaultResultStorageEngine implements ResultStorageEngine {
+    private static final String FORWARD_SLASH = "/";
+
+    @Setter private String downloadURI;
+    @Setter private ElideSettings elideSettings;
+    @Setter private DataStore dataStore;
+
+    public DefaultResultStorageEngine() {
+    }
+
+    /**
+     * Constructor.
+     * @param downloadURI URI Path for the download controller. For example /api/v1/download
+     * @param elideSettings ElideSettings object
+     * @param dataStore DataStore Object
+     */
+    public DefaultResultStorageEngine(String downloadURI, ElideSettings elideSettings, DataStore dataStore) {
+        this.downloadURI = downloadURI != null && !downloadURI.startsWith(FORWARD_SLASH)
+                ? FORWARD_SLASH + downloadURI : downloadURI;
+        this.elideSettings = elideSettings;
+        this.dataStore = dataStore;
+    }
+
+    @Override
+    public AsyncQueryResult storeResults(AsyncQueryResult asyncQueryResult, String result, String asyncQueryId) {
+        log.debug("store AsyncResults for Download");
+
+        byte[] temp = result.getBytes();
+        Blob attachment;
+        try {
+            attachment = new SerialBlob(temp);
+        } catch (SQLException e) {
+            log.error("Exception: {}", e);
+            throw new IllegalStateException(e);
+        }
+
+        asyncQueryResult.setAttachment(attachment);
+
+        return asyncQueryResult;
+    }
+
+    @Override
+    public byte[] getResultsByID(String asyncQueryID) {
+        log.debug("getAsyncResultsByID");
+
+        AsyncQuery asyncQuery = null;
+        byte[] byteResult = null;
+
+        try {
+            asyncQuery = (AsyncQuery) DBUtil.executeInTransaction(elideSettings,
+                    dataStore, (tx, scope) -> {
+
+                        EntityProjection asyncQueryCollection = EntityProjection.builder()
+                                .type(AsyncQuery.class)
+                                .build();
+
+                        Object loaded = tx.loadObject(asyncQueryCollection, asyncQueryID, scope);
+
+                        return loaded;
+                    });
+            if (asyncQuery != null) {
+                Blob result = asyncQuery.getResult().getAttachment();
+                byteResult = result.getBytes(1, (int) result.length());
+            }
+        } catch (SQLException e) {
+            log.error("Exception: {}", e);
+            throw new IllegalStateException(e);
+        }
+
+        return byteResult;
+    }
+
+    @Override
+    public void deleteResultsCollection(Collection<AsyncQuery> asyncQueryList) {
+        log.debug("deleteAsyncQueryResultsCollection");
+        return;
+    }
+
+    @Override
+    public URL generateDownloadUrl(String requestURL, String asyncQueryID) {
+        log.debug("generateDownloadUrl");
+        String baseURL = requestURL != null ? getBasePath(requestURL) : null;
+        String tempURL = baseURL != null && downloadURI != null ? baseURL + downloadURI : null;
+
+        URL url;
+        String downloadURL;
+        if (tempURL == null) {
+            downloadURL = null;
+        } else {
+            downloadURL = tempURL.endsWith(FORWARD_SLASH) ? tempURL + asyncQueryID
+                    : tempURL + FORWARD_SLASH + asyncQueryID;
+        }
+
+        try {
+            url = new URL(downloadURL);
+        } catch (MalformedURLException e) {
+            log.error("Exception: {}", e);
+            //Results persisted, unable to generate URL
+            throw new IllegalStateException(e);
+        }
+        return url;
+    }
+
+    /**
+     * This method parses the URL and gets the scheme, host, port.
+     * @param URL URL from the Async request
+     * @throws URISyntaxException URISyntaxException from malformed or incorrect URI
+     * @return BasePath extracted from URI
+     */
+    private String getBasePath(String URL) {
+        URIBuilder uri;
+        try {
+            uri = new URIBuilder(URL);
+        } catch (URISyntaxException e) {
+            log.debug("extracting base path from requestURL failure. {}", e.getMessage());
+            throw new IllegalStateException(e);
+        }
+        StringBuilder str = new StringBuilder(uri.getScheme() + "://" + uri.getHost());
+        if (uri.getPort() != -1) {
+            str.append(":" + uri.getPort());
+        }
+        return str.toString();
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultResultStorageEngine.java
@@ -95,7 +95,7 @@ public class DefaultResultStorageEngine implements ResultStorageEngine {
 
                         return loaded;
                     });
-            if (asyncQuery != null) {
+            if (asyncQuery != null && asyncQuery.getResult().getAttachment() != null) {
                 Blob result = asyncQuery.getResult().getAttachment();
                 byteResult = result.getBytes(1, (int) result.length());
             }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/DefaultResultStorageEngine.java
@@ -110,7 +110,6 @@ public class DefaultResultStorageEngine implements ResultStorageEngine {
     @Override
     public void deleteResultsCollection(Collection<AsyncQuery> asyncQueryList) {
         log.debug("deleteAsyncQueryResultsCollection");
-        return;
     }
 
     @Override

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/ResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/ResultStorageEngine.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.async.service;
+
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.AsyncQueryResult;
+
+import java.net.URL;
+import java.util.Collection;
+
+/**
+ * Utility interface used for storing the results of AsyncQuery for downloads.
+ */
+public interface ResultStorageEngine {
+
+    /**
+     * Stores the result of the query.
+     * @param asyncQueryResult AsyncQueryResult for storing the results
+     * @param result is the result obtained by running the query
+     * @param asyncQueryId is the ID of the query
+     * @return AsyncQueryResult object
+     */
+    public AsyncQueryResult storeResults(AsyncQueryResult asyncQueryResult, String result, String asyncQueryId);
+
+    /**
+     * Generates the URL to download the result.
+     * @param requestURL is the requestURL of the AsyncQuery
+     * @param asyncQueryID is the query ID of the AsyncQuery
+     * @return it returns the URL from where we can access the result of the query
+     */
+    public URL generateDownloadUrl(String requestURL, String asyncQueryID);
+
+    /**
+     * Searches for the async query results by ID and returns the record.
+     * @param asyncQueryID is the query ID of the AsyncQuery
+     * @return returns the result associated with the AsyncQueryID
+     */
+    public byte[] getResultsByID(String asyncQueryID);
+
+    /**
+     * Deletes all the async results from the storage engine.
+     * @param asyncQueryCollection Collection of AsyncQuery to delete
+     */
+    public void deleteResultsCollection(Collection<AsyncQuery> asyncQueryCollection);
+}

--- a/elide-async/src/test/java/com/yahoo/elide/async/models/AsyncQueryTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/models/AsyncQueryTest.java
@@ -3,11 +3,10 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.async.service;
+package com.yahoo.elide.async.models;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import com.yahoo.elide.async.models.AsyncQuery;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -34,6 +33,7 @@ public class AsyncQueryTest {
     public void testMaxAsyncAfterSeconds() {
         AsyncQuery queryObj = new AsyncQuery();
         queryObj.setAsyncAfterSeconds(12);
+        queryObj.setResultType(ResultType.EMBEDDED);
         Set<ConstraintViolation<AsyncQuery>> constraintViolations = validator.validate(queryObj);
         assertEquals(1, constraintViolations.size());
         assertEquals("must be less than or equal to 10", constraintViolations.iterator().next().getMessage());

--- a/elide-async/src/test/java/com/yahoo/elide/async/models/BlobSerdeTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/models/BlobSerdeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Blob;
+import java.sql.SQLException;
+
+import javax.sql.rowset.serial.SerialBlob;
+import javax.sql.rowset.serial.SerialException;
+
+public class BlobSerdeTest {
+
+    @Test
+    public void testBlobSerialize() throws SerialException, SQLException {
+
+        String responseBody = "responseBody";
+        Blob newBlob = new SerialBlob(responseBody.getBytes());
+
+        BlobSerde blobSerde = new BlobSerde();
+        Object actual = blobSerde.serialize(newBlob);
+        assertEquals(responseBody, actual);
+    }
+
+    @Test
+    public void testBlobDeserialize() throws SerialException, SQLException {
+
+        String responseBody = "responseBody";
+        Blob expectedBlob = new SerialBlob(responseBody.getBytes());
+
+        BlobSerde blobSerde = new BlobSerde();
+        Object actualBlob = blobSerde.deserialize(responseBody);
+        assertEquals(expectedBlob, actualBlob);
+    }
+
+    @Test
+    public void testBlobDeserializeNull() throws SerialException, SQLException {
+
+        Blob expectedBlob = new SerialBlob("".getBytes());
+
+        BlobSerde blobSerde = new BlobSerde();
+        Object actualBlob = blobSerde.deserialize(null);
+        assertEquals(expectedBlob, actualBlob);
+    }
+
+    @Test
+    public void testBlobserializeNull() throws SerialException, SQLException {
+
+        BlobSerde blobSerde = new BlobSerde();
+        Object actualBlob = blobSerde.serialize(null);
+        assertEquals("", actualBlob);
+    }
+}

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncCleanerServiceTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncCleanerServiceTest.java
@@ -23,7 +23,9 @@ public class AsyncCleanerServiceTest {
     public void setupMocks() {
         Elide elide = mock(Elide.class);
         AsyncQueryDAO dao = mock(DefaultAsyncQueryDAO.class);
-        AsyncCleanerService.init(elide, 5, 60, 300, dao);
+
+        ResultStorageEngine resultStorageEngine = mock(DefaultResultStorageEngine.class);
+        AsyncCleanerService.init(elide, 5, 60, 300, dao, resultStorageEngine);
         service = AsyncCleanerService.getInstance();
     }
 

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryCancelThreadTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryCancelThreadTest.java
@@ -78,7 +78,7 @@ public class AsyncQueryCancelThreadTest {
         Collection<AsyncQuery> asyncCollection = new ArrayList<AsyncQuery>();
         asyncCollection.add(asyncQuery1);
         asyncCollection.add(asyncQuery2);
-        when(cancelThread.asyncQueryDao.loadAsyncQueryCollection(any())).thenReturn(asyncCollection);
+        when(cancelThread.getAsyncQueryDao().loadAsyncQueryCollection(any())).thenReturn(asyncCollection);
         cancelThread.cancelAsyncQuery();
         ArgumentCaptor<FilterExpression> filterCaptor = ArgumentCaptor.forClass(FilterExpression.class);
         verify(asyncQueryDao, times(1)).updateStatusAsyncQueryCollection(filterCaptor.capture(), any());
@@ -101,7 +101,7 @@ public class AsyncQueryCancelThreadTest {
         asyncCollection.add(asyncQuery1);
         asyncCollection.add(asyncQuery2);
         asyncCollection.add(asyncQuery3);
-        when(cancelThread.asyncQueryDao.loadAsyncQueryCollection(any())).thenReturn(asyncCollection);
+        when(cancelThread.getAsyncQueryDao().loadAsyncQueryCollection(any())).thenReturn(asyncCollection);
         cancelThread.cancelAsyncQuery();
         ArgumentCaptor<FilterExpression> fltStatusCaptor = ArgumentCaptor.forClass(FilterExpression.class);
         verify(asyncQueryDao, times(1)).loadAsyncQueryCollection(fltStatusCaptor.capture());
@@ -124,7 +124,7 @@ public class AsyncQueryCancelThreadTest {
         asyncCollection.add(asyncQuery1);
         asyncCollection.add(asyncQuery2);
         asyncCollection.add(asyncQuery3);
-        when(cancelThread.asyncQueryDao.loadAsyncQueryCollection(any())).thenReturn(asyncCollection);
+        when(cancelThread.getAsyncQueryDao().loadAsyncQueryCollection(any())).thenReturn(asyncCollection);
         cancelThread.cancelAsyncQuery();
         ArgumentCaptor<FilterExpression> filterCaptor = ArgumentCaptor.forClass(FilterExpression.class);
         verify(asyncQueryDao, times(1)).updateStatusAsyncQueryCollection(filterCaptor.capture(), any());

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryCleanerThreadTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryCleanerThreadTest.java
@@ -5,11 +5,13 @@
  */
 package com.yahoo.elide.async.service;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettingsBuilder;
@@ -72,6 +74,21 @@ public class AsyncQueryCleanerThreadTest {
         assertEquals("asyncQuery.createdOn LE [" + new Date(date) + "]", filterCaptor.getValue().toString());
 
         verify(resultStorageEngine, times(1)).deleteResultsCollection(any());
+    }
+
+    //When AsyncQueryDao gets exception, resultstorageengine will not execute delete and no exception thrown.
+    @Test
+    public void testDeleteAsyncQueryException() {
+        when(asyncQueryDao.deleteAsyncQueryAndResultCollection(any())).thenThrow(IllegalStateException.class);
+        assertDoesNotThrow(() -> cleanerThread.deleteAsyncQuery());
+        verify(resultStorageEngine, times(0)).deleteResultsCollection(any());
+    }
+
+    //When AsyncQueryDao gets exception, no exception is thrown
+    @Test
+    public void testTimeoutAsyncQueryException() {
+        when(asyncQueryDao.updateStatusAsyncQueryCollection(any(), any())).thenThrow(IllegalStateException.class);
+        assertDoesNotThrow(() -> cleanerThread.timeoutAsyncQuery());
     }
 
     @Test

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryThreadTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryThreadTest.java
@@ -6,6 +6,8 @@
 package com.yahoo.elide.async.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,23 +19,28 @@ import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryType;
+import com.yahoo.elide.async.models.ResultType;
+import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.security.User;
 
-import org.apache.http.NoHttpResponseException;
+import com.jayway.jsonpath.InvalidJsonException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.net.URISyntaxException;
+import java.net.URL;
 
 public class AsyncQueryThreadTest {
+    private static final String BASE_URL_ENDPOINT = "http://localhost:8080/api/v1";
+    private static final String DOWNLOAD_BASE_PATH = "/api/v1/download";
 
     private User user;
     private Elide elide;
     private QueryRunner runner;
     private AsyncQueryResult queryResultObj;
     private AsyncQueryDAO asyncQueryDao;
+    private ResultStorageEngine resultStorageEngine;
 
     @BeforeEach
     public void setupMocks() {
@@ -42,10 +49,61 @@ public class AsyncQueryThreadTest {
         runner = mock(QueryRunner.class);
         queryResultObj = mock(AsyncQueryResult.class);
         asyncQueryDao = mock(DefaultAsyncQueryDAO.class);
+        resultStorageEngine = mock(DefaultResultStorageEngine.class);
     }
 
+    //Test with record count = 3
     @Test
-    public void testProcessQueryJsonApi() throws NoHttpResponseException, URISyntaxException {
+    public void testProcessQueryJsonApi() throws Exception {
+        AsyncQuery queryObj = new AsyncQuery();
+        String responseBody = "{\"data\":"
+                + "[{\"type\":\"book\",\"id\":\"3\",\"attributes\":{\"title\":\"For Whom the Bell Tolls\"}}"
+                + ",{\"type\":\"book\",\"id\":\"2\",\"attributes\":{\"title\":\"Song of Ice and Fire\"}},"
+                + "{\"type\":\"book\",\"id\":\"1\",\"attributes\":{\"title\":\"Ender's Game\"}}]}";
+        ElideResponse response = new ElideResponse(200, responseBody);
+        String query = "/group?sort=commonName&fields%5Bgroup%5D=commonName,description";
+        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.JSONAPI_V1_0);
+        queryObj.setResultType(ResultType.EMBEDDED);
+
+        when(elide.get(any(), anyString(), any(), any(), anyString(), any())).thenReturn(response);
+        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                resultStorageEngine, BASE_URL_ENDPOINT);
+        queryResultObj = queryThread.processQuery();
+        assertEquals(queryResultObj.getRecordCount(), 3);
+        assertEquals(queryResultObj.getResponseBody(), responseBody);
+        assertEquals(queryResultObj.getHttpStatus(), 200);
+    }
+
+    //Test with record count = 0
+    @Test
+    public void testProcessQueryJsonApi2() throws Exception {
+        AsyncQuery queryObj = new AsyncQuery();
+        String responseBody = "{\"data\":[]}";
+        ElideResponse response = new ElideResponse(200, responseBody);
+        String query = "/group?sort=commonName&fields%5Bgroup%5D=commonName,description";
+        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.JSONAPI_V1_0);
+        queryObj.setResultType(ResultType.EMBEDDED);
+
+        when(elide.get(any(), anyString(), any(), any(), anyString(), any())).thenReturn(response);
+        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                resultStorageEngine, BASE_URL_ENDPOINT);
+        queryResultObj = queryThread.processQuery();
+
+        assertEquals(queryResultObj.getRecordCount(), 0);
+        assertEquals(queryResultObj.getResponseBody(), responseBody);
+        assertEquals(queryResultObj.getHttpStatus(), 200);
+    }
+
+    //Test with invalid input for responseBody. An exception will be thrown.
+    @Test
+    public void testProcessQueryJsonApi3() throws Exception {
+        assertThrows(InvalidJsonException.class, () -> {
         AsyncQuery queryObj = new AsyncQuery();
         ElideResponse response = new ElideResponse(200, "ResponseBody");
         String query = "/group?sort=commonName&fields%5Bgroup%5D=commonName,description";
@@ -53,26 +111,162 @@ public class AsyncQueryThreadTest {
         queryObj.setId(id);
         queryObj.setQuery(query);
         queryObj.setQueryType(QueryType.JSONAPI_V1_0);
-        when(elide.get(anyString(), anyString(), any(), any(), anyString(), any())).thenReturn(response);
-        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1");
+        queryObj.setResultType(ResultType.EMBEDDED);
+
+        when(elide.get(any(), anyString(), any(), any(), anyString(), any())).thenReturn(response);
+        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                resultStorageEngine, BASE_URL_ENDPOINT);
         queryResultObj = queryThread.processQuery();
+
+        assertEquals(queryResultObj.getRecordCount(), null);
         assertEquals(queryResultObj.getResponseBody(), "ResponseBody");
-        assertEquals(queryResultObj.getHttpStatus(), 200);
+        });
+
     }
 
+    //Test with invalid input for responseBody. An exception will be thrown.
     @Test
-    public void testProcessQueryGraphQl() throws NoHttpResponseException, URISyntaxException {
+    public void testProcessQueryGraphQl() throws Exception {
+        assertThrows(InvalidJsonException.class, () -> {
+            AsyncQuery queryObj = new AsyncQuery();
+            ElideResponse response = new ElideResponse(200, "ResponseBody");
+            String query = "{\"query\":\"{ group { edges { node { name commonName description } } } }\",\"variables\":null}";
+            String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+            queryObj.setId(id);
+            queryObj.setQuery(query);
+            queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+            queryObj.setResultType(ResultType.EMBEDDED);
+
+            when(runner.run(any(), eq(query), eq(user), any())).thenReturn(response);
+            AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                    resultStorageEngine, BASE_URL_ENDPOINT);
+            queryResultObj = queryThread.processQuery();
+            assertEquals(queryResultObj.getResponseBody(), "ResponseBody");
+            assertEquals(queryResultObj.getHttpStatus(), 200);
+        });
+    }
+
+    //Test for when resultStorageEngine fails to store
+    @Test
+    public void testProcessQueryGraphQlStoreException() throws Exception {
+        assertThrows(IllegalStateException.class, () -> {
+            AsyncQuery queryObj = new AsyncQuery();
+            String responseBody = "{\"data\":{\"book\":{\"edges\":[{\"node\":{\"id\":\"1\",\"title\":\"Ender's Game\"}},"
+                    + "{\"node\":{\"id\":\"2\",\"title\":\"Song of Ice and Fire\"}},"
+                    + "{\"node\":{\"id\":\"3\",\"title\":\"For Whom the Bell Tolls\"}}]}}}";
+            ElideResponse response = new ElideResponse(200, responseBody);
+            String query = "{\"query\":\"{ group { edges { node { name commonName description } } } }\",\"variables\":null}";
+            String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+            queryObj.setId(id);
+            queryObj.setQuery(query);
+            queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+            queryObj.setResultType(ResultType.DOWNLOAD);
+
+            when(runner.run(any(), eq(query), eq(user), any())).thenReturn(response);
+            when(resultStorageEngine.storeResults(any(), any(), any())).thenThrow(IllegalStateException.class);
+            AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                    resultStorageEngine, BASE_URL_ENDPOINT);
+            queryResultObj = queryThread.processQuery();
+        });
+    }
+
+    //Test with record count = 3
+    @Test
+    public void testProcessQueryGraphQl2() throws Exception {
+
         AsyncQuery queryObj = new AsyncQuery();
-        ElideResponse response = new ElideResponse(200, "ResponseBody");
+        String responseBody = "{\"data\":{\"book\":{\"edges\":[{\"node\":{\"id\":\"1\",\"title\":\"Ender's Game\"}},"
+                + "{\"node\":{\"id\":\"2\",\"title\":\"Song of Ice and Fire\"}},"
+                + "{\"node\":{\"id\":\"3\",\"title\":\"For Whom the Bell Tolls\"}}]}}}";
+        ElideResponse response = new ElideResponse(200, responseBody);
         String query = "{\"query\":\"{ group { edges { node { name commonName description } } } }\",\"variables\":null}";
         String id = "edc4a871-dff2-4054-804e-d80075cf827d";
         queryObj.setId(id);
         queryObj.setQuery(query);
         queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
-        when(runner.run(anyString(), eq(query), eq(user), any())).thenReturn(response);
-        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1");
+        queryObj.setResultType(ResultType.EMBEDDED);
+
+        when(runner.run(any(), eq(query), eq(user), any())).thenReturn(response);
+        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                resultStorageEngine, BASE_URL_ENDPOINT);
         queryResultObj = queryThread.processQuery();
-        assertEquals(queryResultObj.getResponseBody(), "ResponseBody");
+        assertEquals(queryResultObj.getRecordCount(), 3);
+        assertEquals(queryResultObj.getResponseBody(), responseBody);
         assertEquals(queryResultObj.getHttpStatus(), 200);
+
+    }
+
+    //Test with record count = 3 and Download
+    @Test
+    public void testProcessQueryGraphQlDownload() throws Exception {
+
+        AsyncQuery queryObj = new AsyncQuery();
+        AsyncQueryResult result = new AsyncQueryResult();
+        String responseBody = "{\"data\":{\"book\":{\"edges\":[{\"node\":{\"id\":\"1\",\"title\":\"Ender's Game\"}},"
+                + "{\"node\":{\"id\":\"2\",\"title\":\"Song of Ice and Fire\"}},"
+                + "{\"node\":{\"id\":\"3\",\"title\":\"For Whom the Bell Tolls\"}}]}}}";
+        ElideResponse response = new ElideResponse(200, responseBody);
+        String query = "{\"query\":\"{ group { edges { node { name commonName description } } } }\",\"variables\":null}";
+        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+        queryObj.setResultType(ResultType.DOWNLOAD);
+        URL url = new URL(BASE_URL_ENDPOINT + "/download/" + id);
+
+        when(runner.run(any(), eq(query), eq(user), any())).thenReturn(response);
+        //when(resultStorageEngine.storeResults(any(), any())).thenReturn(result);
+        //when(resultStorageEngine.generateDownloadUrl(any(), any())).thenReturn(url);
+        resultStorageEngine = new DefaultResultStorageEngine(DOWNLOAD_BASE_PATH, elide.getElideSettings(), mock(DataStore.class));
+        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                resultStorageEngine, BASE_URL_ENDPOINT);
+        queryResultObj = queryThread.processQuery();
+        assertEquals(queryResultObj.getRecordCount(), 3);
+        assertEquals(queryResultObj.getResponseBody(), url.toString());
+        assertEquals(queryResultObj.getHttpStatus(), 200);
+
+    }
+
+    // Standard positive test case that converts json to csv format.
+    @Test
+    public void testConvertJsonToCSV() throws Exception {
+
+        String csvStr = "key\n\"value\"\n";
+        String jsonStr = "{\"key\":\"value\"}";
+
+        AsyncQuery queryObj = new AsyncQuery();
+        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                resultStorageEngine, BASE_URL_ENDPOINT);
+
+        assertEquals(queryThread.convertJsonToCSV(jsonStr), csvStr);
+    }
+
+    // Null json to csv format.
+    @Test
+    public void testConvertJsonToCSVNull() throws Exception {
+
+        String jsonStr = null;
+
+        AsyncQuery queryObj = new AsyncQuery();
+        AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                resultStorageEngine, BASE_URL_ENDPOINT);
+
+        assertNull(queryThread.convertJsonToCSV(jsonStr));
+    }
+
+    //Invalid input for the json to csv conversion. This throws an exception.
+    @Test
+    public void testConvertJsonToCSV2() throws Exception {
+
+        String csvStr = "ResponseBody";
+        assertThrows(IllegalStateException.class, () -> {
+            String jsonStr = "ResponseBody";
+
+            AsyncQuery queryObj = new AsyncQuery();
+            AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1",
+                    resultStorageEngine, BASE_URL_ENDPOINT);
+
+            assertEquals(queryThread.convertJsonToCSV(jsonStr), csvStr);
+        });
     }
 }

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
@@ -42,7 +42,6 @@ public class DefaultAsyncQueryDAOTest {
     private AsyncQuery asyncQuery;
     private AsyncQueryResult asyncQueryResult;
     private DataStoreTransaction tx;
-    private EntityDictionary dictionary;
     private FilterExpression filter;
 
     @BeforeEach
@@ -55,7 +54,7 @@ public class DefaultAsyncQueryDAOTest {
 
         Map<String, Class<? extends Check>> checkMappings = new HashMap<>();
 
-        dictionary = new EntityDictionary(checkMappings);
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
         dictionary.bindEntity(AsyncQuery.class);
         dictionary.bindEntity(AsyncQueryResult.class);
 

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultAsyncQueryDAOTest.java
@@ -68,13 +68,14 @@ public class DefaultAsyncQueryDAOTest {
 
         elide = new Elide(elideSettings);
         when(dataStore.beginTransaction()).thenReturn(tx);
-        asyncQueryDAO = new DefaultAsyncQueryDAO(elide, dataStore);
+
+        asyncQueryDAO = new DefaultAsyncQueryDAO(elide.getElideSettings(), dataStore);
     }
 
     @Test
     public void testAsyncQueryCleanerThreadSet() {
-        assertEquals(elide, asyncQueryDAO.getElide());
         assertEquals(dataStore, asyncQueryDAO.getDataStore());
+        assertEquals(elide.getElideSettings(), asyncQueryDAO.getElideSettings());
     }
 
     @Test

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultResultStorageEngineTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.AsyncQueryResult;
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.security.checks.Check;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.sql.rowset.serial.SerialBlob;
+import javax.sql.rowset.serial.SerialException;
+
+public class DefaultResultStorageEngineTest {
+    private DataStoreTransaction tx;
+    private DefaultResultStorageEngine defaultResultStorageEngine;
+    private ElideSettings elideSettings;
+    private Elide elide;
+    private DataStore dataStore;
+
+    @BeforeEach
+    public void setupMocks() {
+        dataStore = mock(DataStore.class);
+        tx = mock(DataStoreTransaction.class);
+        Map<String, Class<? extends Check>> checkMappings = new HashMap<>();
+
+        EntityDictionary dictionary = new EntityDictionary(checkMappings);
+        dictionary.bindEntity(AsyncQuery.class);
+        dictionary.bindEntity(AsyncQueryResult.class);
+
+        elideSettings = new ElideSettingsBuilder(dataStore)
+                .withEntityDictionary(dictionary)
+                .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
+                .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
+                .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"))
+                .build();
+
+        elide = new Elide(elideSettings);
+
+        when(dataStore.beginTransaction()).thenReturn(tx);
+        defaultResultStorageEngine = new DefaultResultStorageEngine("/api/v1/download", elide.getElideSettings(),
+                dataStore);
+    }
+
+    @Test
+    public void testStoreResults() throws SerialException, SQLException {
+        String responseBody = "responseBody";
+        byte[] testResponse = responseBody.getBytes();
+        AsyncQueryResult result = new AsyncQueryResult();
+
+        result = defaultResultStorageEngine.storeResults(result, responseBody, "ID");
+
+        assertEquals(new SerialBlob(testResponse), result.getAttachment());
+    }
+
+    @Test
+    public void testGenerateURLExceptionWithNullRequestURL() throws MalformedURLException {
+        String asyncQueryID = "asyncQueryID";
+        String requestURL = null;
+
+        assertThrows(IllegalStateException.class, () -> {
+            defaultResultStorageEngine.generateDownloadUrl(requestURL, asyncQueryID);
+        });
+    }
+
+    @Test
+    public void testGenerateURExceptionWithNullDownloadURI() throws MalformedURLException {
+        String asyncQueryID = "asyncQueryID";
+        String requestURL = "http://localhost:8080/";
+
+        defaultResultStorageEngine = new DefaultResultStorageEngine(null, elide.getElideSettings(),
+                dataStore);
+
+        assertThrows(IllegalStateException.class, () -> {
+            defaultResultStorageEngine.generateDownloadUrl(requestURL, asyncQueryID);
+        });
+    }
+
+    @Test
+    public void testGenerateURL() throws MalformedURLException {
+        String asyncQueryID = "asyncQueryID";
+        String requestURL = "http://localhost:8080/";
+        URL testURL = new URL(requestURL + "api/v1/download/" + asyncQueryID);
+        URL url = defaultResultStorageEngine.generateDownloadUrl(requestURL, asyncQueryID);
+
+        assertEquals(url, testURL);
+    }
+
+    @Test
+    public void testGetResultsByID() throws SerialException, SQLException {
+        String id = "id";
+        String test = "test";
+        AsyncQuery query = new AsyncQuery();
+        AsyncQueryResult result = new AsyncQueryResult();
+        query.setId(id);
+        result.setAttachment(new SerialBlob(test.getBytes()));
+        query.setResult(result);
+
+        when(tx.loadObject(any(), any(), any())).thenReturn(query);
+
+        byte[] blob = defaultResultStorageEngine.getResultsByID(id);
+
+        assertEquals(new String(blob), test);
+        verify(tx, times(1)).loadObject(any(), any(), any());
+    }
+}

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/DefaultResultStorageEngineTest.java
@@ -40,7 +40,6 @@ import javax.sql.rowset.serial.SerialException;
 public class DefaultResultStorageEngineTest {
     private DataStoreTransaction tx;
     private DefaultResultStorageEngine defaultResultStorageEngine;
-    private ElideSettings elideSettings;
     private Elide elide;
     private DataStore dataStore;
 
@@ -54,7 +53,7 @@ public class DefaultResultStorageEngineTest {
         dictionary.bindEntity(AsyncQuery.class);
         dictionary.bindEntity(AsyncQueryResult.class);
 
-        elideSettings = new ElideSettingsBuilder(dataStore)
+        ElideSettings elideSettings = new ElideSettingsBuilder(dataStore)
                 .withEntityDictionary(dictionary)
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
                 .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -211,10 +211,6 @@ public class AsyncIT extends IntegrationTest {
                 .body("data.id", equalTo("edc4a871-dff2-4054-804e-d80075cf830e"))
                 .body("data.type", equalTo("asyncQuery"))
                 .body("data.attributes.status", notNullValue())
-                .body("data.attributes.result.contentLength", nullValue())
-                .body("data.attributes.result.recordCount", nullValue())
-                .body("data.attributes.result.responseBody", nullValue())
-                .body("data.attributes.result.httpStatus", nullValue())
                 .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
         int i = 0;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -24,7 +24,6 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 
-
 import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -58,6 +57,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -88,6 +88,9 @@ public class AsyncIT extends IntegrationTest {
 
         @JsonSerialize(using = EnumFieldSerializer.class, as = String.class)
         private String status;
+
+        @JsonSerialize(using = EnumFieldSerializer.class, as = String.class)
+        private String resultType;
     }
 
     private static final Resource ENDERS_GAME = resource(
@@ -118,7 +121,7 @@ public class AsyncIT extends IntegrationTest {
     );
 
     public AsyncIT() {
-        super(AsyncIntegrationTestApplicationResourceConfig.class, JsonApiEndpoint.class.getPackage().getName());
+        super(AsyncIntegrationTestApplicationResourceConfig.class, JsonApiEndpoint.class.getPackage().getName(), "50001");
     }
 
     @Override
@@ -193,7 +196,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/book?sort=genre&fields%5Bbook%5D=title"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "0")
+                                                attr("asyncAfterSeconds", "0"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -205,9 +209,10 @@ public class AsyncIT extends IntegrationTest {
                 .body("data.type", equalTo("asyncQuery"))
                 .body("data.attributes.status", equalTo("PROCESSING"))
                 .body("data.attributes.result.contentLength", nullValue())
+                .body("data.attributes.result.recordCount", nullValue())
                 .body("data.attributes.result.responseBody", nullValue())
                 .body("data.attributes.result.httpStatus", nullValue())
-                .body("data.attributes.result.resultType", nullValue());
+                .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
         int i = 0;
         while (i < 1000) {
@@ -230,12 +235,93 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
                         .body("data.attributes.status", equalTo("COMPLETE"))
                         .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.recordCount", equalTo(3))
                         .body("data.attributes.result.responseBody", equalTo("{\"data\":"
                                 + "[{\"type\":\"book\",\"id\":\"3\",\"attributes\":{\"title\":\"For Whom the Bell Tolls\"}}"
                                 + ",{\"type\":\"book\",\"id\":\"2\",\"attributes\":{\"title\":\"Song of Ice and Fire\"}},"
                                 + "{\"type\":\"book\",\"id\":\"1\",\"attributes\":{\"title\":\"Ender's Game\"}}]}"))
                         .body("data.attributes.result.httpStatus", equalTo(200))
-                        .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
+                        .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
+
+                break;
+            } else if (!(outputResponse.equals("PROCESSING"))) {
+                fail("Async Query has failed.");
+                break;
+            }
+
+            i++;
+
+            if (i == 1000) {
+                fail("Async Query not completed.");
+            }
+        }
+    }
+
+    /**
+     * Various tests for a JSONAPI query as a Async Request with asyncAfterSeconds value set to 0.
+     * Happy Path Test Scenario 1 with resultType as DOWNLOAD
+     * @throws InterruptedException
+     */
+    @Test
+    @Tag("skipInMemory") //Without an ORM, there is nothing to hydrate the excluded entity
+    public void jsonApiHappyPath1Download() throws InterruptedException {
+
+        AsyncDelayStoreTransaction.sleep = true;
+
+        //Create Async Request
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .body(
+                        data(
+                                resource(
+                                        type("asyncQuery"),
+                                        id("adc4a871-dff2-4054-804e-d80075cf830e"),
+                                        attributes(
+                                                attr("query", "/book?sort=genre&fields%5Bbook%5D=title"),
+                                                attr("queryType", "JSONAPI_V1_0"),
+                                                attr("status", "QUEUED"),
+                                                attr("asyncAfterSeconds", "0"),
+                                                attr("resultType", "DOWNLOAD")
+                                        )
+                                )
+                        ).toJSON())
+                .when()
+                .post("/asyncQuery")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_CREATED)
+                .body("data.id", equalTo("adc4a871-dff2-4054-804e-d80075cf830e"))
+                .body("data.type", equalTo("asyncQuery"))
+                .body("data.attributes.status", equalTo("PROCESSING"))
+                .body("data.attributes.result.contentLength", nullValue())
+                .body("data.attributes.result.recordCount", nullValue())
+                .body("data.attributes.result.responseBody", nullValue())
+                .body("data.attributes.result.httpStatus", nullValue());
+
+        int i = 0;
+        while (i < 1000) {
+            Thread.sleep(10);
+            Response response = given()
+                    .accept("application/vnd.api+json")
+                    .get("/asyncQuery/adc4a871-dff2-4054-804e-d80075cf830e");
+
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
+            // If Async Query is created and completed
+            if (outputResponse.equals("COMPLETE")) {
+
+                // Validate AsyncQuery Response
+                response
+                        .then()
+                        .statusCode(HttpStatus.SC_OK)
+                        .body("data.id", equalTo("adc4a871-dff2-4054-804e-d80075cf830e"))
+                        .body("data.type", equalTo("asyncQuery"))
+                        .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
+                        .body("data.attributes.status", equalTo("COMPLETE"))
+                        .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.recordCount", equalTo(3))
+                        .body("data.attributes.result.responseBody", equalTo("http://localhost:50001"
+                              + "/download/adc4a871-dff2-4054-804e-d80075cf830e"))
+                        .body("data.attributes.result.httpStatus", equalTo(200));
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
@@ -273,7 +359,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/book?sort=genre&fields%5Bbook%5D=title"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "7")
+                                                attr("asyncAfterSeconds", "7"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -285,12 +372,55 @@ public class AsyncIT extends IntegrationTest {
                 .body("data.type", equalTo("asyncQuery"))
                 .body("data.attributes.status", equalTo("COMPLETE"))
                 .body("data.attributes.result.contentLength", notNullValue())
+                .body("data.attributes.result.recordCount", equalTo(3))
                 .body("data.attributes.result.responseBody", equalTo("{\"data\":"
                         + "[{\"type\":\"book\",\"id\":\"3\",\"attributes\":{\"title\":\"For Whom the Bell Tolls\"}}"
                         + ",{\"type\":\"book\",\"id\":\"2\",\"attributes\":{\"title\":\"Song of Ice and Fire\"}},"
                         + "{\"type\":\"book\",\"id\":\"1\",\"attributes\":{\"title\":\"Ender's Game\"}}]}"))
                 .body("data.attributes.result.httpStatus", equalTo(200))
-                .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
+                .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
+
+    }
+    /**
+     * Various tests for a JSONAPI query as a Async Request with asyncAfterSeconds value set to 7.
+     * Happy Path Test Scenario 2 with resultType as DOWNLOAD
+     * @throws InterruptedException
+     */
+    @Test
+    @Tag("skipInMemory") //Without an ORM, there is nothing to hydrate the excluded entity
+    public void jsonApiHappyPath2Download() throws InterruptedException {
+
+        AsyncDelayStoreTransaction.sleep = true;
+
+        //Create Async Request
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .body(
+                        data(
+                                resource(
+                                        type("asyncQuery"),
+                                        id("adc4a871-dff2-4054-804e-d80075cf831f"),
+                                        attributes(
+                                                attr("query", "/book?sort=genre&fields%5Bbook%5D=title"),
+                                                attr("queryType", "JSONAPI_V1_0"),
+                                                attr("status", "QUEUED"),
+                                                attr("asyncAfterSeconds", "7"),
+                                                attr("resultType", "DOWNLOAD")
+                                        )
+                                )
+                        ).toJSON())
+                .when()
+                .post("/asyncQuery")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_CREATED)
+                .body("data.id", equalTo("adc4a871-dff2-4054-804e-d80075cf831f"))
+                .body("data.type", equalTo("asyncQuery"))
+                .body("data.attributes.status", equalTo("COMPLETE"))
+                .body("data.attributes.result.contentLength", notNullValue())
+                .body("data.attributes.result.recordCount", equalTo(3))
+                .body("data.attributes.result.responseBody", equalTo("http://localhost:50001"
+                        + "/download/adc4a871-dff2-4054-804e-d80075cf831f"))
+                .body("data.attributes.result.httpStatus", equalTo(200));
 
     }
 
@@ -309,6 +439,7 @@ public class AsyncIT extends IntegrationTest {
         queryObj.setQueryType("GRAPHQL_V1_0");
         queryObj.setStatus("QUEUED");
         queryObj.setQuery("{\"query\":\"{ book { edges { node { id title } } } }\",\"variables\":null}");
+        queryObj.setResultType("EMBEDDED");
         String graphQLRequest = document(
                  mutation(
                          selection(
@@ -322,7 +453,8 @@ public class AsyncIT extends IntegrationTest {
                                                  field("id"),
                                                  field("query"),
                                                  field("queryType"),
-                                                 field("status")
+                                                 field("status"),
+                                                 field("resultType")
                                          )
                                  )
                          )
@@ -340,7 +472,7 @@ public class AsyncIT extends IntegrationTest {
 
         String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
-                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\"}}]}}}";
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\",\"resultType\":\"EMBEDDED\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
 
         int i = 0;
@@ -351,7 +483,7 @@ public class AsyncIT extends IntegrationTest {
                     .accept(MediaType.APPLICATION_JSON)
                     .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4054-804e-d80075cf828e\\\"]) "
                             + "{ edges { node { id queryType status result "
-                            + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                            + "{ responseBody httpStatus contentLength } } } } }\","
                             + "\"variables\":null}")
                     .post("/graphQL")
                     .asString();
@@ -362,7 +494,7 @@ public class AsyncIT extends IntegrationTest {
                         + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","
-                        + "\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":177}}}]}}}";
+                        + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
@@ -377,6 +509,92 @@ public class AsyncIT extends IntegrationTest {
             }
         }
     }
+
+    /**
+     * Test for a GraphQL query as a Async Request with asyncAfterSeconds value set to 0.
+     * Happy Path Test Scenario 1 when resultType is DOWNLOAD
+     * @throws InterruptedException
+     */
+    @Test
+    @Tag("skipInMemory") //Without an ORM, there is nothing to hydrate the excluded entity
+    public void graphQLHappyPath1Download() throws InterruptedException {
+
+        AsyncDelayStoreTransaction.sleep = true;
+        AsyncQuery queryObj = new AsyncQuery();
+        queryObj.setId("adc4a871-dff2-4054-804e-d80075cf828e");
+        queryObj.setAsyncAfterSeconds(0);
+        queryObj.setQueryType("GRAPHQL_V1_0");
+        queryObj.setStatus("QUEUED");
+        queryObj.setQuery("{\"query\":\"{ book { edges { node { id title } } } }\",\"variables\":null}");
+        queryObj.setResultType("DOWNLOAD");
+        String graphQLRequest = document(
+                mutation(
+                        selection(
+                                field(
+                                        "asyncQuery",
+                                        arguments(
+                                                argument("op", "UPSERT"),
+                                                argument("data", queryObj, UNQUOTED_VALUE)
+                                        ),
+                                        selections(
+                                                field("id"),
+                                                field("query"),
+                                                field("queryType"),
+                                                field("status"),
+                                                field("resultType")
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
+        ValidatableResponse response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(graphQLJsonNode)
+                .post("/graphQL")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK);
+
+        String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"adc4a871-dff2-4054-804e-d80075cf828e\","
+                + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\",\"resultType\":\"DOWNLOAD\"}}]}}}";
+        assertEquals(expectedResponse, response.extract().body().asString());
+
+        int i = 0;
+        while (i < 1000) {
+            Thread.sleep(10);
+            String responseGraphQL = given()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body("{\"query\":\"{ asyncQuery(ids: [\\\"adc4a871-dff2-4054-804e-d80075cf828e\\\"]) "
+                            + "{ edges { node { id queryType status result "
+                            + "{ responseBody httpStatus contentLength } } } } }\","
+                            + "\"variables\":null}")
+                    .post("/graphQL")
+                    .asString();
+            // If Async Query is created and completed
+            if (responseGraphQL.contains("\"status\":\"COMPLETE\"")) {
+
+                expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"adc4a871-dff2-4054-804e-d80075cf828e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
+                        + "\"result\":{\"responseBody\":\"http://localhost:50001/download/adc4a871-dff2-4054-804e-d80075cf828e\","
+                        + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
+
+                assertEquals(expectedResponse, responseGraphQL);
+                break;
+            } else if (!(responseGraphQL.contains("\"status\":\"PROCESSING\""))) {
+                fail("Async Query has failed.");
+                break;
+            }
+            i++;
+
+            if (i == 1000) {
+                fail("Async Query not completed.");
+            }
+        }
+    }
+
     /**
      * Test for a GraphQL query as a Async Request with asyncAfterSeconds value set to 7.
      * Happy Path Test Scenario 2
@@ -392,6 +610,7 @@ public class AsyncIT extends IntegrationTest {
         queryObj.setQueryType("GRAPHQL_V1_0");
         queryObj.setStatus("QUEUED");
         queryObj.setQuery("{\"query\":\"{ book { edges { node { id title } } } }\",\"variables\":null}");
+        queryObj.setResultType("EMBEDDED");
         String graphQLRequest = document(
                  mutation(
                          selection(
@@ -405,7 +624,8 @@ public class AsyncIT extends IntegrationTest {
                                                  field("id"),
                                                  field("query"),
                                                  field("queryType"),
-                                                 field("status")
+                                                 field("status"),
+                                                 field("resultType")
                                          )
                                  )
                          )
@@ -423,7 +643,7 @@ public class AsyncIT extends IntegrationTest {
 
         String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
-                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\"}}]}}}";
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"EMBEDDED\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
 
         String responseGraphQL = given()
@@ -431,7 +651,7 @@ public class AsyncIT extends IntegrationTest {
                  .accept(MediaType.APPLICATION_JSON)
                  .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4054-804e-d80075cf829e\\\"]) "
                          + "{ edges { node { id queryType status result "
-                         + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                         + "{ responseBody httpStatus contentLength } } } } }\","
                          + "\"variables\":null}")
                  .post("/graphQL")
                  .asString();
@@ -440,7 +660,76 @@ public class AsyncIT extends IntegrationTest {
                  + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","
-                 + "\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":177}}}]}}}";
+                 + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
+
+        assertEquals(expectedResponse, responseGraphQL);
+    }
+
+    /**
+     * Test for a GraphQL query as a Async Request with asyncAfterSeconds value set to 7.
+     * Happy Path Test Scenario 2 with resultType as DOWNLOAD
+     * @throws InterruptedException
+     */
+    @Test
+    @Tag("skipInMemory") //Without an ORM, there is nothing to hydrate the excluded entity
+    public void graphQLHappyPath2Download() throws InterruptedException {
+
+        AsyncDelayStoreTransaction.sleep = true;
+        AsyncQuery queryObj = new AsyncQuery();
+        queryObj.setId("adc4a871-dff2-4054-804e-d80075cf829e");
+        queryObj.setAsyncAfterSeconds(7);
+        queryObj.setQueryType("GRAPHQL_V1_0");
+        queryObj.setStatus("QUEUED");
+        queryObj.setQuery("{\"query\":\"{ book { edges { node { id title } } } }\",\"variables\":null}");
+        queryObj.setResultType("DOWNLOAD");
+        String graphQLRequest = document(
+                mutation(
+                        selection(
+                                field(
+                                        "asyncQuery",
+                                        arguments(
+                                                argument("op", "UPSERT"),
+                                                argument("data", queryObj, UNQUOTED_VALUE)
+                                        ),
+                                        selections(
+                                                field("id"),
+                                                field("query"),
+                                                field("queryType"),
+                                                field("status"),
+                                                field("resultType")
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
+        ValidatableResponse response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(graphQLJsonNode)
+                .post("/graphQL")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK);
+
+        String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"adc4a871-dff2-4054-804e-d80075cf829e\","
+                + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"DOWNLOAD\"}}]}}}";
+        assertEquals(expectedResponse, response.extract().body().asString());
+
+        String responseGraphQL = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{\"query\":\"{ asyncQuery(ids: [\\\"adc4a871-dff2-4054-804e-d80075cf829e\\\"]) "
+                        + "{ edges { node { id queryType status result "
+                        + "{ responseBody httpStatus contentLength } } } } }\","
+                        + "\"variables\":null}")
+                .post("/graphQL")
+                .asString();
+
+        expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"adc4a871-dff2-4054-804e-d80075cf829e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
+                + "\"result\":{\"responseBody\":\"http://localhost:50001/download/adc4a871-dff2-4054-804e-d80075cf829e\","
+                + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
 
         assertEquals(expectedResponse, responseGraphQL);
     }
@@ -450,6 +739,7 @@ public class AsyncIT extends IntegrationTest {
      */
     @Test
     public void graphQLTestCreateFailOnQueryStatus() {
+
 
         AsyncDelayStoreTransaction.sleep = true;
         AsyncQuery queryObj = new AsyncQuery();
@@ -507,7 +797,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/group?sort=genre&fields%5Bgroup%5D=title"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "10")
+                                                attr("asyncAfterSeconds", "10"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -536,6 +827,7 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
                         .body("data.attributes.status", equalTo("COMPLETE"))
                         .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.recordCount", nullValue())
                         .body("data.attributes.result.responseBody", equalTo("{\"errors\":[{\"detail\":\"Unknown collection group\"}]}"))
                         .body("data.attributes.result.httpStatus", equalTo(404));
 
@@ -582,7 +874,7 @@ public class AsyncIT extends IntegrationTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263a\\\"]) "
                         + "{ edges { node { id createdOn updatedOn queryType status result "
-                        + "{ responseBody httpStatus resultType contentLength } } } } }\""
+                        + "{ responseBody httpStatus contentLength } } } } }\""
                         + ",\"variables\":null}")
                 .post("/graphQL")
                 .then()
@@ -611,7 +903,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/noread"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "10")
+                                                attr("asyncAfterSeconds", "10"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -640,9 +933,9 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
                         .body("data.attributes.status", equalTo("COMPLETE"))
                         .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.recordCount", equalTo(0))
                         .body("data.attributes.result.responseBody", equalTo("{\"data\":[]}"))
-                        .body("data.attributes.result.httpStatus", equalTo(200))
-                        .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
+                        .body("data.attributes.result.httpStatus", equalTo(200));
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
@@ -673,6 +966,7 @@ public class AsyncIT extends IntegrationTest {
         queryObj.setQuery(query);
         queryObj.setQueryType(QueryType.JSONAPI_V1_0);
         queryObj.setPrincipalName("owner-user");
+        queryObj.setResultType(ResultType.EMBEDDED);
 
         dataStore.populateEntityDictionary(
                         new EntityDictionary(AsyncIntegrationTestApplicationResourceConfig.MAPPINGS));

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -210,7 +210,7 @@ public class AsyncIT extends IntegrationTest {
                 .statusCode(org.apache.http.HttpStatus.SC_CREATED)
                 .body("data.id", equalTo("edc4a871-dff2-4054-804e-d80075cf830e"))
                 .body("data.type", equalTo("asyncQuery"))
-                .body("data.attributes.status", equalTo("PROCESSING"))
+                .body("data.attributes.status", notNullValue())
                 .body("data.attributes.result.contentLength", nullValue())
                 .body("data.attributes.result.recordCount", nullValue())
                 .body("data.attributes.result.responseBody", nullValue())

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -290,11 +290,8 @@ public class AsyncIT extends IntegrationTest {
                 .statusCode(org.apache.http.HttpStatus.SC_CREATED)
                 .body("data.id", equalTo("adc4a871-dff2-4054-804e-d80075cf830e"))
                 .body("data.type", equalTo("asyncQuery"))
-                .body("data.attributes.status", equalTo("PROCESSING"))
-                .body("data.attributes.result.contentLength", nullValue())
-                .body("data.attributes.result.recordCount", nullValue())
-                .body("data.attributes.result.responseBody", nullValue())
-                .body("data.attributes.result.httpStatus", nullValue());
+                .body("data.attributes.status", notNullValue())
+                .body("data.attributes.resultType", equalTo("DOWNLOAD"));
 
         int i = 0;
         while (i < 1000) {
@@ -499,7 +496,6 @@ public class AsyncIT extends IntegrationTest {
                                                  field("id"),
                                                  field("query"),
                                                  field("queryType"),
-                                                 field("status"),
                                                  field("resultType")
                                          )
                                  )
@@ -518,7 +514,7 @@ public class AsyncIT extends IntegrationTest {
 
         String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
-                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\",\"resultType\":\"EMBEDDED\"}}]}}}";
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"resultType\":\"EMBEDDED\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
 
         int i = 0;
@@ -586,7 +582,6 @@ public class AsyncIT extends IntegrationTest {
                                                 field("id"),
                                                 field("query"),
                                                 field("queryType"),
-                                                field("status"),
                                                 field("resultType")
                                         )
                                 )
@@ -605,7 +600,7 @@ public class AsyncIT extends IntegrationTest {
 
         String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"adc4a871-dff2-4054-804e-d80075cf828e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
-                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\",\"resultType\":\"DOWNLOAD\"}}]}}}";
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"resultType\":\"DOWNLOAD\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
 
         int i = 0;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -430,7 +430,7 @@ public class AsyncIT extends IntegrationTest {
 
     /**
      * Various tests for a JSONAPI query as a Async Request with asyncAfterSeconds value set to 7.
-     * Happy Path Test Scenario 3, CSV Type
+     * Happy Path Test Scenario 3, CSV Type.
      * @throws InterruptedException
      */
     @Test
@@ -445,7 +445,7 @@ public class AsyncIT extends IntegrationTest {
                         data(
                                 resource(
                                         type("asyncQuery"),
-                                        id("edc4a871-dff2-4054-804e-d80075cf831f"),
+                                        id("edc4a871-dff2-4055-804e-d80075cf831f"),
                                         attributes(
                                                 attr("query", "/book?sort=genre&fields%5Bbook%5D=title"),
                                                 attr("queryType", "JSONAPI_V1_0"),
@@ -460,15 +460,15 @@ public class AsyncIT extends IntegrationTest {
                 .post("/asyncQuery")
                 .then()
                 .statusCode(org.apache.http.HttpStatus.SC_CREATED)
-                .body("data.id", equalTo("edc4a871-dff2-4054-804e-d80075cf831f"))
+                .body("data.id", equalTo("edc4a871-dff2-4055-804e-d80075cf831f"))
                 .body("data.type", equalTo("asyncQuery"))
                 .body("data.attributes.status", equalTo("COMPLETE"))
                 .body("data.attributes.result.contentLength", notNullValue())
                 .body("data.attributes.result.recordCount", equalTo(3))
-                .body("data.attributes.result.responseBody", equalTo("data_type, data_id, data_attributes_title\n" +
-                        "\"book\", \"3\", \"For Whom the Bell Tolls\"\n" +
-                        "\"book\", \"2\", \"Song of Ice and Fire\"\n" +
-                        "\"book\", \"1\", \"Ender's Game\"\n"))
+                .body("data.attributes.result.responseBody", equalTo("data_type, data_id, data_attributes_title\n"
+                        + "\"book\", \"3\", \"For Whom the Bell Tolls\"\n"
+                        + "\"book\", \"2\", \"Song of Ice and Fire\"\n"
+                        + "\"book\", \"1\", \"Ender's Game\"\n"))
                 .body("data.attributes.result.httpStatus", equalTo(200))
                 .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
@@ -786,7 +786,7 @@ public class AsyncIT extends IntegrationTest {
 
     /**
      * Test for a GraphQL query as a Async Request with asyncAfterSeconds value set to 7.
-     * Happy Path Test Scenario 3, CSV
+     * Happy Path Test Scenario 3, CSV.
      * @throws InterruptedException
      */
     @Test
@@ -794,7 +794,7 @@ public class AsyncIT extends IntegrationTest {
 
         AsyncDelayStoreTransaction.sleep = true;
         AsyncQuery queryObj = new AsyncQuery();
-        queryObj.setId("edc4a871-dff2-4054-804e-d80075cf829e");
+        queryObj.setId("edc4a871-dff2-4154-804e-d80076cf829e");
         queryObj.setAsyncAfterSeconds(7);
         queryObj.setQueryType("GRAPHQL_V1_0");
         queryObj.setStatus("QUEUED");
@@ -831,7 +831,7 @@ public class AsyncIT extends IntegrationTest {
                 .then()
                 .statusCode(org.apache.http.HttpStatus.SC_OK);
 
-        String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\","
+        String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4154-804e-d80076cf829e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
                 + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"EMBEDDED\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
@@ -839,25 +839,25 @@ public class AsyncIT extends IntegrationTest {
         String responseGraphQL = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
-                .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4054-804e-d80075cf829e\\\"]) "
+                .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4154-804e-d80076cf829e\\\"]) "
                         + "{ edges { node { id queryType status result "
                         + "{ responseBody httpStatus contentLength } } } } }\","
                         + "\"variables\":null}")
                 .post("/graphQL")
                 .asString();
 
-        expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
-                + "\"result\":{\"responseBody\":\"data_book_edges_node_id, data_book_edges_node_title\\n" +
-                "\\\"1\\\", \\\"Ender's Game\\\"\\n" +
-                "\\\"2\\\", \\\"Song of Ice and Fire\\\"\\n" +
-                "\\\"3\\\", \\\"For Whom the Bell Tolls\\\"\\n\","
+        expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4154-804e-d80076cf829e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
+                + "\"result\":{\"responseBody\":\"data_book_edges_node_id, data_book_edges_node_title\\n"
+                + "\\\"1\\\", \\\"Ender's Game\\\"\\n"
+                + "\\\"2\\\", \\\"Song of Ice and Fire\\\"\\n"
+                + "\\\"3\\\", \\\"For Whom the Bell Tolls\\\"\\n\","
                 + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
 
         assertEquals(expectedResponse, responseGraphQL);
     }
 
     /**
-     * Test for QueryStatus Set to PROCESSING instead of Queued
+     * Test for QueryStatus Set to PROCESSING instead of Queued.
      */
     @Test
     public void graphQLTestCreateFailOnQueryStatus() {
@@ -1073,8 +1073,8 @@ public class AsyncIT extends IntegrationTest {
     }
 
     /**
-     * Tests Read Permissions on Async Model for Admin Role
-     * @throws InterruptedException
+     * Tests Read Permissions on Async Model for Admin Role.
+     * @throws IOException IOException
      */
     @Test
     public void asyncModelAdminReadPermissions() throws IOException {
@@ -1155,7 +1155,7 @@ public class AsyncIT extends IntegrationTest {
     }
 
     /**
-     * Reset sleep delay flag after each test
+     * Reset sleep delay flag after each test.
      */
     @AfterEach
     public void sleepDelayReset() {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/IntegrationTest.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/IntegrationTest.java
@@ -65,6 +65,10 @@ public abstract class IntegrationTest {
     }
 
     protected IntegrationTest(final Class<? extends ResourceConfig> resourceConfig, String packageName) {
+        this(resourceConfig, packageName, null);
+    }
+
+    protected IntegrationTest(final Class<? extends ResourceConfig> resourceConfig, String packageName, String port) {
         this.resourceConfig = resourceConfig.getCanonicalName();
         this.packageName = packageName;
 
@@ -74,7 +78,7 @@ public abstract class IntegrationTest {
         this.dataStore = dataStoreHarness.getDataStore();
 
         try {
-            this.server = setUpServer();
+            this.server = setUpServer(port);
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
@@ -109,14 +113,15 @@ public abstract class IntegrationTest {
         dataStoreHarness.cleanseTestData();
     }
 
-    protected final Server setUpServer() throws Exception {
+    protected final Server setUpServer(String port) throws Exception {
         // setup RestAssured
         RestAssured.baseURI = "http://localhost/";
         RestAssured.basePath = "/";
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
         // port randomly picked in pom.xml
-        String restassuredPort = System.getProperty("restassured.port", System.getenv("restassured.port"));
+        String restassuredPort = StringUtils.isNotEmpty(port) ? port
+                : System.getProperty("restassured.port", System.getenv("restassured.port"));
         RestAssured.port =
                 Integer.parseInt(StringUtils.isNotEmpty(restassuredPort) ? restassuredPort : "9999");
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncDownloadProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncDownloadProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import lombok.Data;
+
+/**
+ * Extra properties for setting up async query download support.
+ */
+@Data
+public class AsyncDownloadProperties {
+
+    /**
+     * The URL path prefix for the controller.
+     */
+    private String path = "/download";
+
+    /**
+     * Whether or not to use the default implementation of ResultStorageEngine.
+     * If false, the user will provide custom implementation of ResultStorageEngine.
+     */
+    private boolean defaultResultStorageEngine = true;
+
+    /**
+     * Whether or not the controller is enabled.
+     */
+    private boolean enabled = false;
+
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
@@ -11,7 +11,7 @@ import lombok.Data;
  * Extra properties for setting up async query support.
  */
 @Data
-public class AsyncProperties extends ControllerProperties {
+public class AsyncProperties {
 
     /**
      * Default thread pool size.
@@ -49,5 +49,15 @@ public class AsyncProperties extends ControllerProperties {
      * If false, the user will provide custom implementation of AsyncQueryDAO.
      */
     private boolean defaultAsyncQueryDAO = true;
+
+    /**
+     * Whether or not the controller is enabled.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Settings for the Download controller.
+     */
+    private AsyncDownloadProperties download;
 
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
@@ -108,15 +108,12 @@ public class ElideAsyncConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnProperty(prefix = "elide.async.download", name = "defaultResultStorageEngine", matchIfMissing = true)
     public ResultStorageEngine buildResultStorageEngine(Elide elide, ElideConfigProperties settings) {
-        // Creating a new ElideSettings and Elide object for Async services
-        // which will have ISO8601 Dates. Used for DefaultResultStorageEngine.
-        if (!settings.getAsync().getDownload().isEnabled()) {
-            return null;
-        } else {
-            String downloadURI = settings.getAsync().getDownload().isEnabled()
-                    ? settings.getAsync().getDownload().getPath() : null;
-            return new DefaultResultStorageEngine(downloadURI, elide.getElideSettings(),
+        DefaultResultStorageEngine resultStorageEngine = null;
+        if (settings.getAsync().getDownload().isEnabled()) {
+            String downloadURI = settings.getAsync().getDownload().getPath();
+            resultStorageEngine = new DefaultResultStorageEngine(downloadURI, elide.getElideSettings(),
                     elide.getDataStore());
         }
+        return resultStorageEngine;
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -234,7 +234,7 @@ public class ElideAutoConfiguration {
     }
 
     /**
-     * Creates a querylogger to be used by {@link #buildDataStore} for aggregation
+     * Creates a querylogger to be used by {@link #buildDataStore} for aggregation.
      * @return The default Noop QueryLogger.
      */
     @Bean

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.spring.controllers;
+
+import com.yahoo.elide.async.service.ResultStorageEngine;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@Configuration
+@RestController
+@RequestMapping(value = "${elide.async.download.path:download}")
+@ConditionalOnExpression("${elide.async.download.enabled:false}")
+public class DownloadController {
+
+    private ResultStorageEngine resultStorageEngine;
+
+    @Autowired
+    public DownloadController(ResultStorageEngine resultStorageEngine) {
+        log.debug("Started ~~");
+        this.resultStorageEngine = resultStorageEngine;
+    }
+
+    @GetMapping(path = "/{asyncQueryId}")
+    public void download(@PathVariable String asyncQueryId, HttpServletResponse response)
+            throws SQLException, IOException {
+
+        ///************* Getresults from ResultStorageEngine
+        byte[] temp = resultStorageEngine.getResultsByID(asyncQueryId);
+        //Blob blob = new SerialBlob(temp);
+        //String reconstructedStr = new String(blob.getBytes((long) 1, (int) blob.length()));
+        PrintWriter writer = response.getWriter();
+        String reconstructedStr = "";
+        if (temp == null) {
+            response.sendError(HttpServletResponse.SC_NO_CONTENT);
+        } else {
+            reconstructedStr = new String(temp);
+            response.setContentType("application/octet-stream");
+            response.setHeader("Content-Disposition", "attachment; filename=" + asyncQueryId);
+        }
+        writer.write(reconstructedStr);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
@@ -23,6 +23,7 @@ import java.io.PrintWriter;
 import java.sql.SQLException;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
 
 @Slf4j
 @Configuration
@@ -48,10 +49,11 @@ public class DownloadController {
         PrintWriter writer = response.getWriter();
         String reconstructedStr = "";
         if (temp == null) {
-            response.sendError(HttpServletResponse.SC_NO_CONTENT);
+            response.setContentType(MediaType.APPLICATION_JSON);
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, "Result not found");
         } else {
             reconstructedStr = new String(temp);
-            response.setContentType("application/octet-stream");
+            response.setContentType(MediaType.APPLICATION_OCTET_STREAM);
             response.setHeader("Content-Disposition", "attachment; filename=" + asyncQueryId);
         }
         writer.write(reconstructedStr);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/DownloadController.java
@@ -45,8 +45,6 @@ public class DownloadController {
 
         ///************* Getresults from ResultStorageEngine
         byte[] temp = resultStorageEngine.getResultsByID(asyncQueryId);
-        //Blob blob = new SerialBlob(temp);
-        //String reconstructedStr = new String(blob.getBytes((long) 1, (int) blob.length()));
         PrintWriter writer = response.getWriter();
         String reconstructedStr = "";
         if (temp == null) {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -4,4 +4,5 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
  com.yahoo.elide.spring.config.ElideDynamicConfiguration, \
  com.yahoo.elide.spring.controllers.JsonApiController, \
  com.yahoo.elide.spring.controllers.GraphqlController, \
- com.yahoo.elide.spring.controllers.SwaggerController
+ com.yahoo.elide.spring.controllers.SwaggerController, \
+ com.yahoo.elide.spring.controllers.DownloadController

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -55,7 +55,8 @@ public class AsyncTest extends IntegrationTest {
                                                 attr("query", "/group"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "10")
+                                                attr("asyncAfterSeconds", "10"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -95,13 +96,13 @@ public class AsyncTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\\\"]) "
-                                + "{ edges { node { id queryType status result "
-                                + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                                + "{ edges { node { id queryType status resultType result "
+                                + "{ responseBody httpStatus contentLength } } } } }\","
                                 + "\"variables\":null }")
                         .post("/graphql")
                         .asString();
 
-                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"group\\\",\\\"id\\\":\\\"com.example.repository\\\",\\\"attributes\\\":{\\\"commonName\\\":\\\"Example Repository\\\",\\\"deprecated\\\":false,\\\"description\\\":\\\"The code for this project\\\"},\\\"relationships\\\":{\\\"products\\\":{\\\"data\\\":[]}}}]}\",\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":208}}}]}}}";
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"EMBEDDED\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"group\\\",\\\"id\\\":\\\"com.example.repository\\\",\\\"attributes\\\":{\\\"commonName\\\":\\\"Example Repository\\\",\\\"deprecated\\\":false,\\\"description\\\":\\\"The code for this project\\\"},\\\"relationships\\\":{\\\"products\\\":{\\\"data\\\":[]}}}]}\",\"httpStatus\":200,\"contentLength\":208}}}]}}}";
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -14,6 +14,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 
 import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.yahoo.elide.core.HttpStatus;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
@@ -111,5 +111,80 @@ public class AsyncTest extends IntegrationTest {
                 break;
             }
         }
+    }
+
+    @Test
+    public void testAsyncDownload() throws InterruptedException {
+        //Create Async Request
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .body(
+                        data(
+                                resource(
+                                        type("asyncQuery"),
+                                        id("ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"),
+                                        attributes(
+                                                attr("query", "/group"),
+                                                attr("queryType", "JSONAPI_V1_0"),
+                                                attr("status", "QUEUED"),
+                                                attr("asyncAfterSeconds", "10"),
+                                                attr("resultType", "DOWNLOAD")
+                                        )
+                                )
+                        ).toJSON())
+                .when()
+                .post("/json/asyncQuery")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_CREATED);
+
+        int i = 0;
+        while (i < 1000) {
+            Thread.sleep(10);
+            Response response = given()
+                    .accept("application/vnd.api+json")
+                    .get("/json/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d");
+
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
+             //If Async Query is created and completed then validate results
+            if (outputResponse.equals("COMPLETE")) {
+
+                // Validate AsyncQuery Response
+                response
+                        .then()
+                        .statusCode(HttpStatus.SC_OK)
+                        .body("data.id", equalTo("ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"))
+                        .body("data.type", equalTo("asyncQuery"))
+                        .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
+                        .body("data.attributes.status", equalTo("COMPLETE"))
+                        .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.responseBody",
+                                equalTo("http://localhost:" + port + "/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"));
+
+                // Validate GraphQL Response
+                String responseGraphQL = given()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\\\"]) "
+                                + "{ edges { node { id queryType status resultType result "
+                                + "{ responseBody httpStatus contentLength } } } } }\","
+                                + "\"variables\":null }")
+                        .post("/graphql")
+                        .asString();
+
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"DOWNLOAD\",\"result\":{\"responseBody\":\"http://localhost:" + port + "/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"httpStatus\":200,\"contentLength\":208}}}]}}}";
+
+                assertEquals(expectedResponse, responseGraphQL);
+                break;
+            } else if (!(outputResponse.equals("PROCESSING"))) {
+                fail("Async Query has failed.");
+                break;
+            }
+        }
+
+        when()
+                .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d")
+                .then()
+               .statusCode(HttpStatus.SC_OK);
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -410,6 +410,14 @@ public class ControllerTest extends IntegrationTest {
     }
 
     @Test
+    public void downloadControllerTest() {
+        when()
+                .get("/download/asyncQueryId")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
     public void versionedSwaggerDocumentTest() {
         given()
                 .header("ApiVersion", "1.0")

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -414,7 +414,7 @@ public class ControllerTest extends IntegrationTest {
         when()
                 .get("/download/asyncQueryId")
                 .then()
-                .statusCode(HttpStatus.SC_NO_CONTENT);
+                .statusCode(HttpStatus.SC_NOT_FOUND);
     }
 
     @Test

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application-disableAggStore.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application-disableAggStore.yaml
@@ -19,6 +19,10 @@ elide:
     cleanupEnabled: true
     queryCleanupDays: 7
     defaultAsyncQueryDAO: true
+    download:
+      path: /download
+      enabled: true
+      defaultResultStorageEngine: true
   dynamic-config:
     path: src/test/resources/models
     enabled: true

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -19,6 +19,10 @@ elide:
     cleanupEnabled: true
     queryCleanupDays: 7
     defaultAsyncQueryDAO: true
+    download:
+      path: /download
+      enabled: true
+      defaultResultStorageEngine: true
   dynamic-config:
     path: src/test/resources/models
     enabled: true

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
@@ -101,6 +101,14 @@ public class ElideStandalone {
             jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
         }
 
+        if (elideStandaloneSettings.enableAsyncDownload()) {
+            ServletHolder jerseyServlet = context.addServlet(ServletContainer.class,
+                    elideStandaloneSettings.getDownloadApiPathSpec());
+            jerseyServlet.setInitOrder(0);
+            jerseyServlet.setInitParameter("jersey.config.server.provider.packages", "com.yahoo.elide.async.resources");
+            jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
+        }
+
         if (elideStandaloneSettings.enableServiceMonitoring()) {
             FilterHolder instrumentedFilterHolder = new FilterHolder(InstrumentedFilter.class);
             instrumentedFilterHolder.setName("instrumentedFilter");

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
@@ -101,9 +101,9 @@ public class ElideStandalone {
             jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());
         }
 
-        if (elideStandaloneSettings.enableAsyncDownload()) {
+        if (elideStandaloneSettings.getAsyncProperties().getDownload().isEnabled()) {
             ServletHolder jerseyServlet = context.addServlet(ServletContainer.class,
-                    elideStandaloneSettings.getDownloadApiPathSpec());
+                    elideStandaloneSettings.getAsyncProperties().getDownload().getPathSpec());
             jerseyServlet.setInitOrder(0);
             jerseyServlet.setInitParameter("jersey.config.server.provider.packages", "com.yahoo.elide.async.resources");
             jerseyServlet.setInitParameter("javax.ws.rs.Application", ElideResourceConfig.class.getCanonicalName());

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncDownloadProperties.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncDownloadProperties.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.standalone.config;
 
+import com.yahoo.elide.async.service.ResultStorageEngine;
+
 import lombok.Data;
 
 /**
@@ -14,15 +16,14 @@ import lombok.Data;
 public class AsyncDownloadProperties {
 
     /**
-     * The URL path prefix for the controller.
+     * API root path specification for the download endpoint.
      */
-    private String path = "/download";
+    private String pathSpec = "/download/*";
 
     /**
-     * Whether or not to use the default implementation of ResultStorageEngine.
-     * If false, the user will provide custom implementation of ResultStorageEngine.
+     * Which implementation of ResultStorageEngine to use.
      */
-    private boolean defaultResultStorageEngine = true;
+    private ResultStorageEngine resultStorageEngine = null;
 
     /**
      * Whether or not the controller is enabled.

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncDownloadProperties.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncDownloadProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.standalone.config;
+
+import lombok.Data;
+
+/**
+ * Extra properties for setting up async query download support.
+ */
+@Data
+public class AsyncDownloadProperties {
+
+    /**
+     * The URL path prefix for the controller.
+     */
+    private String path = "/download";
+
+    /**
+     * Whether or not to use the default implementation of ResultStorageEngine.
+     * If false, the user will provide custom implementation of ResultStorageEngine.
+     */
+    private boolean defaultResultStorageEngine = true;
+
+    /**
+     * Whether or not the controller is enabled.
+     */
+    private boolean enabled = false;
+
+}

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncProperties.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncProperties.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.standalone.config;
 
+import com.yahoo.elide.async.service.AsyncQueryDAO;
+
 import lombok.Data;
 
 /**
@@ -21,7 +23,7 @@ public class AsyncProperties {
     /**
      * Default max query run time.
      */
-    private int maxRunTimeMinutes = 60;
+    private int maxRunTimeSeconds = 3600;
 
     /**
      * Whether or not the cleanup is enabled.
@@ -34,19 +36,24 @@ public class AsyncProperties {
     private int queryCleanupDays = 7;
 
     /**
-     * Whether or not to use the default implementation of AsyncQueryDAO.
-     * If false, the user will provide custom implementation of AsyncQueryDAO.
+     * Which implementation of AsyncQueryDAO to use.
      */
-    private boolean defaultAsyncQueryDAO = true;
+    private AsyncQueryDAO asyncQueryDAO = null;
 
     /**
-     * Whether or not the controller is enabled.
+     * Default time interval for cancelling async query transactions
+     * that are in cancelled status or running beyond max runtime.
+     */
+    private int queryCancellationIntervalSeconds = 300;
+
+    /**
+     * Whether or not the async is enabled.
      */
     private boolean enabled = false;
 
     /**
-     * Settings for the Download controller.
+     * Settings for the Download API.
      */
-    private AsyncDownloadProperties download;
+    private AsyncDownloadProperties download = new AsyncDownloadProperties();
 
 }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncProperties.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/AsyncProperties.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.standalone.config;
+
+import lombok.Data;
+
+/**
+ * Extra properties for setting up async query support.
+ */
+@Data
+public class AsyncProperties {
+
+    /**
+     * Default thread pool size.
+     */
+    private int threadPoolSize = 5;
+
+    /**
+     * Default max query run time.
+     */
+    private int maxRunTimeMinutes = 60;
+
+    /**
+     * Whether or not the cleanup is enabled.
+     */
+    private boolean cleanupEnabled = false;
+
+    /**
+     * Default retention of async query and results.
+     */
+    private int queryCleanupDays = 7;
+
+    /**
+     * Whether or not to use the default implementation of AsyncQueryDAO.
+     * If false, the user will provide custom implementation of AsyncQueryDAO.
+     */
+    private boolean defaultAsyncQueryDAO = true;
+
+    /**
+     * Whether or not the controller is enabled.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Settings for the Download controller.
+     */
+    private AsyncDownloadProperties download;
+
+}

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -145,7 +145,7 @@ public class ElideResourceConfig extends ResourceConfig {
                     bind(resultStorageEngine).to(ResultStorageEngine.class).named("resultStorageEngine");
 
                     AsyncExecutorService.init(elide, settings.getAsyncThreadSize(),
-                            settings.getAsyncMaxRunTimeSeconds(), asyncQueryDao), resultStorageEngine);
+                            settings.getAsyncMaxRunTimeSeconds(), asyncQueryDao, resultStorageEngine);
                     bind(AsyncExecutorService.getInstance()).to(AsyncExecutorService.class);
 
                     // Binding AsyncQuery LifeCycleHook

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -138,10 +138,11 @@ public class ElideResourceConfig extends ResourceConfig {
 
                     ResultStorageEngine resultStorageEngine = settings.getResultStorageEngine();
                     if (resultStorageEngine == null) {
-                        resultStorageEngine = new DefaultResultStorageEngine(settings.getDownloadApiPathSpec(),
+                        resultStorageEngine = new DefaultResultStorageEngine(
+                                settings.getDownloadApiPathSpec().replaceAll("/\\*", ""),
                                 elide.getElideSettings(), elide.getDataStore());
                     }
-                    bind(resultStorageEngine).to(ResultStorageEngine.class);
+                    bind(resultStorageEngine).to(ResultStorageEngine.class).named("resultStorageEngine");
 
                     AsyncExecutorService.init(elide, settings.getAsyncThreadSize(),
                             settings.getAsyncMaxRunTimeSeconds(), asyncQueryDao), resultStorageEngine);

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -159,10 +159,10 @@ public interface ElideStandaloneSettings {
     /**
      * API root path specification for Async Results Download.
      *
-     * @return Default: /api/v1/download
+     * @return Default: /download/*
      */
     default String getDownloadApiPathSpec() {
-        return "/api/v1/download";
+        return "/download/*";
     }
 
     /**
@@ -288,15 +288,6 @@ public interface ElideStandaloneSettings {
      */
     default ResultStorageEngine getResultStorageEngine() {
         return null;
-    }
-
-    /**
-     * Generates a default a baseURL.
-     *
-     * @return a URL in String format.
-     */
-    default String getAsyncDownloadPath() {
-        return "/download/api/v1";
     }
 
     /**

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.Injector;
 import com.yahoo.elide.annotation.SecurityCheck;
 import com.yahoo.elide.async.service.AsyncQueryDAO;
+import com.yahoo.elide.async.service.ResultStorageEngine;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.contrib.dynamicconfighelpers.compile.ElideDynamicEntityCompiler;
@@ -62,7 +63,7 @@ import javax.persistence.EntityManagerFactory;
 public interface ElideStandaloneSettings {
     /* Elide settings */
 
-     public final Consumer<EntityManager> TXCANCEL = (em) -> { em.unwrap(Session.class).cancelQuery(); };
+    public final Consumer<EntityManager> TXCANCEL = (em) -> { em.unwrap(Session.class).cancelQuery(); };
 
     /**
      * A map containing check mappings for security across Elide. If not provided, then an empty map is used.
@@ -156,6 +157,15 @@ public interface ElideStandaloneSettings {
     }
 
     /**
+     * API root path specification for Async Results Download.
+     *
+     * @return Default: /api/v1/download
+     */
+    default String getDownloadApiPathSpec() {
+        return "/api/v1/download";
+    }
+
+    /**
      * Enable the JSONAPI endpoint. If false, the endpoint will be disabled.
      *
      * @return Default: True
@@ -171,6 +181,15 @@ public interface ElideStandaloneSettings {
      */
     default boolean enableGraphQL() {
         return true;
+    }
+
+    /**
+     * Enable the Async Download endpoint. If false, the endpoint will be disabled.
+     *
+     * @return Default: false
+     */
+    default boolean enableAsyncDownload() {
+        return false;
     }
 
     /**
@@ -260,6 +279,24 @@ public interface ElideStandaloneSettings {
      */
     default AsyncQueryDAO getAsyncQueryDAO() {
         return null;
+    }
+
+    /**
+     * Implementation of ResultStorageEngine to use.
+     *
+     * @return ResultStorageEngine type object.
+     */
+    default ResultStorageEngine getResultStorageEngine() {
+        return null;
+    }
+
+    /**
+     * Generates a default a baseURL.
+     *
+     * @return a URL in String format.
+     */
+    default String getAsyncDownloadPath() {
+        return "/download/api/v1";
     }
 
     /**

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -11,8 +11,6 @@ import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.Injector;
 import com.yahoo.elide.annotation.SecurityCheck;
-import com.yahoo.elide.async.service.AsyncQueryDAO;
-import com.yahoo.elide.async.service.ResultStorageEngine;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.contrib.dynamicconfighelpers.compile.ElideDynamicEntityCompiler;
@@ -157,15 +155,6 @@ public interface ElideStandaloneSettings {
     }
 
     /**
-     * API root path specification for Async Results Download.
-     *
-     * @return Default: /download/*
-     */
-    default String getDownloadApiPathSpec() {
-        return "/download/*";
-    }
-
-    /**
      * Enable the JSONAPI endpoint. If false, the endpoint will be disabled.
      *
      * @return Default: True
@@ -181,15 +170,6 @@ public interface ElideStandaloneSettings {
      */
     default boolean enableGraphQL() {
         return true;
-    }
-
-    /**
-     * Enable the Async Download endpoint. If false, the endpoint will be disabled.
-     *
-     * @return Default: false
-     */
-    default boolean enableAsyncDownload() {
-        return false;
     }
 
     /**
@@ -219,75 +199,13 @@ public interface ElideStandaloneSettings {
     }
 
     /**
-     * Enable the support for Async querying feature. If false, the async feature will be disabled.
+     * Async Properties.
      *
-     * @return Default: False
+     * @return AsyncProperties type object.
      */
-    default boolean enableAsync() {
-        return false;
-    }
-
-    /**
-     * Enable the support for cleaning up Async query history. If false, the async cleanup feature will be disabled.
-     *
-     * @return Default: False
-     */
-    default boolean enableAsyncCleanup() {
-        return false;
-    }
-
-    /**
-     * Thread Size for Async queries to run in parallel.
-     *
-     * @return Default: 5
-     */
-    default Integer getAsyncThreadSize() {
-        return 5;
-    }
-
-    /**
-     * Maximum Query Run time for Async Queries to mark as TIMEDOUT.
-     *
-     * @return Default: 60
-     */
-    default Integer getAsyncMaxRunTimeSeconds() {
-        return 60;
-    }
-
-    /**
-     * Number of days history to retain for async query executions and results.
-     *
-     * @return Default: 7
-     */
-    default Integer getAsyncQueryCleanupDays() {
-        return 7;
-    }
-
-    /**
-     * Number of seconds  between async query cancellation checks.
-     *
-     * @return Default: 300
-     */
-    default Integer getAsyncQueryCancelCheckIntervalSeconds() {
-        return 300;
-    }
-
-    /**
-     * Implementation of AsyncQueryDAO to use.
-     *
-     * @return AsyncQueryDAO type object.
-     */
-    default AsyncQueryDAO getAsyncQueryDAO() {
-        return null;
-    }
-
-    /**
-     * Implementation of ResultStorageEngine to use.
-     *
-     * @return ResultStorageEngine type object.
-     */
-    default ResultStorageEngine getResultStorageEngine() {
-        return null;
+    default AsyncProperties getAsyncProperties() {
+        //Default Properties
+        return new AsyncProperties();
     }
 
     /**

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -16,8 +16,8 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import com.yahoo.elide.async.service.AsyncQueryDAO;
 import com.yahoo.elide.standalone.ElideStandalone;
+import com.yahoo.elide.standalone.config.AsyncProperties;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import example.models.Post;
 import org.apache.http.HttpStatus;
@@ -75,38 +75,16 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
             }
 
             @Override
-            public boolean enableAsync() {
-                return true;
-            }
-
-            @Override
-            public boolean enableAsyncDownload() {
-                return false;
-            }
-
-            @Override
-            public boolean enableAsyncCleanup() {
-                return true;
-            }
-
-            @Override
-            public Integer getAsyncThreadSize() {
-                return 3;
-            }
-
-            @Override
-            public Integer getAsyncMaxRunTimeSeconds() {
-                return 1800;
-            }
-
-            @Override
-            public Integer getAsyncQueryCleanupDays() {
-                return 3;
-            }
-
-            @Override
-            public AsyncQueryDAO getAsyncQueryDAO() {
-                return null;
+            public AsyncProperties getAsyncProperties() {
+                //Default Properties
+                AsyncProperties asyncPropeties = new AsyncProperties();
+                asyncPropeties.setEnabled(true);
+                asyncPropeties.setCleanupEnabled(true);
+                asyncPropeties.setThreadPoolSize(3);
+                asyncPropeties.setMaxRunTimeSeconds(1800);
+                asyncPropeties.setQueryCleanupDays(3);
+                asyncPropeties.getDownload().setEnabled(false);
+                return asyncPropeties;
             }
 
             @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -80,6 +80,11 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
             }
 
             @Override
+            public boolean enableAsyncDownload() {
+                return false;
+            }
+
+            @Override
             public boolean enableAsyncCleanup() {
                 return true;
             }
@@ -154,5 +159,27 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
         .then()
         .statusCode(HttpStatus.SC_CREATED)
         .extract().body().asString();
+    }
+
+    @Override
+    @Test
+    public void testDownloadEndpoint() throws Exception {
+        given()
+                .when()
+                .get("/download/test")
+                .then()
+                .statusCode(404);
+    }
+
+    @Override
+    @Test
+    public void testAsyncDownloadSuccessful() throws InterruptedException {
+        testAsyncApiEndpoint();
+
+        given()
+        .when()
+        .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9263d")
+        .then()
+        .statusCode(404);
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -8,24 +8,34 @@ package example;
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.yahoo.elide.standalone.ElideStandalone;
 import com.yahoo.elide.standalone.config.AsyncProperties;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import example.models.Post;
+
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import io.restassured.response.Response;
+
 import java.util.Properties;
+
+import javax.ws.rs.core.MediaType;
 
 /**
  * Tests ElideStandalone starts and works.
@@ -152,12 +162,80 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
     @Override
     @Test
     public void testAsyncDownloadSuccessful() throws InterruptedException {
-        testAsyncApiEndpoint();
+        //Create Async Request
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .body(
+                        data(
+                                resource(
+                                        type("asyncQuery"),
+                                        id("ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"),
+                                        attributes(
+                                                attr("query", "/post"),
+                                                attr("queryType", "JSONAPI_V1_0"),
+                                                attr("status", "QUEUED"),
+                                                attr("resultType", "DOWNLOAD")
+                                        )
+                                )
+                        ).toJSON())
+                .when()
+                .post("/api/v1/asyncQuery")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        int i = 0;
+        while (i < 1000) {
+            Thread.sleep(10);
+            Response response = given()
+                    .accept("application/vnd.api+json")
+                    .get("/api/v1/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d");
+
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
+            // If Async Query is created and completed
+            if (outputResponse.equals("COMPLETE")) {
+
+                // Validate AsyncQuery Response
+                response
+                        .then()
+                        .statusCode(com.yahoo.elide.core.HttpStatus.SC_OK)
+                        .body("data.id", equalTo("ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"))
+                        .body("data.type", equalTo("asyncQuery"))
+                        .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
+                        .body("data.attributes.status", equalTo("COMPLETE"))
+                        .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.responseBody",
+                                equalTo("http://localhost:8080/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"));
+
+                // Validate GraphQL Response
+                String responseGraphQL = given()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\\\"]) "
+                                + "{ edges { node { id queryType status resultType result "
+                                + "{ responseBody httpStatus contentLength } } } } }\","
+                                + "\"variables\":null}")
+                        .post("/graphql/api/v1/")
+                        .asString();
+
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"DOWNLOAD\",\"result\":{\"responseBody\":\"http://localhost:8080/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"httpStatus\":200,\"contentLength\":272}}}]}}}";
+                assertEquals(expectedResponse, responseGraphQL);
+                break;
+            } else if (!(outputResponse.equals("PROCESSING"))) {
+                fail("Async Query has failed.");
+                break;
+            }
+            i++;
+
+            if (i == 1000) {
+                fail("Async Query not completed.");
+            }
+        }
 
         given()
-        .when()
-        .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9263d")
-        .then()
-        .statusCode(404);
+                .when()
+                .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d")
+                .then()
+                .statusCode(404);
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
@@ -7,10 +7,10 @@ package example;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.yahoo.elide.async.service.AsyncQueryDAO;
 import com.yahoo.elide.contrib.dynamicconfighelpers.compile.ElideDynamicEntityCompiler;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.standalone.ElideStandalone;
+import com.yahoo.elide.standalone.config.AsyncProperties;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import example.models.Post;
 
@@ -69,33 +69,16 @@ public class ElideStandaloneMetadataStoreMissingTest {
             }
 
             @Override
-            public boolean enableAsync() {
-                return true;
-            }
-
-            @Override
-            public boolean enableAsyncCleanup() {
-                return true;
-            }
-
-            @Override
-            public Integer getAsyncThreadSize() {
-                return 3;
-            }
-
-            @Override
-            public Integer getAsyncMaxRunTimeSeconds() {
-                return 1800;
-            }
-
-            @Override
-            public Integer getAsyncQueryCleanupDays() {
-                return 3;
-            }
-
-            @Override
-            public AsyncQueryDAO getAsyncQueryDAO() {
-                return null;
+            public AsyncProperties getAsyncProperties() {
+                //Default Properties
+                AsyncProperties asyncPropeties = new AsyncProperties();
+                asyncPropeties.setEnabled(true);
+                asyncPropeties.setCleanupEnabled(true);
+                asyncPropeties.setThreadPoolSize(3);
+                asyncPropeties.setMaxRunTimeSeconds(1800);
+                asyncPropeties.setQueryCleanupDays(3);
+                asyncPropeties.getDownload().setEnabled(true);
+                return asyncPropeties;
             }
 
             @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -23,8 +23,8 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.yahoo.elide.async.service.AsyncQueryDAO;
 import com.yahoo.elide.standalone.ElideStandalone;
+import com.yahoo.elide.standalone.config.AsyncProperties;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import example.models.Post;
 import org.apache.http.HttpStatus;
@@ -87,38 +87,16 @@ public class ElideStandaloneTest {
             }
 
             @Override
-            public boolean enableAsync() {
-                return true;
-            }
-
-            @Override
-            public boolean enableAsyncDownload() {
-                return true;
-            }
-
-            @Override
-            public boolean enableAsyncCleanup() {
-                return true;
-            }
-
-            @Override
-            public Integer getAsyncThreadSize() {
-                return 3;
-            }
-
-            @Override
-            public Integer getAsyncMaxRunTimeSeconds() {
-                return 30;
-            }
-
-            @Override
-            public Integer getAsyncQueryCleanupDays() {
-                return 3;
-            }
-
-            @Override
-            public AsyncQueryDAO getAsyncQueryDAO() {
-                return null;
+            public AsyncProperties getAsyncProperties() {
+                //Default Properties
+                AsyncProperties asyncPropeties = new AsyncProperties();
+                asyncPropeties.setEnabled(true);
+                asyncPropeties.setCleanupEnabled(true);
+                asyncPropeties.setThreadPoolSize(3);
+                asyncPropeties.setMaxRunTimeSeconds(30);
+                asyncPropeties.setQueryCleanupDays(3);
+                asyncPropeties.getDownload().setEnabled(true);
+                return asyncPropeties;
             }
 
             @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -95,6 +95,7 @@ public class ElideStandaloneTest {
                 asyncPropeties.setThreadPoolSize(3);
                 asyncPropeties.setMaxRunTimeSeconds(30);
                 asyncPropeties.setQueryCleanupDays(3);
+              //Since AsyncExecutorService is singleton we can not disable Download in 1 test and enable in another.
                 asyncPropeties.getDownload().setEnabled(true);
                 return asyncPropeties;
             }
@@ -328,7 +329,7 @@ public class ElideStandaloneTest {
     @Test
     public void testAsyncDownloadSuccessful() throws InterruptedException {
         //Create Async Request
-        String test = given()
+        given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .body(
                         data(
@@ -345,8 +346,6 @@ public class ElideStandaloneTest {
                         ).toJSON())
                 .when()
                 .post("/api/v1/asyncQuery").asString();
-
-        assertEquals("test", test);
 
         int i = 0;
         while (i < 1000) {
@@ -378,12 +377,12 @@ public class ElideStandaloneTest {
                         .accept(MediaType.APPLICATION_JSON)
                         .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\\\"]) "
                                 + "{ edges { node { id queryType status resultType result "
-                                + "{ responseBody httpStatus contentLength } } } } }\","
+                                + "{ responseBody httpStatus } } } } }\","
                                 + "\"variables\":null}")
                         .post("/graphql/api/v1/")
                         .asString();
 
-                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"DOWNLOAD\",\"result\":{\"responseBody\":\"http://localhost:8080/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"httpStatus\":200,\"contentLength\":272}}}]}}}";
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"DOWNLOAD\",\"result\":{\"responseBody\":\"http://localhost:8080/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"httpStatus\":200}}}]}}}";
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
@@ -401,6 +400,6 @@ public class ElideStandaloneTest {
                 .when()
                 .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d")
                 .then()
-                .statusCode(200);
+                .statusCode(HttpStatus.SC_OK);
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -92,6 +92,11 @@ public class ElideStandaloneTest {
             }
 
             @Override
+            public boolean enableAsyncDownload() {
+                return true;
+            }
+
+            @Override
             public boolean enableAsyncCleanup() {
                 return true;
             }
@@ -249,6 +254,15 @@ public class ElideStandaloneTest {
     }
 
     @Test
+    public void testDownloadEndpoint() throws Exception {
+        given()
+                .when()
+                .get("/download/test")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
     public void swaggerDocumentTest() {
         when()
                .get("/swagger/doc/test")
@@ -329,5 +343,82 @@ public class ElideStandaloneTest {
                 fail("Async Query not completed.");
             }
         }
+    }
+
+    @Test
+    public void testAsyncDownloadSuccessful() throws InterruptedException {
+        //Create Async Request
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .body(
+                        data(
+                                resource(
+                                        type("asyncQuery"),
+                                        id("ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"),
+                                        attributes(
+                                                attr("query", "/post"),
+                                                attr("queryType", "JSONAPI_V1_0"),
+                                                attr("status", "QUEUED"),
+                                                attr("resultType", "DOWNLOAD")
+                                        )
+                                )
+                        ).toJSON())
+                .when()
+                .post("/api/v1/asyncQuery").asString();
+
+        int i = 0;
+        while (i < 1000) {
+            Thread.sleep(10);
+            Response response = given()
+                    .accept("application/vnd.api+json")
+                    .get("/api/v1/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d");
+
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
+            // If Async Query is created and completed
+            if (outputResponse.equals("COMPLETE")) {
+
+                // Validate AsyncQuery Response
+                response
+                        .then()
+                        .statusCode(com.yahoo.elide.core.HttpStatus.SC_OK)
+                        .body("data.id", equalTo("ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"))
+                        .body("data.type", equalTo("asyncQuery"))
+                        .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
+                        .body("data.attributes.status", equalTo("COMPLETE"))
+                        .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.responseBody",
+                                equalTo("http://localhost:8080/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"));
+
+                // Validate GraphQL Response
+                String responseGraphQL = given()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\\\"]) "
+                                + "{ edges { node { id queryType status resultType result "
+                                + "{ responseBody httpStatus contentLength } } } } }\","
+                                + "\"variables\":null}")
+                        .post("/graphql/api/v1/")
+                        .asString();
+
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"DOWNLOAD\",\"result\":{\"responseBody\":\"http://localhost:8080/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"httpStatus\":200,\"contentLength\":272}}}]}}}";
+                assertEquals(expectedResponse, responseGraphQL);
+                break;
+            } else if (!(outputResponse.equals("PROCESSING"))) {
+                fail("Async Query has failed.");
+                break;
+            }
+            i++;
+
+            if (i == 1000) {
+                fail("Async Query not completed.");
+            }
+        }
+
+        given()
+        .when()
+        .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d")
+        .then()
+        .statusCode(200);
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -272,7 +272,8 @@ public class ElideStandaloneTest {
                                         attributes(
                                                 attr("query", "/post"),
                                                 attr("queryType", "JSONAPI_V1_0"),
-                                                attr("status", "QUEUED")
+                                                attr("status", "QUEUED"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -309,13 +310,13 @@ public class ElideStandaloneTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\\\"]) "
-                                + "{ edges { node { id queryType status result "
-                                + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                                + "{ edges { node { id queryType status resultType result "
+                                + "{ responseBody httpStatus contentLength } } } } }\","
                                 + "\"variables\":null}")
                         .post("/graphql/api/v1/")
                         .asString();
 
-                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"post\\\",\\\"id\\\":\\\"2\\\",\\\"attributes\\\":{\\\"abusiveContent\\\":false,\\\"content\\\":\\\"This is my first post. woot.\\\",\\\"date\\\":\\\"2019-01-01T00:00Z\\\"}}]}\",\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":141}}}]}}}";
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"EMBEDDED\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"post\\\",\\\"id\\\":\\\"2\\\",\\\"attributes\\\":{\\\"abusiveContent\\\":false,\\\"content\\\":\\\"This is my first post. woot.\\\",\\\"date\\\":\\\"2019-01-01T00:00Z\\\"}}]}\",\"httpStatus\":200,\"contentLength\":141}}}]}}}";
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -328,7 +328,7 @@ public class ElideStandaloneTest {
     @Test
     public void testAsyncDownloadSuccessful() throws InterruptedException {
         //Create Async Request
-        given()
+        String test = given()
                 .contentType(JSONAPI_CONTENT_TYPE)
                 .body(
                         data(
@@ -344,9 +344,9 @@ public class ElideStandaloneTest {
                                 )
                         ).toJSON())
                 .when()
-                .post("/api/v1/asyncQuery")
-                .then()
-                .statusCode(HttpStatus.SC_CREATED);
+                .post("/api/v1/asyncQuery").asString();
+
+        assertEquals("test", test);
 
         int i = 0;
         while (i < 1000) {

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -270,7 +270,9 @@ public class ElideStandaloneTest {
                                 )
                         ).toJSON())
                 .when()
-                .post("/api/v1/asyncQuery").asString();
+                .post("/api/v1/asyncQuery")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
 
         int i = 0;
         while (i < 1000) {
@@ -342,7 +344,9 @@ public class ElideStandaloneTest {
                                 )
                         ).toJSON())
                 .when()
-                .post("/api/v1/asyncQuery").asString();
+                .post("/api/v1/asyncQuery")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
 
         int i = 0;
         while (i < 1000) {
@@ -394,9 +398,9 @@ public class ElideStandaloneTest {
         }
 
         given()
-        .when()
-        .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d")
-        .then()
-        .statusCode(200);
+                .when()
+                .get("/download/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d")
+                .then()
+                .statusCode(200);
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -234,11 +234,14 @@ public class ElideStandaloneTest {
 
     @Test
     public void testDownloadEndpoint() throws Exception {
-        given()
+        String responseApi = given()
                 .when()
                 .get("/download/test")
                 .then()
-                .statusCode(204);
+                .statusCode(404)
+                .extract().asString();
+
+        assertEquals("Result not found", responseApi);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <version.mysql>8.0.21</version.mysql>
         <hibernate5.version>5.4.18.Final</hibernate5.version>
         <version.mysql>8.0.20</version.mysql>
-        <hibernate5.version>5.4.15.Final</hibernate5.version>
+        <hibernate5.version>5.4.18.Final</hibernate5.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>
 
         <!-- TODO: Need to update locations to be relative to the projects using them -->


### PR DESCRIPTION
Resolves #1272

## Description
i) Update the Async Models, per the RFC-1272.
ii) Update the Async processQuery method to calculate the count of result records from the responseBody and include it in the result.
iii) Unit Test Case update/IT test update.

i) Add the ResultStorageEngine Interface.
ii) Add the default implementation of ResultStorageEngine interface with the methods in elide-async.
iii) Create the ResultStore Table.
iv) Store the results in the new ResultStore table in Process Query.
v) Unit Test Case update/IT test update.
vi) New Controllers for Spring and Standalone.

## Motivation and Context
This change allows the implementation of DefaultResultStorageEngine and helps store the results in the asyncResultStorageEngine.

## How Has This Been Tested?
Existing test cases and new test cases pass.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
