### PR TITLE
Graphql Query Default Pagination Setup

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -195,7 +195,8 @@ public class GraphQLEntityProjectionMaker {
      */
     private EntityProjection createProjection(Class<?> entityType, Field entityField) {
         final EntityProjectionBuilder projectionBuilder = EntityProjection.builder()
-                .type(entityType);
+                .type(entityType)
+                .pagination(PaginationImpl.getDefaultPagination(entityType, elideSettings));
 
         entityField.getSelectionSet().getSelections().forEach(selection -> addSelection(selection, projectionBuilder));
         entityField.getArguments().forEach(argument -> addArgument(argument, projectionBuilder));

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectMakerTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectMakerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.yahoo.elide.graphql.PersistentResourceFetcherTest;
+import com.yahoo.elide.request.Pagination;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class GraphQLEntityProjectMakerTest extends PersistentResourceFetcherTest {
+
+     @Test
+     public void testDefaultPagination() throws IOException {
+         String graphQLRequest = loadGraphQLRequest("fetch/rootSingle" + ".graphql");
+         GraphQLEntityProjectionMaker projectionMaker = new GraphQLEntityProjectionMaker(settings);
+         GraphQLProjectionInfo projectionInfo = projectionMaker.make(graphQLRequest);
+         assertEquals(projectionInfo.getProjections().size(), 1);
+         assertEquals(projectionInfo.getProjections().entrySet().iterator().next().getValue().getPagination().isDefaultInstance(), true);
+     }
+
+     @Test
+     public void testLimitPagination() throws IOException {
+         String graphQLRequest = loadGraphQLRequest("fetch/rootCollectionPaginateWithOffset" + ".graphql");
+         GraphQLEntityProjectionMaker projectionMaker = new GraphQLEntityProjectionMaker(settings);
+         GraphQLProjectionInfo projectionInfo = projectionMaker.make(graphQLRequest);
+         assertEquals(projectionInfo.getProjections().size(), 1);
+         Pagination page = projectionInfo.getProjections().entrySet().iterator().next().getValue().getPagination();
+         assertEquals(page.isDefaultInstance(), false);
+         assertEquals(page.getLimit(), 1);
+     }
+}


### PR DESCRIPTION
## Description
This change enforces default pagination when running GraphQL queries.

## Motivation and Context
GraphQL queries are not enforcing pagination if `first` or `after` arguments are not used. This results in large queries returning all the records which can cause the JVM to throw errors.

## How Has This Been Tested?
Sample Application was tested. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
