### PR TITLE
Table Exporter:  Initial Version

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
@@ -40,6 +40,11 @@ public class TableExporter {
         this.graphQLParser = graphQLParser;
     }
 
+    /**
+     * Exports the Data based on AsyncQuery.
+     * @param query AsyncQuery object.
+     * @return Observable of PersistentResource.
+     */
     public Observable<PersistentResource> export(AsyncQuery query) {
         Observable<PersistentResource> results = Observable.empty();
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.export;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.graphql.GraphQLRequestScope;
+import com.yahoo.elide.request.EntityProjection;
+import com.yahoo.elide.security.User;
+
+import io.reactivex.Observable;
+
+/**
+ * Class for Table Export functionality.  
+ */
+public class TableExporter {
+
+    private Elide elide;
+    private String apiVersion;
+    private User user;
+    private GraphQLParser graphQLParser;
+
+    public TableExporter(Elide elide, String apiVersion, User user) {
+        this(elide, apiVersion, user, new GraphQLParser(elide, apiVersion));
+    }
+
+    public TableExporter(Elide elide, String apiVersion, User user, GraphQLParser graphQLParser) {
+        this.elide = elide;
+        this.apiVersion = apiVersion;
+        this.user = user;
+        this.graphQLParser = graphQLParser;
+    }
+
+    public Observable<PersistentResource> export(AsyncQuery query) {
+        Observable<PersistentResource> results = Observable.empty();
+
+        UUID requestId = UUID.fromString(query.getRequestId());
+
+        try (DataStoreTransaction tx = elide.getDataStore().beginTransaction()) {
+            elide.getTransactionRegistry().addRunningTransaction(requestId, tx);
+            EntityProjection projection = graphQLParser.parse(query);
+
+            //TODO - we need to add the baseUrlEndpoint to the queryObject.
+            //TODO - Can we have projectionInfo as null?
+            GraphQLRequestScope requestScope =
+                    new GraphQLRequestScope("", tx, user, apiVersion, elide.getElideSettings(), null, requestId);
+
+            if (projection != null) {
+                results = PersistentResource.loadRecords(projection, Collections.emptyList(), requestScope);
+            }
+
+            tx.preCommit();
+            requestScope.runQueuedPreSecurityTriggers();
+            requestScope.getPermissionExecutor().executeCommitChecks();
+
+            tx.flush(requestScope);
+
+            requestScope.runQueuedPreCommitTriggers();
+
+            elide.getAuditLogger().commit();
+            tx.commit(requestScope);
+
+            requestScope.runQueuedPostCommitTriggers();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        } finally {
+            elide.getTransactionRegistry().removeRunningTransaction(requestId);
+            elide.getAuditLogger().clear();
+        }
+
+        return results;
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
@@ -5,10 +5,6 @@
  */
 package com.yahoo.elide.async.export;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.UUID;
-
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.core.DataStoreTransaction;
@@ -19,8 +15,12 @@ import com.yahoo.elide.security.User;
 
 import io.reactivex.Observable;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
 /**
- * Class for Table Export functionality.  
+ * Class for Table Export functionality.
  */
 public class TableExporter {
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
@@ -52,23 +52,23 @@ public class TableExporter {
         Observable<PersistentResource> results = Observable.empty();
 
         UUID requestId = UUID.fromString(query.getRequestId());
-        
 
         try (DataStoreTransaction tx = elide.getDataStore().beginTransaction()) {
             elide.getTransactionRegistry().addRunningTransaction(requestId, tx);
-            
+
             EntityProjection projection = null;
             RequestScope requestScope = null;
-            
-            if(query.getQueryType().equals(QueryType.GRAPHQL_V1_0)) {
+
+            if (query.getQueryType().equals(QueryType.GRAPHQL_V1_0)) {
                 projection = graphQLParser.parse(query);
                 //TODO - we need to add the baseUrlEndpoint to the queryObject.
                 //TODO - Can we have projectionInfo as null?
-                requestScope = new GraphQLRequestScope("", tx, user, apiVersion, elide.getElideSettings(), null, requestId);
+                requestScope = new GraphQLRequestScope("", tx, user, apiVersion, elide.getElideSettings(), null,
+                        requestId);
             } else {
-            	//TODO - Add JSON Support
+                //TODO - Add JSON Support
                 throw new InvalidValueException("QueryType not supported");
-            }           
+            }
 
             if (projection != null) {
                 results = PersistentResource.loadRecords(projection, Collections.emptyList(), requestScope);

--- a/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
@@ -12,11 +12,13 @@ import com.yahoo.elide.core.DataStoreTransaction;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
+import com.yahoo.elide.core.exceptions.TransactionException;
 import com.yahoo.elide.graphql.GraphQLRequestScope;
 import com.yahoo.elide.request.EntityProjection;
 import com.yahoo.elide.security.User;
 
 import io.reactivex.Observable;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -25,6 +27,7 @@ import java.util.UUID;
 /**
  * Class for Table Export functionality.
  */
+@Slf4j
 public class TableExporter {
 
     private Elide elide;
@@ -87,7 +90,8 @@ public class TableExporter {
 
             requestScope.runQueuedPostCommitTriggers();
         } catch (IOException e) {
-            throw new IllegalStateException(e);
+            log.error("IOException during TableExport", e);
+            throw new TransactionException(e);
         } finally {
             elide.getTransactionRegistry().removeRunningTransaction(requestId);
             elide.getAuditLogger().clear();

--- a/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.export;
+
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.audit.AuditLogger;
+import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DataStoreTransaction;
+import com.yahoo.elide.core.EntityDictionary;
+import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.TransactionRegistry;
+import com.yahoo.elide.request.EntityProjection;
+import com.yahoo.elide.security.User;
+
+import io.reactivex.Observable;
+
+public class TableExporterTest {
+
+    private DataStoreTransaction tx = mock(DataStoreTransaction.class);
+    private Elide elide;
+    private User user;
+    private GraphQLParser graphQLParser;
+    private AsyncQuery asyncQuery;
+
+    @BeforeEach
+    public void beforeTest() {
+        reset(tx);
+        elide = mock(Elide.class);
+        user = mock(User.class);
+        asyncQuery = mock(AsyncQuery.class);
+        graphQLParser = mock(GraphQLParser.class);
+
+        TransactionRegistry transactionRegistry = mock(TransactionRegistry.class);
+        DataStore dataStore = mock(DataStore.class);
+        AuditLogger auditLogger = mock(AuditLogger.class);
+        ElideSettings settings = mock(ElideSettings.class);
+        EntityDictionary dictionary = mock(EntityDictionary.class);
+        EntityProjection projection = EntityProjection.builder().type(AsyncQuery.class).build();
+
+        when(asyncQuery.getRequestId()).thenReturn(UUID.randomUUID().toString());
+        when(elide.getTransactionRegistry()).thenReturn(transactionRegistry);
+        when(elide.getAuditLogger()).thenReturn(auditLogger);
+        when(elide.getDataStore()).thenReturn(dataStore);
+        when(elide.getElideSettings()).thenReturn(settings);
+        when(settings.getDictionary()).thenReturn(dictionary);
+        when(dataStore.beginTransaction()).thenReturn(tx);
+        when(graphQLParser.parse(any())).thenReturn(projection);
+    }
+    
+    @Test
+    public void testExporterEmptyProjection() {
+        TableExporter exporter = new TableExporter(elide, NO_VERSION, user, graphQLParser);
+        Object[] queries= {asyncQuery};
+        when(tx.loadObjects(any(), any())).thenReturn(Arrays.asList(queries));
+
+        Observable<PersistentResource> results = exporter.export(asyncQuery);
+        
+        assertNotEquals(Observable.empty(), results);
+        assertEquals(1, results.toList(LinkedHashSet::new).blockingGet().size());
+    }
+}

--- a/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
@@ -68,7 +68,7 @@ public class TableExporterTest {
     }
 
     @Test
-    public void testExporterEmptyProjection() {
+    public void testExporterNonEmptyProjection() {
         TableExporter exporter = new TableExporter(elide, NO_VERSION, user, graphQLParser);
         Object[] queries = {asyncQuery};
         when(tx.loadObjects(any(), any())).thenReturn(Arrays.asList(queries));

--- a/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
@@ -13,13 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.UUID;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.async.models.AsyncQuery;
@@ -32,7 +25,14 @@ import com.yahoo.elide.core.TransactionRegistry;
 import com.yahoo.elide.request.EntityProjection;
 import com.yahoo.elide.security.User;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import io.reactivex.Observable;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.UUID;
 
 public class TableExporterTest {
 
@@ -66,15 +66,15 @@ public class TableExporterTest {
         when(dataStore.beginTransaction()).thenReturn(tx);
         when(graphQLParser.parse(any())).thenReturn(projection);
     }
-    
+
     @Test
     public void testExporterEmptyProjection() {
         TableExporter exporter = new TableExporter(elide, NO_VERSION, user, graphQLParser);
-        Object[] queries= {asyncQuery};
+        Object[] queries = {asyncQuery};
         when(tx.loadObjects(any(), any())).thenReturn(Arrays.asList(queries));
 
         Observable<PersistentResource> results = exporter.export(asyncQuery);
-        
+
         assertNotEquals(Observable.empty(), results);
         assertEquals(1, results.toList(LinkedHashSet::new).blockingGet().size());
     }

--- a/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/export/TableExporterTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.async.models.AsyncQuery;
+import com.yahoo.elide.async.models.QueryType;
 import com.yahoo.elide.audit.AuditLogger;
 import com.yahoo.elide.core.DataStore;
 import com.yahoo.elide.core.DataStoreTransaction;
@@ -58,6 +59,7 @@ public class TableExporterTest {
         EntityProjection projection = EntityProjection.builder().type(AsyncQuery.class).build();
 
         when(asyncQuery.getRequestId()).thenReturn(UUID.randomUUID().toString());
+        when(asyncQuery.getQueryType()).thenReturn(QueryType.GRAPHQL_V1_0);
         when(elide.getTransactionRegistry()).thenReturn(transactionRegistry);
         when(elide.getAuditLogger()).thenReturn(auditLogger);
         when(elide.getDataStore()).thenReturn(dataStore);


### PR DESCRIPTION
Resolves #1272 

## Description
TableExporter Initial Version using PersistentResource.loadObjects(...)

## Motivation and Context
#1272

## How Has This Been Tested?
Existing Test Case pass. New Test case added.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
