### PR TITLE
ResultType Default Value

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -69,8 +69,7 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     private QueryStatus status = QueryStatus.QUEUED;
 
     @Enumerated(EnumType.STRING)
-    @NotNull
-    private ResultType resultType; //EMBEDDED, DOWNLOAD
+    private ResultType resultType = ResultType.EMBEDDED; //EMBEDDED, DOWNLOAD
 
     @Embedded
     private AsyncQueryResult result;

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -27,6 +27,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 import javax.validation.constraints.Max;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /**
@@ -68,6 +69,7 @@ public class AsyncQuery extends AsyncBase implements PrincipalOwned {
     private QueryStatus status = QueryStatus.QUEUED;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private ResultType resultType = ResultType.EMBEDDED; //EMBEDDED, DOWNLOAD
 
     @Embedded

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -27,7 +27,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 import javax.validation.constraints.Max;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /**

--- a/elide-async/src/test/java/com/yahoo/elide/async/hooks/ExecuteQueryHookTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/hooks/ExecuteQueryHookTest.java
@@ -67,22 +67,6 @@ public class ExecuteQueryHookTest {
     }
 
     @Test
-    public void testWithResultTypeNull() {
-        AsyncQuery queryObj = new AsyncQuery();
-        String query = "{ \"query\":\"{ group { edges { node { name commonName } } } }\",\"variables\":null}";
-        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
-        queryObj.setId(id);
-        queryObj.setQuery(query);
-        queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
-        queryObj.setResultFormatType(ResultFormatType.CSV);
-
-        ExecuteQueryHook queryHook = new ExecuteQueryHook(asyncExecutorService);
-        assertThrows(InvalidValueException.class, () -> {
-            queryHook.validateOptions(queryObj);
-        });
-    }
-
-    @Test
     public void testWithStorageEngineNull() {
         AsyncQuery queryObj = new AsyncQuery();
         String query = "{ \"query\":\"{ group { edges { node { name commonName } } } }\",\"variables\":null}";

--- a/elide-async/src/test/java/com/yahoo/elide/async/hooks/ExecuteQueryHookTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/hooks/ExecuteQueryHookTest.java
@@ -67,7 +67,7 @@ public class ExecuteQueryHookTest {
     }
 
     @Test
-    public void testWithResultTypeEmpty() {
+    public void testWithResultTypeNotSet() {
         AsyncQuery queryObj = new AsyncQuery();
         String query = "{ \"query\":\"{ group { edges { node { name commonName } } } }\",\"variables\":null}";
         String id = "edc4a871-dff2-4054-804e-d80075cf827d";

--- a/elide-async/src/test/java/com/yahoo/elide/async/hooks/ExecuteQueryHookTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/hooks/ExecuteQueryHookTest.java
@@ -67,6 +67,39 @@ public class ExecuteQueryHookTest {
     }
 
     @Test
+    public void testWithResultTypeEmpty() {
+        AsyncQuery queryObj = new AsyncQuery();
+        String query = "{ \"query\":\"{ group { edges { node { name commonName } } } }\",\"variables\":null}";
+        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+        queryObj.setResultFormatType(ResultFormatType.CSV);
+
+        ExecuteQueryHook queryHook = new ExecuteQueryHook(asyncExecutorService);
+        assertDoesNotThrow(() -> {
+            queryHook.validateOptions(queryObj);
+        });
+    }
+
+    @Test
+    public void testWithResultTypeNull() {
+        AsyncQuery queryObj = new AsyncQuery();
+        String query = "{ \"query\":\"{ group { edges { node { name commonName } } } }\",\"variables\":null}";
+        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+        queryObj.setResultFormatType(ResultFormatType.CSV);
+        queryObj.setResultType(null);
+
+        ExecuteQueryHook queryHook = new ExecuteQueryHook(asyncExecutorService);
+        assertThrows(InvalidValueException.class, () -> {
+            queryHook.validateOptions(queryObj);
+        });
+    }
+
+    @Test
     public void testWithStorageEngineNull() {
         AsyncQuery queryObj = new AsyncQuery();
         String query = "{ \"query\":\"{ group { edges { node { name commonName } } } }\",\"variables\":null}";

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
@@ -48,6 +48,15 @@ public class AsyncQueryTest {
     }
 
     @Test
+    public void testResultTypeNull() {
+        AsyncQuery queryObj = new AsyncQuery();
+        queryObj.setResultType(null);
+        Set<ConstraintViolation<AsyncQuery>> constraintViolations = validator.validate(queryObj);
+        assertEquals(1, constraintViolations.size());
+        assertEquals("must not be null", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
     public void testUUIDGeneration() {
         AsyncQuery queryObj = new AsyncQuery();
         assertNotNull(queryObj.getId());

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncQueryTest.java
@@ -42,6 +42,12 @@ public class AsyncQueryTest {
     }
 
     @Test
+    public void testResultTypeDefault() {
+        AsyncQuery queryObj = new AsyncQuery();
+        assertEquals(queryObj.getResultType(), ResultType.EMBEDDED);
+    }
+
+    @Test
     public void testUUIDGeneration() {
         AsyncQuery queryObj = new AsyncQuery();
         assertNotNull(queryObj.getId());


### PR DESCRIPTION
Setting Default Value for Result Type in AsyncQuery

## Description
Setting Default Value for Result Type in AsyncQuery

## Motivation and Context
Setting Default Value for Result Type in AsyncQuery

## How Has This Been Tested?
Existing Test Cases pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
