### PR TITLE
Fix for Graphql Fragment Error in Debug Mode - Elide 4.x

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -141,8 +141,11 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
         if (children.size() > 0) {
             children.stream().forEach(i -> { if (i.getClass().equals(Field.class)) {
                     fieldName.add(((Field) i).getName());
-                } else {
+                } else if (i.getClass().equals(FragmentSpread.class)) {
                     fieldName.add(((FragmentSpread) i).getName());
+                } else {
+                    log.debug("A new type of Selection, other than Field and FragmentSpread was encountered, {}",
+                            i.getClass());
                 }
             });
         }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.collections4.IterableUtils;
 
 import graphql.language.Field;
+import graphql.language.FragmentSpread;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLType;
@@ -132,11 +133,22 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
      * @param environment Environment encapsulating graphQL's request environment
      */
     private void logContext(RelationshipOp operation, Environment environment) {
-        List<Field> children = (environment.field.getSelectionSet() != null)
+        List<?> children = (environment.field.getSelectionSet() != null)
                 ? (List) environment.field.getSelectionSet().getChildren()
                 : new ArrayList<>();
-        String requestedFields = environment.field.getName() + (children.size() > 0
-                ? "(" + children.stream().map(Field::getName).collect(Collectors.toList()) + ")" : "");
+
+        List<String> fieldName = new ArrayList<String>();
+        if (children.size() > 0) {
+            children.stream().forEach(i -> { if (i.getClass().equals(Field.class)) {
+                    fieldName.add(((Field) i).getName());
+                } else {
+                    fieldName.add(((FragmentSpread) i).getName());
+                }
+            });
+        }
+
+        String requestedFields = environment.field.getName() + fieldName.toString();
+
         GraphQLType parent = environment.parentType;
         if (log.isDebugEnabled()) {
             log.debug("{} {} fields with parent {}<{}>",


### PR DESCRIPTION
## Description
Using Graphql fragments in debug mode gave error, `graphql.language.FragmentSpread cannot be cast to graphql.language.Field`. The error was caused by assuming the type is always Field during the getName operation. Put in a cast by checking the class before calling getName. 

## Motivation and Context
Resolving Error 

## How Has This Been Tested?
Tested with the app that was failing.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.