### PR TITLE
Fixing the schema for Extend in Dynamic Config

### DIFF
--- a/elide-contrib/elide-dynamic-config-helpers/src/main/java/com/yahoo/elide/contrib/dynamicconfighelpers/model/Table.java
+++ b/elide-contrib/elide-dynamic-config-helpers/src/main/java/com/yahoo/elide/contrib/dynamicconfighelpers/model/Table.java
@@ -39,7 +39,7 @@ import java.util.Set;
     "measures",
     "dimensions",
     "tags",
-    "extends",
+    "extend",
     "sql",
     "table"
 })
@@ -83,7 +83,7 @@ public class Table {
     @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> tags = new LinkedHashSet<String>();
 
-    @JsonProperty("extends")
+    @JsonProperty("extend")
     private String extend = "";
 
     @JsonProperty("sql")

--- a/elide-contrib/elide-dynamic-config-helpers/src/main/resources/elideTableSchema.json
+++ b/elide-contrib/elide-dynamic-config-helpers/src/main/resources/elideTableSchema.json
@@ -381,17 +381,17 @@
           },
           {
             "properties": {
-              "extends": {
+              "extend": {
                 "title": "Table Extends",
                 "description": "Extends another logical table.",
                 "type": "string",
+                "pattern": "^[A-Za-z]([0-9A-Za-z]*_?[0-9A-Za-z]*)*$",
                 "default": ""
               }
             },
             "required": [
               "name",
-              "extends",
-              "dimensions"
+              "extend"
             ]
           }
         ]

--- a/elide-contrib/elide-dynamic-config-helpers/src/test/resources/models/tables/table3.hjson
+++ b/elide-contrib/elide-dynamic-config-helpers/src/test/resources/models/tables/table3.hjson
@@ -1,0 +1,13 @@
+{
+  tables:
+  [
+    {
+      name: PlayerExtend
+      schema: playerdb
+      table: player
+      extend: Player
+      description: Player Extend
+      cardinality: large
+    }
+  ]
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromSubquery.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromSubquery.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -17,6 +18,7 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface FromSubquery {
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromTable.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -17,6 +18,7 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface FromTable {
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/VersionQuery.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/VersionQuery.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -17,6 +18,7 @@ import java.lang.annotation.Target;
 @Documented
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface VersionQuery {
 
     /**


### PR DESCRIPTION
Co-authored-by: AvaniMakwana

## Description
FromTable and FromSubquery annotations are now inheritable when models will be extended. Schema is updated according to that. Also `extends` errors out as a keyword during JSON Validation, changed to `extend`.

## Motivation and Context
Schema Verification Failures

## How Has This Been Tested?
Updated Test cases.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
