### PR TITLE
Added links support to entity resource. 

### DIFF
--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Data;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Document;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Id;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Include;
+import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.Links;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperation;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchOperationType;
 import com.yahoo.elide.contrib.testhelpers.jsonapi.elements.PatchSet;
@@ -101,7 +102,34 @@ public class JsonApiDSL {
      * @return the resource
      */
     public static Resource resource(Type type, Id id, Attributes attributes, Relationships relationships) {
-        return new Resource(id, type, attributes, relationships);
+        return new Resource(id, type, attributes, null, relationships);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type          the type
+     * @param id            the id
+     * @param attributes    the attributes
+     * @param link          the link
+     * @param relationships the relationships
+     * @return the resource
+     */
+    public static Resource resource(Type type, Id id, Attributes attributes, Links link, Relationships relationships) {
+        return new Resource(id, type, attributes, link, relationships);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type          the type
+     * @param id            the id
+     * @param attributes    the attributes
+     * @param link          the link
+     * @return the resource
+     */
+    public static Resource resource(Type type, Id id, Attributes attributes, Links link) {
+        return new Resource(id, type, attributes, link, null);
     }
 
     /**
@@ -113,7 +141,7 @@ public class JsonApiDSL {
      * @return the resource
      */
     public static Resource resource(Type type, Id id, Attributes attributes) {
-        return new Resource(id, type, attributes, null);
+        return new Resource(id, type, attributes, null, null);
     }
 
     /**
@@ -125,7 +153,7 @@ public class JsonApiDSL {
      * @return the resource
      */
     public static Resource resource(Type type, Id id, Relationships relationships) {
-        return new Resource(id, type, null, relationships);
+        return new Resource(id, type, null, null, relationships);
     }
 
     /**
@@ -136,7 +164,7 @@ public class JsonApiDSL {
      * @return the resource
      */
     public static Resource resource(Type type, Id id) {
-        return new Resource(id, type, null, null);
+        return new Resource(id, type, null, null, null);
     }
 
     /**
@@ -147,7 +175,7 @@ public class JsonApiDSL {
      * @return the resource
      */
     public static Resource resource(Type type, Attributes attributes) {
-        return new Resource(id(null), type, attributes, null);
+        return new Resource(id(null), type, attributes, null, null);
     }
 
     /**
@@ -159,7 +187,7 @@ public class JsonApiDSL {
      * @return the resource
      */
     public static Resource resource(Type type, Attributes attributes, Relationships relationships) {
-        return new Resource(id(null), type, attributes, relationships);
+        return new Resource(id(null), type, attributes, null, relationships);
     }
 
     /**
@@ -190,6 +218,16 @@ public class JsonApiDSL {
      */
     public static Attributes attributes(Attribute... attrs) {
         return new Attributes(attrs);
+    }
+
+    /**
+     * Links links.
+     *
+     * @param attrs the attrs
+     * @return the attributes
+     */
+    public static Links links(Attribute... attrs) {
+        return new Links(attrs);
     }
 
     /**
@@ -233,7 +271,7 @@ public class JsonApiDSL {
      * @return the relation
      */
     public static Relation relation(String field, boolean toOne, ResourceLinkage... resourceLinkage) {
-        return new Relation(field, toOne, resourceLinkage);
+        return new Relation(field, toOne, null, resourceLinkage);
     }
 
     /**
@@ -244,6 +282,17 @@ public class JsonApiDSL {
      */
     public static Relation relation(String field) {
         return new Relation(field);
+    }
+
+    /**
+     * Relation relation.
+     *
+     * @param field           the field
+     * @param links           the links
+     * @return the relation
+     */
+    public static Relation relation(String field, Links links) {
+        return new Relation(field, links);
     }
 
     /**

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSL.java
@@ -299,6 +299,17 @@ public class JsonApiDSL {
      * Relation relation.
      *
      * @param field           the field
+     * @param links           the links
+     * @param resourceLinkage the resource linkage
+     * @return the relation
+     */
+    public static Relation relation(String field, Links links, ResourceLinkage... resourceLinkage) {
+        return new Relation(field, links, resourceLinkage);
+    }
+    /**
+     * Relation relation.
+     *
+     * @param field           the field
      * @param toOne           whether or not this is a toOne or toMany relationship
      * @return the relation
      */

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Links.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Links.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
+
+import java.util.LinkedHashMap;
+
+public class Links extends LinkedHashMap<String, Object> {
+    /**
+     * Instantiates a new Attributes.
+     *
+     * @param attributes the attributes
+     */
+    public Links(Attribute... attributes) {
+        for (Attribute attribute : attributes) {
+            this.put(attribute.key, attribute.value);
+        }
+    }
+}

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Links.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Links.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Yahoo Inc.
+ * Copyright 2020, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
@@ -25,7 +25,7 @@ public class Relation {
     final boolean toOne;
 
     /**
-     * The Field.
+     * The Links.
      */
     final Links links;
 

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
@@ -24,6 +24,9 @@ public class Relation {
     @Expose(serialize = false)
     final boolean toOne;
 
+    /**
+     * The Field.
+     */
     final Links links;
 
     /**

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
@@ -24,6 +24,8 @@ public class Relation {
     @Expose(serialize = false)
     final boolean toOne;
 
+    final Links links;
+
     /**
      * The Resource linkages.
      */
@@ -36,7 +38,18 @@ public class Relation {
      * @param resourceLinkages the resource linkages
      */
     public Relation(String field, ResourceLinkage... resourceLinkages) {
-        this(field, TO_MANY, resourceLinkages);
+        this(field, TO_MANY, null, resourceLinkages);
+    }
+
+    /**
+     * Instantiates a new Relation.
+     *
+     * @param field            the field
+     * @param links              the links
+     * @param resourceLinkages the resource linkages
+     */
+    public Relation(String field, Links links, ResourceLinkage... resourceLinkages) {
+        this(field, TO_MANY, links, resourceLinkages);
     }
 
     /**
@@ -46,9 +59,10 @@ public class Relation {
      * @param toOne            whether or not the relation is toOne or toMany.
      * @param resourceLinkages the resource linkages
      */
-    public Relation(String field, boolean toOne, ResourceLinkage... resourceLinkages) {
+    public Relation(String field, boolean toOne, Links links, ResourceLinkage... resourceLinkages) {
         this.field = field;
         this.toOne = toOne;
+        this.links = links;
         this.resourceLinkages = resourceLinkages;
     }
 
@@ -61,6 +75,17 @@ public class Relation {
         this(field, TO_MANY);
     }
 
+
+    /**
+     * Instantiates a new Relation.
+     *
+     * @param field            the field
+     * @param links             the links
+     */
+    public Relation(String field, Links links) {
+        this(field, TO_MANY, links);
+    }
+
     /**
      * Instantiates a new Relation.
      *
@@ -70,6 +95,7 @@ public class Relation {
     public Relation(String field, boolean toOne) {
         this.field = field;
         this.toOne = toOne;
+        this.links = null;
         this.resourceLinkages = new ResourceLinkage[0];
     }
 }

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relation.java
@@ -8,6 +8,8 @@ package com.yahoo.elide.contrib.testhelpers.jsonapi.elements;
 
 import com.google.gson.annotations.Expose;
 
+import lombok.Getter;
+
 /**
  * The type Relation.
  */
@@ -19,20 +21,20 @@ public class Relation {
     /**
      * The Field.
      */
-    final String field;
+    @Getter private final String field;
 
     @Expose(serialize = false)
-    final boolean toOne;
+    @Getter private final boolean toOne;
 
     /**
      * The Links.
      */
-    final Links links;
+    @Getter private final Links links;
 
     /**
      * The Resource linkages.
      */
-    final ResourceLinkage[] resourceLinkages;
+    @Getter private final ResourceLinkage[] resourceLinkages;
 
     /**
      * Instantiates a new Relation.

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relationships.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relationships.java
@@ -22,6 +22,9 @@ public class Relationships extends LinkedHashMap<String, Map<String, ?>> {
     public Relationships(Relation... relations) {
         for (Relation relation : relations) {
             Map<String, Object> data = new LinkedHashMap<>();
+            if (relation.links != null) {
+                data.put("links", relation.links);
+            }
             if (relation.toOne) {
                 if (relation.resourceLinkages.length == 0) {
                     data.put("data", null);

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relationships.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Relationships.java
@@ -22,19 +22,19 @@ public class Relationships extends LinkedHashMap<String, Map<String, ?>> {
     public Relationships(Relation... relations) {
         for (Relation relation : relations) {
             Map<String, Object> data = new LinkedHashMap<>();
-            if (relation.links != null) {
-                data.put("links", relation.links);
+            if (relation.getLinks() != null) {
+                data.put("links", relation.getLinks());
             }
-            if (relation.toOne) {
-                if (relation.resourceLinkages.length == 0) {
+            if (relation.isToOne()) {
+                if (relation.getResourceLinkages().length == 0) {
                     data.put("data", null);
                 } else {
-                    data.put("data", relation.resourceLinkages[0]);
+                    data.put("data", relation.getResourceLinkages()[0]);
                 }
             } else {
-                data.put("data", relation.resourceLinkages);
+                data.put("data", relation.getResourceLinkages());
             }
-            this.put(relation.field, data);
+            this.put(relation.getField(), data);
         }
     }
 }

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Resource.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Resource.java
@@ -17,6 +17,7 @@ public class Resource extends ResourceLinkage {
      * @param id            the id
      * @param type          the type
      * @param attributes    the attributes
+     * @param links         the links
      * @param relationships the relationships
      */
     public Resource(Id id, Type type, Attributes attributes, Links links, Relationships relationships) {

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Resource.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/jsonapi/elements/Resource.java
@@ -19,13 +19,16 @@ public class Resource extends ResourceLinkage {
      * @param attributes    the attributes
      * @param relationships the relationships
      */
-    public Resource(Id id, Type type, Attributes attributes, Relationships relationships) {
+    public Resource(Id id, Type type, Attributes attributes, Links links, Relationships relationships) {
         super(id, type);
         if (attributes != null) {
             this.put("attributes", attributes);
         }
         if (relationships != null) {
             this.put("relationships", relationships);
+        }
+        if (links != null) {
+            this.put("links", links);
         }
     }
 }

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -327,6 +327,29 @@ public class JsonApiDSLTest {
     }
 
     @Test
+    public void verifyRequestWithLinks() {
+        String expected = "{\"data\":{\"type\":\"blog\",\"id\":\"1\",\"attributes\":"
+                + "{\"title\":\"Why You Should use Elide\",\"date\":\"2019-01-01\"},"
+                + "\"links\":{\"self\":\"http://localhost:8080/json/api/v1/blog/1\"}}}";
+
+        String actual = datum(
+                resource(
+                        type("blog"),
+                        id("1"),
+                        attributes(
+                                attr("title", "Why You Should use Elide"),
+                                attr("date", "2019-01-01")
+                        ),
+                        links(
+                                attr("self", "http://localhost:8080/json/api/v1/blog/1")
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void verifyRequestWithLinksRelationship() {
         String expected = "{\"data\":{\"type\":\"blog\",\"id\":\"1\",\"attributes\":"
                 + "{\"title\":\"Why You Should use Elide\"},"

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/jsonapi/JsonApiDSLTest.java
@@ -14,6 +14,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.document;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.include;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.links;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchOperation;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchSet;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relation;
@@ -318,6 +319,52 @@ public class JsonApiDSLTest {
                         resource(
                                 type("child"),
                                 id("2")
+                        )
+                )
+        ).toJSON();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void verifyRequestWithLinksRelationship() {
+        String expected = "{\"data\":{\"type\":\"blog\",\"id\":\"1\",\"attributes\":"
+                + "{\"title\":\"Why You Should use Elide\"},"
+                + "\"relationships\":{"
+                +   "\"author\":{"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/api/v1/blog/1/relationships/author\",\"related\":\"http://localhost:8080/json/api/v1/blog/1/author\"},"
+                +       "\"data\":[{\"type\":\"author\",\"id\":\"1\"}]"
+                +   "},"
+                +   "\"comments\":{"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/api/v1/blog/1/relationships/comments\",\"related\":\"http://localhost:8080/json/api/v1/blog/1/comments\"},"
+                +       "\"data\":[]"
+                +   "}},"
+                + "\"links\":{\"self\":\"http://localhost:8080/json/api/v1/blog/1\"}}}";
+
+        String actual = datum(
+                resource(
+                        type("blog"),
+                        id("1"),
+                        attributes(
+                                attr("title", "Why You Should use Elide")
+                        ),
+                        links(
+                                attr("self", "http://localhost:8080/json/api/v1/blog/1")
+                        ),
+                        relationships(
+                                relation("author",
+                                        links(
+                                                attr("self", "http://localhost:8080/json/api/v1/blog/1/relationships/author"),
+                                                attr("related", "http://localhost:8080/json/api/v1/blog/1/author")
+                                        ),
+                                        linkage(type("author"), id("1"))
+                                ),
+                                relation("comments",
+                                        links(
+                                                attr("self", "http://localhost:8080/json/api/v1/blog/1/relationships/comments"),
+                                                attr("related", "http://localhost:8080/json/api/v1/blog/1/comments")
+                                        )
+                                )
                         )
                 )
         ).toJSON();

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -162,9 +162,25 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse get(String path, MultivaluedMap<String, String> queryParams, Object opaqueUser) {
+        return get(null, path, queryParams, opaqueUser);
+
+    }
+
+    /**
+     * Handle GET.
+     *
+     * @param baseUrlEndPoint base URL with prefix endpoint
+     * @param path the path
+     * @param queryParams the query params
+     * @param opaqueUser the opaque user
+     * @return Elide response object
+     */
+    public ElideResponse get(String baseUrlEndPoint, String path,
+                             MultivaluedMap<String, String> queryParams, Object opaqueUser) {
         return handleRequest(true, opaqueUser, dataStore::beginReadTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = new JsonApiDocument();
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
+            RequestScope requestScope = new RequestScope(
+                    baseUrlEndPoint, path, jsonApiDoc, tx, user, queryParams, elideSettings);
             BaseVisitor visitor = new GetVisitor(requestScope);
             return visit(path, requestScope, visitor);
         });
@@ -194,9 +210,25 @@ public class Elide {
      */
     public ElideResponse post(String path, String jsonApiDocument,
                               MultivaluedMap<String, String> queryParams, Object opaqueUser) {
+        return post(null, path, jsonApiDocument, queryParams, opaqueUser);
+    }
+
+    /**
+     * Handle POST.
+     *
+     * @param baseUrlEndPoint base URL with prefix endpoint
+     * @param path the path
+     * @param jsonApiDocument the json api document
+     * @param queryParams the query params
+     * @param opaqueUser the opaque user
+     * @return Elide response object
+     */
+    public ElideResponse post(String baseUrlEndPoint, String path, String jsonApiDocument,
+                              MultivaluedMap<String, String> queryParams, Object opaqueUser) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
+            RequestScope requestScope = new RequestScope(
+                    baseUrlEndPoint, path, jsonApiDoc, tx, user, queryParams, elideSettings);
             BaseVisitor visitor = new PostVisitor(requestScope);
             return visit(path, requestScope, visitor);
         });

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -156,19 +156,6 @@ public class Elide {
     /**
      * Handle GET.
      *
-     * @param path the path
-     * @param queryParams the query params
-     * @param opaqueUser the opaque user
-     * @return Elide response object
-     */
-    public ElideResponse get(String path, MultivaluedMap<String, String> queryParams, Object opaqueUser) {
-        return get(null, path, queryParams, opaqueUser);
-
-    }
-
-    /**
-     * Handle GET.
-     *
      * @param baseUrlEndPoint base URL with prefix endpoint
      * @param path the path
      * @param queryParams the query params
@@ -184,34 +171,21 @@ public class Elide {
             BaseVisitor visitor = new GetVisitor(requestScope);
             return visit(path, requestScope, visitor);
         });
-
     }
 
     /**
      * Handle POST.
      *
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param path the path
      * @param jsonApiDocument the json api document
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse post(String path, String jsonApiDocument, Object opaqueUser) {
-        return post(path, jsonApiDocument, null, opaqueUser);
+    public ElideResponse post(String baseUrlEndPoint, String path, String jsonApiDocument, Object opaqueUser) {
+        return post(baseUrlEndPoint, path, jsonApiDocument, null, opaqueUser);
     }
 
-    /**
-     * Handle POST.
-     *
-     * @param path the path
-     * @param jsonApiDocument the json api document
-     * @param queryParams the query params
-     * @param opaqueUser the opaque user
-     * @return Elide response object
-     */
-    public ElideResponse post(String path, String jsonApiDocument,
-                              MultivaluedMap<String, String> queryParams, Object opaqueUser) {
-        return post(null, path, jsonApiDocument, queryParams, opaqueUser);
-    }
 
     /**
      * Handle POST.
@@ -237,6 +211,7 @@ public class Elide {
     /**
      * Handle PATCH.
      *
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param contentType the content type
      * @param accept the accept
      * @param path the path
@@ -244,14 +219,15 @@ public class Elide {
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse patch(String contentType, String accept,
+    public ElideResponse patch(String baseUrlEndPoint, String contentType, String accept,
                                String path, String jsonApiDocument, Object opaqueUser) {
-        return patch(contentType, accept, path, jsonApiDocument, null, opaqueUser);
+        return patch(baseUrlEndPoint, contentType, accept, path, jsonApiDocument, null, opaqueUser);
     }
 
     /**
      * Handle PATCH.
      *
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param contentType the content type
      * @param accept the accept
      * @param path the path
@@ -260,14 +236,14 @@ public class Elide {
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse patch(String contentType, String accept,
+    public ElideResponse patch(String baseUrlEndPoint, String contentType, String accept,
                                String path, String jsonApiDocument,
                                MultivaluedMap<String, String> queryParams, Object opaqueUser) {
 
         Handler<DataStoreTransaction, User, HandlerResult> handler;
         if (JsonApiPatch.isPatchExtension(contentType) && JsonApiPatch.isPatchExtension(accept)) {
             handler = (tx, user) -> {
-                PatchRequestScope requestScope = new PatchRequestScope(path, tx, user, elideSettings);
+                PatchRequestScope requestScope = new PatchRequestScope(baseUrlEndPoint, path, tx, user, elideSettings);
                 try {
                     Supplier<Pair<Integer, JsonNode>> responder =
                             JsonApiPatch.processJsonPatch(dataStore, path, jsonApiDocument, requestScope);
@@ -279,7 +255,8 @@ public class Elide {
         } else {
             handler = (tx, user) -> {
                 JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
-                RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
+                RequestScope requestScope = new RequestScope(
+                        baseUrlEndPoint, path, jsonApiDoc, tx, user, queryParams, elideSettings);
                 BaseVisitor visitor = new PatchVisitor(requestScope);
                 return visit(path, requestScope, visitor);
             };
@@ -291,31 +268,34 @@ public class Elide {
     /**
      * Handle DELETE.
      *
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param path the path
      * @param jsonApiDocument the json api document
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse delete(String path, String jsonApiDocument, Object opaqueUser) {
-        return delete(path, jsonApiDocument, null, opaqueUser);
+    public ElideResponse delete(String baseUrlEndPoint, String path, String jsonApiDocument, Object opaqueUser) {
+        return delete(baseUrlEndPoint, path, jsonApiDocument, null, opaqueUser);
     }
 
     /**
      * Handle DELETE.
      *
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param path the path
      * @param jsonApiDocument the json api document
      * @param queryParams the query params
      * @param opaqueUser the opaque user
      * @return Elide response object
      */
-    public ElideResponse delete(String path, String jsonApiDocument,
+    public ElideResponse delete(String baseUrlEndPoint, String path, String jsonApiDocument,
                                 MultivaluedMap<String, String> queryParams, Object opaqueUser) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, (tx, user) -> {
             JsonApiDocument jsonApiDoc = StringUtils.isEmpty(jsonApiDocument)
                     ? new JsonApiDocument()
                     : mapper.readJsonApiDocument(jsonApiDocument);
-            RequestScope requestScope = new RequestScope(path, jsonApiDoc, tx, user, queryParams, elideSettings);
+            RequestScope requestScope = new RequestScope(
+                    baseUrlEndPoint, path, jsonApiDoc, tx, user, queryParams, elideSettings);
             BaseVisitor visitor = new DeleteVisitor(requestScope);
             return visit(path, requestScope, visitor);
         });

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -7,8 +7,8 @@ package com.yahoo.elide;
 
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.core.DataStore;
-import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.JSONApiLinks;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.dialect.JoinFilterDialect;
 import com.yahoo.elide.core.filter.dialect.SubqueryFilterDialect;
@@ -35,7 +35,7 @@ public class ElideSettings {
     @Getter private final Function<RequestScope, PermissionExecutor> permissionExecutor;
     @Getter private final List<JoinFilterDialect> joinFilterDialects;
     @Getter private final List<SubqueryFilterDialect> subqueryFilterDialects;
-    @Getter private final DefaultJSONApiLinks defaultJsonApiLinks;
+    @Getter private final JSONApiLinks jsonApiLinks;
     @Getter private final int defaultMaxPageSize;
     @Getter private final int defaultPageSize;
     @Getter private final boolean useFilterExpressions;

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -7,6 +7,7 @@ package com.yahoo.elide;
 
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.dialect.JoinFilterDialect;
@@ -34,6 +35,7 @@ public class ElideSettings {
     @Getter private final Function<RequestScope, PermissionExecutor> permissionExecutor;
     @Getter private final List<JoinFilterDialect> joinFilterDialects;
     @Getter private final List<SubqueryFilterDialect> subqueryFilterDialects;
+    @Getter private final DefaultJSONApiLinks defaultJsonApiLinks;
     @Getter private final int defaultMaxPageSize;
     @Getter private final int defaultPageSize;
     @Getter private final boolean useFilterExpressions;
@@ -41,4 +43,5 @@ public class ElideSettings {
     @Getter private final boolean returnErrorObjects;
     @Getter private final Map<Class, Serde> serdes;
     @Getter private final boolean encodeErrorResponses;
+    @Getter private final boolean enableJsonLinks;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -8,6 +8,7 @@ package com.yahoo.elide;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.core.RequestScope;
@@ -44,6 +45,7 @@ public class ElideSettingsBuilder {
     private Function<RequestScope, PermissionExecutor> permissionExecutorFunction = ActivePermissionExecutor::new;
     private List<JoinFilterDialect> joinFilterDialects;
     private List<SubqueryFilterDialect> subqueryFilterDialects;
+    private DefaultJSONApiLinks defaultJsonApiLinks;
     private Map<Class, Serde> serdes;
     private int defaultMaxPageSize = Pagination.MAX_PAGE_LIMIT;
     private int defaultPageSize = Pagination.DEFAULT_PAGE_LIMIT;
@@ -51,6 +53,7 @@ public class ElideSettingsBuilder {
     private int updateStatusCode;
     private boolean returnErrorObjects;
     private boolean encodeErrorResponses;
+    private boolean enableJsonLinks;
 
     /**
      * A new builder used to generate Elide instances. Instantiates an {@link EntityDictionary} without
@@ -66,6 +69,8 @@ public class ElideSettingsBuilder {
         this.subqueryFilterDialects = new ArrayList<>();
         updateStatusCode = HttpStatus.SC_NO_CONTENT;
         this.serdes = new HashMap<>();
+        //this.defaultJsonApiLinks = new DefaultJSONApiLinks();
+        this.enableJsonLinks = false;
 
         //By default, Elide supports epoch based dates.
         this.withEpochDates();
@@ -90,13 +95,15 @@ public class ElideSettingsBuilder {
                 permissionExecutorFunction,
                 joinFilterDialects,
                 subqueryFilterDialects,
+                defaultJsonApiLinks,
                 defaultMaxPageSize,
                 defaultPageSize,
                 useFilterExpressions,
                 updateStatusCode,
                 returnErrorObjects,
                 serdes,
-                encodeErrorResponses);
+                encodeErrorResponses,
+                enableJsonLinks);
     }
 
     public ElideSettingsBuilder withAuditLogger(AuditLogger auditLogger) {
@@ -199,6 +206,12 @@ public class ElideSettingsBuilder {
 
     public ElideSettingsBuilder withEncodeErrorResponses(boolean encodeErrorResponses) {
         this.encodeErrorResponses = encodeErrorResponses;
+        return this;
+    }
+
+    public ElideSettingsBuilder withJSONApiLinks(DefaultJSONApiLinks links) {
+        this.enableJsonLinks = true;
+        this.defaultJsonApiLinks = links;
         return this;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -8,9 +8,9 @@ package com.yahoo.elide;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.core.DataStore;
-import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.HttpStatus;
+import com.yahoo.elide.core.JSONApiLinks;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.dialect.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.dialect.JoinFilterDialect;
@@ -45,7 +45,7 @@ public class ElideSettingsBuilder {
     private Function<RequestScope, PermissionExecutor> permissionExecutorFunction = ActivePermissionExecutor::new;
     private List<JoinFilterDialect> joinFilterDialects;
     private List<SubqueryFilterDialect> subqueryFilterDialects;
-    private DefaultJSONApiLinks defaultJsonApiLinks;
+    private JSONApiLinks jsonApiLinks;
     private Map<Class, Serde> serdes;
     private int defaultMaxPageSize = Pagination.MAX_PAGE_LIMIT;
     private int defaultPageSize = Pagination.DEFAULT_PAGE_LIMIT;
@@ -94,7 +94,7 @@ public class ElideSettingsBuilder {
                 permissionExecutorFunction,
                 joinFilterDialects,
                 subqueryFilterDialects,
-                defaultJsonApiLinks,
+                jsonApiLinks,
                 defaultMaxPageSize,
                 defaultPageSize,
                 useFilterExpressions,
@@ -208,9 +208,9 @@ public class ElideSettingsBuilder {
         return this;
     }
 
-    public ElideSettingsBuilder withJSONApiLinks(DefaultJSONApiLinks links) {
+    public ElideSettingsBuilder withJSONApiLinks(JSONApiLinks links) {
         this.enableJsonLinks = true;
-        this.defaultJsonApiLinks = links;
+        this.jsonApiLinks = links;
         return this;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -69,7 +69,6 @@ public class ElideSettingsBuilder {
         this.subqueryFilterDialects = new ArrayList<>();
         updateStatusCode = HttpStatus.SC_NO_CONTENT;
         this.serdes = new HashMap<>();
-        //this.defaultJsonApiLinks = new DefaultJSONApiLinks();
         this.enableJsonLinks = false;
 
         //By default, Elide supports epoch based dates.

--- a/elide-core/src/main/java/com/yahoo/elide/core/DefaultJSONApiLinks.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DefaultJSONApiLinks.java
@@ -36,6 +36,9 @@ public class DefaultJSONApiLinks implements JSONApiLinks {
      */
     protected String getResourceUrl(PersistentResource resource) {
         StringBuilder result = new StringBuilder();
+        if (resource.getRequestScope().getBaseUrlEndPoint() != null) {
+            result.append(resource.getRequestScope().getBaseUrlEndPoint());
+        }
         for (PersistentResource resourcePath : resource.getLineage().getResourcePath()) {
             result.append(String.join("/", resourcePath.getType(), resourcePath.getId()));
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/DefaultJSONApiLinks.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DefaultJSONApiLinks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Yahoo Inc.
+ * Copyright 2020, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -14,21 +14,14 @@ import java.util.Map;
  * To add custom links, Override `getResourceLevelLinks` and `getRelationshipLinks`.
  * Ad the subclass object in ElideAutoConfiguration.
  */
-public class DefaultJSONApiLinks {
-    /**
-     * Links to be used in EntityProjection
-     * @param resource
-     * @return
-     */
+public class DefaultJSONApiLinks implements JSONApiLinks {
+
+    @Override
     public Map<String, String> getResourceLevelLinks(PersistentResource resource) {
         return ImmutableMap.of("self", getResourceUrl(resource));
     }
 
-    /**
-     * Links to be used in Relationships of EntityProjection
-     * @param resource
-     * @return
-     */
+    @Override
     public Map<String, String> getRelationshipLinks(PersistentResource resource, String field) {
         String resourceUrl = getResourceUrl(resource);
         return ImmutableMap.of(

--- a/elide-core/src/main/java/com/yahoo/elide/core/DefaultJSONApiLinks.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/DefaultJSONApiLinks.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/***
+ * Default API links populate provide 'self' and 'related' links.
+ * To add custom links, Override `getResourceLevelLinks` and `getRelationshipLinks`.
+ * Ad the subclass object in ElideAutoConfiguration.
+ */
+public class DefaultJSONApiLinks {
+    /**
+     * Links to be used in EntityProjection
+     * @param resource
+     * @return
+     */
+    public Map<String, String> getResourceLevelLinks(PersistentResource resource) {
+        return ImmutableMap.of("self", getResourceUrl(resource));
+    }
+
+    /**
+     * Links to be used in Relationships of EntityProjection
+     * @param resource
+     * @return
+     */
+    public Map<String, String> getRelationshipLinks(PersistentResource resource, String field) {
+        String resourceUrl = getResourceUrl(resource);
+        return ImmutableMap.of(
+                "self", String.join("/", resourceUrl, "relationships", field),
+                "related", String.join("/", resourceUrl, field));
+    }
+
+    /**
+     * Creates the link from resources path
+     * @param resource
+     * @return
+     */
+    protected String getResourceUrl(PersistentResource resource) {
+        StringBuilder result = new StringBuilder();
+        for (PersistentResource resourcePath : resource.getLineage().getResourcePath()) {
+            result.append(String.join("/", resourcePath.getType(), resourcePath.getId()));
+        }
+        result.append(String.join("/", resource.getType(), resource.getId()));
+        return result.toString();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/JSONApiLinks.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/JSONApiLinks.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core;
+
+import java.util.Map;
+
+public interface JSONApiLinks {
+    /**
+     * Links to be used in the Respose Entity
+     * @param resource
+     * @return
+     */
+    Map<String, String> getResourceLevelLinks(PersistentResource resource);
+
+    /**
+     * Links to be used in Relationships of the Response Entity
+     * @param resource
+     * @return
+     */
+    Map<String, String> getRelationshipLinks(PersistentResource resource, String field);
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1206,6 +1206,9 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
                 : dictionary.getId(obj));
         resource.setRelationships(relationshipSupplier.get());
         resource.setAttributes(attributeSupplier.get());
+        if (requestScope.getElideSettings().isEnableJsonLinks()) {
+            resource.setLinks(requestScope.getElideSettings().getDefaultJsonApiLinks().getResourceLevelLinks(this));
+        }
         return resource;
     }
 
@@ -1264,8 +1267,13 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             } else {
                 data = new Data<>(resources);
             }
-            // TODO - links
-            relationshipMap.put(field, new Relationship(null, data));
+            Map<String, String> links = null;
+            if (requestScope.getElideSettings().isEnableJsonLinks()) {
+                 links = requestScope.getElideSettings()
+                        .getDefaultJsonApiLinks()
+                        .getRelationshipLinks(this, field);
+            }
+            relationshipMap.put(field, new Relationship(links, data));
         }
 
         return relationshipMap;

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1207,7 +1207,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
         resource.setRelationships(relationshipSupplier.get());
         resource.setAttributes(attributeSupplier.get());
         if (requestScope.getElideSettings().isEnableJsonLinks()) {
-            resource.setLinks(requestScope.getElideSettings().getDefaultJsonApiLinks().getResourceLevelLinks(this));
+            resource.setLinks(requestScope.getElideSettings().getJsonApiLinks().getResourceLevelLinks(this));
         }
         return resource;
     }
@@ -1270,7 +1270,7 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
             Map<String, String> links = null;
             if (requestScope.getElideSettings().isEnableJsonLinks()) {
                  links = requestScope.getElideSettings()
-                        .getDefaultJsonApiLinks()
+                        .getJsonApiLinks()
                         .getRelationshipLinks(this, field);
             }
             relationshipMap.put(field, new Relationship(links, data));

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -87,17 +87,10 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     /* Used to filter across heterogeneous types during the first load */
     private FilterExpression globalFilterExpression;
 
-    public RequestScope(String path,
-                        JsonApiDocument jsonApiDocument,
-                        DataStoreTransaction transaction,
-                        User user,
-                        MultivaluedMap<String, String> queryParams,
-                        ElideSettings elideSettings) {
-        this(null, path, jsonApiDocument, transaction, user, queryParams, elideSettings);
-    }
     /**
      * Create a new RequestScope with specified update status code.
      *
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param path the URL path
      * @param jsonApiDocument the document for this request
      * @param transaction the transaction for this request
@@ -204,7 +197,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      */
     protected RequestScope(String path, JsonApiDocument jsonApiDocument, RequestScope outerRequestScope) {
         this.jsonApiDocument = jsonApiDocument;
-        this.baseUrlEndPoint = null;
+        this.baseUrlEndPoint = outerRequestScope.baseUrlEndPoint;
         this.path = path;
         this.transaction = outerRequestScope.transaction;
         this.user = outerRequestScope.user;

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -71,6 +71,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     @Getter private final Set<PersistentResource> newPersistentResources;
     @Getter private final LinkedHashSet<PersistentResource> dirtyResources;
     @Getter private final LinkedHashSet<PersistentResource> deletedResources;
+    @Getter private final String baseUrlEndPoint;
     @Getter private final String path;
     @Getter private final ElideSettings elideSettings;
     @Getter private final boolean useFilterExpressions;
@@ -86,6 +87,14 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
     /* Used to filter across heterogeneous types during the first load */
     private FilterExpression globalFilterExpression;
 
+    public RequestScope(String path,
+                        JsonApiDocument jsonApiDocument,
+                        DataStoreTransaction transaction,
+                        User user,
+                        MultivaluedMap<String, String> queryParams,
+                        ElideSettings elideSettings) {
+        this(null, path, jsonApiDocument, transaction, user, queryParams, elideSettings);
+    }
     /**
      * Create a new RequestScope with specified update status code.
      *
@@ -96,7 +105,8 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      * @param queryParams the query parameters
      * @param elideSettings Elide settings object
      */
-    public RequestScope(String path,
+    public RequestScope(String baseUrlEndPoint,
+                        String path,
                         JsonApiDocument jsonApiDocument,
                         DataStoreTransaction transaction,
                         User user,
@@ -108,6 +118,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
         this.distinctLifecycleEvents.subscribe(queuedLifecycleEvents);
 
         this.path = path;
+        this.baseUrlEndPoint = baseUrlEndPoint;
         this.jsonApiDocument = jsonApiDocument;
         this.transaction = transaction;
         this.user = user;
@@ -193,6 +204,7 @@ public class RequestScope implements com.yahoo.elide.security.RequestScope {
      */
     protected RequestScope(String path, JsonApiDocument jsonApiDocument, RequestScope outerRequestScope) {
         this.jsonApiDocument = jsonApiDocument;
+        this.baseUrlEndPoint = null;
         this.path = path;
         this.transaction = outerRequestScope.transaction;
         this.user = outerRequestScope.user;

--- a/elide-core/src/main/java/com/yahoo/elide/core/ResourceLineage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/ResourceLineage.java
@@ -107,10 +107,7 @@ public class ResourceLineage {
                 return false;
             }
         }
-        if (!other.resourcePath.equals(this.resourcePath)) {
-            return false;
-        }
-        return true;
+        return other.resourcePath.equals(this.resourcePath);
     }
 
     private void addRecord(PersistentResource latest, String alias) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/ResourceLineage.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/ResourceLineage.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -19,12 +20,14 @@ import java.util.List;
  */
 public class ResourceLineage {
     private final LinkedMap<String, List<PersistentResource>> resourceMap;
+    private final List<PersistentResource> resourcePath;
 
     /**
      * Empty lineage for objects rooted in the URL.
      */
     public ResourceLineage() {
         resourceMap = new LinkedMap<>();
+        resourcePath = new LinkedList<>();
     }
 
     /**
@@ -34,6 +37,7 @@ public class ResourceLineage {
      */
     public ResourceLineage(ResourceLineage sharedLineage, PersistentResource next) {
         resourceMap = new LinkedMap<>(sharedLineage.resourceMap);
+        resourcePath = new LinkedList<>(sharedLineage.resourcePath);
         addRecord(next);
     }
 
@@ -49,6 +53,7 @@ public class ResourceLineage {
      */
     public ResourceLineage(ResourceLineage sharedLineage, PersistentResource next, String nextAlias) {
         resourceMap = new LinkedMap<>(sharedLineage.resourceMap);
+        resourcePath = new LinkedList<>(sharedLineage.resourcePath);
         addRecord(next, nextAlias);
     }
 
@@ -70,6 +75,10 @@ public class ResourceLineage {
      */
     public List<String> getKeys() {
         return resourceMap.asList();
+    }
+
+    public List<PersistentResource> getResourcePath() {
+        return resourcePath;
     }
 
     private void addRecord(PersistentResource latest) {
@@ -98,6 +107,9 @@ public class ResourceLineage {
                 return false;
             }
         }
+        if (!other.resourcePath.equals(this.resourcePath)) {
+            return false;
+        }
         return true;
     }
 
@@ -110,5 +122,6 @@ public class ResourceLineage {
             resourceMap.put(alias, resources);
         }
         resources.add(latest);
+        resourcePath.add(latest);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/extensions/PatchRequestScope.java
@@ -21,17 +21,20 @@ public class PatchRequestScope extends RequestScope {
     /**
      * Outer RequestScope constructor for use by Patch Extension.
      *
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param path the URL path
      * @param transaction current database transaction
      * @param user        request user
      * @param elideSettings Elide settings object
      */
     public PatchRequestScope(
+            String baseUrlEndPoint,
             String path,
             DataStoreTransaction transaction,
             User user,
             ElideSettings elideSettings) {
         super(
+                baseUrlEndPoint,
                 path,
                 (JsonApiDocument) null,
                 transaction,

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -68,12 +68,8 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-        return build(
-                elide.post(uriInfo.getBaseUri().toString(),
-                        path,
-                        jsonapiDocument,
-                        queryParams,
-                        getUser.apply(securityContext)));
+        return build(elide.post(uriInfo.getBaseUri().toString(), path, jsonapiDocument,
+                queryParams, getUser.apply(securityContext)));
     }
 
     /**
@@ -116,7 +112,7 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-        return build(elide.patch(contentType, accept, path, jsonapiDocument,
+        return build(elide.patch(uriInfo.getBaseUri().toString(), contentType, accept, path, jsonapiDocument,
                                  queryParams, getUser.apply(securityContext)));
     }
 
@@ -138,7 +134,8 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-        return build(elide.delete(path, jsonApiDocument, queryParams, getUser.apply(securityContext)));
+        return build(elide.delete(uriInfo.getBaseUri().toString(), path, jsonApiDocument,
+                queryParams, getUser.apply(securityContext)));
     }
 
     private static Response build(ElideResponse response) {

--- a/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/resources/JsonApiEndpoint.java
@@ -68,7 +68,12 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-        return build(elide.post(path, jsonapiDocument, queryParams, getUser.apply(securityContext)));
+        return build(
+                elide.post(uriInfo.getBaseUri().toString(),
+                        path,
+                        jsonapiDocument,
+                        queryParams,
+                        getUser.apply(securityContext)));
     }
 
     /**
@@ -86,7 +91,7 @@ public class JsonApiEndpoint {
         @Context UriInfo uriInfo,
         @Context SecurityContext securityContext) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-        return build(elide.get(path, queryParams, getUser.apply(securityContext)));
+        return build(elide.get(uriInfo.getBaseUri().toString(), path, queryParams, getUser.apply(securityContext)));
     }
 
     /**

--- a/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/audit/LogMessageTest.java
@@ -53,7 +53,7 @@ public class LogMessageTest {
         friend.setId(9);
         child.setFriends(Sets.newHashSet(friend));
 
-        final RequestScope requestScope = new RequestScope(null, null, null, new User(
+        final RequestScope requestScope = new RequestScope(null, null, null, null, new User(
             new Principal() {
                 @Override
                 public String getName() {

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -83,6 +83,7 @@ import javax.ws.rs.core.MultivaluedMap;
 public class LifeCycleTest {
 
     private static final AuditLogger MOCK_AUDIT_LOGGER = mock(AuditLogger.class);
+    private final String baseUrl = "http://localhost:8080/api/v1";
     private EntityDictionary dictionary;
     private MockCallback callback;
     private MockCallback onUpdateDeferredCallback;
@@ -157,7 +158,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.createNewObject(Book.class)).thenReturn(book);
 
-        ElideResponse response = elide.post("/book", bookBody, null);
+        ElideResponse response = elide.post(baseUrl, "/book", bookBody, null);
         assertEquals(HttpStatus.SC_CREATED, response.getResponseCode());
 
         /*
@@ -192,7 +193,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.createNewObject(Book.class)).thenReturn(book);
 
-        ElideResponse response = elide.post("/book", bookBody, null);
+        ElideResponse response = elide.post(baseUrl, "/book", bookBody, null);
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getResponseCode());
         assertEquals(
                 "{\"errors\":[{\"detail\":\"InternalServerErrorException: Unexpected exception caught\"}]}",
@@ -231,7 +232,7 @@ public class LifeCycleTest {
         when(tx.loadObject(eq(Book.class), any(), any(), isA(RequestScope.class))).thenReturn(book);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
-        ElideResponse response = elide.get("/book/1", headers, null);
+        ElideResponse response = elide.get(baseUrl, "/book/1", headers, null);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         /*
@@ -265,7 +266,7 @@ public class LifeCycleTest {
         when(tx.loadObject(eq(Book.class), any(), any(), isA(RequestScope.class))).thenReturn(book);
 
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
-        ElideResponse response = elide.get("/book/1/relationships/authors", headers, null);
+        ElideResponse response = elide.get(baseUrl, "/book/1/relationships/authors", headers, null);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         /*
@@ -297,7 +298,7 @@ public class LifeCycleTest {
         String bookBody = "{\"data\":{\"type\":\"book\",\"id\":1,\"attributes\": {\"title\":\"Grapes of Wrath\"}}}";
 
         String contentType = JSONAPI_CONTENT_TYPE;
-        ElideResponse response = elide.patch(contentType, contentType, "/book/1", bookBody, null);
+        ElideResponse response = elide.patch(baseUrl, contentType, contentType, "/book/1", bookBody, null);
         assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
 
         /*
@@ -339,7 +340,7 @@ public class LifeCycleTest {
         String bookBody = "{\"data\":{\"type\":\"book\",\"id\":1,\"attributes\": {\"title\":\"Grapes of Wrath\"}}}";
 
         String contentType = JSONAPI_CONTENT_TYPE;
-        ElideResponse response = elide.patch(contentType, contentType, "/book/1", bookBody, null);
+        ElideResponse response = elide.patch(baseUrl, contentType, contentType, "/book/1", bookBody, null);
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
         assertEquals(
                 "{\"errors\":[{\"detail\":\"Constraint violation\"}]}",
@@ -380,7 +381,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(eq(Book.class), any(), any(), isA(RequestScope.class))).thenReturn(book);
 
-        ElideResponse response = elide.delete("/book/1", "", null);
+        ElideResponse response = elide.delete(baseUrl, "/book/1", "", null);
         assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
 
         /*
@@ -414,7 +415,7 @@ public class LifeCycleTest {
         when(tx.createNewObject(Book.class)).thenReturn(book);
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
+        ElideResponse response = elide.patch(baseUrl, contentType, contentType, "/", bookBody, null);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         /*
@@ -450,7 +451,7 @@ public class LifeCycleTest {
         when(tx.createNewObject(Book.class)).thenReturn(book);
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
+        ElideResponse response = elide.patch(baseUrl, contentType, contentType, "/", bookBody, null);
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
         assertEquals(
                 "{\"errors\":[{\"detail\":\"JsonPatchExtensionException\"}]}",
@@ -480,7 +481,7 @@ public class LifeCycleTest {
                 + "\"type\":\"book\",\"id\":1,\"attributes\": {\"title\":\"Grapes of Wrath\"}}}]";
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
+        ElideResponse response = elide.patch(baseUrl, contentType, contentType, "/", bookBody, null);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals("[{\"data\":null}]", response.getBody());
 
@@ -523,7 +524,7 @@ public class LifeCycleTest {
                 + "\"type\":\"book\",\"id\": \"1\"}}]";
 
         String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-        ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
+        ElideResponse response = elide.patch(baseUrl, contentType, contentType, "/", bookBody, null);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
         /*
@@ -1299,6 +1300,7 @@ public class LifeCycleTest {
     }
 
     private RequestScope buildRequestScope(EntityDictionary dict, DataStoreTransaction tx) {
-        return new RequestScope(null, null, tx, new User(1), null, getElideSettings(null, dict, MOCK_AUDIT_LOGGER));
+        return new RequestScope(null, null, null, tx, new User(1),
+                null, getElideSettings(null, dict, MOCK_AUDIT_LOGGER));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/PermissionAnnotationTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PermissionAnnotationTest.java
@@ -55,9 +55,9 @@ public class PermissionAnnotationTest {
                 .withEntityDictionary(dictionary)
                 .build();
 
-        RequestScope goodScope = new RequestScope(null, null, null, GOOD_USER, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, null, null, null, GOOD_USER, null, elideSettings);
         funRecord = new PersistentResource<>(fun, null, goodScope.getUUIDFor(fun), goodScope);
-        RequestScope badScope = new RequestScope(null, null, null, BAD_USER, null, elideSettings);
+        RequestScope badScope = new RequestScope(null, null, null, null, BAD_USER, null, elideSettings);
         badRecord = new PersistentResource<>(fun, null, badScope.getUUIDFor(fun), badScope);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -115,7 +115,7 @@ public class PersistenceResourceTestSetup extends PersistentResource {
                 new Child(),
                 null,
                 null, // new request scope + new Child == cannot possibly be a UUID for this object
-                new RequestScope(null, null, null, null, null,
+                new RequestScope(null, null, null, null, null, null,
                         initSettings()
                 )
         );
@@ -142,7 +142,7 @@ public class PersistenceResourceTestSetup extends PersistentResource {
     }
 
     protected RequestScope buildRequestScope(String path, DataStoreTransaction tx, User user, MultivaluedMap<String, String> queryParams) {
-        return new RequestScope(path, null, tx, user, queryParams, elideSettings);
+        return new RequestScope(null, path, null, tx, user, queryParams, elideSettings);
     }
 
     protected <T> PersistentResource<T> bootstrapPersistentResource(T obj) {
@@ -151,12 +151,12 @@ public class PersistenceResourceTestSetup extends PersistentResource {
 
     protected <T> PersistentResource<T> bootstrapPersistentResource(T obj, DataStoreTransaction tx) {
         User goodUser = new User(1);
-        RequestScope requestScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope requestScope = new RequestScope(null, null, null, tx, goodUser, null, elideSettings);
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 
     protected RequestScope getUserScope(User user, AuditLogger auditLogger) {
-        return new RequestScope(null, new JsonApiDocument(), null, user, null,
+        return new RequestScope(null, null, new JsonApiDocument(), null, user, null,
                 new ElideSettingsBuilder(null)
                     .withEntityDictionary(dictionary)
                     .withAuditLogger(auditLogger)

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceNoopUpdateTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSetup {
     private final RequestScope goodUserScope;
     PersistentResourceNoopUpdateTest() {
-        goodUserScope = new RequestScope(null, null, mock(DataStoreTransaction.class),
+        goodUserScope = new RequestScope(null, null, null, mock(DataStoreTransaction.class),
                 new User(1), null, elideSettings);
         initDictionary();
         reset(goodUserScope.getTransaction());
@@ -39,7 +39,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, null, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
         //We do not want the update to one method to be called when we add the existing entity to the relation
@@ -57,7 +57,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, null, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, "1", goodScope);
         funResource.addRelation("relation3", childResource);
@@ -77,7 +77,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, null, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
         //We do not want the update to one method to be called when we add the existing entity to the relation
@@ -94,7 +94,7 @@ public class PersistentResourceNoopUpdateTest extends PersistenceResourceTestSet
 
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, null, null, tx, goodUser, null, elideSettings);
         PersistentResource<FunWithPermissions> funResource = new PersistentResource<>(fun, null, "3", goodScope);
         PersistentResource<Child> childResource = new PersistentResource<>(child, null, null, goodScope);
         funResource.addRelation("relation1", childResource);

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -716,7 +716,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         @SuppressWarnings("resource")
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
-        RequestScope goodScope = new RequestScope(null, null, tx, goodUser, null, elideSettings);
+        RequestScope goodScope = new RequestScope(null, null, null, tx, goodUser, null, elideSettings);
 
         // null resource in toMany relationship is not valid
         List<Resource> idList = new ArrayList<>();
@@ -2198,7 +2198,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     public void testPatchRequestScope() {
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
         PatchRequestScope parentScope =
-                new PatchRequestScope(null, tx, new User(1), elideSettings);
+                new PatchRequestScope(null, null, tx, new User(1), elideSettings);
         PatchRequestScope scope = new PatchRequestScope(
                 parentScope.getPath(), parentScope.getJsonApiDocument(), parentScope);
         // verify wrap works

--- a/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
@@ -65,7 +65,7 @@ public class RequestScopeTest {
         dictionary.bindEntity(MyBaseClass.class);
         dictionary.bindEntity(MyInheritedClass.class);
 
-        RequestScope requestScope = new RequestScope("/", null, null, null, null,
+        RequestScope requestScope = new RequestScope(null, "/", null, null, null, null,
                 new ElideSettingsBuilder(null)
                         .withEntityDictionary(dictionary)
                         .build());

--- a/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/UpdateOnCreateTest.java
@@ -57,13 +57,13 @@ public class UpdateOnCreateTest extends PersistenceResourceTestSetup {
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
 
         User userOne = new User(1);
-        userOneScope = new RequestScope(null, null, tx, userOne, null, elideSettings);
+        userOneScope = new RequestScope(null, null, null, tx, userOne, null, elideSettings);
         User userTwo = new User(2);
-        userTwoScope = new RequestScope(null, null, tx, userTwo, null, elideSettings);
+        userTwoScope = new RequestScope(null, null, null, tx, userTwo, null, elideSettings);
         User userThree = new User(3);
-        userThreeScope = new RequestScope(null, null, tx, userThree, null, elideSettings);
+        userThreeScope = new RequestScope(null, null, null, tx, userThree, null, elideSettings);
         User userFour = new User(4);
-        userFourScope = new RequestScope(null, null, tx, userFour, null, elideSettings);
+        userFourScope = new RequestScope(null, null, null, tx, userFour, null, elideSettings);
 
         when(tx.createNewObject(UpdateAndCreate.class)).thenReturn(updateAndCreateNewObject);
         when(tx.loadObject(eq(UpdateAndCreate.class),

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.audit.TestAuditLogger;
 import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
@@ -67,6 +68,7 @@ public class JsonApiTest {
                         .withJsonApiMapper(mapper)
                         .withAuditLogger(testLogger)
                         .withEntityDictionary(dictionary)
+                        .withJSONApiLinks(new DefaultJSONApiLinks())
                         .build());
     }
 
@@ -91,7 +93,18 @@ public class JsonApiTest {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
         jsonApiDocument.setData(new Data<>(new PersistentResource<>(parent, null, userScope.getUUIDFor(parent), userScope).toResource()));
 
-        String expected = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":null},\"relationships\":{\"children\":{\"data\":[]},\"spouses\":{\"data\":[]}}}}";
+        String expected = "{\"data\":{"
+                + "\"type\":\"parent\","
+                + "\"id\":\"123\","
+                + "\"attributes\":{\"firstName\":null},"
+                + "\"relationships\":{"
+                +   "\"children\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"data\":[]},"
+                +   "\"spouses\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"data\":[]}},"
+                + "\"links\":{\"self\":\"parent/123\"}}}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -115,7 +128,18 @@ public class JsonApiTest {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
         jsonApiDocument.setData(new Data<>(new PersistentResource<>(parent, null, userScope.getUUIDFor(parent), userScope).toResource()));
 
-        String expected = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}}}";
+        String expected = "{\"data\":{"
+                + "\"type\":\"parent\","
+                + "\"id\":\"123\","
+                + "\"attributes\":{\"firstName\":\"bob\"},"
+                + "\"relationships\":{"
+                +   "\"children\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
+                +   "\"spouses\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"data\":[]}},"
+                + "\"links\":{\"self\":\"parent/123\"}}}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -142,7 +166,32 @@ public class JsonApiTest {
         jsonApiDocument.setData(new Data<>(pRec.toResource()));
         jsonApiDocument.addIncluded(new PersistentResource<>(child, pRec, userScope.getUUIDFor(child), userScope).toResource());
 
-        String expected = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}},\"included\":[{\"type\":\"child\",\"id\":\"2\",\"attributes\":{\"name\":null},\"relationships\":{\"friends\":{\"data\":[]},\"parents\":{\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}}}]}";
+        String expected1 = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}},\"included\":[{\"type\":\"child\",\"id\":\"2\",\"attributes\":{\"name\":null},\"relationships\":{\"friends\":{\"data\":[]},\"parents\":{\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}}}]}";
+
+        String expected = "{\"data\":{"
+                + "\"type\":\"parent\","
+                + "\"id\":\"123\","
+                + "\"attributes\":{\"firstName\":\"bob\"},"
+                + "\"relationships\":{"
+                +   "\"children\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
+                +   "\"spouses\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"data\":[]}},"
+                + "\"links\":{\"self\":\"parent/123\"}},"
+                + "\"included\":[{"
+                +   "\"type\":\"child\","
+                +   "\"id\":\"2\","
+                +   "\"attributes\":{\"name\":null},"
+                +   "\"relationships\":{"
+                +       "\"friends\":{"
+                +           "\"links\":{\"self\":\"parent/123child/2/relationships/friends\",\"related\":\"parent/123child/2/friends\"},"
+                +           "\"data\":[]},"
+                +       "\"parents\":{"
+                +           "\"links\":{\"self\":\"parent/123child/2/relationships/parents\",\"related\":\"parent/123child/2/parents\"},"
+                +           "\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}},"
+                +   "\"links\":{\"self\":\"parent/123child/2\"}}]}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -168,7 +217,18 @@ public class JsonApiTest {
         jsonApiDocument.setData(
             new Data<>(Collections.singletonList(new PersistentResource<>(parent, null, userScope.getUUIDFor(parent), userScope).toResource())));
 
-        String expected = "{\"data\":[{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}}]}";
+        String expected = "{\"data\":[{"
+                + "\"type\":\"parent\","
+                + "\"id\":\"123\","
+                + "\"attributes\":{\"firstName\":\"bob\"},"
+                + "\"relationships\":{"
+                +   "\"children\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
+                +   "\"spouses\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"data\":[]}},"
+                + "\"links\":{\"self\":\"parent/123\"}}]}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -197,7 +257,31 @@ public class JsonApiTest {
         // duplicate will be ignored
         jsonApiDocument.addIncluded(new PersistentResource<>(child, pRec, userScope.getUUIDFor(child), userScope).toResource());
 
-        String expected = "{\"data\":[{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}}],\"included\":[{\"type\":\"child\",\"id\":\"2\",\"attributes\":{\"name\":null},\"relationships\":{\"friends\":{\"data\":[]},\"parents\":{\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}}}]}";
+        String expected = "{\"data\":[{"
+                + "\"type\":\"parent\","
+                + "\"id\":\"123\","
+                + "\"attributes\":{\"firstName\":\"bob\"},"
+                + "\"relationships\":{"
+                +   "\"children\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
+                +   "\"spouses\":{"
+                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"data\":[]}},"
+                + "\"links\":{\"self\":\"parent/123\"}}],"
+                + "\"included\":[{"
+                +   "\"type\":\"child\","
+                +   "\"id\":\"2\","
+                +   "\"attributes\":{\"name\":null},"
+                +   "\"relationships\":{"
+                +       "\"friends\":{"
+                +           "\"links\":{\"self\":\"parent/123child/2/relationships/friends\",\"related\":\"parent/123child/2/friends\"},"
+                +           "\"data\":[]},"
+                +       "\"parents\":{"
+                +           "\"links\":{\"self\":\"parent/123child/2/relationships/parents\",\"related\":\"parent/123child/2/parents\"},"
+                +           "\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}},"
+                +   "\"links\":{\"self\":\"parent/123child/2\"}}]"
+                + "}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -62,7 +62,7 @@ public class JsonApiTest {
         dictionary.bindInitializer(Parent::doInit, Parent.class);
         mapper = new JsonApiMapper(dictionary);
         AuditLogger testLogger = new TestAuditLogger();
-        userScope = new RequestScope(null, new JsonApiDocument(),
+        userScope = new RequestScope("http://localhost:8080/json/", null, new JsonApiDocument(),
                 mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS), new User(0), null,
                 new ElideSettingsBuilder(null)
                         .withJsonApiMapper(mapper)
@@ -99,12 +99,12 @@ public class JsonApiTest {
                 + "\"attributes\":{\"firstName\":null},"
                 + "\"relationships\":{"
                 +   "\"children\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/children\",\"related\":\"http://localhost:8080/json/parent/123/children\"},"
                 +       "\"data\":[]},"
                 +   "\"spouses\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/spouses\",\"related\":\"http://localhost:8080/json/parent/123/spouses\"},"
                 +       "\"data\":[]}},"
-                + "\"links\":{\"self\":\"parent/123\"}}}";
+                + "\"links\":{\"self\":\"http://localhost:8080/json/parent/123\"}}}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -134,12 +134,12 @@ public class JsonApiTest {
                 + "\"attributes\":{\"firstName\":\"bob\"},"
                 + "\"relationships\":{"
                 +   "\"children\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/children\",\"related\":\"http://localhost:8080/json/parent/123/children\"},"
                 +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
                 +   "\"spouses\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/spouses\",\"related\":\"http://localhost:8080/json/parent/123/spouses\"},"
                 +       "\"data\":[]}},"
-                + "\"links\":{\"self\":\"parent/123\"}}}";
+                + "\"links\":{\"self\":\"http://localhost:8080/json/parent/123\"}}}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -172,24 +172,24 @@ public class JsonApiTest {
                 + "\"attributes\":{\"firstName\":\"bob\"},"
                 + "\"relationships\":{"
                 +   "\"children\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/children\",\"related\":\"http://localhost:8080/json/parent/123/children\"},"
                 +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
                 +   "\"spouses\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/spouses\",\"related\":\"http://localhost:8080/json/parent/123/spouses\"},"
                 +       "\"data\":[]}},"
-                + "\"links\":{\"self\":\"parent/123\"}},"
+                + "\"links\":{\"self\":\"http://localhost:8080/json/parent/123\"}},"
                 + "\"included\":[{"
                 +   "\"type\":\"child\","
                 +   "\"id\":\"2\","
                 +   "\"attributes\":{\"name\":null},"
                 +   "\"relationships\":{"
                 +       "\"friends\":{"
-                +           "\"links\":{\"self\":\"parent/123child/2/relationships/friends\",\"related\":\"parent/123child/2/friends\"},"
+                +           "\"links\":{\"self\":\"http://localhost:8080/json/parent/123child/2/relationships/friends\",\"related\":\"http://localhost:8080/json/parent/123child/2/friends\"},"
                 +           "\"data\":[]},"
                 +       "\"parents\":{"
-                +           "\"links\":{\"self\":\"parent/123child/2/relationships/parents\",\"related\":\"parent/123child/2/parents\"},"
+                +           "\"links\":{\"self\":\"http://localhost:8080/json/parent/123child/2/relationships/parents\",\"related\":\"http://localhost:8080/json/parent/123child/2/parents\"},"
                 +           "\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}},"
-                +   "\"links\":{\"self\":\"parent/123child/2\"}}]}";
+                +   "\"links\":{\"self\":\"http://localhost:8080/json/parent/123child/2\"}}]}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -221,12 +221,12 @@ public class JsonApiTest {
                 + "\"attributes\":{\"firstName\":\"bob\"},"
                 + "\"relationships\":{"
                 +   "\"children\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/children\",\"related\":\"http://localhost:8080/json/parent/123/children\"},"
                 +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
                 +   "\"spouses\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/spouses\",\"related\":\"http://localhost:8080/json/parent/123/spouses\"},"
                 +       "\"data\":[]}},"
-                + "\"links\":{\"self\":\"parent/123\"}}]}";
+                + "\"links\":{\"self\":\"http://localhost:8080/json/parent/123\"}}]}";
 
         Data<Resource> data = jsonApiDocument.getData();
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
@@ -261,24 +261,24 @@ public class JsonApiTest {
                 + "\"attributes\":{\"firstName\":\"bob\"},"
                 + "\"relationships\":{"
                 +   "\"children\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/children\",\"related\":\"parent/123/children\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/children\",\"related\":\"http://localhost:8080/json/parent/123/children\"},"
                 +       "\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},"
                 +   "\"spouses\":{"
-                +       "\"links\":{\"self\":\"parent/123/relationships/spouses\",\"related\":\"parent/123/spouses\"},"
+                +       "\"links\":{\"self\":\"http://localhost:8080/json/parent/123/relationships/spouses\",\"related\":\"http://localhost:8080/json/parent/123/spouses\"},"
                 +       "\"data\":[]}},"
-                + "\"links\":{\"self\":\"parent/123\"}}],"
+                + "\"links\":{\"self\":\"http://localhost:8080/json/parent/123\"}}],"
                 + "\"included\":[{"
                 +   "\"type\":\"child\","
                 +   "\"id\":\"2\","
                 +   "\"attributes\":{\"name\":null},"
                 +   "\"relationships\":{"
                 +       "\"friends\":{"
-                +           "\"links\":{\"self\":\"parent/123child/2/relationships/friends\",\"related\":\"parent/123child/2/friends\"},"
+                +           "\"links\":{\"self\":\"http://localhost:8080/json/parent/123child/2/relationships/friends\",\"related\":\"http://localhost:8080/json/parent/123child/2/friends\"},"
                 +           "\"data\":[]},"
                 +       "\"parents\":{"
-                +           "\"links\":{\"self\":\"parent/123child/2/relationships/parents\",\"related\":\"parent/123child/2/parents\"},"
+                +           "\"links\":{\"self\":\"http://localhost:8080/json/parent/123child/2/relationships/parents\",\"related\":\"http://localhost:8080/json/parent/123child/2/parents\"},"
                 +           "\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}},"
-                +   "\"links\":{\"self\":\"parent/123child/2\"}}]"
+                +   "\"links\":{\"self\":\"http://localhost:8080/json/parent/123child/2\"}}]"
                 + "}";
 
         Data<Resource> data = jsonApiDocument.getData();

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -166,8 +166,6 @@ public class JsonApiTest {
         jsonApiDocument.setData(new Data<>(pRec.toResource()));
         jsonApiDocument.addIncluded(new PersistentResource<>(child, pRec, userScope.getUUIDFor(child), userScope).toResource());
 
-        String expected1 = "{\"data\":{\"type\":\"parent\",\"id\":\"123\",\"attributes\":{\"firstName\":\"bob\"},\"relationships\":{\"children\":{\"data\":[{\"type\":\"child\",\"id\":\"2\"}]},\"spouses\":{\"data\":[]}}},\"included\":[{\"type\":\"child\",\"id\":\"2\",\"attributes\":{\"name\":null},\"relationships\":{\"friends\":{\"data\":[]},\"parents\":{\"data\":[{\"type\":\"parent\",\"id\":\"123\"}]}}}]}";
-
         String expected = "{\"data\":{"
                 + "\"type\":\"parent\","
                 + "\"id\":\"123\","

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
@@ -69,12 +69,12 @@ public class IncludedProcessorTest {
                 .withEntityDictionary(dictionary)
                 .build();
 
-        RequestScope goodUserScope = new RequestScope(null,
+        RequestScope goodUserScope = new RequestScope(null, null,
                 new JsonApiDocument(), mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS),
                 new User(1), null,
                 elideSettings);
 
-        RequestScope badUserScope = new RequestScope(null,
+        RequestScope badUserScope = new RequestScope(null, null,
                 new JsonApiDocument(), mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS),
                 new User(-1), null,
                 elideSettings);

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -228,7 +228,7 @@ public class PermissionToFilterExpressionVisitorTest {
     //
     public RequestScope newRequestScope() {
         User john = new User("John");
-        return requestScope = new RequestScope(null, null, null, john, null, elideSettings);
+        return requestScope = new RequestScope(null, null, null, null, john, null, elideSettings);
     }
 
     private FilterExpression filterExpressionForPermissions(String permission) {

--- a/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/PermissionExecutorTest.java
@@ -452,14 +452,14 @@ public class PermissionExecutorTest {
     public <T> PersistentResource<T> newResource(T obj, Class<T> cls) {
         EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(cls);
-        RequestScope requestScope = new RequestScope(null, null, null, null, null, getElideSettings(dictionary));
+        RequestScope requestScope = new RequestScope(null, null, null, null, null, null, getElideSettings(dictionary));
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 
     public <T> PersistentResource<T> newResource(Class<T> cls) {
         EntityDictionary dictionary = new EntityDictionary(TestCheckMappings.MAPPINGS);
         dictionary.bindEntity(cls);
-        RequestScope requestScope = new RequestScope(null, null, null, null, null, getElideSettings(dictionary));
+        RequestScope requestScope = new RequestScope(null, null, null, null, null, null, getElideSettings(dictionary));
         try {
             T obj = cls.newInstance();
             return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);

--- a/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilderTest.java
@@ -127,7 +127,7 @@ public class PermissionExpressionBuilderTest {
      }
 
     public <T> PersistentResource newResource(T obj, Class<T> cls) {
-        RequestScope requestScope = new RequestScope(null, null, null, null, null, elideSettings);
+        RequestScope requestScope = new RequestScope(null, null, null, null, null, null, elideSettings);
         return new PersistentResource<>(obj, null, requestScope.getUUIDFor(obj), requestScope);
     }
 }

--- a/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate3/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -54,6 +54,7 @@ public class DataStoreIT extends IntegrationTest {
     private static final String ATTRIBUTES = "attributes";
     private static final String TITLE = "title";
     private static final String CHAPTER_COUNT = "chapterCount";
+    private static final String BASEURL = "http://localhost:8080/api";
 
     private static final int ICE_AND_FIRE_CHAPTER_COUNT = 10;
     private static final int CLASH_OF_KINGS_CHAPTER_COUNT = 20;
@@ -123,7 +124,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testRootEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/book", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -140,7 +141,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testSubcollectionEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/author/1/books", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -158,7 +159,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/book", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/book", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -172,7 +173,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/author/1/books", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -186,7 +187,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/book", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -204,7 +205,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/author/1/books", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -225,7 +226,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), 1);
+        ElideResponse response = elide.get(BASEURL, "filtered", new MultivaluedHashMap<>(), 1);
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(data.toJSON(), response.getBody());
     }
@@ -237,7 +238,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), -1);
+        ElideResponse response = elide.get(BASEURL, "filtered", new MultivaluedHashMap<>(), -1);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals(data.toJSON(), response.getBody());
     }

--- a/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/test/java/com/yahoo/elide/tests/DataStoreIT.java
@@ -54,6 +54,7 @@ public class DataStoreIT extends IntegrationTest {
     private static final String ATTRIBUTES = "attributes";
     private static final String TITLE = "title";
     private static final String CHAPTER_COUNT = "chapterCount";
+    private static final String BASEURL = "http://localhost:8080/api";
 
     private static final int ICE_AND_FIRE_CHAPTER_COUNT = 10;
     private static final int CLASH_OF_KINGS_CHAPTER_COUNT = 20;
@@ -123,7 +124,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testRootEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/book", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -140,7 +141,7 @@ public class DataStoreIT extends IntegrationTest {
     public void testSubcollectionEntityFormulaFetch() throws Exception {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/author/1/books", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -158,7 +159,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/book", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/book", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -172,7 +173,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("filter[book.chapterCount]", Arrays.asList("20"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/author/1/books", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(1, result.get(DATA).size());
@@ -186,7 +187,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/book", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/book", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -204,7 +205,7 @@ public class DataStoreIT extends IntegrationTest {
         MultivaluedHashMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fields[book]", Arrays.asList("title,chapterCount"));
         queryParams.put("sort", Arrays.asList("-chapterCount"));
-        ElideResponse response = elide.get("/author/1/books", queryParams, 1);
+        ElideResponse response = elide.get(BASEURL, "/author/1/books", queryParams, 1);
 
         JsonNode result = mapper.readTree(response.getBody());
         assertEquals(ALL_BOOKS_COUNT, result.get(DATA).size());
@@ -225,7 +226,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), 1);
+        ElideResponse response = elide.get(BASEURL, "filtered", new MultivaluedHashMap<>(), 1);
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(data.toJSON(), response.getBody());
     }
@@ -237,7 +238,7 @@ public class DataStoreIT extends IntegrationTest {
                 linkage(type("filtered"), id("3"))
         );
 
-        ElideResponse response = elide.get("filtered", new MultivaluedHashMap<>(), -1);
+        ElideResponse response = elide.get(BASEURL, "filtered", new MultivaluedHashMap<>(), -1);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals(data.toJSON(), response.getBody());
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 
 /**
  * Default endpoint/servlet for using Elide and JSONAPI.
@@ -58,10 +59,12 @@ public class GraphQLEndpoint {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     public Response post(
+            @Context UriInfo uriInfo,
             @Context SecurityContext securityContext,
             String graphQLDocument) {
 
-        ElideResponse response = runner.run(graphQLDocument, getUser.apply(securityContext));
+        ElideResponse response = runner.run(uriInfo.getBaseUri().toString(),
+                graphQLDocument, getUser.apply(securityContext));
         return Response.status(response.getResponseCode()).entity(response.getBody()).build();
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
@@ -23,13 +23,14 @@ import javax.ws.rs.core.MultivaluedHashMap;
 public class GraphQLRequestScope extends RequestScope {
     @Getter private final Map<String, Long> totalRecordCounts = new HashMap<>();
 
-    public GraphQLRequestScope(DataStoreTransaction transaction,
+    public GraphQLRequestScope(String baseUrlEndpoint,
+                               DataStoreTransaction transaction,
                                User user,
                                ElideSettings elideSettings) {
         // TODO: We're going to break out the two request scopes. `RequestScope` should become an interface and
         // we should have a GraphQLRequestScope and a JSONAPIRequestScope.
         // TODO: What should mutate multiple entity value be? There is a problem with this setting in practice.
         // Namely, we don't filter or paginate in the data store.
-        super(null, "/", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
+        super(baseUrlEndpoint, "/", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLRequestScope.java
@@ -30,6 +30,6 @@ public class GraphQLRequestScope extends RequestScope {
         // we should have a GraphQLRequestScope and a JSONAPIRequestScope.
         // TODO: What should mutate multiple entity value be? There is a problem with this setting in practice.
         // Namely, we don't filter or paginate in the data store.
-        super("/", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
+        super(null, "/", null, transaction, user, new MultivaluedHashMap<>(), elideSettings);
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -82,11 +82,12 @@ public class QueryRunner {
 
     /**
      * Execute a GraphQL query and return the response.
+     * @param baseUrlEndPoint base URL with prefix endpoint
      * @param graphQLDocument The graphQL document (wrapped in JSON payload).
      * @param user The user who issued the query.
      * @return The response.
      */
-    public ElideResponse run(String graphQLDocument, Object user) {
+    public ElideResponse run(String baseUrlEndPoint, String graphQLDocument, Object user) {
         ObjectMapper mapper = elide.getMapper().getObjectMapper();
 
         JsonNode topLevel;
@@ -101,7 +102,7 @@ public class QueryRunner {
         }
 
         Function<JsonNode, ElideResponse> executeRequest =
-                (node) -> executeGraphQLRequest(mapper, user, graphQLDocument, node);
+                (node) -> executeGraphQLRequest(baseUrlEndPoint, mapper, user, graphQLDocument, node);
 
         if (topLevel.isArray()) {
             Iterator<JsonNode> nodeIterator = topLevel.iterator();
@@ -139,12 +140,13 @@ public class QueryRunner {
         return executeRequest.apply(topLevel);
     }
 
-    private ElideResponse executeGraphQLRequest(ObjectMapper mapper, Object principal,
+    private ElideResponse executeGraphQLRequest(String baseUrlEndPoint, ObjectMapper mapper, Object principal,
                                                 String graphQLDocument, JsonNode jsonDocument) {
         boolean isVerbose = false;
         try (DataStoreTransaction tx = elide.getDataStore().beginTransaction()) {
             final User user = tx.accessUser(principal);
-            GraphQLRequestScope requestScope = new GraphQLRequestScope(tx, user, elide.getElideSettings());
+            GraphQLRequestScope requestScope = new GraphQLRequestScope(
+                    baseUrlEndPoint, tx, user, elide.getElideSettings());
             isVerbose = requestScope.getPermissionExecutor().isVerbose();
 
             if (!jsonDocument.has(QUERY)) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -140,8 +140,11 @@ public class QueryRunner {
         return executeRequest.apply(topLevel);
     }
 
-    private ElideResponse executeGraphQLRequest(String baseUrlEndPoint, ObjectMapper mapper, Object principal,
-                                                String graphQLDocument, JsonNode jsonDocument) {
+    private ElideResponse executeGraphQLRequest(String baseUrlEndPoint,
+                                                ObjectMapper mapper,
+                                                Object principal,
+                                                String graphQLDocument,
+                                                JsonNode jsonDocument) {
         boolean isVerbose = false;
         try (DataStoreTransaction tx = elide.getDataStore().beginTransaction()) {
             final User user = tx.accessUser(principal);

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -22,6 +22,8 @@ import graphql.ExecutionResult;
  */
 public class FetcherFetchTest extends PersistentResourceFetcherTest {
 
+    private final String baseUrl = "http://localhost:8080/graphql";
+
     @Test
     public void testRootSingle() throws Exception {
         runComparisonTest("rootSingle");
@@ -115,7 +117,7 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     @Test
     public void testFailuresWithBody() throws Exception {
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
-        RequestScope requestScope = new GraphQLRequestScope(tx, null, settings);
+        RequestScope requestScope = new GraphQLRequestScope(baseUrl, tx, null, settings);
 
         String graphQLRequest = "{ "
                 + "book(ids: [\"1\"], data: [{\"id\": \"1\"}]) { "
@@ -167,7 +169,7 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     @Test
     public void testSchemaIntrospection() throws Exception {
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
-        RequestScope requestScope = new GraphQLRequestScope(tx, null, settings);
+        RequestScope requestScope = new GraphQLRequestScope(baseUrl, tx, null, settings);
 
         String graphQLRequest = "{"
             + "__schema {"
@@ -184,7 +186,7 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     @Test
     public void testTypeIntrospection() throws Exception {
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
-        RequestScope requestScope = new GraphQLRequestScope(tx, null, settings);
+        RequestScope requestScope = new GraphQLRequestScope(baseUrl, tx, null, settings);
 
         String graphQLRequest = "{"
             + "__type(name: \"author\") {"

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -51,6 +51,7 @@ import graphqlEndpointTestModels.security.CommitChecks;
 import graphqlEndpointTestModels.security.UserChecks;
 
 import java.io.IOException;
+import java.net.URI;
 import java.security.Principal;
 import java.util.AbstractMap;
 import java.util.Arrays;
@@ -62,6 +63,7 @@ import java.util.stream.Stream;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
 
 /**
  * GraphQL endpoint tests tested against the in-memory store.
@@ -74,6 +76,7 @@ public class GraphQLEndpointTest {
     private final SecurityContext user2 = Mockito.mock(SecurityContext.class);
     private final SecurityContext user3 = Mockito.mock(SecurityContext.class);
     private final AuditLogger audit = Mockito.mock(AuditLogger.class);
+    private final UriInfo uriInfo = Mockito.mock(UriInfo.class);
 
     public static class User implements Principal {
         String log = "";
@@ -108,6 +111,7 @@ public class GraphQLEndpointTest {
         Mockito.when(user1.getUserPrincipal()).thenReturn(new User().withName("1"));
         Mockito.when(user2.getUserPrincipal()).thenReturn(new User().withName("2"));
         Mockito.when(user3.getUserPrincipal()).thenReturn(new User().withName("3"));
+        Mockito.when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost:8080/graphql"));
     }
 
     @BeforeEach
@@ -214,7 +218,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -267,7 +271,7 @@ public class GraphQLEndpointTest {
 
         Map<String, String> variables = new HashMap<>();
         variables.put("bookId", "1");
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest, variables));
+        Response response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest, variables));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -295,7 +299,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -312,7 +316,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -350,7 +354,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
         assert200DataEqual(response, expectedData);
     }
@@ -408,7 +412,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
 
         graphQLRequest = document(
@@ -435,7 +439,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post(uriInfo, user2, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -479,7 +483,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
 
         assertHasErrors(response);
 
@@ -526,7 +530,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -571,7 +575,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         String expectedLog = "On Title Update Pre Security\nOn Title Update Pre Commit\nOn Title Update Post Commit\n";
@@ -604,7 +608,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
 
         Mockito.verify(audit, Mockito.times(1)).log(Mockito.any());
         Mockito.verify(audit, Mockito.times(1)).commit(Mockito.any());
@@ -653,7 +657,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         graphQLRequest = document(
@@ -706,7 +710,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -735,7 +739,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user3, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user3, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 
@@ -789,7 +793,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -814,7 +818,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user1, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
     }
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -379,7 +379,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post(uriInfo, user2, graphQLRequestToJSON(graphQLRequest));
         JsonNode node = extract200Response(response);
         Iterator<JsonNode> errors = node.get("errors").elements();
         assertTrue(errors.hasNext());

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -62,6 +62,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
     protected GraphQL api;
     protected ObjectMapper mapper = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(GraphQL.class);
+    private final String baseUrl = "http://localhost:8080/graphql";
 
     protected HashMapDataStore hashMapDataStore;
     protected InMemoryDataStore inMemoryDataStore;
@@ -189,7 +190,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
         boolean isMutation = graphQLRequest.startsWith("mutation");
 
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
-        RequestScope requestScope = new GraphQLRequestScope(tx, null, settings);
+        RequestScope requestScope = new GraphQLRequestScope(baseUrl, tx, null, settings);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope, variables);
         // NOTE: We're forcing commit even in case of failures. GraphQLEndpoint tests should ensure we do not commit on
@@ -214,7 +215,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
         boolean isMutation = graphQLRequest.startsWith("mutation");
 
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
-        RequestScope requestScope = new GraphQLRequestScope(tx, null, settings);
+        RequestScope requestScope = new GraphQLRequestScope(baseUrl, tx, null, settings);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope);
         if (isMutation) {
@@ -233,7 +234,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
 
     protected void assertQueryFails(String graphQLRequest) {
         DataStoreTransaction tx = inMemoryDataStore.beginTransaction();
-        RequestScope requestScope = new GraphQLRequestScope(tx, null, settings);
+        RequestScope requestScope = new GraphQLRequestScope(baseUrl, tx, null, settings);
 
         ExecutionResult result = api.execute(graphQLRequest, requestScope);
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -88,6 +88,8 @@ import javax.ws.rs.core.Response.Status;
 public class ResourceIT extends IntegrationTest {
     private final JsonParser jsonParser = new JsonParser();
 
+    private final String baseUrl = "http://localhost:8080/api";
+
     private static final Resource PARENT1 = resource(
             type("parent"),
             id("1"),
@@ -2508,7 +2510,7 @@ public class ResourceIT extends IntegrationTest {
                 .withEntityDictionary(new EntityDictionary(TestCheckMappings.MAPPINGS))
                 .build());
         ElideResponse response =
-                elide.get("parent/1/children/1", new MultivaluedHashMap<>(), -1);
+                elide.get(baseUrl, "parent/1/children/1", new MultivaluedHashMap<>(), -1);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
         assertEquals(datum(child).toJSON(), response.getBody());
     }
@@ -2519,7 +2521,7 @@ public class ResourceIT extends IntegrationTest {
                 .withEntityDictionary(new EntityDictionary(TestCheckMappings.MAPPINGS))
                 .withAuditLogger(new TestAuditLogger())
                 .build());
-        ElideResponse response = elide.get("parent/1/children", new MultivaluedHashMap<>(), -1);
+        ElideResponse response = elide.get(baseUrl, "parent/1/children", new MultivaluedHashMap<>(), -1);
         assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
         assertEquals(response.getBody(), "{\"data\":[]}");
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -11,7 +11,6 @@ import com.yahoo.elide.Injector;
 import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 import com.yahoo.elide.core.DataStore;
-import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.datastores.jpa.JpaDataStore;
@@ -54,7 +53,6 @@ public class ElideAutoConfiguration {
                 .withEntityDictionary(dictionary)
                 .withDefaultMaxPageSize(settings.getMaxPageSize())
                 .withDefaultPageSize(settings.getPageSize())
-                .withJSONApiLinks(new DefaultJSONApiLinks())
                 .withUseFilterExpressions(true)
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
                 .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.Injector;
 import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.datastores.jpa.JpaDataStore;
@@ -53,6 +54,7 @@ public class ElideAutoConfiguration {
                 .withEntityDictionary(dictionary)
                 .withDefaultMaxPageSize(settings.getMaxPageSize())
                 .withDefaultPageSize(settings.getPageSize())
+                .withJSONApiLinks(new DefaultJSONApiLinks())
                 .withUseFilterExpressions(true)
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
                 .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,13 +37,15 @@ import java.security.Principal;
 public class GraphqlController {
 
     private final QueryRunner runner;
+    private final ElideConfigProperties settings;
 
     private static final String JSON_CONTENT_TYPE = "application/json";
 
     @Autowired
-    public GraphqlController(Elide elide) {
+    public GraphqlController(Elide elide, ElideConfigProperties settings) {
         log.debug("Started ~~");
         this.runner = new QueryRunner(elide);
+        this.settings = settings;
     }
 
     /**
@@ -55,7 +58,10 @@ public class GraphqlController {
     @PostMapping(value = {"/**", ""}, consumes = JSON_CONTENT_TYPE, produces = JSON_CONTENT_TYPE)
     public ResponseEntity<String> post(@RequestBody String graphQLDocument, Principal user) {
 
-        ElideResponse response = runner.run(graphQLDocument, user);
+        String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+                + settings.getGraphql().getPath() + "/";
+
+        ElideResponse response = runner.run(baseUrl, graphQLDocument, user);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -60,9 +60,7 @@ public class JsonApiController {
     public ResponseEntity<String> elideGet(@RequestParam Map<String, String> allRequestParams,
                                            HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
-
-        String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
-                + settings.getJsonApi().getPath() + "/";
+        String baseUrl = getBaseUrlEndpoint();
 
         ElideResponse response = elide
                 .get(baseUrl, pathname, new MultivaluedHashMap<>(allRequestParams), authentication);
@@ -74,9 +72,7 @@ public class JsonApiController {
                                             @RequestParam Map<String, String> allRequestParams,
                                             HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
-
-        String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
-                + settings.getJsonApi().getPath() + "/";
+        String baseUrl = getBaseUrlEndpoint();
 
         ElideResponse response = elide
                 .post(baseUrl, pathname, body, new MultivaluedHashMap<>(allRequestParams), authentication);
@@ -88,9 +84,10 @@ public class JsonApiController {
                                              @RequestParam Map<String, String> allRequestParams,
                                              HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
+        String baseUrl = getBaseUrlEndpoint();
 
         ElideResponse response = elide
-                .patch(request.getContentType(), request.getContentType(), pathname, body,
+                .patch(baseUrl, request.getContentType(), request.getContentType(), pathname, body,
                        new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
@@ -100,9 +97,10 @@ public class JsonApiController {
                                              @RequestParam Map<String, String> allRequestParams,
                                              Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
+        String baseUrl = getBaseUrlEndpoint();
 
         ElideResponse response = elide
-                .delete(pathname, null, new MultivaluedHashMap<>(allRequestParams), authentication);
+                .delete(baseUrl, pathname, null, new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
@@ -111,9 +109,10 @@ public class JsonApiController {
                                                           @RequestParam Map<String, String> allRequestParams,
                                                           HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
+        String baseUrl = getBaseUrlEndpoint();
 
         ElideResponse response = elide
-                .delete(pathname, body, new MultivaluedHashMap<>(allRequestParams), authentication);
+                .delete(baseUrl, pathname, body, new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
@@ -122,5 +121,10 @@ public class JsonApiController {
                 .getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
 
         return pathname.replaceFirst(prefix, "");
+    }
+
+    private String getBaseUrlEndpoint() {
+        return ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+                + settings.getJsonApi().getPath() + "/";
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,7 +61,11 @@ public class JsonApiController {
                                            HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
-        ElideResponse response = elide.get(pathname, new MultivaluedHashMap<>(allRequestParams), authentication);
+        String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+                + settings.getJsonApi().getPath() + "/";
+
+        ElideResponse response = elide
+                .get(baseUrl, pathname, new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 
@@ -70,8 +75,11 @@ public class JsonApiController {
                                             HttpServletRequest request, Principal authentication) {
         String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
 
+        String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+                + settings.getJsonApi().getPath() + "/";
+
         ElideResponse response = elide
-                .post(pathname, body, new MultivaluedHashMap<>(allRequestParams), authentication);
+                .post(baseUrl, pathname, body, new MultivaluedHashMap<>(allRequestParams), authentication);
         return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
@@ -17,6 +17,7 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.data;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.linkage;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.links;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchOperation;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.patchSet;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relation;
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 import com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL;
 import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.spring.controllers.JsonApiController;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
@@ -66,8 +68,17 @@ public class ControllerTest extends IntegrationTest {
                                                 attr("deprecated", false),
                                                 attr("description", "The code for this project")
                                         ),
+                                        links(
+                                                attr("self", "group/com.example.repository")
+                                        ),
                                         relationships(
-                                                relation("products")
+                                                relation(
+                                                        "products",
+                                                        links(
+                                                                attr("self", "group/com.example.repository/relationships/products"),
+                                                                attr("related", "group/com.example.repository/products")
+                                                        )
+                                                )
                                         )
                                 )
                         ).toJSON())
@@ -109,13 +120,23 @@ public class ControllerTest extends IntegrationTest {
                                                 attr("deprecated", false),
                                                 attr("description", "The code for this project")
                                         ),
+                                        links(
+                                                attr("self", "group/com.example.repository")
+                                        ),
                                         relationships(
-                                                relation("products")
+                                                relation(
+                                                        "products",
+                                                            links(
+                                                                    attr("self", "group/com.example.repository/relationships/products"),
+                                                                    attr("related", "group/com.example.repository/products")
+                                                            )
+
+                                                )
                                         )
                                 )
                         ).toJSON())
                 )
-                .statusCode(HttpStatus.SC_OK);
+                        .statusCode(HttpStatus.SC_OK);
     }
 
     @Test
@@ -191,8 +212,17 @@ public class ControllerTest extends IntegrationTest {
                                         attr("deprecated", false),
                                         attr("description", "")
                                 ),
+                                links(
+                                        attr("self", "group/com.example.repository2")
+                                ),
                                 relationships(
-                                        relation("products")
+                                        relation(
+                                                "products",
+                                                links(
+                                                        attr("self", "group/com.example.repository2/relationships/products"),
+                                                        attr("related", "group/com.example.repository2/products")
+                                                )
+                                        )
                                 )
                         )
                 ).toJSON()))

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
@@ -50,11 +50,13 @@ import javax.ws.rs.core.MediaType;
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
         statements = "DELETE FROM ArtifactVersion; DELETE FROM ArtifactProduct; DELETE FROM ArtifactGroup;")
 public class ControllerTest extends IntegrationTest {
+    private String hostname = "localhost";
     /**
      * This test demonstrates an example test using the JSON-API DSL.
      */
     @Test
     public void jsonApiGetTest() {
+        String baseUrl = "http://" + hostname + ":" + port + "/json/";
         when()
                 .get("/json/group")
                 .then()
@@ -69,14 +71,14 @@ public class ControllerTest extends IntegrationTest {
                                                 attr("description", "The code for this project")
                                         ),
                                         links(
-                                                attr("self", "group/com.example.repository")
+                                                attr("self", baseUrl + "group/com.example.repository")
                                         ),
                                         relationships(
                                                 relation(
                                                         "products",
                                                         links(
-                                                                attr("self", "group/com.example.repository/relationships/products"),
-                                                                attr("related", "group/com.example.repository/products")
+                                                                attr("self", baseUrl + "group/com.example.repository/relationships/products"),
+                                                                attr("related", baseUrl + "group/com.example.repository/products")
                                                         )
                                                 )
                                         )
@@ -88,6 +90,7 @@ public class ControllerTest extends IntegrationTest {
 
     @Test
     public void jsonApiPatchTest() {
+        String baseUrl = "http://" + hostname + ":" + port + "/json/";
         given()
             .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
             .body(
@@ -121,14 +124,14 @@ public class ControllerTest extends IntegrationTest {
                                                 attr("description", "The code for this project")
                                         ),
                                         links(
-                                                attr("self", "group/com.example.repository")
+                                                attr("self", baseUrl + "group/com.example.repository")
                                         ),
                                         relationships(
                                                 relation(
                                                         "products",
                                                             links(
-                                                                    attr("self", "group/com.example.repository/relationships/products"),
-                                                                    attr("related", "group/com.example.repository/products")
+                                                                    attr("self", baseUrl + "group/com.example.repository/relationships/products"),
+                                                                    attr("related", baseUrl + "group/com.example.repository/products")
                                                             )
 
                                                 )
@@ -187,6 +190,7 @@ public class ControllerTest extends IntegrationTest {
 
     @Test
     public void jsonApiPostTest() {
+        String baseUrl = "http://" + hostname + ":" + port + "/json/";
         given()
                 .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
                 .body(
@@ -213,14 +217,14 @@ public class ControllerTest extends IntegrationTest {
                                         attr("description", "")
                                 ),
                                 links(
-                                        attr("self", "group/com.example.repository2")
+                                        attr("self", baseUrl + "group/com.example.repository2")
                                 ),
                                 relationships(
                                         relation(
                                                 "products",
                                                 links(
-                                                        attr("self", "group/com.example.repository2/relationships/products"),
-                                                        attr("related", "group/com.example.repository2/products")
+                                                        attr("self", baseUrl + "group/com.example.repository2/relationships/products"),
+                                                        attr("related", baseUrl + "group/com.example.repository2/products")
                                                 )
                                         )
                                 )

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/IntegrationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/IntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 
 import io.restassured.RestAssured;
 
@@ -18,6 +19,7 @@ import io.restassured.RestAssured;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Import(IntegrationTestSetup.class)
 public class IntegrationTest {
 
     @LocalServerPort

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/IntegrationTestSetup.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/IntegrationTestSetup.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.tests;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.audit.Slf4jLogger;
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DefaultJSONApiLinks;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.spring.config.ElideConfigProperties;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.util.TimeZone;
+
+@TestConfiguration
+public class IntegrationTestSetup {
+
+    @Bean
+    @Primary
+    public Elide initializeElide(EntityDictionary dictionary,
+                                 DataStore dataStore, ElideConfigProperties settings) {
+
+        ElideSettingsBuilder builder = new ElideSettingsBuilder(dataStore)
+                .withEntityDictionary(dictionary)
+                .withDefaultMaxPageSize(settings.getMaxPageSize())
+                .withDefaultPageSize(settings.getPageSize())
+                .withJSONApiLinks(new DefaultJSONApiLinks())
+                .withUseFilterExpressions(true)
+                .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
+                .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
+                .withAuditLogger(new Slf4jLogger())
+                .withEncodeErrorResponses(true)
+                .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
+
+        return new Elide(builder.build());
+    }
+}

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -9,20 +9,33 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attr;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.links;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relation;
+import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relationships;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.Injector;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.datastores.jpa.JpaDataStore;
+import com.yahoo.elide.datastores.jpa.transaction.NonJtaTransaction;
 import com.yahoo.elide.standalone.config.ElideStandaloneSettings;
 import com.yahoo.elide.standalone.models.Post;
 
 import com.google.common.collect.Maps;
 
 import org.apache.http.HttpStatus;
+import org.glassfish.hk2.api.ServiceLocator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -34,6 +47,9 @@ import io.swagger.models.Swagger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
+
+import javax.persistence.EntityManagerFactory;
 
 /**
  * Tests ElideStandalone starts and works
@@ -45,6 +61,43 @@ public class ElideStandaloneTest {
     @BeforeAll
     public void init() throws Exception {
         elide = new ElideStandalone(new ElideStandaloneSettings() {
+            @Override
+            public ElideSettings getElideSettings(ServiceLocator injector) {
+                EntityManagerFactory entityManagerFactory = Util.getEntityManagerFactory(getModelPackageName(),
+                        getDatabaseProperties());
+                DataStore dataStore = new JpaDataStore(
+                        () -> { return entityManagerFactory.createEntityManager(); },
+                        (em -> { return new NonJtaTransaction(em); }));
+
+                EntityDictionary dictionary = new EntityDictionary(getCheckMappings(),
+                        new Injector() {
+                            @Override
+                            public void inject(Object entity) {
+                                injector.inject(entity);
+                            }
+
+                            @Override
+                            public <T> T instantiate(Class<T> cls) {
+                                return injector.create(cls);
+                            }
+                        });
+
+                dictionary.scanForSecurityChecks();
+
+                ElideSettingsBuilder builder = new ElideSettingsBuilder(dataStore)
+                        .withUseFilterExpressions(true)
+                        .withEntityDictionary(dictionary)
+                        .withJSONApiLinks(new DefaultJSONApiLinks())
+                        .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
+                        .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
+                        .withAuditLogger(getAuditLogger());
+
+                if (enableIS06081Dates()) {
+                    builder = builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
+                }
+
+                return builder.build();
+            }
 
             @Override
             public Properties getDatabaseProperties() {
@@ -95,24 +148,38 @@ public class ElideStandaloneTest {
     @Test
     public void testJsonAPIPost() {
         given()
-            .contentType(JSONAPI_CONTENT_TYPE)
-            .accept(JSONAPI_CONTENT_TYPE)
-            .body(
-                datum(
-                    resource(
-                        type("post"),
-                        id("1"),
-                        attributes(
-                            attr("content", "This is my first post. woot."),
-                            attr("date", "2019-01-01T00:00Z")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("post"),
+                                        id("1"),
+                                        attributes(
+                                                attr("content", "This is my first post. woot."),
+                                                attr("date", "2019-01-01T00:00Z")
+                                        )
+                                )
                         )
-                    )
                 )
-            )
-            .post("/api/v1/post")
-            .then()
-            .statusCode(HttpStatus.SC_CREATED)
-            .extract().body().asString();
+                .post("/api/v1/post")
+                .then()
+                .body(equalTo(
+                        datum(
+                                resource(
+                                        type("post"),
+                                        id("1"),
+                                        attributes(
+                                                attr("abusiveContent", false),
+                                                attr("content", "This is my first post. woot."),
+                                                attr("date", "2019-01-01T00:00Z")
+                                        ),
+                                        links(
+                                                attr("self", "http://localhost:8080/api/v1/post/1")
+                                        )
+                                )
+                        ).toJSON()))
+                .statusCode(HttpStatus.SC_CREATED);
     }
 
     @Test

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -10,8 +10,6 @@ import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.links;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relation;
-import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.relationships;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.contrib.testhelpers.jsonapi.JsonApiDSL.type;
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;


### PR DESCRIPTION
Resolves #282  (if appropriate)

## Description
This PR enables the API response to have link attributes, which by default contain self and related. However, user can extend this functionality to implement their own logic to build links.

## How Has This Been Tested?
Unit test and IT. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
