### PR TITLE
Open Async Model Read/Update Permissions to Admin

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -34,7 +34,7 @@ import javax.validation.constraints.Pattern;
  */
 @Entity
 @Include(type = "asyncQuery", rootLevel = true)
-@ReadPermission(expression = "Principal is Owner")
+@ReadPermission(expression = "Principal is Owner OR Principal is Admin")
 @UpdatePermission(expression = "Prefab.Role.None")
 @DeletePermission(expression = "Prefab.Role.None")
 @Data
@@ -57,7 +57,7 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     @Exclude
     private String requestId = UUID.randomUUID().toString();
 
-    @UpdatePermission(expression = "Principal is Owner AND value is Cancelled")
+    @UpdatePermission(expression = "(Principal is Admin OR Principal is Owner) AND value is Cancelled")
     @CreatePermission(expression = "value is Queued")
     private QueryStatus status = QueryStatus.QUEUED;
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryInlineChecks.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryInlineChecks.java
@@ -11,7 +11,9 @@ import com.yahoo.elide.async.models.PrincipalOwned;
 import com.yahoo.elide.async.models.QueryStatus;
 import com.yahoo.elide.security.ChangeSpec;
 import com.yahoo.elide.security.RequestScope;
+import com.yahoo.elide.security.User;
 import com.yahoo.elide.security.checks.OperationCheck;
+import com.yahoo.elide.security.checks.UserCheck;
 
 import java.security.Principal;
 import java.util.Optional;
@@ -19,7 +21,7 @@ import java.util.Optional;
 /**
  * Operation Checks on the Async Query and Result objects.
  */
-public class AsyncQueryOperationChecks {
+public class AsyncQueryInlineChecks {
     @SecurityCheck(AsyncQueryOwner.PRINCIPAL_IS_OWNER)
     public static class AsyncQueryOwner extends OperationCheck<Object> {
 
@@ -36,6 +38,17 @@ public class AsyncQueryOperationChecks {
                 status = principalName.equals(principal.getName());
             }
             return status;
+        }
+    }
+
+    @SecurityCheck(AsyncQueryAdmin.PRINCIPAL_IS_ADMIN)
+    public static class AsyncQueryAdmin extends UserCheck {
+
+        public static final String PRINCIPAL_IS_ADMIN = "Principal is Admin";
+
+        @Override
+        public boolean ok(User user) {
+            return user.isInRole("admin");
         }
     }
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryInlineChecks.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/security/AsyncQueryInlineChecks.java
@@ -48,7 +48,10 @@ public class AsyncQueryInlineChecks {
 
         @Override
         public boolean ok(User user) {
-            return user.isInRole("admin");
+            if (user != null && user.getPrincipal() != null) {
+                return user.isInRole("admin");
+            }
+            return false;
         }
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -25,6 +25,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -32,15 +33,24 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideResponse;
+import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.async.integration.tests.framework.AsyncIntegrationTestApplicationResourceConfig;
+import com.yahoo.elide.async.models.QueryType;
 import com.yahoo.elide.async.models.ResultType;
+import com.yahoo.elide.audit.TestAuditLogger;
 import com.yahoo.elide.contrib.testhelpers.graphql.EnumFieldSerializer;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Resource;
 import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.core.datastore.test.DataStoreTestHarness;
 import com.yahoo.elide.initialization.IntegrationTest;
 import com.yahoo.elide.resources.JsonApiEndpoint;
+import com.yahoo.elide.resources.SecurityContextUser;
+import com.yahoo.elide.security.User;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -55,9 +65,13 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import lombok.Data;
 
+import java.io.IOException;
+import java.security.Principal;
 import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.SecurityContext;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AsyncIT extends IntegrationTest {
@@ -641,6 +655,89 @@ public class AsyncIT extends IntegrationTest {
                 fail("Async Query not completed.");
             }
         }
+    }
+
+    /**
+     * Tests Read Permissions on Async Model for Admin Role
+     * @throws InterruptedException
+     */
+    @Test
+    public void asyncModelAdminReadPermissions() throws IOException {
+
+        ElideResponse response = null;
+        String id = "edc4a871-dff2-4054-804e-d80075c08959";
+        String query = "test-query";
+
+        com.yahoo.elide.async.models.AsyncQuery queryObj = new com.yahoo.elide.async.models.AsyncQuery();
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.JSONAPI_V1_0);
+        queryObj.setPrincipalName("owner-user");
+
+        dataStore.populateEntityDictionary(
+                        new EntityDictionary(AsyncIntegrationTestApplicationResourceConfig.MAPPINGS));
+        DataStoreTransaction tx = dataStore.beginTransaction();
+        tx.createObject(queryObj, null);
+        tx.commit(null);
+        tx.close();
+
+        Elide elide = new Elide(new ElideSettingsBuilder(dataStore)
+                        .withEntityDictionary(
+                                        new EntityDictionary(AsyncIntegrationTestApplicationResourceConfig.MAPPINGS))
+                        .withAuditLogger(new TestAuditLogger()).build());
+
+        User ownerUser = new User(() -> "owner-user");
+        User anyUser = new User(() -> "any-user");
+        SecurityContextUser securityContextAdminUser = new SecurityContextUser(new SecurityContext() {
+            @Override
+            public Principal getUserPrincipal() {
+                return () -> "1";
+            }
+            @Override
+            public boolean isUserInRole(String s) {
+                return true;
+            }
+            @Override
+            public boolean isSecure() {
+                return false;
+            }
+            @Override
+            public String getAuthenticationScheme() {
+                return null;
+            }
+        });
+        SecurityContextUser securityContextNonAdminUser = new SecurityContextUser(new SecurityContext() {
+            @Override
+            public Principal getUserPrincipal() {
+                return () -> "2";
+            }
+            @Override
+            public boolean isUserInRole(String s) {
+                return false;
+            }
+            @Override
+            public boolean isSecure() {
+                return false;
+            }
+            @Override
+            public String getAuthenticationScheme() {
+                return null;
+            }
+        });
+
+        // Principal is Owner
+        response = elide.get("/asyncQuery/" + id, new MultivaluedHashMap<>(), ownerUser, NO_VERSION);
+        assertEquals(HttpStatus.SC_OK, response.getResponseCode());
+
+        // Principal has Admin Role
+        response = elide.get("/asyncQuery/" + id, new MultivaluedHashMap<>(), securityContextAdminUser, NO_VERSION);
+        assertEquals(HttpStatus.SC_OK, response.getResponseCode());
+
+        // Any Other Principal
+        response = elide.get("/asyncQuery/" + id, new MultivaluedHashMap<>(), anyUser, NO_VERSION);
+        assertEquals(HttpStatus.SC_FORBIDDEN, response.getResponseCode());
+        response = elide.get("/asyncQuery/" + id, new MultivaluedHashMap<>(), securityContextNonAdminUser, NO_VERSION);
+        assertEquals(HttpStatus.SC_FORBIDDEN, response.getResponseCode());
     }
 
     /**

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -687,7 +687,6 @@ public class AsyncIT extends IntegrationTest {
                         .withAuditLogger(new TestAuditLogger()).build());
 
         User ownerUser = new User(() -> "owner-user");
-        User anyUser = new User(() -> "any-user");
         SecurityContextUser securityContextAdminUser = new SecurityContextUser(new SecurityContext() {
             @Override
             public Principal getUserPrincipal() {
@@ -733,9 +732,7 @@ public class AsyncIT extends IntegrationTest {
         response = elide.get("/asyncQuery/" + id, new MultivaluedHashMap<>(), securityContextAdminUser, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
-        // Any Other Principal
-        response = elide.get("/asyncQuery/" + id, new MultivaluedHashMap<>(), anyUser, NO_VERSION);
-        assertEquals(HttpStatus.SC_FORBIDDEN, response.getResponseCode());
+        // Principal without Admin Role
         response = elide.get("/asyncQuery/" + id, new MultivaluedHashMap<>(), securityContextNonAdminUser, NO_VERSION);
         assertEquals(HttpStatus.SC_FORBIDDEN, response.getResponseCode());
     }


### PR DESCRIPTION
Authored-by: rishi-aga

## Description
Make Async Model Read/Update Permissions open to Admin Role.

## Motivation and Context
Make Async Model Read/Update Permissions open to Admin for the usage stats dashboard. Currently, only the query submitter can read/update the query. Update permissions are needed to cancel the query. 

## How Has This Been Tested?
Included Integration tests for added functionality
Existing Tests Pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
