### PR TITLE
Fix for Graphql Fragment Error in Debug Mode 

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -130,8 +130,11 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
         if (children.size() > 0) {
             children.stream().forEach(i -> { if (i.getClass().equals(Field.class)) {
                     fieldName.add(((Field) i).getName());
-                } else {
+                } else if (i.getClass().equals(FragmentSpread.class)) {
                     fieldName.add(((FragmentSpread) i).getName());
+                } else {
+                    log.debug("A new type of Selection, other than Field and FragmentSpread was encountered, {}",
+                            i.getClass());
                 }
             });
         }


### PR DESCRIPTION

## Description
Using Graphql fragments in debug mode gave error, `graphql.language.FragmentSpread cannot be cast to graphql.language.Field`. The error was caused by assuming the type is always Field during the getName operation. Put in a cast by checking the class before calling getName. 

## Motivation and Context
Resolving Error 

## How Has This Been Tested?
Tested with the app that was failing.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
