### PR TITLE
Elide 5 ignores rootLevel = false

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
@@ -83,13 +83,13 @@ public class EntityProjectionMaker
     @Override
     public Function<Class<?>, NamedEntityProjection> visitRootCollectionLoadEntities(
             CoreParser.RootCollectionLoadEntitiesContext ctx) {
-        return visitTerminalCollection(ctx.term());
+        return visitTerminalCollection(ctx.term(), true);
     }
 
     @Override
     public Function<Class<?>, NamedEntityProjection> visitSubCollectionReadCollection(
             CoreParser.SubCollectionReadCollectionContext ctx) {
-        return visitTerminalCollection(ctx.term());
+        return visitTerminalCollection(ctx.term(), false);
     }
 
     @Override
@@ -256,11 +256,16 @@ public class EntityProjectionMaker
         };
     }
 
-    private Function<Class<?>, NamedEntityProjection> visitTerminalCollection(CoreParser.TermContext collectionName) {
+    private Function<Class<?>, NamedEntityProjection> visitTerminalCollection(CoreParser.TermContext collectionName,
+                                                                              boolean isRoot) {
         return (parentClass) -> {
             String collectionNameText = collectionName.getText();
 
             Class<?> entityClass = getEntityClass(parentClass, collectionNameText);
+
+            if (isRoot && !dictionary.isRoot(entityClass)) {
+                throw new InvalidCollectionException(collectionNameText);
+            }
 
             FilterExpression filter;
             if (parentClass == null) {

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/state/StartState.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.parsers.state;
 
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.exceptions.InvalidCollectionException;
 import com.yahoo.elide.generated.parsers.CoreParser.EntityContext;
 import com.yahoo.elide.generated.parsers.CoreParser.RootCollectionLoadEntitiesContext;
 import com.yahoo.elide.generated.parsers.CoreParser.RootCollectionLoadEntityContext;
@@ -64,6 +65,13 @@ public class StartState extends BaseState {
 
     private PersistentResource<?> entityRecord(StateContext state, EntityContext entity) {
         String id = entity.id().getText();
+        String entityName = entity.term().getText();
+        EntityDictionary dictionary = state.getRequestScope().getDictionary();
+        Class<?> entityClass = dictionary.getEntityClass(entityName, state.getRequestScope().getApiVersion());
+
+        if (entityClass == null || !dictionary.isRoot(entityClass)) {
+            throw new InvalidCollectionException(entityName);
+        }
 
         return PersistentResource.loadRecord(state.getRequestScope().getEntityProjection(),
                 id, state.getRequestScope());

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -68,7 +68,7 @@ import javax.ws.rs.core.MultivaluedMap;
  * Tests the invocation &amp; sequencing of DataStoreTransaction method invocations and life cycle events.
  * Model used to mock different lifecycle test scenarios.  This model uses fields instead of properties.
  */
-@Include(rootLevel = false, type = "testModel")
+@Include(type = "testModel")
 @LifeCycleHookBinding(hook = FieldTestModel.ClassPreSecurityHook.class, operation = CREATE, phase = PRESECURITY)
 @LifeCycleHookBinding(hook = FieldTestModel.ClassPreCommitHook.class, operation = CREATE, phase = PRECOMMIT)
 @LifeCycleHookBinding(hook = FieldTestModel.ClassPostCommitHook.class, operation = CREATE, phase = POSTCOMMIT)
@@ -247,7 +247,7 @@ class FieldTestModel {
 /**
  * Model used to mock different lifecycle test scenarios.  This model uses properties instead of fields.
  */
-@Include(rootLevel = false)
+@Include
 class PropertyTestModel {
     private String id;
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -100,7 +100,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/dimension/playerStats.playerName")
+                .get("/table/playerStats/dimensions/playerStats.playerName")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("playerName"))
@@ -117,7 +117,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/dimension/playerStats.countryIsoCode")
+                .get("/table/playerStats/dimensions/playerStats.countryIsoCode")
                 .then()
                 .body("data.attributes.values", hasItems("US", "HK"))
                 .body("data.attributes.valueSourceType", equalTo("ENUM"))
@@ -131,7 +131,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/dimension/playerStats.overallRating")
+                .get("/table/playerStats/dimensions/playerStats.overallRating")
                 .then()
                 .body("data.attributes.values", hasItems("GOOD", "OK", "TERRIBLE"))
                 .body("data.attributes.valueSourceType", equalTo("ENUM"))
@@ -145,7 +145,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/dimension/playerStats.overallRating")
+                .get("/table/playerStats/dimensions/playerStats.overallRating")
                 .then()
                 .body("data.attributes.tags", hasItems("PUBLIC"))
                 .statusCode(HttpStatus.SC_OK);
@@ -156,7 +156,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/dimension/playerStats.countryNickName")
+                .get("/table/playerStats/dimensions/playerStats.countryNickName")
                 .then()
                 .body("data.attributes.valueSourceType", equalTo("TABLE"))
                 .body("data.attributes.columnType", equalTo("REFERENCE"))
@@ -171,7 +171,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/timeDimension/playerStats.recordedDate?include=supportedGrain")
+                .get("/table/playerStats/timeDimensions/playerStats.recordedDate?include=supportedGrain")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("recordedDate"))
@@ -191,7 +191,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/metric/playerStats.lowScore?include=metricFunction")
+                .get("/table/playerStats/metrics/playerStats.lowScore?include=metricFunction")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("lowScore"))
@@ -209,7 +209,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                 .accept("application/vnd.api+json")
-                .get("/metric/videoGame.timeSpentPerSession")
+                .get("/table/videoGame-mycon/metrics/videoGame.timeSpentPerSession")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("timeSpentPerSession"))

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -378,6 +378,24 @@ public class FilterIT extends IntegrationTest {
     }
 
     @Test
+    void testNonRootCollectionError() {
+        given()
+                .get("/publisher")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body("errors.detail", contains("Unknown collection publisher"));
+    }
+
+    @Test
+    void testNonRootEntityError() {
+        given()
+                .get("/publisher/1")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body("errors.detail", contains("Unknown collection publisher"));
+    }
+
+    @Test
     void testRootFilterPostfix() throws JsonProcessingException {
         int genreEndsWithFictionBookCount = 0;
         for (JsonNode node : books.get("data")) {


### PR DESCRIPTION
There was a regression in Elide 5 where  `@Include(rootLevel=false)` was being ignored.  This PR fixes the regression.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
