### PR TITLE
use alias for order by

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/AbstractSqlDialect.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/AbstractSqlDialect.java
@@ -9,6 +9,10 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects;
  * Common code for {@link SQLDialect} implementations.
  */
 public abstract class AbstractSqlDialect implements SQLDialect {
+    @Override
+    public boolean useAliasForOrderByClause() {
+        return false;
+    }
 
     public String generateCountDistinctClause(String dimensions) {
         return String.format("COUNT(DISTINCT(%s))", dimensions);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialect.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialect.java
@@ -17,6 +17,12 @@ public interface SQLDialect {
     String getDialectType();
 
     /**
+     * Checks whether we need to use alias for orderby
+     * @return boolean.
+     */
+    boolean useAliasForOrderByClause();
+
+    /**
      * Generates an SQL clause that requests the count of distinct values for the input dimensions.
      * @param dimensions for which to request a distinct count.
      * @return the SQL clause as a string.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/impl/PrestoDialect.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/impl/PrestoDialect.java
@@ -15,4 +15,9 @@ public class PrestoDialect extends AbstractSqlDialect {
     public String getDialectType() {
         return "Presto";
     }
+
+    @Override
+    public boolean useAliasForOrderByClause() {
+        return true;
+    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLQueryConstructor.java
@@ -310,7 +310,10 @@ public class SQLQueryConstructor {
                     Path.PathElement last = path.lastElement().get();
 
                     SQLColumnProjection projection = fieldToColumnProjection(template, last.getFieldName());
-                    String orderByClause = projection.toSQL(template);
+                    String orderByClause = (template.getColumnProjections().contains(projection)
+                            && dialect.useAliasForOrderByClause())
+                            ? projection.getAlias()
+                            : projection.toSQL(template);
 
                     return orderByClause + (order.equals(Sorting.SortOrder.desc) ? " DESC" : " ASC");
                 })

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
@@ -194,7 +194,6 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
         compareQueryLists(expectedQueryList, engine.explain(TestQuery.PAGINATION_TOTAL.getQuery()));
     }
 
-    // TODO - Query generation needs to support aliases in ORDER BY to make these pass
     @Test
     public void testExplainSortingAscending() {
         String expectedQueryStr =
@@ -226,11 +225,6 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
         compareQueryLists(expectedQueryList, engine.explain(TestQuery.SORT_DIM_DESC.getQuery()));
     }
 
-//    TODO: This test won't work because:
-//     * 1) dims can only be added in aggregations, which means metrics must be aggregated
-//     * 2) metrics aggregations are expanded in ORDER BY.
-//     * Using aliases in ORDER BY will fix this.
-//     *
     @Test
     public void testExplainSortingByMetricAndDimension() {
         String expectedQueryStr =

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
@@ -194,55 +194,55 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
         compareQueryLists(expectedQueryList, engine.explain(TestQuery.PAGINATION_TOTAL.getQuery()));
     }
 
-    /* TODO - Query generation needs to support aliases in ORDER BY to make these pass
+    // TODO - Query generation needs to support aliases in ORDER BY to make these pass
     @Test
-    public void testExplainSortingAscending(){
+    public void testExplainSortingAscending() {
         String expectedQueryStr =
                 "SELECT highScore AS highScoreNoAgg "
                         + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats   "
-                        + "ORDER BY highScore ASC";
+                        + "ORDER BY highScoreNoAgg ASC";
         List<String> expectedQueryList = Arrays.asList(expectedQueryStr);
         compareQueryLists(expectedQueryList, engine.explain(TestQuery.SORT_METRIC_ASC.getQuery()));
     }
 
     @Test
-    public void testExplainSortingDecending(){
+    public void testExplainSortingDecending() {
         String expectedQueryStr =
                 "SELECT highScore AS highScoreNoAgg "
                         + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats   "
-                        + "ORDER BY highScore DESC";
+                        + "ORDER BY highScoreNoAgg DESC";
         List<String> expectedQueryList = Arrays.asList(expectedQueryStr);
         compareQueryLists(expectedQueryList, engine.explain(TestQuery.SORT_METRIC_DESC.getQuery()));
     }
-    */
+
 
     @Test
     public void testExplainSortingByDimensionDesc() {
         String expectedQueryStr =
                 "SELECT DISTINCT com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS "
                         + "overallRating FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "ORDER BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating DESC";
+                        + "ORDER BY overallRating DESC";
         List<String> expectedQueryList = Arrays.asList(expectedQueryStr);
         compareQueryLists(expectedQueryList, engine.explain(TestQuery.SORT_DIM_DESC.getQuery()));
     }
 
-    /* TODO: This test won't work because:
-     * 1) dims can only be added in aggregations, which means metrics must be aggregated
-     * 2) metrics aggregations are expanded in ORDER BY.
-     * Using aliases in ORDER BY will fix this.
-     *
+//    TODO: This test won't work because:
+//     * 1) dims can only be added in aggregations, which means metrics must be aggregated
+//     * 2) metrics aggregations are expanded in ORDER BY.
+//     * Using aliases in ORDER BY will fix this.
+//     *
     @Test
-    public void testExplainSortingByMetricAndDimension(){
+    public void testExplainSortingByMetricAndDimension() {
         String expectedQueryStr =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) "
                         + "AS highScore,com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS "
                         + "overallRating FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
                         + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating "
-                        + "ORDER BY MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) DESC";
+                        + "ORDER BY highScore DESC,overallRating DESC";
         List<String> expectedQueryList = Arrays.asList(expectedQueryStr);
         compareQueryLists(expectedQueryList, engine.explain(TestQuery.SORT_METRIC_AND_DIM_DESC.getQuery()));
     }
-    */
+
 
     @Test
     public void testExplainSelectFromSubquery() {


### PR DESCRIPTION
Resolves CARBON-258

## Description
Use an alias in order by clause for PRESTO

Order by for aggregated metric works only if the alias is mentioned in the query.

## How Has This Been Tested?
Unit test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
