### PR TITLE
Use alias if exist in select projection for order by

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
@@ -307,7 +307,9 @@ public class SQLQueryConstructor {
                     Path.PathElement last = path.lastElement().get();
 
                     SQLColumnProjection projection = fieldToColumnProjection(template, last.getFieldName());
-                    String orderByClause = projection.toSQL(template);
+                    String orderByClause = (template.getColumnProjections().contains(projection))
+                            ? projection.getAlias()
+                            : projection.toSQL(template);
 
                     return orderByClause + (order.equals(Sorting.SortOrder.desc) ? " DESC" : " ASC");
                 })


### PR DESCRIPTION
Resolves CARBON-258

## Description
Order by in aggregation datastore now uses alias if the order by metric is present in select projection.

## Motivation and Context
Hibernate JDBC connector throws error if the order by clause has aggregation function.

`org.hibernate.exception.GenericJDBCException: could not extract ResultSet`


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
