### PR TITLE
escape quotes in quoted strings

### DIFF
--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSL.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSL.java
@@ -486,7 +486,7 @@ public final class GraphQLDSL {
      */
     public static Argument argument(String name, Object value, boolean quoted) {
         if (value instanceof String) {
-            value = quoted ? String.format("\"%s\"", value) : value;
+            value = quoted ? Field.quoteValue(value.toString()) : value;
             return new Argument(name, value);
         }
         // this is an object which needs to be Jackson-serialized

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/elements/Field.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/elements/Field.java
@@ -44,7 +44,7 @@ public class Field extends Selection {
     }
 
     public static String quoteValue(String value) {
-        return String.format("\"%s\"", value);
+        return String.format("\"%s\"", value.replace("\"", "\\\""));
     }
 
     @Getter(AccessLevel.PRIVATE)

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/elements/Field.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/elements/Field.java
@@ -104,9 +104,6 @@ public class Field extends Selection {
     }
 
     private String selection() {
-        if (getSelectionSet() instanceof String) {
-            return getSelectionSet().toString();
-        }
         return getSelectionSet() == null ? "" : " " + ((SelectionSet) getSelectionSet()).toGraphQLSpec();
     }
 }

--- a/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/elements/Field.java
+++ b/elide-contrib/elide-test-helpers/src/main/java/com/yahoo/elide/contrib/testhelpers/graphql/elements/Field.java
@@ -104,6 +104,9 @@ public class Field extends Selection {
     }
 
     private String selection() {
+        if (getSelectionSet() instanceof String) {
+            return getSelectionSet().toString();
+        }
         return getSelectionSet() == null ? "" : " " + ((SelectionSet) getSelectionSet()).toGraphQLSpec();
     }
 }

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSLTest.java
@@ -133,6 +133,29 @@ public class GraphQLDSLTest {
     }
 
     @Test
+    public void verifyRequestWithNonStringArguments() {
+        String expected = "{book(ids: [1,2] map: {key:\"value\"}) {edges {node {id title}}}}";
+
+        String actual = document(
+                selections(
+                        field(
+                                "book",
+                                arguments(
+                                        argument("ids", new Long[]{ 1L, 2L }),
+                                        argument("map", ImmutableMap.of("key", "value"))
+                                ),
+                                selections(
+                                        field("id"),
+                                        field("title")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void verifyRequestWithVariable() {
         String expected = "query myQuery($bookId: [String]) {book(ids: $bookId) {edges {node {id title authors {edges"
                 + " {node {name}}}}}}}";

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSLTest.java
@@ -156,6 +156,28 @@ public class GraphQLDSLTest {
     }
 
     @Test
+    public void verifyRequestWithQuotedArgument() {
+        String expected = "{book(desc: \"has \\\"quotes\\\"\") {edges {node {id title}}}}";
+
+        String actual = document(
+                selections(
+                        field(
+                                "book",
+                                argument(
+                                        argument("desc", "has \"quotes\"", QUOTE_VALUE)
+                                ),
+                                selections(
+                                        field("id"),
+                                        field("title")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void verifyRequestWithVariable() {
         String expected = "query myQuery($bookId: [String]) {book(ids: $bookId) {edges {node {id title authors {edges"
                 + " {node {name}}}}}}}";

--- a/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSLTest.java
+++ b/elide-contrib/elide-test-helpers/src/test/java/com/yahoo/elide/contrib/testhelpers/graphql/GraphQLDSLTest.java
@@ -17,6 +17,9 @@ import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.variableDef
 import static com.yahoo.elide.contrib.testhelpers.graphql.GraphQLDSL.variableDefinitions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+
 import org.junit.jupiter.api.Test;
 
 public class GraphQLDSLTest {
@@ -238,6 +241,27 @@ public class GraphQLDSLTest {
                                                         field("id", "1")
                                                 )
                                         )
+                                )
+                        )
+                )
+        ).toResponse();
+
+        assertEquals(expected, actual);
+    }
+
+
+    @Test
+    public void verifyJsonStringField() {
+        String jsonField = new Gson().toJson(ImmutableMap.of("key", "value"));
+        String jsonNode = new Gson().toJson(ImmutableMap.of("json", jsonField));
+        String expected = "{\"data\":{\"container\":{\"edges\":[{\"node\":" + jsonNode + "}]}}}";
+
+        String actual = document(
+                selection(
+                        field(
+                                "container",
+                                selections(
+                                        field("json", jsonField)
                                 )
                         )
                 )


### PR DESCRIPTION
## Description
GraphQL test helper should escape any quotes when quoting the string.

## Motivation and Context
GraphQL tests are failing for JSON strings.

## How Has This Been Tested?
Unit testing.  Local product testing with the fix.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
