### PR TITLE
add queryParams variants for post(), patch() and delete()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 4.6.5
+**Fixes**
+   * [view commit](https://github.com/yahoo/elide/commit/bd516473fbeeb47ca05eaf510734f06432c4280a) Disabling Legacy Filter Dialect in Swagger Documentation (#1363) 
+   * [view commit](https://github.com/yahoo/elide/commit/d3cbcc23e9c7719b1a73f627121c6bc5fcb1bf23) Bumping Hibernate Validator Version (#1377) 
+   * [view commit](https://github.com/yahoo/elide/commit/6186da248b7249bcd858a4a433bfdbc50744af60) Bump classgraph from 4.8.78 to 4.8.86 (#1373) 
+   * [view commit](https://github.com/yahoo/elide/commit/e71dd40dfb8adf1b997a345317b016338e2b8153) make sub-ordinate dictionaries inherit injector from multiplexManager's dictionary. (#1380) 
+   * [view commit](https://github.com/yahoo/elide/commit/57dea8e19495e67f83130bb58f99aa2e5c915184) Bump liquibase-core from 3.8.9 to 3.10.0 (#1372) 
+   * [view commit](https://github.com/yahoo/elide/commit/4054908fa66648a0feb2c3001d234556f2fcb463) Bump checkstyle from 8.32 to 8.33 (#1361) 
+   * [view commit](https://github.com/yahoo/elide/commit/27d841954541ebe1a1648fde5a294b003ef1d7e0) Bump junit-jupiter-params from 5.6.0 to 5.6.2 (#1356) 
+   * [view commit](https://github.com/yahoo/elide/commit/2c3c32e7ee729426850f54da9295961192af17d6) Bump jersey-container-servlet-core from 2.30.1 to 2.31 (#1358) 
+   * [view commit](https://github.com/yahoo/elide/commit/7910f05a4ea7cd614798580082f8350843888fde) Bump version.log4j from 2.13.2 to 2.13.3 (#1355) 
+
 ## 4.6.4
 **Fixes**
    * [view commit](https://github.com/yahoo/elide/commit/96d8f4c1ad42728e75b7b841c7dad6f58d006f8f) Supported embedded entities in graphql (#1339) 

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -180,9 +180,23 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse post(String path, String jsonApiDocument, Object opaqueUser) {
+        return post(path, jsonApiDocument, null, opaqueUser);
+    }
+
+    /**
+     * Handle POST.
+     *
+     * @param path the path
+     * @param jsonApiDocument the json api document
+     * @param queryParams the query params
+     * @param opaqueUser the opaque user
+     * @return Elide response object
+     */
+    public ElideResponse post(String path, String jsonApiDocument, 
+                              MultivaluedMap<String, String> queryParams, Object opaqueUser) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, null, elideSettings);
+            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
             BaseVisitor visitor = new PostVisitor(requestScope);
             return visit(path, requestScope, visitor);
         });
@@ -195,11 +209,29 @@ public class Elide {
      * @param accept the accept
      * @param path the path
      * @param jsonApiDocument the json api document
+     * @param queryParams the query params
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
     public ElideResponse patch(String contentType, String accept,
                                String path, String jsonApiDocument, Object opaqueUser) {
+        return patch(contentType, accept, path, jsonApiDocument, null, opaqueUser);
+    }
+
+    /**
+     * Handle PATCH.
+     *
+     * @param contentType the content type
+     * @param accept the accept
+     * @param path the path
+     * @param jsonApiDocument the json api document
+     * @param queryParams the query params
+     * @param opaqueUser the opaque user
+     * @return Elide response object
+     */
+    public ElideResponse patch(String contentType, String accept,
+                               String path, String jsonApiDocument, 
+                               MultivaluedMap<String, String> queryParams, Object opaqueUser) {
 
         Handler<DataStoreTransaction, User, HandlerResult> handler;
         if (JsonApiPatch.isPatchExtension(contentType) && JsonApiPatch.isPatchExtension(accept)) {
@@ -216,7 +248,7 @@ public class Elide {
         } else {
             handler = (tx, user) -> {
                 JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-                RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, null, elideSettings);
+                RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
                 BaseVisitor visitor = new PatchVisitor(requestScope);
                 return visit(path, requestScope, visitor);
             };
@@ -234,11 +266,25 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse delete(String path, String jsonApiDocument, Object opaqueUser) {
+        return delete(path, jsonApiDocument, null, opaqueUser);
+    }
+    
+    /**
+     * Handle DELETE.
+     *
+     * @param path the path
+     * @param jsonApiDocument the json api document
+     * @param queryParams the query params
+     * @param opaqueUser the opaque user
+     * @return Elide response object
+     */
+    public ElideResponse delete(String path, String jsonApiDocument, 
+                                MultivaluedMap<String, String> queryParams, Object opaqueUser) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = StringUtils.isEmpty(jsonApiDocument)
                     ? new JsonApiDocument()
                     : mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, null, elideSettings);
+            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
             BaseVisitor visitor = new DeleteVisitor(requestScope);
             return visit(path, requestScope, visitor);
         });

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -192,7 +192,7 @@ public class Elide {
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse post(String path, String jsonApiDocument, 
+    public ElideResponse post(String path, String jsonApiDocument,
                               MultivaluedMap<String, String> queryParams, Object opaqueUser) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
@@ -230,7 +230,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse patch(String contentType, String accept,
-                               String path, String jsonApiDocument, 
+                               String path, String jsonApiDocument,
                                MultivaluedMap<String, String> queryParams, Object opaqueUser) {
 
         Handler<DataStoreTransaction, User, HandlerResult> handler;
@@ -268,7 +268,7 @@ public class Elide {
     public ElideResponse delete(String path, String jsonApiDocument, Object opaqueUser) {
         return delete(path, jsonApiDocument, null, opaqueUser);
     }
-    
+
     /**
      * Handle DELETE.
      *
@@ -278,7 +278,7 @@ public class Elide {
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse delete(String path, String jsonApiDocument, 
+    public ElideResponse delete(String path, String jsonApiDocument,
                                 MultivaluedMap<String, String> queryParams, Object opaqueUser) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = StringUtils.isEmpty(jsonApiDocument)

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -111,7 +111,8 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-        return build(elide.patch(contentType, accept, path, jsonapiDocument, queryParams, getUser.apply(securityContext)));
+        return build(elide.patch(contentType, accept, path, jsonapiDocument,
+                                 queryParams, getUser.apply(securityContext)));
     }
 
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -66,41 +66,46 @@ public class JsonApiController {
 
     @PostMapping(value = "/**", consumes = JSON_API_CONTENT_TYPE, produces = JSON_API_CONTENT_TYPE)
     public ResponseEntity<String> elidePost(@RequestBody String body,
+                                            @RequestParam Map<String, String> allRequestParams,
                                             HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         ElideResponse response = elide
-                .post(pathname, body, authentication);
+                .post(pathname, body, new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
     @PatchMapping(value = "/**", consumes = { JSON_API_CONTENT_TYPE, JSON_API_PATCH_CONTENT_TYPE})
     public ResponseEntity<String> elidePatch(@RequestBody String body,
+                                             @RequestParam Map<String, String> allRequestParams,
                                              HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         ElideResponse response = elide
-                .patch(request.getContentType(), request.getContentType(), pathname, body, authentication);
+                .patch(request.getContentType(), request.getContentType(), pathname, body,
+                       new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
     @DeleteMapping(value = "/**")
     public ResponseEntity<String> elideDelete(HttpServletRequest request,
-                                              Principal authentication) {
+                                             @RequestParam Map<String, String> allRequestParams,
+                                             Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         ElideResponse response = elide
-                .delete(pathname, null, authentication);
+                .delete(pathname, null, new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
     @DeleteMapping(value = "/**", consumes = JSON_API_CONTENT_TYPE)
     public ResponseEntity<String> elideDeleteRelationship(@RequestBody String body,
+                                                          @RequestParam Map<String, String> allRequestParams,
                                                           HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
         ElideResponse response = elide
-                .delete(pathname, body, authentication);
+                .delete(pathname, body, new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 


### PR DESCRIPTION
Resolves #1410

## Description
See issue for details

## Motivation and Context
query parameters currently not accessible from request scope when processing POST, PATCH or DELETE operations.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
