### PR TITLE
Elide 5.x - Async Tests, Break loop when fail

### DIFF
--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -227,7 +227,7 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
                 break;
-            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+            } else if (!(outputResponse.equals("PROCESSING"))) {
                 fail("Async Query not completed.");
                 break;
             }
@@ -356,7 +356,7 @@ public class AsyncIT extends IntegrationTest {
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
-            } else if (!(responseGraphQL.contains("\"status\":\"PROCESSING\"") || responseGraphQL.contains("\"status\":\"QUEUED\""))) {
+            } else if (!(responseGraphQL.contains("\"status\":\"PROCESSING\""))) {
                 fail("Async Query not completed.");
                 break;
             }
@@ -486,7 +486,7 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.result.httpStatus", equalTo(404));
 
                 break;
-            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+            } else if (!(outputResponse.equals("PROCESSING"))) {
                 fail("Async Query not completed.");
                 break;
             }
@@ -592,7 +592,7 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
                 break;
-            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+            } else if (!(outputResponse.equals("PROCESSING"))) {
                 fail("Async Query not completed.");
                 break;
             }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -227,7 +227,7 @@ public class AsyncIT extends IntegrationTest {
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
-                fail("Async Query not completed.");
+                fail("Async Query has failed.");
                 break;
             }
 
@@ -356,7 +356,7 @@ public class AsyncIT extends IntegrationTest {
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(responseGraphQL.contains("\"status\":\"PROCESSING\""))) {
-                fail("Async Query not completed.");
+                fail("Async Query has failed.");
                 break;
             }
             i++;
@@ -486,7 +486,7 @@ public class AsyncIT extends IntegrationTest {
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
-                fail("Async Query not completed.");
+                fail("Async Query has failed.");
                 break;
             }
             i++;
@@ -592,7 +592,7 @@ public class AsyncIT extends IntegrationTest {
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
-                fail("Async Query not completed.");
+                fail("Async Query has failed.");
                 break;
             }
             i++;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -29,7 +29,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -29,6 +29,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -227,6 +228,7 @@ public class AsyncIT extends IntegrationTest {
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+                fail("Async Query not completed.");
                 break;
             }
 
@@ -355,6 +357,7 @@ public class AsyncIT extends IntegrationTest {
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(responseGraphQL.contains("\"status\":\"PROCESSING\"") || responseGraphQL.contains("\"status\":\"QUEUED\""))) {
+                fail("Async Query not completed.");
                 break;
             }
             i++;
@@ -484,6 +487,7 @@ public class AsyncIT extends IntegrationTest {
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+                fail("Async Query not completed.");
                 break;
             }
             i++;
@@ -589,6 +593,7 @@ public class AsyncIT extends IntegrationTest {
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+                fail("Async Query not completed.");
                 break;
             }
             i++;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -204,8 +204,10 @@ public class AsyncIT extends IntegrationTest {
                     .accept("application/vnd.api+json")
                     .get("/asyncQuery/edc4a871-dff2-4054-804e-d80075cf830e");
 
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
             // If Async Query is created and completed
-            if (response.jsonPath().getString("data.attributes.status").equals("COMPLETE")) {
+            if (outputResponse.equals("COMPLETE")) {
 
                 // Validate AsyncQuery Response
                 response
@@ -223,9 +225,11 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.result.httpStatus", equalTo(200))
                         .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
-
+                break;
+            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
                 break;
             }
+
             i++;
 
             if (i == 1000) {
@@ -350,6 +354,8 @@ public class AsyncIT extends IntegrationTest {
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
+            } else if (!(responseGraphQL.contains("\"status\":\"PROCESSING\"") || responseGraphQL.contains("\"status\":\"QUEUED\""))) {
+                break;
             }
             i++;
 
@@ -460,8 +466,10 @@ public class AsyncIT extends IntegrationTest {
                     .accept("application/vnd.api+json")
                     .get("/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9263b");
 
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
             // If Async Query is created and completed then validate results
-            if (response.jsonPath().getString("data.attributes.status").equals("COMPLETE")) {
+            if (outputResponse.equals("COMPLETE")) {
                 // Validate AsyncQuery Response
                 response
                         .then()
@@ -474,6 +482,8 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.result.responseBody", equalTo("{\"errors\":[{\"detail\":\"Unknown collection group\"}]}"))
                         .body("data.attributes.result.httpStatus", equalTo(404));
 
+                break;
+            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
                 break;
             }
             i++;
@@ -560,8 +570,10 @@ public class AsyncIT extends IntegrationTest {
                     .accept("application/vnd.api+json")
                     .get("/asyncQuery/0b0dd4e7-9cdc-4bbc-8db2-5c1491c5ee1e");
 
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
             // If Async Query is created and completed
-            if (response.jsonPath().getString("data.attributes.status").equals("COMPLETE")) {
+            if (outputResponse.equals("COMPLETE")) {
                 // Validate AsyncQuery Response
                 response
                         .then()
@@ -575,6 +587,8 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.result.httpStatus", equalTo(200))
                         .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
+                break;
+            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
                 break;
             }
             i++;

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <spring.boot.version>2.3.0.RELEASE</spring.boot.version>
-        <tomcat.version>9.0.35</tomcat.version>
+        <tomcat.version>9.0.37</tomcat.version>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
         <min_jdk_version>1.8</min_jdk_version>
         <max_jdk_version>1.8</max_jdk_version>

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -16,7 +16,9 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.yahoo.elide.core.HttpStatus;
 
@@ -106,6 +108,7 @@ public class AsyncTest extends IntegrationTest {
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+                fail("Async Query not completed.");
                 break;
             }
         }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -107,7 +107,7 @@ public class AsyncTest extends IntegrationTest {
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
-            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
+            } else if (!(outputResponse.equals("PROCESSING"))) {
                 fail("Async Query not completed.");
                 break;
             }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -107,7 +107,7 @@ public class AsyncTest extends IntegrationTest {
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
-                fail("Async Query not completed.");
+                fail("Async Query has failed.");
                 break;
             }
         }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -71,8 +71,10 @@ public class AsyncTest extends IntegrationTest {
                     .accept("application/vnd.api+json")
                     .get("/json/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9263d");
 
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
              //If Async Query is created and completed then validate results
-            if (response.jsonPath().getString("data.attributes.status").equals("COMPLETE")) {
+            if (outputResponse.equals("COMPLETE")) {
 
                 // Validate AsyncQuery Response
                 response
@@ -102,6 +104,8 @@ public class AsyncTest extends IntegrationTest {
                 String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"group\\\",\\\"id\\\":\\\"com.example.repository\\\",\\\"attributes\\\":{\\\"commonName\\\":\\\"Example Repository\\\",\\\"deprecated\\\":false,\\\"description\\\":\\\"The code for this project\\\"},\\\"relationships\\\":{\\\"products\\\":{\\\"data\\\":[]}}}]}\",\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":208}}}]}}}";
 
                 assertEquals(expectedResponse, responseGraphQL);
+                break;
+            } else if (!(outputResponse.equals("PROCESSING") || outputResponse.equals("QUEUED"))) {
                 break;
             }
         }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -16,7 +16,6 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -281,8 +281,10 @@ public class ElideStandaloneTest {
                     .accept("application/vnd.api+json")
                     .get("/api/v1/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9263d");
 
+            String outputResponse = response.jsonPath().getString("data.attributes.status");
+
             // If Async Query is created and completed
-            if (response.jsonPath().getString("data.attributes.status").equals("COMPLETE")) {
+            if (outputResponse.equals("COMPLETE")) {
 
                 // Validate AsyncQuery Response
                 response
@@ -310,6 +312,9 @@ public class ElideStandaloneTest {
 
                 String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"post\\\",\\\"id\\\":\\\"2\\\",\\\"attributes\\\":{\\\"abusiveContent\\\":false,\\\"content\\\":\\\"This is my first post. woot.\\\",\\\"date\\\":\\\"2019-01-01T00:00Z\\\"}}]}\",\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":141}}}]}}}";
                 assertEquals(expectedResponse, responseGraphQL);
+                break;
+            } else if (!(outputResponse.equals("PROCESSING"))) {
+                fail("Async Query not completed.");
                 break;
             }
             i++;

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -314,7 +314,7 @@ public class ElideStandaloneTest {
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
-                fail("Async Query not completed.");
+                fail("Async Query has failed.");
                 break;
             }
             i++;


### PR DESCRIPTION
## Description
Async Tests will now exit the status check loop when failed.

## Motivation and Context
Status check loop will continue till the iterations were exhausted even though query had failed.

## How Has This Been Tested?
Existing tests pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
