### PR TITLE
Table filter validations

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.filter.visitor;
+
+import com.yahoo.elide.core.filter.FilterPredicate;
+import com.yahoo.elide.core.filter.expression.AndFilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
+import com.yahoo.elide.core.filter.expression.NotFilterExpression;
+import com.yahoo.elide.core.filter.expression.OrFilterExpression;
+import com.yahoo.elide.parsers.expression.FilterExpressionNormalizationVisitor;
+import lombok.AllArgsConstructor;
+
+/**
+ * Validates whether a client provided filter either:
+ * 1. Directly matches a template filter.
+ * 2. Contains through conjunction (logical AND) a filter expression that matches a template filter.
+ * This is used to enforce table filter constraints.
+ */
+@AllArgsConstructor
+public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> {
+    private FilterExpression expressionToMatch;
+
+    @Override
+    public Boolean visitPredicate(FilterPredicate filterPredicate) {
+        if (matches(expressionToMatch, filterPredicate)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visitAndExpression(AndFilterExpression expression) {
+        if (matches(expressionToMatch, expression)) {
+            return true;
+        }
+        return expression.getLeft().accept(this) || expression.getRight().accept(this);
+    }
+
+    @Override
+    public Boolean visitOrExpression(OrFilterExpression expression) {
+        if (matches(expressionToMatch, expression)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Boolean visitNotExpression(NotFilterExpression expression) {
+        if (matches(expressionToMatch, expression)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean matches(FilterExpression a, FilterExpression b) {
+        if (! a.getClass().equals(b.getClass())) {
+            return false;
+        }
+
+        if (a instanceof AndFilterExpression) {
+            AndFilterExpression andA = (AndFilterExpression) a;
+            AndFilterExpression andB = (AndFilterExpression) b;
+
+            return matches(andA.getLeft(), andB.getLeft()) && matches(andA.getRight(), andB.getRight());
+        } else if (a instanceof OrFilterExpression) {
+            OrFilterExpression orA = (OrFilterExpression) a;
+            OrFilterExpression orB = (OrFilterExpression) b;
+
+            return matches(orA.getLeft(), orB.getLeft()) && matches(orA.getRight(), orB.getRight());
+        } else if (a instanceof NotFilterExpression) {
+            NotFilterExpression notA = (NotFilterExpression) a;
+            NotFilterExpression notB = (NotFilterExpression) b;
+
+            return matches(notA.getNegated(), notB.getNegated());
+        } else {
+            FilterPredicate predicateA = (FilterPredicate) a;
+            FilterPredicate predicateB = (FilterPredicate) b;
+
+            return predicateA.getPath().equals(predicateB.getPath())
+                    && predicateA.getOperator().equals(predicateB.getOperator());
+        }
+    }
+
+    /**
+     * Determines if a client filter matches or contains a subexpression that matches a template filter.
+     * @param templateFilter A templated filter expression
+     * @param clientFilter The client provided filter expression.
+     * @return True if the client filter matches.  False otherwise.
+     */
+    public static boolean isValid(FilterExpression templateFilter, FilterExpression clientFilter) {
+
+        //First we normalize the filters so any NOT clauses are pushed down immediately in front of a predicate.
+        //This lets us treat logical AND and OR without regard for any preceding NOT clauses.
+        FilterExpression normalizedTemplateFilter = templateFilter.accept(new FilterExpressionNormalizationVisitor());
+        FilterExpression normalizedClientFilter = clientFilter.accept(new FilterExpressionNormalizationVisitor());
+
+        return normalizedClientFilter.accept(new MatchesTemplateVisitor(normalizedTemplateFilter));
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.filter.visitor;
+
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.datastores.aggregation.example.Player;
+import com.yahoo.elide.datastores.aggregation.example.PlayerStats;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class MatchesTemplateVisitorTest {
+    private RSQLFilterDialect dialect;
+
+    @BeforeEach
+    public void setup() {
+        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
+        dictionary.bindEntity(PlayerStats.class);
+        dictionary.bindEntity(Player.class);
+        dialect = new RSQLFilterDialect(dictionary);
+    }
+
+    @Test
+    public void exactMatchTest() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("highScore==123",
+                PlayerStats.class, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",
+                PlayerStats.class, false, true);
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -11,12 +11,12 @@ import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.datastores.aggregation.example.Player;
 import com.yahoo.elide.datastores.aggregation.example.PlayerStats;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -32,8 +32,75 @@ public class MatchesTemplateVisitorTest {
     }
 
     @Test
-    public void exactMatchTest() throws Exception {
+    public void predicateMatchTest() throws Exception {
         FilterExpression clientExpression = dialect.parseFilterExpression("highScore==123",
+                PlayerStats.class, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",
+                PlayerStats.class, false, true);
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+    }
+
+    @Test
+    public void conjunctionMatchTest() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("lowScore>100;highScore==123",
+                PlayerStats.class, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",
+                PlayerStats.class, false, true);
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+    }
+
+    @Test
+    public void conjunctionMismatchTest() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("lowScore>100;player.name==Bob*",
+                PlayerStats.class, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",
+                PlayerStats.class, false, true);
+
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+    }
+
+    @Test
+    public void disjunctionMatchTest() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("lowScore>100,highScore==123",
+                PlayerStats.class, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",
+                PlayerStats.class, false, true);
+
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+    }
+
+    @Test
+    public void disjunctionMismatchTest() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("lowScore>100,player.name==Bob*",
+                PlayerStats.class, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",
+                PlayerStats.class, false, true);
+
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+    }
+
+    @Test
+    public void predicateMismatchTest() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("highScore!=123",
+                PlayerStats.class, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",
+                PlayerStats.class, false, true);
+
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+    }
+
+    @Test
+    public void complexExpressionTest() throws Exception {
+        String complexExpression = "(lowScore>100;((player.name==Bob*,lowScore>100);(highScore==123)))";
+        FilterExpression clientExpression = dialect.parseFilterExpression(complexExpression,
                 PlayerStats.class, true);
 
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore==${variable}",

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -6,6 +6,9 @@
 
 package com.yahoo.elide.datastores.aggregation.filter.visitor;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -15,10 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 
 public class MatchesTemplateVisitorTest {
     private RSQLFilterDialect dialect;


### PR DESCRIPTION
First PR to add table filters for Aggregation Data Store

## Description
This PR adds the logic to validate whether a client filter conforms to a template filter.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
