### PR TITLE
H2 MVCC setting is removed

### DIFF
--- a/elide-datastore/elide-datastore-search/src/test/resources/META-INF/persistence.xml
+++ b/elide-datastore/elide-datastore-search/src/test/resources/META-INF/persistence.xml
@@ -18,7 +18,7 @@
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
             <property name="hibernate.search.default.locking_strategy" value="single"/>
             <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
-            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE;INIT=RUNSCRIPT FROM 'classpath:create_tables.sql'"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:create_tables.sql'"/>
             <property name="javax.persistence.jdbc.user" value=""/>
             <property name="javax.persistence.jdbc.password" value=""/>
         </properties>

--- a/elide-example/elide-blog-example/src/test/java/com/yahoo/elide/example/IntegrationTest.java
+++ b/elide-example/elide-blog-example/src/test/java/com/yahoo/elide/example/IntegrationTest.java
@@ -30,7 +30,7 @@ import java.util.Properties;
 public class IntegrationTest {
     private ElideStandalone elide;
 
-    protected static final String JDBC_URL = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE";
+    protected static final String JDBC_URL = "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1";
     protected static final String JDBC_USER = "sa";
     protected static final String JDBC_PASSWORD = "";
 

--- a/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/com/yahoo/elide/standalone/ElideStandaloneTest.java
@@ -108,7 +108,7 @@ public class ElideStandaloneTest {
                 options.put("hibernate.jdbc.use_scrollable_resultset", "true");
 
                 options.put("javax.persistence.jdbc.driver", "org.h2.Driver");
-                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE;");
+                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;");
                 options.put("javax.persistence.jdbc.user", "sa");
                 options.put("javax.persistence.jdbc.password", "");
                 return options;

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.199</version>
+                <version>1.4.200</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Description
H2 deprecated the MVCC setting in version 1.4.198
https://github.com/h2database/h2database/releases/tag/version-1.4.198

This was removed entirely in 1.4.200 and use will now cause an error.
https://github.com/h2database/h2database/releases/tag/version-1.4.200

## Motivation and Context
Required to upgrade H2

## How Has This Been Tested?
Unit and IT tests

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.