### PR TITLE
H2 5.x

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/pom.xml
+++ b/elide-datastore/elide-datastore-aggregation/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.197</version>
+            <version>1.4.200</version>
             <scope>test</scope>
         </dependency>
 

--- a/elide-datastore/elide-datastore-search/src/test/resources/META-INF/persistence.xml
+++ b/elide-datastore/elide-datastore-search/src/test/resources/META-INF/persistence.xml
@@ -18,7 +18,7 @@
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
             <property name="hibernate.search.default.locking_strategy" value="single"/>
             <property name="javax.persistence.jdbc.driver" value="org.h2.Driver"/>
-            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE;INIT=RUNSCRIPT FROM 'classpath:create_tables.sql'"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:create_tables.sql'"/>
             <property name="javax.persistence.jdbc.user" value=""/>
             <property name="javax.persistence.jdbc.password" value=""/>
         </properties>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.199</version>
+            <version>1.4.200</version>
             <scope>test</scope>
         </dependency>
 

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -48,7 +48,7 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
                 options.put("hibernate.jdbc.use_scrollable_resultset", "true");
 
                 options.put("javax.persistence.jdbc.driver", "org.h2.Driver");
-                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE;");
+                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;");
                 options.put("javax.persistence.jdbc.user", "sa");
                 options.put("javax.persistence.jdbc.password", "");
                 return options;

--- a/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
@@ -42,7 +42,7 @@ public class ElideStandaloneMetadataStoreMissingTest {
                 options.put("hibernate.jdbc.use_scrollable_resultset", "true");
 
                 options.put("javax.persistence.jdbc.driver", "org.h2.Driver");
-                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE;");
+                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;");
                 options.put("javax.persistence.jdbc.user", "sa");
                 options.put("javax.persistence.jdbc.password", "");
                 return options;

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -61,7 +61,7 @@ public class ElideStandaloneTest {
                 options.put("hibernate.jdbc.use_scrollable_resultset", "true");
 
                 options.put("javax.persistence.jdbc.driver", "org.h2.Driver");
-                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;MVCC=TRUE;");
+                options.put("javax.persistence.jdbc.url", "jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;");
                 options.put("javax.persistence.jdbc.user", "sa");
                 options.put("javax.persistence.jdbc.password", "");
                 return options;

--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>1.4.199</version>
+                <version>1.4.200</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Description
H2 deprecated the MVCC setting in version 1.4.198
https://github.com/h2database/h2database/releases/tag/version-1.4.198

This was removed entirely in 1.4.200 and use will now cause an error.
https://github.com/h2database/h2database/releases/tag/version-1.4.200

## Motivation and Context
Required to upgrade H2

## How Has This Been Tested?
Unit and IT tests

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.