### PR TITLE
Convert DateTimeParseException into IllegalArgumentException

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/InstantSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/InstantSerde.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.utils.coerce.converters;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Convert an Instant to/from an ISO-8601 string representation.
@@ -17,12 +18,17 @@ import java.time.format.DateTimeFormatter;
 public class InstantSerde implements Serde<String, Instant> {
     @Override
     public Instant deserialize(final String value) {
-        return Instant.from(
-            // NB. ideally we would use ISO_INSTANT here but there is a bug in JDK-8 that
-            // means that parsing an ISO offset time doesn't work :-(
-            // https://bugs.openjdk.java.net/browse/JDK-8166138
-            DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(value)
-        );
+        try {
+            return Instant.from(
+                // NB. ideally we would use ISO_INSTANT here but there is a bug in JDK-8 that
+                // means that parsing an ISO offset time doesn't work :-(
+                // https://bugs.openjdk.java.net/browse/JDK-8166138
+                DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(value)
+            );
+        } catch (final DateTimeParseException ex) {
+            // Translate parsing exception to something CoerceUtil will handle appropriately
+            throw new IllegalArgumentException(ex);
+        }
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeSerde.java
@@ -7,13 +7,19 @@ package com.yahoo.elide.utils.coerce.converters;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 @ElideTypeConverter(type = OffsetDateTime.class, name = "OffsetDateTime")
 public class OffsetDateTimeSerde implements Serde<String, OffsetDateTime> {
 
     @Override
     public OffsetDateTime deserialize(String val) {
-        return OffsetDateTime.parse(val, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        try {
+            return OffsetDateTime.parse(val, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } catch (final DateTimeParseException ex) {
+            // Translate parsing exception to something CoerceUtil will handle appropriately
+            throw new IllegalArgumentException(ex);
+        }
     }
 
     @Override

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/InstantSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/InstantSerdeTest.java
@@ -6,7 +6,7 @@
 package com.yahoo.elide.utils.coerce.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -58,8 +58,10 @@ public class InstantSerdeTest {
     @Test(expected = IllegalArgumentException.class)
     public void failsParsingWithIllegalArgumentException() {
 
-        serde.deserialize("2019-06-01T09:42:55.12X3Z");
-        fail("didn't raise exception");
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> serde.deserialize("2019-06-01T09:42:55.12X3Z")
+        );
 
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/InstantSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/InstantSerdeTest.java
@@ -55,7 +55,7 @@ public class InstantSerdeTest {
         );
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void failsParsingWithIllegalArgumentException() {
 
         assertThrows(

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/InstantSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/InstantSerdeTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.utils.coerce.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -52,5 +53,13 @@ public class InstantSerdeTest {
             "2019-06-01T09:42:55.123Z",
             serde.serialize(Instant.ofEpochMilli(1559382175123L))
         );
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsParsingWithIllegalArgumentException() {
+
+        serde.deserialize("2019-06-01T09:42:55.12X3Z");
+        fail("didn't raise exception");
+
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
@@ -6,7 +6,7 @@
 package com.yahoo.elide.utils.coerce.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +41,9 @@ public class OffsetDateTimeTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void failsParsingWithIllegalArgumentException() {
-        serde.deserialize("2019-06-01T09:42:55.12X3Z");
-        fail("didn't raise exception");
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> serde.deserialize("2019-06-01T09:42:55.12X3Z")
+        );
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
@@ -41,9 +41,10 @@ public class OffsetDateTimeTest {
 
     @Test
     public void failsParsingWithIllegalArgumentException() {
+        OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
         assertThrows(
             IllegalArgumentException.class,
-            () -> serde.deserialize("2019-06-01T09:42:55.12X3Z")
+            () -> offsetDateTimeScaler.deserialize("2019-06-01T09:42:55.12X3Z")
         );
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
@@ -41,7 +41,7 @@ public class OffsetDateTimeTest {
 
     @Test
     public void failsParsingWithIllegalArgumentException() {
-        OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
+        final OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
         assertThrows(
             IllegalArgumentException.class,
             () -> offsetDateTimeScaler.deserialize("2019-06-01T09:42:55.12X3Z")

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
@@ -44,7 +44,7 @@ public class OffsetDateTimeTest {
         final OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
         assertThrows(
             IllegalArgumentException.class,
-            () -> offsetDateTimeScaler.deserialize("2019-06-01T09:42:55.12X3Z")
+            () -> offsetDateTimeScalar.deserialize("2019-06-01T09:42:55.12X3Z")
         );
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.utils.coerce.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,5 +37,11 @@ public class OffsetDateTimeTest {
         OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
         Object expected = offsetDateTimeScalar.deserialize(actual);
         assertEquals(expected, actualDate);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsParsingWithIllegalArgumentException() {
+        serde.deserialize("2019-06-01T09:42:55.12X3Z");
+        fail("didn't raise exception");
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/OffsetDateTimeTest.java
@@ -39,7 +39,7 @@ public class OffsetDateTimeTest {
         assertEquals(expected, actualDate);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void failsParsingWithIllegalArgumentException() {
         assertThrows(
             IllegalArgumentException.class,


### PR DESCRIPTION
## Description
Avoid "500 Internal Server Error" responses by handling DateTimeParseException.

### Current JSON-API behaviour
Current OffsetDateTime and Instant (de)serializers can raise the JAVA standard `DateTimeParseException` if the value passed in is of an incorrect format.

This can cause a 500 Internal Server error to occur when invalid values are passed in via a REST API.
```json
500 Internal Server Error
{
    "timestamp": "2020-07-13T11:36:07.924+00:00",
    "status": 500,
    "error": "Internal Server Error",
    "message": "Text '2020-07-10T11:19:52+0200' could not be parsed, unparsed text found at index 22",
    "path": "/pwStats"
}
```
### Updated JSON-API response
We convert the exception into an `IllegalArgumentException` which the CoreceUtil class handles.
```json
400 Bad Request
{
    "errors": [
        {
            "detail": "InvalidValueException: Invalid value: 2020-07-10T11:19:52+0200"
        }
    ]
}
```

## Motivation and Context
Should never allow user ingress data to cause `500 Internal Server Error`

## How Has This Been Tested?
Unittests updated to ensure `IllegalArgumentException` is raised.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
