### PR TITLE
Introduce case insensitive equality rsql operator. Default is case sensitive

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.FilterPredicate;
+import com.yahoo.elide.core.filter.InInsensitivePredicate;
 import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.IsEmptyPredicate;
 import com.yahoo.elide.core.filter.IsNullPredicate;
@@ -59,6 +60,8 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
     private static final String SINGLE_PARAMETER_ONLY = "There can only be a single filter query parameter";
     private static final String INVALID_QUERY_PARAMETER = "Invalid query parameter: ";
     private static final Pattern TYPED_FILTER_PATTERN = Pattern.compile("filter\\[([^\\]]+)\\]");
+    private static final ComparisonOperator INI = new ComparisonOperator("=ini=", true);
+    private static final ComparisonOperator NOT_INI = new ComparisonOperator("=outi=", true);
     private static final ComparisonOperator ISNULL_OP = new ComparisonOperator("=isnull=", false);
     private static final ComparisonOperator ISEMPTY_OP = new ComparisonOperator("=isempty=", false);
     private static final ComparisonOperator HASMEMBER_OP = new ComparisonOperator("=hasmember=", false);
@@ -81,7 +84,7 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
     private final CaseSensitivityStrategy caseSensitivityStrategy;
 
     public RSQLFilterDialect(EntityDictionary dictionary) {
-        this(dictionary, new CaseSensitivityStrategy.FIQLCompliant());
+        this(dictionary, new CaseSensitivityStrategy.UseColumnCollation());
     }
 
     public RSQLFilterDialect(EntityDictionary dictionary, CaseSensitivityStrategy caseSensitivityStrategy) {
@@ -93,6 +96,8 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
     //add rsql isnull op to the default ops
     private static Set<ComparisonOperator> getDefaultOperatorsWithIsnull() {
         Set<ComparisonOperator> operators = RSQLOperators.defaultOperators();
+        operators.add(INI);
+        operators.add(NOT_INI);
         operators.add(ISNULL_OP);
         operators.add(ISEMPTY_OP);
         operators.add(HASMEMBER_OP);
@@ -343,10 +348,16 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
                     .collect(Collectors.toList());
 
             if (op.equals(RSQLOperators.EQUAL) || op.equals(RSQLOperators.IN)) {
-                return equalityExpression(arguments.get(0), path, values);
+                return equalityExpression(arguments.get(0), path, values, true);
+            }
+            if (op.equals(INI)) {
+                return equalityExpression(arguments.get(0), path, values, false);
             }
             if (op.equals(RSQLOperators.NOT_EQUAL) || op.equals(RSQLOperators.NOT_IN)) {
-                return new NotFilterExpression(equalityExpression(arguments.get(0), path, values));
+                return new NotFilterExpression(equalityExpression(arguments.get(0), path, values, true));
+            }
+            if (op.equals(NOT_INI)) {
+                return new NotFilterExpression(equalityExpression(arguments.get(0), path, values, false));
             }
             if (OPERATOR_MAP.containsKey(op)) {
                 return new FilterPredicate(path, OPERATOR_MAP.get(op), values);
@@ -355,33 +366,45 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
             throw new RSQLParseException(String.format("Invalid Operator %s", op.getSymbol()));
         }
 
-        private FilterExpression equalityExpression(String argument, Path path, List<Object> values) {
+        private FilterExpression equalityExpression(String argument, Path path,
+                                                    List<Object> values, boolean caseSensitive) {
             boolean startsWith = argument.startsWith("*");
             boolean endsWith = argument.endsWith("*");
             if (startsWith && endsWith && argument.length() > 2) {
                 String value = argument.substring(1, argument.length() - 1);
-                return new FilterPredicate(path, caseSensitivityStrategy.mapOperator(Operator.INFIX),
-                        Collections.singletonList(value));
+                Operator op = caseSensitive
+                        ? caseSensitivityStrategy.mapOperator(Operator.INFIX)
+                        : Operator.INFIX_CASE_INSENSITIVE;
+                return new FilterPredicate(path, op, Collections.singletonList(value));
             }
             if (startsWith && argument.length() > 1) {
                 String value = argument.substring(1, argument.length());
-                return new FilterPredicate(path, caseSensitivityStrategy.mapOperator(Operator.POSTFIX),
-                        Collections.singletonList(value));
+                Operator op = caseSensitive
+                        ? caseSensitivityStrategy.mapOperator(Operator.POSTFIX)
+                        : Operator.POSTFIX_CASE_INSENSITIVE;
+                return new FilterPredicate(path, op, Collections.singletonList(value));
             }
             if (endsWith && argument.length() > 1) {
                 String value = argument.substring(0, argument.length() - 1);
-                return new FilterPredicate(path, caseSensitivityStrategy.mapOperator(Operator.PREFIX),
-                        Collections.singletonList(value));
+                Operator op = caseSensitive
+                        ? caseSensitivityStrategy.mapOperator(Operator.PREFIX)
+                        : Operator.PREFIX_CASE_INSENSITIVE;
+                return new FilterPredicate(path, op, Collections.singletonList(value));
             }
 
             Boolean isStringLike = path.lastElement()
                     .map(e -> e.getFieldType().isAssignableFrom(String.class))
                     .orElse(false);
             if (isStringLike) {
-                return new FilterPredicate(path, caseSensitivityStrategy.mapOperator(Operator.IN), values);
+                Operator op = caseSensitive
+                        ? caseSensitivityStrategy.mapOperator(Operator.IN)
+                        : Operator.IN_INSENSITIVE;
+                return new FilterPredicate(path, op, values);
             }
 
-            return new InPredicate(path, values);
+            return caseSensitive
+                    ? new InPredicate(path, values)
+                    : new InInsensitivePredicate(path, values);
         }
 
         /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -347,19 +347,16 @@ public class RSQLFilterDialect implements SubqueryFilterDialect, JoinFilterDiale
                     .map((argument) -> (Object) CoerceUtil.coerce(argument, relationshipType))
                     .collect(Collectors.toList());
 
+
             if (op.equals(RSQLOperators.EQUAL) || op.equals(RSQLOperators.IN)) {
                 return equalityExpression(arguments.get(0), path, values, true);
-            }
-            if (op.equals(INI)) {
+            } else if (op.equals(INI)) {
                 return equalityExpression(arguments.get(0), path, values, false);
-            }
-            if (op.equals(RSQLOperators.NOT_EQUAL) || op.equals(RSQLOperators.NOT_IN)) {
+            } else if (op.equals(RSQLOperators.NOT_EQUAL) || op.equals(RSQLOperators.NOT_IN)) {
                 return new NotFilterExpression(equalityExpression(arguments.get(0), path, values, true));
-            }
-            if (op.equals(NOT_INI)) {
+            } else if (op.equals(NOT_INI)) {
                 return new NotFilterExpression(equalityExpression(arguments.get(0), path, values, false));
-            }
-            if (OPERATOR_MAP.containsKey(op)) {
+            } else if (OPERATOR_MAP.containsKey(op)) {
                 return new FilterPredicate(path, OPERATOR_MAP.get(op), values);
             }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -389,11 +389,11 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
             assertEquals("Book", pathElement.getType().getSimpleName());
             assertEquals(GENRE, filterPredicate.getField());
-            assertEquals("book.genre IN_INSENSITIVE [foo]", filterPredicate.toString());
+            assertEquals("book.genre IN [foo]", filterPredicate.toString());
 
             // custom processing
             return "Book".equals(pathElement.getType().getSimpleName())
-                    && filterPredicate.toString().matches("book.genre IN_INSENSITIVE \\[\\w+\\]")
+                    && filterPredicate.toString().matches("book.genre IN \\[\\w+\\]")
                     && reason.getLoggedMessage().matches(".*Message=ReadPermission Denied.*")
                             ? ExpressionResult.DEFERRED
                             : ExpressionResult.FAIL;

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithFIQLCompliantStrategyTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithFIQLCompliantStrategyTest.java
@@ -24,7 +24,7 @@ import javax.ws.rs.core.MultivaluedMap;
 /**
  * Tests RSQLFilterDialect
  */
-public class RSQLFilterDialectWithColumnCollationStrategyTest {
+public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
     private static RSQLFilterDialect dialect;
 
     @BeforeAll
@@ -33,7 +33,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Book.class);
-        dialect = new RSQLFilterDialect(dictionary, new CaseSensitivityStrategy.UseColumnCollation());
+        dialect = new RSQLFilterDialect(dictionary, new CaseSensitivityStrategy.FIQLCompliant());
     }
 
     @Test
@@ -49,8 +49,8 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         assertEquals(1, expressionMap.size());
         assertEquals(
-                "((book.title INFIX [foo] AND NOT (book.title PREFIX [bar])) "
-                        + "AND (book.genre IN [sci-fi, action] OR book.publishDate GT [123]))",
+                "((book.title INFIX_CASE_INSENSITIVE [foo] AND NOT (book.title PREFIX_CASE_INSENSITIVE [bar])) "
+                        + "AND (book.genre IN_INSENSITIVE [sci-fi, action] OR book.publishDate GT [123]))",
                 expressionMap.get("book").toString()
         );
     }
@@ -66,7 +66,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
-        assertEquals("(book.title INFIX [foo] AND book.authors.name IN [Hemingway])", expression.toString());
+        assertEquals("(book.title INFIX_CASE_INSENSITIVE [foo] AND book.authors.name IN_INSENSITIVE [Hemingway])", expression.toString());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
-        assertEquals("book.title IN [Hemingway]", expression.toString());
+        assertEquals("book.title IN_INSENSITIVE [Hemingway]", expression.toString());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
-        assertEquals("NOT (book.title IN [Hemingway])", expression.toString());
+        assertEquals("NOT (book.title IN_INSENSITIVE [Hemingway])", expression.toString());
     }
 
     @Test
@@ -108,7 +108,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
-        assertEquals("book.title IN [Hemingway]", expression.toString());
+        assertEquals("book.title IN_INSENSITIVE [Hemingway]", expression.toString());
     }
 
     @Test
@@ -122,7 +122,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
-        assertEquals("NOT (book.title IN [Hemingway])", expression.toString());
+        assertEquals("NOT (book.title IN_INSENSITIVE [Hemingway])", expression.toString());
     }
 
     @Test
@@ -159,7 +159,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
         assertEquals(
-                "((book.title INFIX [Hemingway] OR book.title POSTFIX [Hemingway]) OR book.title PREFIX [Hemingway])",
+                "((book.title INFIX_CASE_INSENSITIVE [Hemingway] OR book.title POSTFIX_CASE_INSENSITIVE [Hemingway]) OR book.title PREFIX_CASE_INSENSITIVE [Hemingway])",
                 expression.toString()
         );
     }
@@ -175,7 +175,7 @@ public class RSQLFilterDialectWithColumnCollationStrategyTest {
 
         FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
 
-        assertEquals("(book.title IN [foo] AND (book.title IN [bar] AND book.title IN [baz]))", expression.toString());
+        assertEquals("(book.title IN_INSENSITIVE [foo] AND (book.title IN_INSENSITIVE [bar] AND book.title IN_INSENSITIVE [baz]))", expression.toString());
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
@@ -13,7 +13,7 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.TestRequestScope;
-import com.yahoo.elide.core.filter.InInsensitivePredicate;
+import com.yahoo.elide.core.filter.InPredicate;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.PaginationImpl;
 import com.yahoo.elide.core.sort.SortingImpl;
@@ -608,7 +608,7 @@ public class EntityProjectionMakerTest {
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
 
         FilterExpression expression =
-                new InInsensitivePredicate(new Path(Book.class, dictionary, "genre"), "Science Fiction");
+                new InPredicate(new Path(Book.class, dictionary, "genre"), "Science Fiction");
 
         EntityProjectionMaker maker = new EntityProjectionMaker(dictionary, scope);
 
@@ -645,7 +645,7 @@ public class EntityProjectionMakerTest {
         String path = "/author/1/books/3/publisher";
 
         FilterExpression expression =
-                new InInsensitivePredicate(new Path(Publisher.class, dictionary, "name"), "Foo");
+                new InPredicate(new Path(Publisher.class, dictionary, "name"), "Foo");
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
 
@@ -694,7 +694,7 @@ public class EntityProjectionMakerTest {
                 .type(Book.class)
                 .relationship("publisher", EntityProjection.builder()
                         .type(Publisher.class)
-                        .filterExpression(new InInsensitivePredicate(new Path(Publisher.class, dictionary, "name"), "Foo"))
+                        .filterExpression(new InPredicate(new Path(Publisher.class, dictionary, "name"), "Foo"))
                         .sorting(sorting)
                         .pagination(PaginationImpl.getDefaultPagination(Publisher.class))
                         .build())
@@ -703,7 +703,7 @@ public class EntityProjectionMakerTest {
                         .attribute(Attribute.builder().name("type").type(Author.AuthorType.class).build())
                         .attribute(Attribute.builder().name("homeAddress").type(Address.class).build())
                         .attribute(Attribute.builder().name("awards").type(Collection.class).build())
-                        .filterExpression(new InInsensitivePredicate(new Path(Author.class, dictionary, "name"), "Foo"))
+                        .filterExpression(new InPredicate(new Path(Author.class, dictionary, "name"), "Foo"))
                         .relationship("books", EntityProjection.builder()
                                 .type(Book.class)
                                 .build())
@@ -728,7 +728,7 @@ public class EntityProjectionMakerTest {
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
 
         FilterExpression expression =
-                new InInsensitivePredicate(new Path(Book.class, dictionary, "genre"), "Science Fiction");
+                new InPredicate(new Path(Book.class, dictionary, "genre"), "Science Fiction");
 
         EntityProjectionMaker maker = new EntityProjectionMaker(dictionary, scope);
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
@@ -75,7 +75,7 @@ public class QueryKeyExtractorTest {
                         + "{playerStats.highScore;}" // columns
                         + "{playerStats.overallRating;overallRating;{}}" // group by
                         + "{playerStats.recordedDate;recordedDate;{}}" // time dimensions
-                        + "{P;{{com.yahoo.elide.datastores.aggregation.example.PlayerStats;java.lang.String;countryNickName;}}IN_INSENSITIVE;9;Uncle Sam;}" // where
+                        + "{P;{{com.yahoo.elide.datastores.aggregation.example.PlayerStats;java.lang.String;countryNickName;}}IN;9;Uncle Sam;}" // where
                         + "{P;{{com.yahoo.elide.datastores.aggregation.example.PlayerStats;long;highScore;}}GT;3;300;}" // having
                         + "{com.yahoo.elide.datastores.aggregation.example.PlayerStats;{{com.yahoo.elide.datastores.aggregation.example.PlayerStats;java.lang.String;playerName;}}asc;}" // sort
                         + "{0;2;1;}", // pagination

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
@@ -263,8 +263,8 @@ public class H2ExplainQueryTest extends SQLUnitTest {
                         + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = "
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
                         + "WHERE highScore > " + whereParams.get(0).getPlaceholder() + " "
-                        + "HAVING LOWER(com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code) "
-                        + "IN (LOWER(" + havingParams.get(0).getPlaceholder() + "))";
+                        + "HAVING com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code "
+                        + "IN (" + havingParams.get(0).getPlaceholder() + ")";
         String expectedQueryStr2 =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating,"
@@ -279,8 +279,8 @@ public class H2ExplainQueryTest extends SQLUnitTest {
                         + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating, "
                         + "PARSEDATETIME(FORMATDATETIME("
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.recordedDate, 'yyyy-MM-dd'), 'yyyy-MM-dd') "
-                        + "HAVING LOWER(com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code) "
-                        + "IN (LOWER(" + havingParams.get(0).getPlaceholder() + ")) "
+                        + "HAVING com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code "
+                        + "IN (" + havingParams.get(0).getPlaceholder() + ") "
                         + "ORDER BY highScore DESC";
         List<String> expectedQueryList = new ArrayList<String>();
         expectedQueryList.add(expectedQueryStr1);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
@@ -278,8 +278,8 @@ public class HiveExplainQueryTest extends SQLUnitTest {
                         + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = "
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
                         + "WHERE highScore > " + whereParams.get(0).getPlaceholder() + " "
-                        + "HAVING LOWER(com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code) "
-                        + "IN (LOWER(" + havingParams.get(0).getPlaceholder() + "))";
+                        + "HAVING com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code "
+                        + "IN (" + havingParams.get(0).getPlaceholder() + ")";
         String expectedQueryStr2 =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating,"
@@ -294,8 +294,8 @@ public class HiveExplainQueryTest extends SQLUnitTest {
                         + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating, "
                         + "PARSEDATETIME(FORMATDATETIME("
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.recordedDate, 'yyyy-MM-dd'), 'yyyy-MM-dd') "
-                        + "HAVING LOWER(com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code) "
-                        + "IN (LOWER(" + havingParams.get(0).getPlaceholder() + ")) "
+                        + "HAVING com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code "
+                        + "IN (" + havingParams.get(0).getPlaceholder() + ") "
                         + "ORDER BY highScore DESC";
         List<String> expectedQueryList = new ArrayList<String>();
         expectedQueryList.add(expectedQueryStr1);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
@@ -277,8 +277,8 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
                         + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = "
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
                         + "WHERE highScore > " + whereParams.get(0).getPlaceholder() + " "
-                        + "HAVING LOWER(com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code) "
-                        + "IN (LOWER(" + havingParams.get(0).getPlaceholder() + "))";
+                        + "HAVING com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code "
+                        + "IN (" + havingParams.get(0).getPlaceholder() + ")";
         String expectedQueryStr2 =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating,"
@@ -293,8 +293,8 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
                         + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating, "
                         + "PARSEDATETIME(FORMATDATETIME("
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.recordedDate, 'yyyy-MM-dd'), 'yyyy-MM-dd') "
-                        + "HAVING LOWER(com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code) "
-                        + "IN (LOWER(" + havingParams.get(0).getPlaceholder() + ")) "
+                        + "HAVING com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code "
+                        + "IN (" + havingParams.get(0).getPlaceholder() + ") "
                         + "ORDER BY highScore DESC";
         List<String> expectedQueryList = new ArrayList<String>();
         expectedQueryList.add(expectedQueryStr1);

--- a/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DataStoreLoadTest.java
+++ b/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DataStoreLoadTest.java
@@ -186,7 +186,7 @@ public class DataStoreLoadTest {
         DataStoreTransaction testTransaction = searchStore.beginReadTransaction();
 
         //Case sensitive query against case insensitive index must lowercase
-        FilterExpression filter = filterParser.parseFilterExpression("name=='*est\tTa*'", Item.class, false);
+        FilterExpression filter = filterParser.parseFilterExpression("name=ini='*est\tTa*'", Item.class, false);
 
         Iterable<Object> loaded = testTransaction.loadObjects(EntityProjection.builder()
                 .type(Item.class)
@@ -203,7 +203,7 @@ public class DataStoreLoadTest {
         DataStoreTransaction testTransaction = searchStore.beginReadTransaction();
 
         //Case insensitive query against case insensitive index
-        FilterExpression filter = filterParser.parseFilterExpression("name==*DrU*", Item.class, false);
+        FilterExpression filter = filterParser.parseFilterExpression("name=ini=*DrU*", Item.class, false);
 
         Iterable<Object> loaded = testTransaction.loadObjects(EntityProjection.builder()
                 .type(Item.class)

--- a/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/SearchDataStoreITTest.java
+++ b/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/SearchDataStoreITTest.java
@@ -34,7 +34,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
         given()
             .contentType(JSONAPI_CONTENT_TYPE)
             .when()
-            .get("/item?filter[item]=name==*-Luc*")
+            .get("/item?filter[item]=name==*-luc*")
             .then()
             .statusCode(HttpStatus.SC_OK)
             .body("data.id", equalTo(Arrays.asList("6")));
@@ -65,7 +65,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
         given()
             .contentType(JSONAPI_CONTENT_TYPE)
             .when()
-            .get("/item?filter[item]=name==*DrU*")
+            .get("/item?filter[item]=name=ini=*DrU*")
             .then()
             .statusCode(HttpStatus.SC_OK)
             .body("data.id", containsInAnyOrder("1", "3", "1000"));
@@ -91,7 +91,7 @@ public class SearchDataStoreITTest extends AbstractApiResourceInitializer {
         given()
             .contentType(JSONAPI_CONTENT_TYPE)
             .when()
-            .get("/item?filter[item]=name==*DrU*")
+            .get("/item?filter[item]=name==*dru*")
             .then()
             .statusCode(HttpStatus.SC_OK)
             .body("data.id", containsInAnyOrder("1", "3"));

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -280,6 +280,10 @@ public class FilterIT extends IntegrationTest {
         literaryFictionBooks = getAsNode("/book?filter=genre=in='Literary Fiction'");
 
         assertEquals(literaryFictionBookCount, literaryFictionBooks.get("data").size());
+
+        literaryFictionBooks = getAsNode("/book?filter=genre=ini='literary FICTION'");
+
+        assertEquals(literaryFictionBookCount, literaryFictionBooks.get("data").size());
     }
 
     @Test
@@ -365,6 +369,10 @@ public class FilterIT extends IntegrationTest {
 
         /* Test RSQL global */
         literaryAndScienceFictionBooks = getAsNode("/book?filter=genre=in=('Literary Fiction','Science Fiction')");
+
+        assertEquals(literaryAndScienceFictionBookCount, literaryAndScienceFictionBooks.get("data").size());
+
+        literaryAndScienceFictionBooks = getAsNode("/book?filter=genre=ini=('LITERARY FICTION','SCIENCE FICTION')");
 
         assertEquals(literaryAndScienceFictionBookCount, literaryAndScienceFictionBooks.get("data").size());
     }
@@ -475,6 +483,10 @@ public class FilterIT extends IntegrationTest {
 
         /* Test RSQL Global */
         titleContainsTheBooks = getAsNode("/book?filter=title==*the*");
+
+        assertEquals(titleContainsTheBookCount, titleContainsTheBooks.get("data").size());
+
+        titleContainsTheBooks = getAsNode("/book?filter=title=ini=*THE*");
 
         assertEquals(titleContainsTheBookCount, titleContainsTheBooks.get("data").size());
     }
@@ -757,6 +769,10 @@ public class FilterIT extends IntegrationTest {
         /* Test RSQL Typed */
         editorNameEndsWithd = getAsNode(String.format("/author/%s/books?filter[book]=editorName==*D", nullNedId));
 
+        assertEquals(0, editorNameEndsWithd.get("data").size());
+
+        editorNameEndsWithd = getAsNode(String.format("/author/%s/books?filter[book]=editorName=ini=*D", nullNedId));
+
         assertEquals(editorEdBooks, editorNameEndsWithd.get("data").size());
     }
 
@@ -781,7 +797,12 @@ public class FilterIT extends IntegrationTest {
         assertEquals(editorEdBooks, editorNameStartsWithE.get("data").size());
 
         /* Test RSQL Typed */
+
         editorNameStartsWithE = getAsNode(String.format("/author/%s/books?filter[book]=editorName==e*", nullNedId));
+
+        assertEquals(0, editorNameStartsWithE.get("data").size());
+
+        editorNameStartsWithE = getAsNode(String.format("/author/%s/books?filter[book]=editorName=ini=e*", nullNedId));
 
         assertEquals(editorEdBooks, editorNameStartsWithE.get("data").size());
     }
@@ -808,6 +829,10 @@ public class FilterIT extends IntegrationTest {
 
         /* Test RSQL Typed */
         editorNameContainsEd = getAsNode(String.format("/author/%s/books?filter[book]=editorName==*eD*", nullNedId));
+
+        assertEquals(0, editorNameContainsEd.get("data").size());
+
+        editorNameContainsEd = getAsNode(String.format("/author/%s/books?filter[book]=editorName=ini=*eD*", nullNedId));
 
         assertEquals(editorEditBooks, editorNameContainsEd.get("data").size());
     }
@@ -1155,7 +1180,7 @@ public class FilterIT extends IntegrationTest {
      */
     @Test
     void testIssue508() throws JsonProcessingException {
-        JsonNode result = getAsNode("book?filter=(authors.name=='Thomas Harris',publisher.name=='Default Publisher')&page[totals]");
+        JsonNode result = getAsNode("book?filter=(authors.name=='Thomas Harris',publisher.name=='Default publisher')&page[totals]");
 
         assertEquals(2, result.get("data").size());
 
@@ -1170,7 +1195,7 @@ public class FilterIT extends IntegrationTest {
         assertNotNull(pageNode);
         assertEquals(pageNode.get("totalRecords").asInt(), 1);
 
-        result = getAsNode("book?filter=(publisher.name=='Default Publisher')&page[totals]");
+        result = getAsNode("book?filter=(publisher.name=='Default publisher')&page[totals]");
         assertEquals(1, result.get("data").size());
 
         pageNode = result.get("meta").get("page");


### PR DESCRIPTION
## Description
RSQL default operations are made case sensitive. Case Insensitive Equality operators are added. 

`==` and `=in=` are now Case Sensitive
`=ini=` is the case insensitive equivalent.
**Usage** :
 `=ini='val'` -> IN_INSENSITIVE
 `=ini='*val'` -> PREFIX_CASE_INSENSITIVE
 `=ini='*val*'` -> INFIX_CASE_INSENSITIVE
 `=ini='val*'` -> POSTFIX_CASE_INSENSITIVE
 `=in='val'` or `=='val'` -> IN
 `=in='*val'` or `=='*val'` -> PREFIX
 `=in='*val*'` or `=='*val*'` -> INFIX
 `=in='val*'` or `=='val*'` -> POSTFIX


## Motivation and Context
Having a default case insensitive filter bypasses the datastore index (if exist) thereby making queries slow. User needs to select whether they want CI or CS filter. 

## How Has This Been Tested?
Integration test and Unit Test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
