### PR TITLE
Added item expiration to AggregationDataStore cache

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -82,11 +82,12 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
             Query query = buildQuery(entityProjection, scope);
             if (cache != null && !query.isBypassingCache()) {
                 String tableVersion = queryEngine.getTableVersion(query.getTable(), queryEngineTransaction);
-                if (tableVersion != null) {
-                    cacheKey = tableVersion + ';' + QueryKeyExtractor.extractKey(query);
-                    result = cache.get(cacheKey);
-                }
+                tableVersion = tableVersion == null ? "" : tableVersion;
+
+                cacheKey = tableVersion + ';' + QueryKeyExtractor.extractKey(query);
+                result = cache.get(cacheKey);
             }
+
             boolean isCached = result == null ? false : true;
             List<String> queryText = queryEngine.explain(query);
             queryLogger.processQuery(scope.getRequestId(), query, queryText, isCached);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/CaffeineCache.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/CaffeineCache.java
@@ -10,6 +10,8 @@ import com.yahoo.elide.datastores.aggregation.query.QueryResult;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A basic local-only cache.
  */
@@ -18,8 +20,12 @@ public class CaffeineCache implements Cache {
 
     private final com.github.benmanes.caffeine.cache.Cache<Object, QueryResult> cache;
 
-    public CaffeineCache(int maximumSize) {
-        cache = Caffeine.newBuilder().maximumSize(maximumSize).recordStats().build();
+    public CaffeineCache(int maximumSize, long defaultExprirationMinutes) {
+        cache = Caffeine.newBuilder()
+                .maximumSize(maximumSize)
+                .expireAfterWrite(defaultExprirationMinutes, TimeUnit.MINUTES)
+                .recordStats()
+                .build();
     }
 
     @Override

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AggregationStoreProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AggregationStoreProperties.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.spring.config;
 
+import static com.yahoo.elide.datastores.aggregation.cache.CaffeineCache.DEFAULT_MAXIMUM_ENTRIES;
+
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialect;
 
 import lombok.Data;
@@ -24,4 +26,14 @@ public class AggregationStoreProperties {
      * {@link SQLDialect} type for default DataSource Object.
      */
     private String defaultDialect = "Hive";
+
+    /**
+     * Limit on number of query cache entries. Non-positive values disable the query cache.
+     */
+    private int queryCacheMaximumEntries = DEFAULT_MAXIMUM_ENTRIES;
+
+    /**
+     * Default Cache Expiration.
+     */
+    private long defaultCacheExpirationMinutes = 10;
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -249,8 +249,10 @@ public class ElideAutoConfiguration {
     @ConditionalOnProperty(name = "elide.aggregation-store.enabled", havingValue = "true")
     public Cache buildQueryCache(ElideConfigProperties settings) {
         CaffeineCache cache = null;
-        if (settings.getQueryCacheMaximumEntries() > 0) {
-            cache = new CaffeineCache(settings.getQueryCacheMaximumEntries());
+
+        int maxCacheItems = settings.getAggregationStore().getQueryCacheMaximumEntries();
+        if (maxCacheItems > 0) {
+            cache = new CaffeineCache(maxCacheItems, settings.getAggregationStore().getDefaultCacheExpirationMinutes());
             if (meterRegistry != null) {
                 CaffeineCacheMetrics.monitor(meterRegistry, cache.getImplementation(), "elideQueryCache");
             }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -5,8 +5,6 @@
  */
 package com.yahoo.elide.spring.config;
 
-import static com.yahoo.elide.datastores.aggregation.cache.CaffeineCache.DEFAULT_MAXIMUM_ENTRIES;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.Data;
@@ -57,9 +55,4 @@ public class ElideConfigProperties {
      * The maximum pagination size a client can request.
      */
     private int maxPageSize = 10000;
-
-    /**
-     * Limit on number of query cache entries. Non-positive values disable the query cache.
-     */
-    private int queryCacheMaximumEntries = DEFAULT_MAXIMUM_ENTRIES;
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AggregationStoreTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AggregationStoreTest.java
@@ -57,7 +57,7 @@ public class AggregationStoreTest extends IntegrationTest {
 
         // query cache was active and publishing metrics
         assertEquals(
-                1,
+                3,
                 metrics.get("cache.gets").tags("cache", "elideQueryCache", "result", "miss").functionCounter().count()
         );
     }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -335,12 +335,23 @@ public interface ElideStandaloneSettings {
     }
 
     /**
+     * Returns the default expiration in minutes of items in the AggregationDataStore query cache.
+     *
+     * @return Default: 10
+     */
+    default Long getDefaultCacheExpirationMinutes() {
+        return 10L;
+    }
+
+    /**
      * Get the query cache implementation. If null, query cache is disabled.
      *
      * @return Default: {@code new CaffeineCache(getQueryCacheSize())}
      */
     default Cache getQueryCache() {
-        return getQueryCacheMaximumEntries() > 0 ? new CaffeineCache(getQueryCacheMaximumEntries()) : null;
+        return getQueryCacheMaximumEntries() > 0
+                ? new CaffeineCache(getQueryCacheMaximumEntries(), getDefaultCacheExpirationMinutes())
+                : null;
     }
 
     /**


### PR DESCRIPTION
## Description
PR adds a default item expiration to the Aggregation Data Store query cache.

## Motivation and Context
The cache was only leveraged if a particular table supported a version query.  This change allows the cache to work in a more primitive context - simply based on item expiration.

## How Has This Been Tested?
Updated unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
