### PR TITLE
Update timegrain serde to return java.sql.Date instead of java.util.Date

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/NamedParamPreparedStatement.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/NamedParamPreparedStatement.java
@@ -7,6 +7,8 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql;
 
 import lombok.Getter;
 
+import com.yahoo.elide.core.filter.FilterPredicate;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -21,7 +23,10 @@ import java.util.regex.Pattern;
  */
 public class NamedParamPreparedStatement {
 
-    private static final Pattern PARAMETER_PATTERN = Pattern.compile("(?<!')(:[\\w]*)(?!')");
+    /**
+     * Pattern as defined in {@link FilterPredicate#getParameters()}
+     */
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("(?<!')(:[\\w]+_[0-9A-Fa-f]+_[\\d]+)(?!')");
 
     @Getter
     private PreparedStatement preparedStatement;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/NamedParamPreparedStatement.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/NamedParamPreparedStatement.java
@@ -24,7 +24,10 @@ import java.util.regex.Pattern;
 public class NamedParamPreparedStatement {
 
     /**
-     * Pattern as defined in {@link FilterPredicate#getParameters()}
+     * Parameter Pattern as defined in {@link FilterPredicate#getParameters()}
+     * examples:
+     * :overallRating_c82e10a5_0
+     * :lowScore_7c4e440_0
      */
     private static final Pattern PARAMETER_PATTERN = Pattern.compile("(?<!')(:[\\w]+_[0-9A-Fa-f]+_[\\d]+)(?!')");
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/NamedParamPreparedStatement.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/NamedParamPreparedStatement.java
@@ -5,9 +5,9 @@
  */
 package com.yahoo.elide.datastores.aggregation.queryengines.sql;
 
-import lombok.Getter;
-
 import com.yahoo.elide.core.filter.FilterPredicate;
+
+import lombok.Getter;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/DateTime.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/DateTime.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.timegrains;
 
-import java.util.Date;
+import java.sql.Date;
 
 /**
  * Time Grain class for DATETIME("yyyy-MM-dd HH:mm:ss").
@@ -14,11 +14,7 @@ public class DateTime extends Date {
 
     private static final long serialVersionUID = -4541422985328136461L;
 
-    public DateTime() {
-        super();
-    }
-
-    public DateTime(Date date) {
+    public DateTime(java.util.Date date) {
         super(date.getTime());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/DateTime.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/DateTime.java
@@ -5,12 +5,12 @@
  */
 package com.yahoo.elide.datastores.aggregation.timegrains;
 
-import java.sql.Date;
+import java.sql.Timestamp;
 
 /**
  * Time Grain class for DATETIME("yyyy-MM-dd HH:mm:ss").
  */
-public class DateTime extends Date {
+public class DateTime extends Timestamp {
 
     private static final long serialVersionUID = -4541422985328136461L;
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/MonthYear.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/MonthYear.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.timegrains;
 
-import java.util.Date;
+import java.sql.Date;
 
 /**
  * Time Grain class for MONTHYEAR("MMM yyyy").
@@ -14,11 +14,7 @@ public class MonthYear extends Date {
 
     private static final long serialVersionUID = -6996481791560356547L;
 
-    public MonthYear() {
-        super();
-    }
-
-    public MonthYear(Date date) {
+    public MonthYear(java.util.Date date) {
         super(date.getTime());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/SimpleDate.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/SimpleDate.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.timegrains;
 
-import java.util.Date;
+import java.sql.Date;
 
 /**
  * Time Grain class for SIMPLEDATE("yyyy-MM-dd").
@@ -14,11 +14,7 @@ public class SimpleDate extends Date {
 
     private static final long serialVersionUID = 6443998660242635314L;
 
-    public SimpleDate() {
-        super();
-    }
-
-    public SimpleDate(Date date) {
+    public SimpleDate(java.util.Date date) {
         super(date.getTime());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/WeekDate.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/WeekDate.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.timegrains;
 
-import java.util.Date;
+import java.sql.Date;
 
 /**
  * Time Grain class for WEEKDATE("yyyy-MM-dd").
@@ -14,11 +14,7 @@ public class WeekDate extends Date {
 
     private static final long serialVersionUID = -8590233329032795743L;
 
-    public WeekDate() {
-        super();
-    }
-
-    public WeekDate(Date date) {
+    public WeekDate(java.util.Date date) {
         super(date.getTime());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Year.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Year.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.timegrains;
 
-import java.util.Date;
+import java.sql.Date;
 
 /**
  * Time Grain class for YEAR("yyyy").
@@ -14,11 +14,7 @@ public class Year extends Date {
 
     private static final long serialVersionUID = -4697241489345142589L;
 
-    public Year() {
-        super();
-    }
-
-    public Year(Date date) {
+    public Year(java.util.Date date) {
         super(date.getTime());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/YearMonth.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/YearMonth.java
@@ -5,7 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.timegrains;
 
-import java.util.Date;
+import java.sql.Date;
 
 /**
  * Time Grain class for YEARMONTH("yyyy-MM").
@@ -14,11 +14,7 @@ public class YearMonth extends Date {
 
     private static final long serialVersionUID = -6996481791560356547L;
 
-    public YearMonth() {
-        super();
-    }
-
-    public YearMonth(Date date) {
+    public YearMonth(java.util.Date date) {
         super(date.getTime());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DateTimeSerde.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DateTimeSerde.java
@@ -10,9 +10,9 @@ import com.yahoo.elide.datastores.aggregation.timegrains.DateTime;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
+import java.sql.Date;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Serde class for bidirectional conversion from Elide DateTime type to java.util.Date.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DateTimeSerde.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DateTimeSerde.java
@@ -10,7 +10,7 @@ import com.yahoo.elide.datastores.aggregation.timegrains.DateTime;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Date;
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
@@ -18,30 +18,30 @@ import java.text.SimpleDateFormat;
  * Serde class for bidirectional conversion from Elide DateTime type to java.util.Date.
  */
 @ElideTypeConverter(type = DateTime.class, name = "DateTime")
-public class DateTimeSerde implements Serde<Object, Date> {
+public class DateTimeSerde implements Serde<Object, Timestamp> {
 
     private static final SimpleDateFormat DATETIME_FORMATTER = new SimpleDateFormat(TimeGrain.DATETIME.getFormat());
 
     @Override
-    public Date deserialize(Object val) {
+    public Timestamp deserialize(Object val) {
 
-        Date date = null;
+        Timestamp timestamp = null;
 
         try {
             if (val instanceof String) {
-                date = new Date(DATETIME_FORMATTER.parse((String) val).getTime());
+                timestamp = new Timestamp(DATETIME_FORMATTER.parse((String) val).getTime());
             } else {
-                date = new DateTime(DATETIME_FORMATTER.parse(DATETIME_FORMATTER.format(val)));
+                timestamp = new DateTime(DATETIME_FORMATTER.parse(DATETIME_FORMATTER.format(val)));
             }
         } catch (ParseException e) {
             throw new IllegalArgumentException("Date strings must be formated as " + DATETIME_FORMATTER.toPattern());
         }
 
-        return date;
+        return timestamp;
     }
 
     @Override
-    public String serialize(Date val) {
+    public String serialize(Timestamp val) {
         return DATETIME_FORMATTER.format(val).toString();
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MonthYearSerde.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MonthYearSerde.java
@@ -10,9 +10,9 @@ import com.yahoo.elide.datastores.aggregation.timegrains.MonthYear;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
+import java.sql.Date;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Serde class for bidirectional conversion from Elide MonthYear type to java.util.Date.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SimpleDateSerde.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SimpleDateSerde.java
@@ -10,9 +10,9 @@ import com.yahoo.elide.datastores.aggregation.timegrains.SimpleDate;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
+import java.sql.Date;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Serde class for bidirectional conversion from Elide SimpleDate type to java.util.Date.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/WeekDateSerde.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/WeekDateSerde.java
@@ -10,9 +10,9 @@ import com.yahoo.elide.datastores.aggregation.timegrains.WeekDate;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
+import java.sql.Date;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Serde class for bidirectional conversion from Elide WeekDate type to java.util.Date.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearMonthSerde.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearMonthSerde.java
@@ -10,9 +10,9 @@ import com.yahoo.elide.datastores.aggregation.timegrains.YearMonth;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
+import java.sql.Date;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Serde class for bidirectional conversion from Elide YearMonth type to java.util.Date.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerde.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerde.java
@@ -10,9 +10,9 @@ import com.yahoo.elide.datastores.aggregation.timegrains.Year;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
+import java.sql.Date;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Serde class for bidirectional conversion from Elide Year type to java.util.Date.

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -847,4 +847,41 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
 
         runQueryWithExpectedResult(graphQLRequest, expected);
     }
+
+    @Test
+    public void testGraphQLDynamicAggregationModelDateTime() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "orderDetails",
+                                arguments(
+                                        argument("sort", "\"customerRegion\""),
+                                        argument("filter", "\"orderTime=='2020-09-08 16:30:11'\"")
+                                ),
+                                selections(
+                                        field("orderTotal"),
+                                        field("customerRegion"),
+                                        field("orderMonth"),
+                                        field("orderTime")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "orderDetails",
+                                selections(
+                                        field("orderTotal", 181.47F),
+                                        field("customerRegion", "Virginia"),
+                                        field("orderMonth", "2020-09"),
+                                        field("orderTime", "2020-09-08 16:30:11")
+                                )
+                        )
+                )
+        ).toResponse();
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -807,4 +807,44 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                             allOf(hasEntry("customerRegion", "Virginia"), hasEntry("orderMonth", "2020-09"))))
             .body("data.attributes.orderTotal", hasItems(61.43F, 113.07F, 260.34F));
     }
+
+    @Test
+    public void testGraphQLDynamicAggregationModel() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "orderDetails",
+                                arguments(
+                                        argument("sort", "\"customerRegion\""),
+                                        argument("filter", "\"orderMonth=='2020-08'\"")
+                                ),
+                                selections(
+                                        field("orderTotal"),
+                                        field("customerRegion"),
+                                        field("orderMonth")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "orderDetails",
+                                selections(
+                                        field("orderTotal", 61.43F),
+                                        field("customerRegion", "NewYork"),
+                                        field("orderMonth", "2020-08")
+                                ),
+                                selections(
+                                        field("orderTotal", 113.07F),
+                                        field("customerRegion", "Virginia"),
+                                        field("orderMonth", "2020-08")
+                                )
+                        )
+                )
+        ).toResponse();
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DateTimeSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DateTimeSerdeTest.java
@@ -23,7 +23,7 @@ public class DateTimeSerdeTest {
     @Test
     public void testDateSerialize() throws ParseException {
 
-        String expected = "2020-01-01 01:00:00";
+        String expected = "2020-01-01 01:18:19";
         DateTime expectedDate = new DateTime(formatter.parse(expected));
         DateTimeSerde dateSerde = new DateTimeSerde();
         Object actual = dateSerde.serialize(expectedDate);
@@ -33,9 +33,9 @@ public class DateTimeSerdeTest {
     @Test
     public void testDateDeserializeString() throws ParseException {
 
-        String dateInString = "2020-01-01 01:00:00";
+        String dateInString = "2020-01-01 01:18:19";
         Date expectedDate = new Date(formatter.parse(dateInString).getTime());
-        String actual = "2020-01-01 01:00:00";
+        String actual = "2020-01-01 01:18:19";
         DateTimeSerde dateTimeSerde = new DateTimeSerde();
         Object actualDate = dateTimeSerde.deserialize(actual);
         assertEquals(expectedDate, actualDate);
@@ -44,7 +44,7 @@ public class DateTimeSerdeTest {
     @Test
     public void testDeserializeTimestamp() throws ParseException {
 
-        String dateInString = "2020-01-01 01:00:00";
+        String dateInString = "2020-01-01 01:18:19";
         DateTime expectedDate = new DateTime(formatter.parse(dateInString));
         Timestamp timestamp = new Timestamp(formatter.parse(dateInString).getTime());
         DateTimeSerde dateTimeSerde = new DateTimeSerde();
@@ -55,7 +55,7 @@ public class DateTimeSerdeTest {
     @Test
     public void testDeserializeDateInvalidFormat() throws ParseException {
 
-        String dateInString = "00:00:00 2020-01-01";
+        String dateInString = "00:18:19 2020-01-01";
         DateTimeSerde dateTimeSerde = new DateTimeSerde();
         assertThrows(IllegalArgumentException.class, () -> {
             dateTimeSerde.deserialize(dateInString);

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
@@ -61,6 +61,17 @@
             sql: PARSEDATETIME(FORMATDATETIME({{}}, 'yyyy-MM-01'), 'yyyy-MM-dd')
           }
         }
+        {
+          name: orderTime
+          type: TIME
+          definition: createdOn
+          readAccess: allow all
+          grain:
+          {
+            type: DATETIME
+            sql: '{{}}'
+          }
+        }
       ]
     }
     {

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
@@ -58,7 +58,7 @@
           grain:
           {
             type: YEARMONTH
-            sql: PARSEDATETIME(FORMATDATETIME({{}}, 'yyyy-MM-01'), 'yyyy-MM-dd')
+            sql: PARSEDATETIME(FORMATDATETIME({{}}, 'yyyy-MM'), 'yyyy-MM')
           }
         }
         {

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
@@ -69,7 +69,8 @@
           grain:
           {
             type: DATETIME
-            sql: '{{}}'
+            // sql: '{{}}' OR
+            sql: PARSEDATETIME(FORMATDATETIME({{}}, 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')
           }
         }
       ]

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_SalesDB_tables.sql
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_SalesDB_tables.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS OrderDetails
 );
 
 INSERT INTO OrderDetails SELECT 'order-1a', 'cust1', 103.72, '2020-08-30 16:30:11' WHERE NOT EXISTS(SELECT * FROM OrderDetails WHERE orderId = 'order-1a');
-INSERT INTO OrderDetails SELECT 'order-1b', 'cust1', 84.11, '2020-09-05 16:30:11' WHERE NOT EXISTS(SELECT * FROM OrderDetails WHERE orderId = 'order-1b');
+INSERT INTO OrderDetails SELECT 'order-1b', 'cust1', 84.11, '2020-09-08 16:30:11' WHERE NOT EXISTS(SELECT * FROM OrderDetails WHERE orderId = 'order-1b');
 INSERT INTO OrderDetails SELECT 'order-1c', 'cust1', 97.36, '2020-09-08 16:30:11' WHERE NOT EXISTS(SELECT * FROM OrderDetails WHERE orderId = 'order-1c');
 INSERT INTO OrderDetails SELECT 'order-2a', 'cust2', 17.82, '2020-08-25 16:30:11' WHERE NOT EXISTS(SELECT * FROM OrderDetails WHERE orderId = 'order-2a');
 INSERT INTO OrderDetails SELECT 'order-2b', 'cust2', 43.61, '2020-08-26 16:30:11' WHERE NOT EXISTS(SELECT * FROM OrderDetails WHERE orderId = 'order-2b');

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -197,10 +197,10 @@ public interface ElideStandaloneSettings {
 
     /**
      * Base path to Hjson dynamic model configurations.
-     * @return Default: /models/
+     * @return Default: /configs/
      */
     default String getDynamicConfigPath() {
-        return File.separator + "models" + File.separator;
+        return File.separator + "configs" + File.separator;
     }
 
     /**


### PR DESCRIPTION
One of the multiple PRs that will resolve https://github.com/yahoo/elide/issues/1465

## Description
Update: Timegrain serde to return java.sql.Date instead of java.util.Date
Improve regex for Parameter name matching

## Motivation and Context
After switching to use PreparedStatement, found an issue that java.sql.Date is not supported by PreparedStatement of PrestoDB driver https://github.com/prestodb/presto/blob/master/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java. So updating Timegrain serdes to return java.sql.Date instead of java.util.Date

## How Has This Been Tested?
Existing Tests Pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.