### PR TITLE
make ThreadLocal usage static as per recommendations

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/audit/AuditLogger.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/AuditLogger.java
@@ -17,20 +17,17 @@ import java.util.List;
  * This class uses ThreadLocal list to be thread safe.
  */
 public abstract class AuditLogger {
-    protected final ThreadLocal<List<LogMessage>> messages;
-
-    public AuditLogger() {
-        messages = ThreadLocal.withInitial(ArrayList::new);
-    }
+    protected static final ThreadLocal<List<LogMessage>> MESSAGES =
+        ThreadLocal.withInitial(ArrayList::new);
 
     public void log(LogMessage message) {
-        messages.get().add(message);
+        MESSAGES.get().add(message);
     }
 
     public abstract void commit(RequestScope requestScope) throws IOException;
 
     public void clear() {
-        List<LogMessage> remainingMessages = messages.get();
+        List<LogMessage> remainingMessages = MESSAGES.get();
         if (remainingMessages != null) {
             remainingMessages.clear();
         }

--- a/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
+++ b/elide-core/src/main/java/com/yahoo/elide/audit/Slf4jLogger.java
@@ -20,11 +20,11 @@ public class Slf4jLogger extends AuditLogger {
     @Override
     public void commit(RequestScope requestScope) throws IOException {
         try {
-            for (LogMessage message : messages.get()) {
+            for (LogMessage message : MESSAGES.get()) {
                 log.info("{} {} {}", System.currentTimeMillis(), message.getOperationCode(), message.getMessage());
             }
         } finally {
-            messages.get().clear();
+            MESSAGES.get().clear();
         }
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/audit/TestAuditLogger.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/TestAuditLogger.java
@@ -17,6 +17,6 @@ public class TestAuditLogger extends AuditLogger {
     }
 
     public List<LogMessage> getMessages() {
-        return new ArrayList<>(this.messages.get());
+        return new ArrayList<>(this.MESSAGES.get());
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -1800,6 +1800,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         assertEquals("UPDATE Child 5 Parent 7", message.getMessage(), "Logging template should match");
 
         assertEquals(1, message.getOperationCode(), "Operation code should match");
+        logger.clear(); // tidy up this thread's messages
     }
 
     @Test
@@ -1823,6 +1824,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         assertEquals("CREATE Child 5 Parent 7", message.getMessage(), "Logging template should match");
 
         assertEquals(0, message.getOperationCode(), "Operation code should match");
+        logger.clear(); // tidy up this thread's messages
     }
 
     @Test

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/audit/InMemoryLogger.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/audit/InMemoryLogger.java
@@ -21,7 +21,7 @@ public class InMemoryLogger extends AuditLogger {
 
     @Override
     public void commit(RequestScope requestScope) throws IOException {
-        for (LogMessage message : messages.get()) {
+        for (LogMessage message : MESSAGES.get()) {
             if (message.getChangeSpec().isPresent()) {
                 logMessages.add(changeSpecToString(message.getChangeSpec().get()));
             }


### PR DESCRIPTION
## Description
The current `AuditLogger` current uses a `ThreadLocal<>` generic as a data member.

Given that typically there is only a single instance of an `AuditLogger`, this shouldn't cause a resource leak, however the documentation for [`ThreadLocal`](https://docs.oracle.com/javase/8/docs/api/java/lang/ThreadLocal.html) makes a strong suggestion that 
> ThreadLocal instances are typically private static fields in classes that wish to associate state with a thread (e.g., a user ID or Transaction ID).

This PR simply updates the implementation to make this a static field, as per the recommendation.

## Motivation and Context
As part of the static analysis of one of our projects, that uses the Elide library, we have a possible "singleton race condition" which has been raised via bytecode analysis, which suggests our usage of  the `elide.get()` method is somehow mutating the `elide` instance in a "race-like manner". Whilst looking at the code flow I noticed that the class instance does mutate the audit logger but it _should_ be safe because of its use of `ThreadLocal`.

Whilst reading up on this I noticed that the current usage is not "best practice" hence this PR.

## How Has This Been Tested?
Any regression should be identified by current `audit` unittests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
