### PR TITLE
Reduce Standalone Logging

### DIFF
--- a/elide-standalone/src/test/resources/logback.xml
+++ b/elide-standalone/src/test/resources/logback.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020, Yahoo Inc.
+  ~ Licensed under the Apache License, Version 2.0
+  ~ See LICENSE file in project root for terms.
+  -->
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter
+      class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/xml.header
+++ b/xml.header
@@ -1,6 +1,6 @@
 ^<\?xml version="1.0" encoding="UTF-8"\?>$
 ^<!--$
-^  ~ Copyright 20[0-1][0-9],.*\.$
+^  ~ Copyright 20[0-3][0-9],.*\.$
 ^  ~ Licensed under the Apache License, Version 2.0$
 ^  ~ See LICENSE file in project root for terms\.$
 ^  -->$


### PR DESCRIPTION
Elide standalone has the most logging during builds (about half of the build).  This is an attempt to reduce that build logging.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
