### PR TITLE
Async change to use onReadPreSecurity Hook

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.async.hooks;
 
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.QueryStatus;
 import com.yahoo.elide.async.service.AsyncExecutorService;
 import com.yahoo.elide.functions.LifeCycleHook;
 import com.yahoo.elide.security.ChangeSpec;
@@ -28,6 +29,8 @@ public class ExecuteQueryHook implements LifeCycleHook<AsyncQuery> {
     @Override
     public void execute(LifeCycleHookBinding.Operation operation, AsyncQuery query,
                         RequestScope requestScope, Optional<ChangeSpec> changes) {
-        asyncExecutorService.executeQuery(query, requestScope.getUser(), requestScope.getApiVersion());
+        if (query.getStatus() == QueryStatus.QUEUED && query.getResult() == null) {
+            asyncExecutorService.executeQuery(query, requestScope.getUser(), requestScope.getApiVersion());
+        }
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
@@ -31,7 +31,6 @@ public class ExecuteQueryHook implements LifeCycleHook<AsyncQuery> {
                         RequestScope requestScope, Optional<ChangeSpec> changes) {
         if (query.getStatus() == QueryStatus.QUEUED && query.getResult() == null) {
             asyncExecutorService.executeQuery(query, requestScope.getUser(), requestScope.getApiVersion());
-            query.prePersist();
         }
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
@@ -31,6 +31,7 @@ public class ExecuteQueryHook implements LifeCycleHook<AsyncQuery> {
                         RequestScope requestScope, Optional<ChangeSpec> changes) {
         if (query.getStatus() == QueryStatus.QUEUED && query.getResult() == null) {
             asyncExecutorService.executeQuery(query, requestScope.getUser(), requestScope.getApiVersion());
+            query.prePersist();
         }
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncBase.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncBase.java
@@ -14,7 +14,6 @@ import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.MappedSuperclass;
-//import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 
 @MappedSuperclass

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncBase.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncBase.java
@@ -28,7 +28,14 @@ public abstract class AsyncBase {
 
     @PrePersist
     public void prePersist() {
-        createdOn = updatedOn = new Date();
+
+        if (createdOn == null) {
+            createdOn = new Date();
+        }
+
+        if (updatedOn == null) {
+            updatedOn = new Date();
+        }
     }
 
     @PreUpdate

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncBase.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncBase.java
@@ -8,35 +8,24 @@ package com.yahoo.elide.async.models;
 import com.yahoo.elide.annotation.Exclude;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.Date;
 import java.util.UUID;
 
 import javax.persistence.MappedSuperclass;
-import javax.persistence.PrePersist;
+//import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 
 @MappedSuperclass
 public abstract class AsyncBase {
 
-    @Getter private Date createdOn;
+    @Getter private Date createdOn = new Date();
 
-    @Getter private Date updatedOn;
+    @Getter @Setter private Date updatedOn = new Date();
 
     @Exclude
     protected String naturalKey = UUID.randomUUID().toString();
-
-    @PrePersist
-    public void prePersist() {
-
-        if (createdOn == null) {
-            createdOn = new Date();
-        }
-
-        if (updatedOn == null) {
-            updatedOn = new Date();
-        }
-    }
 
     @PreUpdate
     public void preUpdate() {

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -69,7 +69,10 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
 
     @PrePersist
     public void prePersistStatus() {
-        status = QueryStatus.QUEUED;
+        if (status == null) {
+            status = QueryStatus.QUEUED;
+        }
+
         if (id == null || id.isEmpty()) {
             id = UUID.randomUUID().toString();
         }

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
@@ -32,7 +32,7 @@ public class AsyncQueryOperationChecks {
             String principalName = ((PrincipalOwned) object).getPrincipalName();
             if (principalName == null && (principal == null || principal.getName() == null)) {
                 status = true;
-            } else {
+            } else if (principalName != null && principal != null && principal.getName() != null){
                 status = principalName.equals(principal.getName());
             }
             return status;

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
@@ -32,7 +32,7 @@ public class AsyncQueryOperationChecks {
             String principalName = ((PrincipalOwned) object).getPrincipalName();
             if (principalName == null && (principal == null || principal.getName() == null)) {
                 status = true;
-            } else if (principalName != null && principal != null && principal.getName() != null){
+            } else if (principalName != null && principal != null && principal.getName() != null) {
                 status = principalName.equals(principal.getName());
             }
             return status;

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.security.User;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -104,6 +105,7 @@ public class AsyncExecutorService {
             AsyncQueryResult queryResultObj = task.get(queryObj.getAsyncAfterSeconds(), TimeUnit.SECONDS);
             queryObj.setResult(queryResultObj);
             queryObj.setStatus(QueryStatus.COMPLETE);
+            queryObj.setUpdatedOn(new Date());
         } catch (InterruptedException e) {
             log.error("InterruptedException: {}", e);
             queryObj.setStatus(QueryStatus.FAILURE);

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
@@ -44,7 +44,6 @@ public class AsyncQueryTest {
     public void testUUIDGeneration() {
         AsyncQuery queryObj = new AsyncQuery();
         assertNull(queryObj.getId());
-        queryObj.prePersistStatus();
         assertNotNull(queryObj.getId());
     }
 }

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.async.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import com.yahoo.elide.async.models.AsyncQuery;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -43,7 +42,6 @@ public class AsyncQueryTest {
     @Test
     public void testUUIDGeneration() {
         AsyncQuery queryObj = new AsyncQuery();
-        assertNull(queryObj.getId());
         assertNotNull(queryObj.getId());
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
 import lombok.Data;
 
 import java.util.Map;
@@ -313,13 +314,18 @@ public class AsyncIT extends IntegrationTest {
         ).toQuery();
 
         JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
-        given()
-        .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .body(graphQLJsonNode)
-        .post("/graphQL")
-        .then()
-        .statusCode(org.apache.http.HttpStatus.SC_OK);
+        ValidatableResponse response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(graphQLJsonNode)
+                .post("/graphQL")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK);
+
+        String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\","
+                + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\"}}]}}}";
+        assertEquals(expectedResponse, response.extract().body().asString());
 
         int i = 0;
         while (i < 1000) {
@@ -336,7 +342,7 @@ public class AsyncIT extends IntegrationTest {
             // If Async Query is created and completed
             if (responseGraphQL.contains("\"status\":\"COMPLETE\"")) {
 
-                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
+                expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
                         + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","
@@ -388,13 +394,18 @@ public class AsyncIT extends IntegrationTest {
         ).toQuery();
 
         JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
-        given()
-        .contentType(MediaType.APPLICATION_JSON)
-        .accept(MediaType.APPLICATION_JSON)
-        .body(graphQLJsonNode)
-        .post("/graphQL")
-        .then()
-        .statusCode(org.apache.http.HttpStatus.SC_OK);
+        ValidatableResponse response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(graphQLJsonNode)
+                .post("/graphQL")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK);
+
+        String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\","
+                + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\"}}]}}}";
+        assertEquals(expectedResponse, response.extract().body().asString());
 
         String responseGraphQL = given()
                  .contentType(MediaType.APPLICATION_JSON)
@@ -406,7 +417,7 @@ public class AsyncIT extends IntegrationTest {
                  .post("/graphQL")
                  .asString();
 
-        String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
+        expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
                  + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.async.integration.tests.framework;
 
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.READ;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.UPDATE;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
@@ -102,7 +103,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                 UpdatePrincipalNameHook updatePrincipalNameHook = new UpdatePrincipalNameHook();
                 InvoiceCompletionHook invoiceCompletionHook = new InvoiceCompletionHook(billingService);
 
-                dictionary.bindTrigger(AsyncQuery.class, CREATE, PRECOMMIT, executeQueryHook, false);
+                dictionary.bindTrigger(AsyncQuery.class, READ, PRESECURITY, executeQueryHook, false);
                 dictionary.bindTrigger(AsyncQuery.class, CREATE, POSTCOMMIT, completeQueryHook, false);
                 dictionary.bindTrigger(AsyncQuery.class, CREATE, PRESECURITY, updatePrincipalNameHook, false);
                 dictionary.bindTrigger(Invoice.class, "complete", CREATE, PRECOMMIT, invoiceCompletionHook);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
@@ -6,8 +6,8 @@
 package com.yahoo.elide.spring.config;
 
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.READ;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
-import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRESECURITY;
 
 import com.yahoo.elide.Elide;
@@ -63,7 +63,7 @@ public class ElideAsyncConfiguration {
         ExecuteQueryHook executeQueryHook = new ExecuteQueryHook(asyncExecutorService);
         CompleteQueryHook completeQueryHook = new CompleteQueryHook(asyncExecutorService);
         UpdatePrincipalNameHook updatePrincipalNameHook = new UpdatePrincipalNameHook();
-        dictionary.bindTrigger(AsyncQuery.class, CREATE, PRECOMMIT, executeQueryHook, false);
+        dictionary.bindTrigger(AsyncQuery.class, READ, PRESECURITY, executeQueryHook, false);
         dictionary.bindTrigger(AsyncQuery.class, CREATE, POSTCOMMIT, completeQueryHook, false);
         dictionary.bindTrigger(AsyncQuery.class, CREATE, PRESECURITY, updatePrincipalNameHook, false);
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -6,8 +6,8 @@
 package com.yahoo.elide.standalone.config;
 
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.READ;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
-import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRESECURITY;
 
 import com.yahoo.elide.Elide;
@@ -141,7 +141,7 @@ public class ElideResourceConfig extends ResourceConfig {
                     CompleteQueryHook completeQueryHook = new CompleteQueryHook(AsyncExecutorService.getInstance());
                     UpdatePrincipalNameHook updatePrincipalNameHook = new UpdatePrincipalNameHook();
 
-                    dictionary.bindTrigger(AsyncQuery.class, CREATE, PRECOMMIT, executeQueryHook, false);
+                    dictionary.bindTrigger(AsyncQuery.class, READ, PRESECURITY, executeQueryHook, false);
                     dictionary.bindTrigger(AsyncQuery.class, CREATE, POSTCOMMIT, completeQueryHook, false);
                     dictionary.bindTrigger(AsyncQuery.class, CREATE, PRESECURITY, updatePrincipalNameHook, false);
 


### PR DESCRIPTION
## Description
i) Moved Async execute query hook to onReadPreSecurity Hook.
ii) Had to tweak the logic for values updated using `@PrePersist` annotation as they were overriding the values set in onReadPreSecurity hook.
iii) A fix for potential NPE in Async Models Operation Check.

## Motivation and Context
AsyncQuery submitted through Graphql end-point with asyncAfterSeconds 10 still comes back with embeddable results as null even though it finished before 10 seconds.
Based on debugging, its happening cos of [this](https://github.com/yahoo/elide/blob/d4901c6f07e57aa179c5afd640c9c67e90a8cdaf/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java#L190). In GraphQL, the only part of the body that is lazily returned is the ID

## How Has This Been Tested?
Existing test cases passed.
Modified Graphql tests for Async
Verified that the example code worked.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
