### PR TITLE
Elide 5.x Async Create Permission Fix

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.async.models;
 
 import com.yahoo.elide.annotation.ComputedAttribute;
+import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
@@ -56,6 +57,7 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     private String requestId; //Client provided
 
     @UpdatePermission(expression = "Principal is Owner AND value is Cancelled")
+    @CreatePermission(expression = "value is Queued")
     private QueryStatus status = QueryStatus.QUEUED;
 
     @Embedded

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryOperationChecks.java
@@ -49,4 +49,13 @@ public class AsyncQueryOperationChecks {
             return changeSpec.get().getModified().toString().equals(QueryStatus.CANCELLED.name());
         }
     }
+
+    @SecurityCheck(AsyncQueryStatusQueuedValue.VALUE_IS_QUEUED)
+    public static class AsyncQueryStatusQueuedValue extends OperationCheck<AsyncQuery> {
+        public static final String VALUE_IS_QUEUED = "value is Queued";
+        @Override
+        public boolean ok(AsyncQuery object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            return changeSpec.get().getModified().toString().equals(QueryStatus.QUEUED.name());
+        }
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -147,8 +147,8 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         // Keep track of new resources for non-transferable resources
         requestScope.getNewPersistentResources().add(newResource);
-        checkPermission(CreatePermission.class, newResource);
-        //checkUserPermission(CreatePermission.class, newResource);
+        //checkPermission(CreatePermission.class, newResource);
+        checkUserPermission(CreatePermission.class, obj, requestScope);
 
         newResource.auditClass(Audit.Action.CREATE, new ChangeSpec(newResource, null, null, newResource.getObject()));
 
@@ -1739,8 +1739,8 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
     }
 
     private static <A extends Annotation> ExpressionResult checkUserPermission(
-            Class<A> annotationClass, PersistentResource resource) {
-        return resource.requestScope.getPermissionExecutor().checkUserPermissions(resource.getClass(), annotationClass);
+            Class<A> annotationClass, Object resource, RequestScope requestScope) {
+        return requestScope.getPermissionExecutor().checkUserPermissions(resource.getClass(), annotationClass);
     }
 
     private <A extends Annotation> ExpressionResult checkFieldAwarePermissions(Class<A> annotationClass) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -148,6 +148,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         // Keep track of new resources for non-transferable resources
         requestScope.getNewPersistentResources().add(newResource);
         checkPermission(CreatePermission.class, newResource);
+        //checkUserPermission(CreatePermission.class, newResource);
 
         newResource.auditClass(Audit.Action.CREATE, new ChangeSpec(newResource, null, null, newResource.getObject()));
 
@@ -1735,6 +1736,11 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
     private static <A extends Annotation> ExpressionResult checkPermission(
             Class<A> annotationClass, PersistentResource resource) {
         return resource.requestScope.getPermissionExecutor().checkPermission(annotationClass, resource);
+    }
+
+    private static <A extends Annotation> ExpressionResult checkUserPermission(
+            Class<A> annotationClass, PersistentResource resource) {
+        return resource.requestScope.getPermissionExecutor().checkUserPermissions(resource.getClass(), annotationClass);
     }
 
     private <A extends Annotation> ExpressionResult checkFieldAwarePermissions(Class<A> annotationClass) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -147,7 +147,6 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
 
         // Keep track of new resources for non-transferable resources
         requestScope.getNewPersistentResources().add(newResource);
-        //checkPermission(CreatePermission.class, newResource);
         checkUserPermission(CreatePermission.class, obj, requestScope);
 
         newResource.auditClass(Audit.Action.CREATE, new ChangeSpec(newResource, null, null, newResource.getObject()));
@@ -1739,8 +1738,8 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
     }
 
     private static <A extends Annotation> ExpressionResult checkUserPermission(
-            Class<A> annotationClass, Object resource, RequestScope requestScope) {
-        return requestScope.getPermissionExecutor().checkUserPermissions(resource.getClass(), annotationClass);
+            Class<A> annotationClass, Object obj, RequestScope requestScope) {
+        return requestScope.getPermissionExecutor().checkUserPermissions(obj.getClass(), annotationClass);
     }
 
     private <A extends Annotation> ExpressionResult checkFieldAwarePermissions(Class<A> annotationClass) {

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
@@ -33,14 +33,17 @@ public class AnyFieldExpression implements Expression {
 
     @Override
     public ExpressionResult evaluate(EvaluationMode mode) {
+        if (entityExpression == null) {
+            return PASS;
+        }
+
         ExpressionResult fieldResult = fieldExpression.evaluate(mode);
 
         if (fieldResult != FAIL) {
             return fieldResult;
+        } else {
+            return entityExpression.evaluate(mode);
         }
-
-        ExpressionResult entityResult = (entityExpression == null) ? PASS : entityExpression.evaluate(mode);
-        return entityResult;
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
@@ -33,17 +33,14 @@ public class AnyFieldExpression implements Expression {
 
     @Override
     public ExpressionResult evaluate(EvaluationMode mode) {
-        if (entityExpression == null) {
-            return PASS;
-        }
-
         ExpressionResult fieldResult = fieldExpression.evaluate(mode);
 
         if (fieldResult != FAIL) {
             return fieldResult;
-        } else {
-            return entityExpression.evaluate(mode);
         }
+
+        ExpressionResult entityResult = (entityExpression == null) ? PASS : entityExpression.evaluate(mode);
+        return entityResult;
     }
 
     @Override

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -427,6 +427,51 @@ public class AsyncIT extends IntegrationTest {
     }
 
     /**
+     * Test for QueryStatus Set to PROCESSING instead of Queued
+     */
+    @Test
+    public void graphQLTestCreateFailOnQueryStatus() {
+
+        AsyncDelayStoreTransaction.sleep = true;
+        AsyncQuery queryObj = new AsyncQuery();
+        queryObj.setId("edc4a871-dff2-4054-804e-d80075cf839e");
+        queryObj.setAsyncAfterSeconds(0);
+        queryObj.setQueryType("GRAPHQL_V1_0");
+        queryObj.setStatus("PROCESSING");
+        queryObj.setQuery("{\"query\":\"{ book { edges { node { id title } } } }\",\"variables\":null}");
+        String graphQLRequest = document(
+                mutation(
+                        selection(
+                                field(
+                                        "asyncQuery",
+                                        arguments(
+                                                argument("op", "UPSERT"),
+                                                argument("data", queryObj, UNQUOTED_VALUE)
+                                        ),
+                                        selections(
+                                                field("id"),
+                                                field("query"),
+                                                field("queryType"),
+                                                field("status")
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
+        ValidatableResponse response = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(graphQLJsonNode)
+                .post("/graphQL")
+                .then()
+                .statusCode(org.apache.http.HttpStatus.SC_OK);
+
+        assertEquals(true, response.extract().body().asString().contains("errors"));
+    }
+
+    /**
      * Various tests for an unknown collection (group) that does not exist JSONAPI query as a Async Request.
      * @throws InterruptedException
      */

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -59,6 +59,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                 Map<String, Class<? extends Check>> checkMappings = new HashMap<>(TestCheckMappings.MAPPINGS);
                 checkMappings.put(AsyncQueryOperationChecks.AsyncQueryOwner.PRINCIPAL_IS_OWNER, AsyncQueryOperationChecks.AsyncQueryOwner.class);
                 checkMappings.put(AsyncQueryOperationChecks.AsyncQueryStatusValue.VALUE_IS_CANCELLED, AsyncQueryOperationChecks.AsyncQueryStatusValue.class);
+                checkMappings.put(AsyncQueryOperationChecks.AsyncQueryStatusQueuedValue.VALUE_IS_QUEUED, AsyncQueryOperationChecks.AsyncQueryStatusQueuedValue.class);
 
                 EntityDictionary dictionary = new EntityDictionary(checkMappings, injector::inject);
 

--- a/elide-integration-tests/src/test/java/example/NoCommitEntity.java
+++ b/elide-integration-tests/src/test/java/example/NoCommitEntity.java
@@ -12,6 +12,9 @@ import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.OperationCheck;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.Optional;
 
 import javax.persistence.Entity;
@@ -27,6 +30,9 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "nocommit")
 public class NoCommitEntity extends BaseId {
+    @Getter @Setter
+    private String value;
+
     static public class NoCommitCheck<T> extends OperationCheck<T> {
         @Override
         public boolean ok(T record, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {

--- a/elide-integration-tests/src/test/resources/ResourceIT/testPatchExtNoCommit.req.json
+++ b/elide-integration-tests/src/test/resources/ResourceIT/testPatchExtNoCommit.req.json
@@ -4,7 +4,10 @@
         "path":"/nocommit",
         "value":{
             "type":"nocommit",
-            "id":"12345678-1234-1234-1234-123456789ab1"
+            "id":"12345678-1234-1234-1234-123456789ab1",
+            "attributes":{
+                "value":"value"
+            }
         }
     }
 ]


### PR DESCRIPTION
## Description
Adding create permission check in AsyncQuery to make sure QueryStatus is set to Queued.
Changed PersistentResource to only do USER CHECKS when creating a new object.

## Motivation and Context
ExecuteQueryHook.java has a check to trigger when the query status is Queued. 

## How Has This Been Tested?
Existing test cases pass.
New Test case is added. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
