### PR TITLE
Fixing elide build to only compile once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
       - "/^[0-9]+\\.[0-9]+(\\.[0-9]+|-(alpha|beta)-[0-9]+)/"
 
   install: true
-  script: mvn -B clean verify coveralls:report
+  script: mvn -B clean verify coveralls:report deploy --settings travis/settings.xml
   after_success:
     - echo "(${TRAVIS_TAG}) (${TRAVIS_PULL_REQUEST})"
-    - test "${TRAVIS_TAG}" != "" && mvn -B -DskipTests deploy --settings travis/settings.xml
+    - test "${TRAVIS_TAG}" != ""


### PR DESCRIPTION
## Motivation and Context
Elide builds and compiles twice (increasing the log output).  This PR attempts to run a single build.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
