### PR TITLE
Delete Requests no longer trigger read life cycle hooks

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -777,22 +777,22 @@ public class PersistentResource<T> implements com.yahoo.elide.security.Persisten
      */
     public void deleteResource() throws ForbiddenAccessException {
         checkPermission(DeletePermission.class, this);
-
         /*
          * Search for bidirectional relationships.  For each bidirectional relationship,
          * we need to remove ourselves from that relationship
          */
-        Map<String, Relationship> relations = getRelationships();
-        for (Map.Entry<String, Relationship> entry : relations.entrySet()) {
-            String relationName = entry.getKey();
+
+        Class<?> resourceClass = getResourceClass();
+        List<String> relationships = dictionary.getRelationships(resourceClass);
+        for (String relationName : relationships) {
 
             /* Skip updating inverse relationships for deletes which are cascaded */
-            if (dictionary.cascadeDeletes(getResourceClass(), relationName)) {
+            if (dictionary.cascadeDeletes(resourceClass, relationName)) {
                 continue;
             }
-            String inverseRelationName = dictionary.getRelationInverse(getResourceClass(), relationName);
+            String inverseRelationName = dictionary.getRelationInverse(resourceClass, relationName);
             if (!"".equals(inverseRelationName)) {
-                for (PersistentResource inverseResource : getRelationCheckedUnfiltered(relationName)
+                for (PersistentResource inverseResource : getRelationUncheckedUnfiltered(relationName)
                         .toList().blockingGet()) {
                     if (hasInverseRelation(relationName)) {
                         deleteInverseRelation(relationName, inverseResource.getObject());

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -589,9 +589,8 @@ public class LifeCycleTest {
 
         verify(mockModel, never()).classCallback(eq(UPDATE), any());
         verify(mockModel, never()).classCallback(eq(CREATE), any());
-        verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
-        verify(mockModel, times(1)).classCallback(eq(READ), eq(PRECOMMIT));
-        verify(mockModel, times(1)).classCallback(eq(READ), eq(POSTCOMMIT));
+        verify(mockModel, never()).classCallback(eq(READ), any());
+
         verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRESECURITY));
         verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRECOMMIT));
         verify(mockModel, times(1)).classCallback(eq(DELETE), eq(POSTCOMMIT));
@@ -601,13 +600,10 @@ public class LifeCycleTest {
         verify(mockModel, never()).attributeCallback(eq(READ), any(), any());
         verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
 
-        //TODO - Read should not be called for a delete.
         verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
         verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
+        verify(mockModel, never()).relationCallback(eq(READ), any(), any());
         verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
-        verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRESECURITY), any());
-        verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRECOMMIT), any());
-        verify(mockModel, times(1)).relationCallback(eq(READ), eq(POSTCOMMIT), any());
 
         verify(tx).preCommit();
         verify(tx).delete(eq(mockModel), isA(RequestScope.class));
@@ -1094,13 +1090,10 @@ public class LifeCycleTest {
 
         resource.deleteResource();
 
-        verify(mockModel, times(2)).classCallback(any(), any());
+        verify(mockModel, times(1)).classCallback(any(), any());
         verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRESECURITY));
 
-        //TODO - DELETE should not invoke READ.
-        verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
-        verify(mockModel, times(1)).relationCallback(any(), any(), any());
-        verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRESECURITY), any());
+        verify(mockModel, never()).relationCallback(any(), any(), any());
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
         verify(mockModel, never()).attributeCallback(any(), any(), any());
 
@@ -1114,13 +1107,9 @@ public class LifeCycleTest {
 
         scope.runQueuedPreCommitTriggers();
 
-        verify(mockModel, times(2)).classCallback(any(), any());
+        verify(mockModel, times(1)).classCallback(any(), any());
         verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRECOMMIT));
-
-        //TODO - DELETE should not invoke READ.
-        verify(mockModel, times(1)).classCallback(eq(READ), eq(PRECOMMIT));
-        verify(mockModel, times(1)).relationCallback(any(), any(), any());
-        verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRECOMMIT), any());
+        verify(mockModel, never()).relationCallback(any(), any(), any());
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
         verify(mockModel, never()).attributeCallback(any(), any(), any());
 
@@ -1128,13 +1117,9 @@ public class LifeCycleTest {
         scope.getPermissionExecutor().executeCommitChecks();
         scope.runQueuedPostCommitTriggers();
 
-        verify(mockModel, times(2)).classCallback(any(), any());
+        verify(mockModel, times(1)).classCallback(any(), any());
         verify(mockModel, times(1)).classCallback(eq(DELETE), eq(POSTCOMMIT));
-
-        //TODO - DELETE should not invoke READ.
-        verify(mockModel, times(1)).classCallback(eq(READ), eq(POSTCOMMIT));
-        verify(mockModel, times(1)).relationCallback(any(), any(), any());
-        verify(mockModel, times(1)).relationCallback(eq(READ), eq(POSTCOMMIT), any());
+        verify(mockModel, never()).relationCallback(any(), any(), any());
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
         verify(mockModel, never()).attributeCallback(any(), any(), any());
     }


### PR DESCRIPTION
## Description
Calls to delete a resource erroneously read the resource relationships - resulting in life cycle hook invocations for reads.  This PR fixes the problem.

## Motivation and Context
Calling a delete on a resource should not trigger a read life cycle hook.

## How Has This Been Tested?
Existing life cycle hook tests were updated.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
