### PR TITLE
Fixes #1520 by using explicit left join when sorting over relationships

### DIFF
--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
@@ -49,7 +49,8 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
 
             //Build the JOIN clause
             String joinClause =  getJoinClauseFromFilters(filterExpression.get())
-                    + extractToOneMergeJoins(entityClass, entityAlias);
+                    + extractToOneMergeJoins(entityClass, entityAlias)
+                    + explicitSortJoins(sorting, entityClass);
 
             boolean requiresDistinct = pagination.isPresent() && containsOneToMany(filterExpression.get());
             Boolean sortOverRelationship = sorting
@@ -88,6 +89,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                     + entityAlias
                     + SPACE
                     + extractToOneMergeJoins(entityClass, entityAlias)
+                    + explicitSortJoins(sorting, entityClass)
                     + SPACE
                     + getSortClause(sorting, entityClass, USE_ALIAS));
         }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -72,7 +72,8 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
             String filterClause = new FilterTranslator().apply(fe, USE_ALIAS);
 
             String joinClause =  getJoinClauseFromFilters(filterExpression.get())
-                    + extractToOneMergeJoins(relationship.getChildType(), childAlias);
+                    + extractToOneMergeJoins(relationship.getChildType(), childAlias)
+                    + explicitSortJoins(sorting, relationship.getChildType());
 
             //SELECT parent_children from Parent parent JOIN parent.children parent_children
             Query q = session.createQuery(SELECT
@@ -98,6 +99,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                             + JOIN
                             + parentAlias + PERIOD + relationshipName + SPACE + childAlias
                             + extractToOneMergeJoins(relationship.getChildType(), childAlias)
+                            + explicitSortJoins(sorting, relationship.getChildType())
                             + " WHERE " + parentAlias + "=:" + parentAlias
                             + getSortClause(sorting, relationship.getChildType(), USE_ALIAS)
         ));

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
@@ -108,9 +108,9 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
     public void testFetchJoinClause() {
         String actual = extractToOneMergeJoins(Left.class, "right_alias");
 
-        String expected = " LEFT JOIN FETCH right_alias.noDeleteOne2One  "
-                + "LEFT JOIN FETCH right_alias.noUpdateOne2One  "
-                + "LEFT JOIN FETCH right_alias.one2one ";
+        String expected = " LEFT JOIN FETCH right_alias.noDeleteOne2One right_alias_noDeleteOne2One  "
+                + "LEFT JOIN FETCH right_alias.noUpdateOne2One right_alias_noUpdateOne2One  "
+                + "LEFT JOIN FETCH right_alias.one2one right_alias_one2one ";
         assertEquals(expected, actual);
     }
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -25,6 +25,7 @@ import com.yahoo.elide.core.sort.Sorting;
 import example.Author;
 import example.Book;
 import example.Chapter;
+import example.Editor;
 import example.Publisher;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -40,6 +41,12 @@ public class RootCollectionFetchQueryBuilderTest {
     private EntityDictionary dictionary;
 
     private static final String TITLE = "title";
+    private static final String PUBLISHER = "publisher";
+    private static final String EDITOR = "editor";
+    private static final String PERIOD = ".";
+    private static final String NAME = "name";
+    private static final String FIRSTNAME = "firstName";
+
     private RSQLFilterDialect filterParser;
 
     @BeforeAll
@@ -49,6 +56,7 @@ public class RootCollectionFetchQueryBuilderTest {
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Publisher.class);
         dictionary.bindEntity(Chapter.class);
+        dictionary.bindEntity(Editor.class);
         filterParser = new RSQLFilterDialect(dictionary, new CaseSensitivityStrategy.UseColumnCollation());
     }
 
@@ -60,7 +68,7 @@ public class RootCollectionFetchQueryBuilderTest {
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
 
         String expected =
-                "SELECT example_Book FROM example.Book AS example_Book  LEFT JOIN FETCH example_Book.publisher  ";
+                "SELECT example_Book FROM example.Book AS example_Book  LEFT JOIN FETCH example_Book.publisher example_Book_publisher  ";
         String actual = query.getQueryText();
 
         assertEquals(expected, actual);
@@ -79,7 +87,7 @@ public class RootCollectionFetchQueryBuilderTest {
                 .build();
 
         String expected = "SELECT example_Book FROM example.Book AS example_Book  "
-                + "LEFT JOIN FETCH example_Book.publisher   order by example_Book.title asc";
+                + "LEFT JOIN FETCH example_Book.publisher example_Book_publisher   order by example_Book.title asc";
         String actual = query.getQueryText();
 
         assertEquals(expected, actual);
@@ -135,7 +143,6 @@ public class RootCollectionFetchQueryBuilderTest {
                 .withPossibleFilterExpression(Optional.of(expression))
                 .build();
 
-
         String expected =
                 "SELECT DISTINCT example_Author FROM example.Author AS example_Author  "
                 + "LEFT JOIN example_Author.books example_Author_books  "
@@ -189,10 +196,68 @@ public class RootCollectionFetchQueryBuilderTest {
                 .build();
 
         String expected =
-                "SELECT example_Book FROM example.Book AS example_Book  LEFT JOIN FETCH example_Book.publisher"
+                "SELECT example_Book FROM example.Book AS example_Book  LEFT JOIN FETCH example_Book.publisher example_Book_publisher"
                 + "  WHERE example_Book.id IN (:id_XXX)  order by example_Book.title asc";
 
         String actual = query.getQueryText();
+        actual = actual.replaceFirst(":id_\\w+", ":id_XXX");
+
+        assertEquals(expected, actual);
+    }
+
+
+    @Test
+    public void testSortingWithJoin() {
+        RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
+                Book.class, dictionary, new TestSessionWrapper());
+
+        Map<String, Sorting.SortOrder> sorting = new HashMap<>();
+        sorting.put(PUBLISHER + PERIOD + NAME, Sorting.SortOrder.asc);
+
+
+        TestQueryWrapper query = (TestQueryWrapper) builder
+                .withPossibleSorting(Optional.of(new Sorting(sorting)))
+                .build();
+
+        String expected =
+                "SELECT example_Book FROM example.Book AS example_Book "
+                        + "LEFT JOIN FETCH example_Book.publisher example_Book_publisher "
+                        + "order by example_Book_publisher.name asc";
+
+        String actual = query.getQueryText();
+        actual = actual.trim().replaceAll(" +", " ");
+        actual = actual.replaceFirst(":id_\\w+", ":id_XXX");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testRootFetchWithRelationshipSortingAndFilters() {
+        RootCollectionFetchQueryBuilder builder = new RootCollectionFetchQueryBuilder(
+                Book.class, dictionary, new TestSessionWrapper());
+
+        Map<String, Sorting.SortOrder> sorting = new HashMap<>();
+        sorting.put(PUBLISHER + PERIOD + EDITOR + PERIOD + FIRSTNAME, Sorting.SortOrder.desc);
+
+        Path.PathElement idPath = new Path.PathElement(Book.class, Chapter.class, "id");
+
+        FilterPredicate idPredicate = new InPredicate(idPath, 1);
+
+
+        TestQueryWrapper query = (TestQueryWrapper) builder
+                .withPossibleSorting(Optional.of(new Sorting(sorting)))
+                .withPossibleFilterExpression(Optional.of(idPredicate))
+                .build();
+
+        String expected =
+                "SELECT example_Book FROM example.Book AS example_Book"
+                        + " LEFT JOIN FETCH example_Book.publisher example_Book_publisher"
+                        + " LEFT JOIN example_Book_publisher.editor example_Publisher_editor"
+                        + " WHERE example_Book.id IN (:id_XXX)"
+                        + " order by example_Publisher_editor.firstName desc";
+
+        String actual = query.getQueryText();
+        actual = actual.trim().replaceAll(" +", " ");
         actual = actual.replaceFirst(":id_\\w+", ":id_XXX");
 
         assertEquals(expected, actual);

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -41,6 +41,7 @@ public class SubCollectionFetchQueryBuilderTest {
     private static final String BOOKS = "books";
     private static final String NAME = "name";
     private static final String PUBLISHER = "publisher";
+    private static final String PERIOD = ".";
     private static final String PUB1 = "Pub1";
 
     @BeforeAll
@@ -101,7 +102,7 @@ public class SubCollectionFetchQueryBuilderTest {
                 .build();
 
         String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
-                + "JOIN example_Author__fetch.books example_Book LEFT JOIN FETCH example_Book.publisher  "
+                + "JOIN example_Author__fetch.books example_Book LEFT JOIN FETCH example_Book.publisher example_Book_publisher  "
                 + "WHERE example_Author__fetch=:example_Author__fetch order by example_Book.title asc";
         String actual = query.getQueryText();
 
@@ -229,6 +230,41 @@ public class SubCollectionFetchQueryBuilderTest {
 
         String actual = query.getQueryText();
         actual = actual.replaceFirst(":publisher_name_\\w+", ":publisher_name_XXX");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSubCollectionFetchWithRelationshipSorting() {
+        Author author = new Author();
+        author.setId(1L);
+
+        Book book = new Book();
+        book.setId(2);
+
+        RelationshipImpl relationship = new RelationshipImpl(
+                Author.class,
+                Book.class,
+                BOOKS,
+                author,
+                Arrays.asList(book));
+
+        SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(relationship,
+                dictionary, new TestSessionWrapper());
+
+        Map<String, Sorting.SortOrder> sorting = new HashMap<>();
+        sorting.put(PUBLISHER + PERIOD + NAME, Sorting.SortOrder.asc);
+
+        TestQueryWrapper query = (TestQueryWrapper) builder
+                .withPossibleSorting(Optional.of(new Sorting(sorting)))
+                .build();
+
+        String expected = "SELECT example_Book FROM example.Author example_Author__fetch "
+                + "JOIN example_Author__fetch.books example_Book "
+                + "LEFT JOIN FETCH example_Book.publisher example_Book_publisher "
+                + "WHERE example_Author__fetch=:example_Author__fetch order by example_Book_publisher.name asc";
+        String actual = query.getQueryText();
+        actual = actual.trim().replaceAll(" +", " ");
 
         assertEquals(expected, actual);
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/SortingIT.java
@@ -7,6 +7,8 @@ package com.yahoo.elide.tests;
 
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -60,6 +62,7 @@ public class SortingIT extends IntegrationTest {
     public void testSortingRootCollectionByRelationshipProperty() throws IOException {
         JsonNode result = getAsNode("/book?sort=-publisher.name");
         int size = result.get("data").size();
+        assertEquals(8, size);
 
         JsonNode books = result.get("data");
         String firstBookName = books.get(0).get("attributes").get("title").asText();
@@ -69,6 +72,8 @@ public class SortingIT extends IntegrationTest {
         assertEquals("The Old Man and the Sea", secondBookName);
 
         result = getAsNode("/book?sort=publisher.name");
+        size = result.get("data").size();
+        assertEquals(8, size);
 
         books = result.get("data");
         firstBookName = books.get(size - 2).get("attributes").get("title").asText();
@@ -156,5 +161,36 @@ public class SortingIT extends IntegrationTest {
             String actualTitle = books.get(idx).get("attributes").get("title").asText();
             assertEquals(expectedTitle, actualTitle);
         }
+    }
+
+
+    @Test
+    public void testRootCollectionByNullRelationshipProperty() throws IOException {
+        // Test whether all book records are received
+        when()
+                .get("/book?sort=publisher.editor.lastName")
+                .then()
+                .body("data", hasSize(8))
+        ;
+        when()
+                .get("/book?sort=-publisher.editor.lastName")
+                .then()
+                .body("data", hasSize(8))
+        ;
+
+    }
+
+    @Test
+    public void testSubcollectionByNullRelationshipProperty() throws IOException {
+        when()
+                .get("/author/1/books?sort=publisher.editor.lastName")
+                .then()
+                .body("data", hasSize(2))
+        ;
+        when()
+                .get("/author/1/books?sort=-publisher.editor.lastName")
+                .then()
+                .body("data", hasSize(2))
+        ;
     }
 }


### PR DESCRIPTION
Resolves #1520

## Description
When resolving hibernate query add explicit joins based on sort paths

## Motivation and Context
See issue

## How Has This Been Tested?
Just by debugging generated query.
I would like to do some unit/IT tests, but didn't figured how can I debug elide while running IT.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
