### PR TITLE
Elide 5: Support sorting and filtering by alias in GraphQL

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/Path.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/Path.java
@@ -9,12 +9,12 @@ import static com.yahoo.elide.core.EntityDictionary.getSimpleName;
 import static com.yahoo.elide.utils.TypeHelper.appendAlias;
 import static com.yahoo.elide.utils.TypeHelper.getTypeAlias;
 
-import com.google.common.collect.Lists;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
+import com.yahoo.elide.request.Argument;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
-import com.yahoo.elide.request.Argument;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -97,7 +97,8 @@ public class Path {
                 elements.add(new PathElement(currentClass, joinClass, fieldName));
                 currentClass = joinClass;
             } else {
-                elements.add(resolvePathAttribute(entityClass, fieldName, fieldName, Collections.EMPTY_SET, dictionary));
+                elements.add(resolvePathAttribute(currentClass, fieldName,
+                        fieldName, Collections.EMPTY_SET, dictionary));
             }
         }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/Path.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/Path.java
@@ -9,18 +9,22 @@ import static com.yahoo.elide.core.EntityDictionary.getSimpleName;
 import static com.yahoo.elide.utils.TypeHelper.appendAlias;
 import static com.yahoo.elide.utils.TypeHelper.getTypeAlias;
 
+import com.google.common.collect.Lists;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 
 import com.google.common.collect.ImmutableList;
 
+import com.yahoo.elide.request.Argument;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -39,9 +43,20 @@ public class Path {
     @ToString
     @EqualsAndHashCode
     public static class PathElement {
+
+        public PathElement(Class type, Class fieldType, String fieldName) {
+            this.type = type;
+            this.fieldType = fieldType;
+            this.fieldName = fieldName;
+            this.alias = fieldName;
+            this.arguments = Collections.EMPTY_SET;
+        }
+
         @Getter private Class type;
         @Getter private Class fieldType;
         @Getter private String fieldName;
+        @Getter private String alias;
+        @Getter private Set<Argument> arguments;
     }
 
     public Path(Path copy) {
@@ -54,6 +69,11 @@ public class Path {
 
     public Path(Class<?> entityClass, EntityDictionary dictionary, String dotSeparatedPath) {
         pathElements = resolvePathElements(entityClass, dictionary, dotSeparatedPath);
+    }
+
+    public Path(Class<?> entityClass, EntityDictionary dictionary, String fieldName,
+                String alias, Set<Argument> arguments) {
+        pathElements = Lists.newArrayList(resolvePathAttribute(entityClass, fieldName, alias, arguments, dictionary));
     }
 
     /**
@@ -76,19 +96,29 @@ public class Path {
                 Class<?> joinClass = dictionary.getParameterizedType(currentClass, fieldName);
                 elements.add(new PathElement(currentClass, joinClass, fieldName));
                 currentClass = joinClass;
-            } else if (dictionary.isAttribute(currentClass, fieldName)
-                    || fieldName.equals(dictionary.getIdFieldName(entityClass))) {
-                Class<?> attributeClass = dictionary.getType(currentClass, fieldName);
-                elements.add(new PathElement(currentClass, attributeClass, fieldName));
-            } else if ("this".equals(fieldName)) {
-                elements.add(new PathElement(currentClass, null, fieldName));
             } else {
-                String alias = dictionary.getJsonAliasFor(currentClass);
-                throw new InvalidValueException(alias + " does not contain the field " + fieldName);
+                elements.add(resolvePathAttribute(entityClass, fieldName, fieldName, Collections.EMPTY_SET, dictionary));
             }
         }
 
         return ImmutableList.copyOf(elements);
+    }
+
+    private PathElement resolvePathAttribute(Class<?> entityClass,
+                                             String fieldName,
+                                             String alias,
+                                             Set<Argument> arguments,
+                                             EntityDictionary dictionary) {
+        if (dictionary.isAttribute(entityClass, fieldName)
+                || fieldName.equals(dictionary.getIdFieldName(entityClass))) {
+            Class<?> attributeClass = dictionary.getType(entityClass, fieldName);
+            return new PathElement(entityClass, attributeClass, fieldName, alias, arguments);
+        } else if ("this".equals(fieldName)) {
+            return new PathElement(entityClass, null, fieldName);
+        } else {
+            String entityAlias = dictionary.getJsonAliasFor(entityClass);
+            throw new InvalidValueException(entityAlias + " does not contain the field " + fieldName);
+        }
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/Path.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/Path.java
@@ -43,6 +43,11 @@ public class Path {
     @ToString
     @EqualsAndHashCode
     public static class PathElement {
+        @Getter private Class type;
+        @Getter private Class fieldType;
+        @Getter private String fieldName;
+        @Getter private String alias;
+        @Getter private Set<Argument> arguments;
 
         public PathElement(Class type, Class fieldType, String fieldName) {
             this.type = type;
@@ -51,12 +56,6 @@ public class Path {
             this.alias = fieldName;
             this.arguments = Collections.EMPTY_SET;
         }
-
-        @Getter private Class type;
-        @Getter private Class fieldType;
-        @Getter private String fieldName;
-        @Getter private String alias;
-        @Getter private Set<Argument> arguments;
     }
 
     public Path(Path copy) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -115,7 +115,7 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
                                   String filterText,
                                   String apiVersion)
             throws ParseException {
-        return parseFilterExpression(filterText, entityClass, true);
+        return parseFilterExpression(filterText, entityClass, true, true, attributes);
     }
 
     @Override
@@ -222,10 +222,30 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
                                                   Class<?> entityType,
                                                   boolean coerceValues,
                                                   boolean allowNestedToManyAssociations) throws ParseException {
+        return parseFilterExpression(expressionText, entityType, coerceValues,
+                allowNestedToManyAssociations, Collections.EMPTY_SET);
+
+    }
+
+    /**
+     * Parses a RSQL string into an Elide FilterExpression.
+     * @param expressionText the RSQL string
+     * @param entityType The type associated with the predicate
+     * @param coerceValues Convert values into their underlying type.
+     * @param allowNestedToManyAssociations Whether or not to reject nested filter paths.
+     * @param attributes the set of model attributes being requested.
+     * @return An elide FilterExpression abstract syntax tree
+     * @throws ParseException
+     */
+    public FilterExpression parseFilterExpression(String expressionText,
+                                                  Class<?> entityType,
+                                                  boolean coerceValues,
+                                                  boolean allowNestedToManyAssociations,
+                                                  Set<Attribute> attributes) throws ParseException {
         try {
             Node ast = parser.parse(expressionText);
             RSQL2FilterExpressionVisitor visitor = new RSQL2FilterExpressionVisitor(allowNestedToManyAssociations,
-                    coerceValues);
+                    coerceValues, attributes);
             return ast.accept(visitor, entityType);
         } catch (RSQLParserException e) {
             throw new ParseException(e.getMessage());
@@ -255,14 +275,30 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
     public class RSQL2FilterExpressionVisitor implements RSQLVisitor<FilterExpression, Class> {
         private boolean allowNestedToManyAssociations = false;
         private boolean coerceValues = true;
+        private Set<Attribute> attributes;
 
         public RSQL2FilterExpressionVisitor(boolean allowNestedToManyAssociations) {
-            this(allowNestedToManyAssociations, true);
+            this(allowNestedToManyAssociations, true, Collections.EMPTY_SET);
         }
 
-        public RSQL2FilterExpressionVisitor(boolean allowNestedToManyAssociations, boolean coerceValues) {
+        public RSQL2FilterExpressionVisitor(boolean allowNestedToManyAssociations,
+                                            boolean coerceValues, Set<Attribute> attributes) {
             this.allowNestedToManyAssociations = allowNestedToManyAssociations;
             this.coerceValues = coerceValues;
+            this.attributes = attributes;
+        }
+
+        private Path buildAttribute(Class rootEntityType, String attributeName) {
+            Attribute attribute = attributes.stream()
+                    .filter(attr -> attr.getName().equals(attributeName) || attr.getAlias().equals(attributeName))
+                    .findFirst().orElse(null);
+
+            if (attribute != null) {
+                return new Path(rootEntityType, dictionary, attribute.getName(),
+                        attribute.getAlias(), attribute.getArguments());
+            } else {
+                return buildPath(rootEntityType, attributeName);
+            }
         }
 
         private Path buildPath(Class rootEntityType, String selector) {
@@ -338,7 +374,14 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
             ComparisonOperator op = node.getOperator();
             String relationship = node.getSelector();
             List<String> arguments = node.getArguments();
-            Path path = buildPath(entityType, relationship);
+
+            Path path;
+            if (relationship.contains(".")) {
+                path = buildPath(entityType, relationship);
+            } else {
+                path = buildAttribute(entityType, relationship);
+
+            }
 
             //handles '=isempty=' op before coerce arguments
             // ToMany Association is allowed if the operation is IsEmpty

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -27,6 +27,7 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.NotFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.parsers.JsonApiParser;
+import com.yahoo.elide.request.Attribute;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 
 import com.google.common.collect.ImmutableMap;
@@ -110,7 +111,7 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
 
     @Override
     public FilterExpression parse(Class<?> entityClass,
-                                  Map<String, String> aliasMap,
+                                  Set<Attribute> attributes,
                                   String filterText,
                                   String apiVersion)
             throws ParseException {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/graphql/FilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/graphql/FilterDialect.java
@@ -8,8 +8,9 @@ package com.yahoo.elide.core.filter.dialect.graphql;
 
 import com.yahoo.elide.core.filter.dialect.ParseException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.request.Attribute;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
  * GraphQL Dialect for parsing filter API parameters into Filter Expressions.
@@ -19,14 +20,14 @@ public interface FilterDialect {
     /**
      * Parses a graphQL collection filter parameter and converts it into a FilterExpression.
      * @param entityClass The model type of the collection.
-     * @param aliasMap A map of alias to field names from GraphQL.
+     * @param attributes The requested attributes, their aliases, and arguments for the given entity model.
      * @param filterText The filter string to parse.
      * @param apiVersion The API version.
      * @return A filter expression.
      * @throws ParseException If the filter text is invalid.
      */
     FilterExpression parse(Class<?> entityClass,
-                           Map<String, String> aliasMap,
+                           Set<Attribute> attributes,
                            String filterText,
                            String apiVersion) throws ParseException;
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -467,7 +467,8 @@ public class GraphQLEntityProjectionMaker {
         String sortRule = (String) variableResolver.resolveValue(argument.getValue());
 
         try {
-            Sorting sorting = SortingImpl.parseSortRule(sortRule, projectionBuilder.getType(), entityDictionary);
+            Sorting sorting = SortingImpl.parseSortRule(sortRule, projectionBuilder.getType(),
+                    projectionBuilder.getAttributes(), entityDictionary);
             projectionBuilder.sorting(sorting);
         } catch (InvalidValueException e) {
             throw new BadRequestException("Invalid sorting clause " + sortRule

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -508,11 +508,9 @@ public class GraphQLEntityProjectionMaker {
         if (!(filterString instanceof String)) {
             throw new BadRequestException("Filter of type " + typeName + " is not StringValue.");
         }
-        Map<String, String> aliasMap = builder.getAttributes().stream()
-                .collect(Collectors.toMap(Attribute::getAlias, Attribute::getName));
 
         try {
-            return filterDialect.parse(builder.getType(), aliasMap, (String) filterString, apiVersion);
+            return filterDialect.parse(builder.getType(), builder.getAttributes(), (String) filterString, apiVersion);
         } catch (ParseException e) {
             throw new BadRequestException(e.getMessage() + "\n" + e.getMessage());
         }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -114,6 +114,11 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     }
 
     @Test
+    public void sortByAlias() throws Exception {
+        runComparisonTest("sortByAlias");
+    }
+
+    @Test
     public void testRootCollectionFilter() throws Exception {
         runComparisonTest("rootCollectionFilter");
     }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -109,6 +109,11 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     }
 
     @Test
+    public void testFilterByAlias() throws Exception {
+        runComparisonTest("filterByAlias");
+    }
+
+    @Test
     public void testRootCollectionFilter() throws Exception {
         runComparisonTest("rootCollectionFilter");
     }

--- a/elide-graphql/src/test/resources/graphql/requests/fetch/filterByAlias.graphql
+++ b/elide-graphql/src/test/resources/graphql/requests/fetch/filterByAlias.graphql
@@ -1,0 +1,10 @@
+{
+  book(filter: "title_alias==\"Libro*\"") {
+    edges {
+      node {
+        id
+        title_alias: title
+      }
+    }
+  }
+}

--- a/elide-graphql/src/test/resources/graphql/requests/fetch/sortByAlias.graphql
+++ b/elide-graphql/src/test/resources/graphql/requests/fetch/sortByAlias.graphql
@@ -1,0 +1,10 @@
+{
+  book(sort: "title_alias") {
+    edges {
+      node {
+        id
+        title_alias: title
+      }
+    }
+  }
+}

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/filterByAlias.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/filterByAlias.json
@@ -1,0 +1,19 @@
+{
+  "book": {
+    "edges": [
+      {
+        "node": {
+          "id": "1",
+          "title_alias": "Libro Uno"
+
+        }
+      },
+      {
+        "node": {
+          "id": "2",
+          "title_alias": "Libro Dos"
+        }
+      }
+    ]
+  }
+}

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/sortByAlias.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/sortByAlias.json
@@ -1,0 +1,25 @@
+{
+  "book": {
+    "edges": [
+      {
+        "node": {
+          "id": "3",
+          "title_alias": "Doctor Zhivago"
+
+        }
+      },
+      {
+        "node": {
+          "id": "2",
+          "title_alias": "Libro Dos"
+        }
+      },
+      {
+        "node": {
+          "id": "1",
+          "title_alias": "Libro Uno"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds plumbing to sort and filter by alias for GraphQL queries.

Also adds plumbing to pass along attribute arguments to later support parameterized attributes.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
