### PR TITLE
Data Export - Model Changes

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -27,6 +27,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /**
@@ -51,6 +52,8 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
 
     private QueryType queryType; //GRAPHQL, JSONAPI
 
+    private ResultFormatType resultFormatType = ResultFormatType.JSONAPI;
+
     @Transient
     @Max(10)
     @ComputedAttribute
@@ -64,6 +67,10 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     @CreatePermission(expression = "value is Queued")
     @Enumerated(EnumType.STRING)
     private QueryStatus status = QueryStatus.QUEUED;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    private ResultType resultType; //EMBEDDED, DOWNLOAD
 
     @Embedded
     private AsyncQueryResult result;

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -27,7 +27,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 import javax.validation.constraints.Max;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /**
@@ -69,8 +68,8 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     private QueryStatus status = QueryStatus.QUEUED;
 
     @Enumerated(EnumType.STRING)
-    @NotNull
-    private ResultType resultType; //EMBEDDED, DOWNLOAD
+    // TODO : Remove default and make not null
+    private ResultType resultType = ResultType.EMBEDDED; //EMBEDDED, DOWNLOAD
 
     @Embedded
     private AsyncQueryResult result;

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -10,8 +10,6 @@ import lombok.Data;
 import java.util.Date;
 
 import javax.persistence.Embeddable;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 
 /**
  * Model for Async Query Result.
@@ -23,12 +21,11 @@ public class AsyncQueryResult {
 
     private Integer contentLength;
 
+    private Integer recordCount;
+
     private String responseBody;  //URL or Response body
 
     private Integer httpStatus; // HTTP Status
-
-    @Enumerated(EnumType.STRING)
-    private ResultType resultType; //EMBEDDED, DOWNLOAD
 
     private Date completedOn = new Date();
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/ResultFormatType.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/ResultFormatType.java
@@ -11,7 +11,10 @@ import lombok.Getter;
 import java.util.EnumSet;
 import java.util.Set;
 
-
+/**
+ * ENUM of supported result format types.
+ * ex. JSON, CSV etc.
+ */
 public enum ResultFormatType {
     JSONAPI(EnumSet.of(ResultType.EMBEDDED)),
     GRAPHQLAPI(EnumSet.of(ResultType.EMBEDDED)),

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/ResultFormatType.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/ResultFormatType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.async.models;
+
+import lombok.Getter;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+
+public enum ResultFormatType {
+    JSONAPI(EnumSet.of(ResultType.EMBEDDED)),
+    GRAPHQLAPI(EnumSet.of(ResultType.EMBEDDED)),
+    //TODO - Add JSON(ResultType.EMBEDDED, ResultType.DOWNLOAD),
+    CSV(EnumSet.of(ResultType.EMBEDDED, ResultType.DOWNLOAD));
+
+    @Getter private final Set<ResultType> supportedResultType;
+
+    private ResultFormatType(Set<ResultType> supportedResultType) {
+        this.supportedResultType = supportedResultType;
+    }
+
+    public boolean supportsDownload() {
+        return this.supportedResultType.contains(ResultType.DOWNLOAD);
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/ResultType.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/ResultType.java
@@ -9,5 +9,6 @@ package com.yahoo.elide.async.models;
  * ENUM of supported result types.
  */
 public enum ResultType {
-    EMBEDDED
+    EMBEDDED,
+    DOWNLOAD
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncQueryThread.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryType;
-import com.yahoo.elide.async.models.ResultType;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.security.User;
 
@@ -101,7 +100,6 @@ public class AsyncQueryThread implements Callable<AsyncQueryResult> {
         queryResultObj.setHttpStatus(response.getResponseCode());
         queryResultObj.setResponseBody(response.getBody());
         queryResultObj.setContentLength(response.getBody().length());
-        queryResultObj.setResultType(ResultType.EMBEDDED);
         queryResultObj.setCompletedOn(new Date());
 
         return queryResultObj;

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.async.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.ResultType;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ public class AsyncQueryTest {
     public void testMaxAsyncAfterSeconds() {
         AsyncQuery queryObj = new AsyncQuery();
         queryObj.setAsyncAfterSeconds(12);
+        queryObj.setResultType(ResultType.EMBEDDED);
         Set<ConstraintViolation<AsyncQuery>> constraintViolations = validator.validate(queryObj);
         assertEquals(1, constraintViolations.size());
         assertEquals("must be less than or equal to 10", constraintViolations.iterator().next().getMessage());

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryThreadTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryThreadTest.java
@@ -17,6 +17,7 @@ import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryType;
+import com.yahoo.elide.async.models.ResultType;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.security.User;
 
@@ -53,6 +54,8 @@ public class AsyncQueryThreadTest {
         queryObj.setId(id);
         queryObj.setQuery(query);
         queryObj.setQueryType(QueryType.JSONAPI_V1_0);
+        queryObj.setResultType(ResultType.EMBEDDED);
+
         when(elide.get(anyString(), anyString(), any(), any(), anyString(), any())).thenReturn(response);
         AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1");
         queryResultObj = queryThread.processQuery();
@@ -69,6 +72,8 @@ public class AsyncQueryThreadTest {
         queryObj.setId(id);
         queryObj.setQuery(query);
         queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+        queryObj.setResultType(ResultType.EMBEDDED);
+
         when(runner.run(anyString(), eq(query), eq(user), any())).thenReturn(response);
         AsyncQueryThread queryThread = new AsyncQueryThread(queryObj, user, elide, runner, asyncQueryDao, "v1");
         queryResultObj = queryThread.processQuery();

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -210,7 +210,10 @@ public class AsyncIT extends IntegrationTest {
                 .statusCode(org.apache.http.HttpStatus.SC_CREATED)
                 .body("data.id", equalTo("edc4a871-dff2-4054-804e-d80075cf830e"))
                 .body("data.type", equalTo("asyncQuery"))
-                .body("data.attributes.status", notNullValue())
+                .body("data.attributes.status", equalTo("PROCESSING"))
+                .body("data.attributes.result.contentLength", nullValue())
+                .body("data.attributes.result.responseBody", nullValue())
+                .body("data.attributes.result.httpStatus", nullValue())
                 .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
         int i = 0;
@@ -330,6 +333,7 @@ public class AsyncIT extends IntegrationTest {
                                                  field("id"),
                                                  field("query"),
                                                  field("queryType"),
+                                                 field("status"),
                                                  field("resultType")
                                          )
                                  )
@@ -348,7 +352,7 @@ public class AsyncIT extends IntegrationTest {
 
         String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
-                + "\"queryType\":\"GRAPHQL_V1_0\",\"resultType\":\"EMBEDDED\"}}]}}}";
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\",\"resultType\":\"EMBEDDED\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
 
         int i = 0;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -444,14 +444,14 @@ public class AsyncIT extends IntegrationTest {
                  .contentType(MediaType.APPLICATION_JSON)
                  .accept(MediaType.APPLICATION_JSON)
                  .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4054-804e-d80075cf829e\\\"]) "
-                         + "{ edges { node { id queryType status result "
+                         + "{ edges { node { id queryType status resultType result "
                          + "{ responseBody httpStatus contentLength } } } } }\","
                          + "\"variables\":null}")
                  .post("/graphQL")
                  .asString();
 
         expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
-                 + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
+                 + "\"resultType\":\"EMBEDDED\",\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","
                  + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
@@ -596,7 +596,7 @@ public class AsyncIT extends IntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263a\\\"]) "
-                        + "{ edges { node { id createdOn updatedOn queryType status result "
+                        + "{ edges { node { id createdOn updatedOn queryType status resultType result "
                         + "{ responseBody httpStatus contentLength } } } } }\""
                         + ",\"variables\":null}")
                 .post("/graphQL")

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -362,7 +362,7 @@ public class AsyncIT extends IntegrationTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)
                     .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4054-804e-d80075cf828e\\\"]) "
-                            + "{ edges { node { id queryType status result "
+                            + "{ edges { node { id queryType status resultType result "
                             + "{ responseBody httpStatus contentLength } } } } }\","
                             + "\"variables\":null}")
                     .post("/graphQL")
@@ -371,7 +371,7 @@ public class AsyncIT extends IntegrationTest {
             if (responseGraphQL.contains("\"status\":\"COMPLETE\"")) {
 
                 expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\",\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\","
-                        + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
+                        + "\"resultType\":\"EMBEDDED\",\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","
                         + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -88,6 +88,12 @@ public class AsyncIT extends IntegrationTest {
 
         @JsonSerialize(using = EnumFieldSerializer.class, as = String.class)
         private String status;
+
+        @JsonSerialize(using = EnumFieldSerializer.class, as = String.class)
+        private String resultType;
+
+        @JsonSerialize(using = EnumFieldSerializer.class, as = String.class)
+        private String resultFormatType;
     }
 
     private static final Resource ENDERS_GAME = resource(
@@ -193,7 +199,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/book?sort=genre&fields%5Bbook%5D=title"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "0")
+                                                attr("asyncAfterSeconds", "0"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -203,11 +210,8 @@ public class AsyncIT extends IntegrationTest {
                 .statusCode(org.apache.http.HttpStatus.SC_CREATED)
                 .body("data.id", equalTo("edc4a871-dff2-4054-804e-d80075cf830e"))
                 .body("data.type", equalTo("asyncQuery"))
-                .body("data.attributes.status", equalTo("PROCESSING"))
-                .body("data.attributes.result.contentLength", nullValue())
-                .body("data.attributes.result.responseBody", nullValue())
-                .body("data.attributes.result.httpStatus", nullValue())
-                .body("data.attributes.result.resultType", nullValue());
+                .body("data.attributes.status", notNullValue())
+                .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
         int i = 0;
         while (i < 1000) {
@@ -230,12 +234,13 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
                         .body("data.attributes.status", equalTo("COMPLETE"))
                         .body("data.attributes.result.contentLength", notNullValue())
+                        .body("data.attributes.result.recordCount", nullValue())
                         .body("data.attributes.result.responseBody", equalTo("{\"data\":"
                                 + "[{\"type\":\"book\",\"id\":\"3\",\"attributes\":{\"title\":\"For Whom the Bell Tolls\"}}"
                                 + ",{\"type\":\"book\",\"id\":\"2\",\"attributes\":{\"title\":\"Song of Ice and Fire\"}},"
                                 + "{\"type\":\"book\",\"id\":\"1\",\"attributes\":{\"title\":\"Ender's Game\"}}]}"))
                         .body("data.attributes.result.httpStatus", equalTo(200))
-                        .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
+                        .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
@@ -273,7 +278,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/book?sort=genre&fields%5Bbook%5D=title"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "7")
+                                                attr("asyncAfterSeconds", "7"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -285,12 +291,13 @@ public class AsyncIT extends IntegrationTest {
                 .body("data.type", equalTo("asyncQuery"))
                 .body("data.attributes.status", equalTo("COMPLETE"))
                 .body("data.attributes.result.contentLength", notNullValue())
+                .body("data.attributes.result.recordCount", nullValue())
                 .body("data.attributes.result.responseBody", equalTo("{\"data\":"
                         + "[{\"type\":\"book\",\"id\":\"3\",\"attributes\":{\"title\":\"For Whom the Bell Tolls\"}}"
                         + ",{\"type\":\"book\",\"id\":\"2\",\"attributes\":{\"title\":\"Song of Ice and Fire\"}},"
                         + "{\"type\":\"book\",\"id\":\"1\",\"attributes\":{\"title\":\"Ender's Game\"}}]}"))
                 .body("data.attributes.result.httpStatus", equalTo(200))
-                .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
+                .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
     }
 
@@ -309,6 +316,7 @@ public class AsyncIT extends IntegrationTest {
         queryObj.setQueryType("GRAPHQL_V1_0");
         queryObj.setStatus("QUEUED");
         queryObj.setQuery("{\"query\":\"{ book { edges { node { id title } } } }\",\"variables\":null}");
+        queryObj.setResultType("EMBEDDED");
         String graphQLRequest = document(
                  mutation(
                          selection(
@@ -322,7 +330,7 @@ public class AsyncIT extends IntegrationTest {
                                                  field("id"),
                                                  field("query"),
                                                  field("queryType"),
-                                                 field("status")
+                                                 field("resultType")
                                          )
                                  )
                          )
@@ -340,7 +348,7 @@ public class AsyncIT extends IntegrationTest {
 
         String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf828e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
-                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"PROCESSING\"}}]}}}";
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"resultType\":\"EMBEDDED\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
 
         int i = 0;
@@ -351,7 +359,7 @@ public class AsyncIT extends IntegrationTest {
                     .accept(MediaType.APPLICATION_JSON)
                     .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4054-804e-d80075cf828e\\\"]) "
                             + "{ edges { node { id queryType status result "
-                            + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                            + "{ responseBody httpStatus contentLength } } } } }\","
                             + "\"variables\":null}")
                     .post("/graphQL")
                     .asString();
@@ -362,7 +370,7 @@ public class AsyncIT extends IntegrationTest {
                         + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                         + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","
-                        + "\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":177}}}]}}}";
+                        + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
@@ -392,6 +400,7 @@ public class AsyncIT extends IntegrationTest {
         queryObj.setQueryType("GRAPHQL_V1_0");
         queryObj.setStatus("QUEUED");
         queryObj.setQuery("{\"query\":\"{ book { edges { node { id title } } } }\",\"variables\":null}");
+        queryObj.setResultType("EMBEDDED");
         String graphQLRequest = document(
                  mutation(
                          selection(
@@ -405,7 +414,8 @@ public class AsyncIT extends IntegrationTest {
                                                  field("id"),
                                                  field("query"),
                                                  field("queryType"),
-                                                 field("status")
+                                                 field("status"),
+                                                 field("resultType")
                                          )
                                  )
                          )
@@ -423,7 +433,7 @@ public class AsyncIT extends IntegrationTest {
 
         String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"edc4a871-dff2-4054-804e-d80075cf829e\","
                 + "\"query\":\"{\\\"query\\\":\\\"{ book { edges { node { id title } } } }\\\",\\\"variables\\\":null}\","
-                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\"}}]}}}";
+                + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"EMBEDDED\"}}]}}}";
         assertEquals(expectedResponse, response.extract().body().asString());
 
         String responseGraphQL = given()
@@ -431,7 +441,7 @@ public class AsyncIT extends IntegrationTest {
                  .accept(MediaType.APPLICATION_JSON)
                  .body("{\"query\":\"{ asyncQuery(ids: [\\\"edc4a871-dff2-4054-804e-d80075cf829e\\\"]) "
                          + "{ edges { node { id queryType status result "
-                         + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                         + "{ responseBody httpStatus contentLength } } } } }\","
                          + "\"variables\":null}")
                  .post("/graphQL")
                  .asString();
@@ -440,7 +450,7 @@ public class AsyncIT extends IntegrationTest {
                  + "\"result\":{\"responseBody\":\"{\\\"data\\\":{\\\"book\\\":{\\\"edges\\\":[{\\\"node\\\":{\\\"id\\\":\\\"1\\\",\\\"title\\\":\\\"Ender's Game\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"2\\\",\\\"title\\\":\\\"Song of Ice and Fire\\\"}},"
                  + "{\\\"node\\\":{\\\"id\\\":\\\"3\\\",\\\"title\\\":\\\"For Whom the Bell Tolls\\\"}}]}}}\","
-                 + "\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":177}}}]}}}";
+                 + "\"httpStatus\":200,\"contentLength\":177}}}]}}}";
 
         assertEquals(expectedResponse, responseGraphQL);
     }
@@ -507,7 +517,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/group?sort=genre&fields%5Bgroup%5D=title"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "10")
+                                                attr("asyncAfterSeconds", "10"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -582,7 +593,7 @@ public class AsyncIT extends IntegrationTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263a\\\"]) "
                         + "{ edges { node { id createdOn updatedOn queryType status result "
-                        + "{ responseBody httpStatus resultType contentLength } } } } }\""
+                        + "{ responseBody httpStatus contentLength } } } } }\""
                         + ",\"variables\":null}")
                 .post("/graphQL")
                 .then()
@@ -611,7 +622,8 @@ public class AsyncIT extends IntegrationTest {
                                                 attr("query", "/noread"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "10")
+                                                attr("asyncAfterSeconds", "10"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -639,10 +651,11 @@ public class AsyncIT extends IntegrationTest {
                         .body("data.type", equalTo("asyncQuery"))
                         .body("data.attributes.queryType", equalTo("JSONAPI_V1_0"))
                         .body("data.attributes.status", equalTo("COMPLETE"))
+                        .body("data.attributes.result.recordCount", nullValue())
                         .body("data.attributes.result.contentLength", notNullValue())
                         .body("data.attributes.result.responseBody", equalTo("{\"data\":[]}"))
                         .body("data.attributes.result.httpStatus", equalTo(200))
-                        .body("data.attributes.result.resultType", equalTo(ResultType.EMBEDDED.toString()));
+                        .body("data.attributes.resultType", equalTo(ResultType.EMBEDDED.toString()));
 
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {
@@ -659,7 +672,7 @@ public class AsyncIT extends IntegrationTest {
 
     /**
      * Tests Read Permissions on Async Model for Admin Role
-     * @throws InterruptedException
+     * @throws IOException IOException
      */
     @Test
     public void asyncModelAdminReadPermissions() throws IOException {
@@ -673,6 +686,7 @@ public class AsyncIT extends IntegrationTest {
         queryObj.setQuery(query);
         queryObj.setQueryType(QueryType.JSONAPI_V1_0);
         queryObj.setPrincipalName("owner-user");
+        queryObj.setResultType(ResultType.EMBEDDED);
 
         dataStore.populateEntityDictionary(
                         new EntityDictionary(AsyncIntegrationTestApplicationResourceConfig.MAPPINGS));
@@ -739,7 +753,7 @@ public class AsyncIT extends IntegrationTest {
     }
 
     /**
-     * Reset sleep delay flag after each test
+     * Reset sleep delay flag after each test.
      */
     @AfterEach
     public void sleepDelayReset() {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -55,7 +55,8 @@ public class AsyncTest extends IntegrationTest {
                                                 attr("query", "/group"),
                                                 attr("queryType", "JSONAPI_V1_0"),
                                                 attr("status", "QUEUED"),
-                                                attr("asyncAfterSeconds", "10")
+                                                attr("asyncAfterSeconds", "10"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -95,13 +96,13 @@ public class AsyncTest extends IntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\\\"]) "
-                                + "{ edges { node { id queryType status result "
-                                + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                                + "{ edges { node { id queryType status resultType result "
+                                + "{ responseBody httpStatus contentLength } } } } }\","
                                 + "\"variables\":null }")
                         .post("/graphql")
                         .asString();
 
-                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"group\\\",\\\"id\\\":\\\"com.example.repository\\\",\\\"attributes\\\":{\\\"commonName\\\":\\\"Example Repository\\\",\\\"deprecated\\\":false,\\\"description\\\":\\\"The code for this project\\\"},\\\"relationships\\\":{\\\"products\\\":{\\\"data\\\":[]}}}]}\",\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":208}}}]}}}";
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"EMBEDDED\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"group\\\",\\\"id\\\":\\\"com.example.repository\\\",\\\"attributes\\\":{\\\"commonName\\\":\\\"Example Repository\\\",\\\"deprecated\\\":false,\\\"description\\\":\\\"The code for this project\\\"},\\\"relationships\\\":{\\\"products\\\":{\\\"data\\\":[]}}}]}\",\"httpStatus\":200,\"contentLength\":208}}}]}}}";
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -272,7 +272,8 @@ public class ElideStandaloneTest {
                                         attributes(
                                                 attr("query", "/post"),
                                                 attr("queryType", "JSONAPI_V1_0"),
-                                                attr("status", "QUEUED")
+                                                attr("status", "QUEUED"),
+                                                attr("resultType", "EMBEDDED")
                                         )
                                 )
                         ).toJSON())
@@ -309,13 +310,13 @@ public class ElideStandaloneTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .body("{\"query\":\"{ asyncQuery(ids: [\\\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\\\"]) "
-                                + "{ edges { node { id queryType status result "
-                                + "{ responseBody httpStatus resultType contentLength } } } } }\","
+                                + "{ edges { node { id queryType status resultType result "
+                                + "{ responseBody httpStatus  contentLength } } } } }\","
                                 + "\"variables\":null}")
                         .post("/graphql/api/v1/")
                         .asString();
 
-                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"post\\\",\\\"id\\\":\\\"2\\\",\\\"attributes\\\":{\\\"abusiveContent\\\":false,\\\"content\\\":\\\"This is my first post. woot.\\\",\\\"date\\\":\\\"2019-01-01T00:00Z\\\"}}]}\",\"httpStatus\":200,\"resultType\":\"EMBEDDED\",\"contentLength\":141}}}]}}}";
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"EMBEDDED\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"post\\\",\\\"id\\\":\\\"2\\\",\\\"attributes\\\":{\\\"abusiveContent\\\":false,\\\"content\\\":\\\"This is my first post. woot.\\\",\\\"date\\\":\\\"2019-01-01T00:00Z\\\"}}]}\",\"httpStatus\":200,\"contentLength\":141}}}]}}}";
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             } else if (!(outputResponse.equals("PROCESSING"))) {


### PR DESCRIPTION
Resolves part of #1272

## Description
Update the Async Models, per the RFC-1272 to add ResultFormat and move ResultType to AsyncQuery Class instead of AsyncQueryResult

## Motivation and Context
Refer #1272

## How Has This Been Tested?
Existing Tests pass. Test Cases have been updated.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
