### PR TITLE
Cleaned SQL Generation Tests

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -120,14 +120,14 @@ public abstract class SQLUnitTest {
                     .whereFilter(new AndFilterExpression(ratingFilter, highScoreFilter))
                     .build();
         }),
-        WHERE_METRICS_OR_DIMS (() -> {
+        WHERE_OR (() -> {
             FilterPredicate ratingFilter = new FilterPredicate(
                     new Path(PlayerStats.class, dictionary, "overallRating"),
                     Operator.NOTNULL, new ArrayList<Object>());
             FilterPredicate highScoreFilter = new FilterPredicate(
-                    new Path(PlayerStats.class, dictionary, "highScore"),
-                    Operator.GT,
-                    Arrays.asList(9000));
+                    new Path(PlayerStats.class, dictionary, "countryIsoCode"),
+                    Operator.IN,
+                    Arrays.asList("USA"));
             return Query.builder()
                     .source(playerStatsTable)
                     .metricProjection(playerStatsTable.getMetricProjection("highScore"))

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -95,16 +95,6 @@ public abstract class SQLUnitTest {
 
     // Standard set of test queries used in dialect tests
     protected enum TestQuery {
-        WHERE_METRICS_ONLY (() -> {
-            return Query.builder()
-                    .source(playerStatsTable)
-                    .metricProjection(playerStatsTable.getMetricProjection("lowScore"))
-                    .whereFilter(new FilterPredicate(
-                            new Path(PlayerStats.class, dictionary, "lowScore"),
-                            Operator.GT,
-                            Arrays.asList(9000)))
-                    .build();
-        }),
         WHERE_DIMS_ONLY (() -> {
             return Query.builder()
                     .source(playerStatsTable)
@@ -115,14 +105,14 @@ public abstract class SQLUnitTest {
                             new ArrayList<Object>()))
                     .build();
         }),
-        WHERE_METRICS_AND_DIMS (() -> {
+        WHERE_AND (() -> {
             FilterPredicate ratingFilter = new FilterPredicate(
                     new Path(PlayerStats.class, dictionary, "overallRating"),
                     Operator.NOTNULL, new ArrayList<Object>());
             FilterPredicate highScoreFilter = new FilterPredicate(
-                    new Path(PlayerStats.class, dictionary, "highScore"),
-                    Operator.GT,
-                    Arrays.asList(9000));
+                new Path(PlayerStats.class, dictionary, "countryIsoCode"),
+                    Operator.IN,
+                    Arrays.asList("USA"));
             return Query.builder()
                     .source(playerStatsTable)
                     .metricProjection(playerStatsTable.getMetricProjection("highScore"))
@@ -143,17 +133,6 @@ public abstract class SQLUnitTest {
                     .metricProjection(playerStatsTable.getMetricProjection("highScore"))
                     .dimensionProjection(playerStatsTable.getDimensionProjection("overallRating"))
                     .whereFilter(new OrFilterExpression(ratingFilter, highScoreFilter))
-                    .build();
-        }),
-        WHERE_METRICS_AGGREGATION (() -> {
-            return Query.builder()
-                    .source(playerStatsTable)
-                    .metricProjection(playerStatsTable.getMetricProjection("highScore"))
-                    .metricProjection(playerStatsTable.getMetricProjection("lowScore"))
-                    .whereFilter(new FilterPredicate(
-                            new Path(PlayerStats.class, dictionary, "highScore"),
-                            Operator.GT,
-                            Arrays.asList(9000)))
                     .build();
         }),
         HAVING_METRICS_ONLY (() -> {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
@@ -62,15 +62,17 @@ public class H2ExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
-    public void testExplainWhereMetricsOrDims() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_OR_DIMS.getQuery();
+    public void textExplainWhereOr() throws Exception {
+        Query query = TestQuery.WHERE_OR.getQuery();
         String expectedQueryStr =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
                         + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
-                        + "OR MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > :XXX"
-                        + ") GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
+                        + "LEFT JOIN countries AS com_yahoo_elide_datastores_aggregation_example_PlayerStats_country "
+                        + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
+                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL OR com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code IN (:XXX)) "
+                        + " GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating\n";
+
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
@@ -38,16 +38,6 @@ public class H2ExplainQueryTest extends SQLUnitTest {
 //    }
 
     @Test
-    public void testExplainWhereMetricsOnly() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_ONLY.getQuery();
-        String expectedQueryStr =
-                "SELECT MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) AS lowScore "
-                        + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) > :XXX";
-        compareQueryLists(expectedQueryStr, engine.explain(query));
-    }
-
-    @Test
     public void testExplainWhereDimsOnly() throws Exception {
         String expectedQueryStr =
                 "SELECT DISTINCT com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
@@ -57,15 +47,17 @@ public class H2ExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
-    public void testExplainWhereMetricsAndDims() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_AND_DIMS.getQuery();
+    public void testExplainWhereAnd() throws Exception {
+        Query query = TestQuery.WHERE_AND.getQuery();
         String expectedQueryStr =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
                         + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
-                        + "AND MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > :XXX"
-                        + ") GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
+                        + "LEFT JOIN countries AS com_yahoo_elide_datastores_aggregation_example_PlayerStats_country "
+                        + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
+                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL AND com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code IN (:XXX)) "
+                        + " GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating\n";
+
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
 
@@ -79,17 +71,6 @@ public class H2ExplainQueryTest extends SQLUnitTest {
                         + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
                         + "OR MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > :XXX"
                         + ") GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
-        compareQueryLists(expectedQueryStr, engine.explain(query));
-    }
-
-    @Test
-    public void testExplainWhereMetricsAgg() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_AGGREGATION.getQuery();
-        String expectedQueryStr =
-                "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
-                        + "MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) AS lowScore "
-                        + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > :XXX";
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
@@ -37,16 +37,6 @@ public class HiveExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
-    public void testExplainWhereMetricsOnly() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_ONLY.getQuery();
-        String expectedQueryStr =
-                "SELECT MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) AS lowScore "
-                        + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) > :XXX";
-        compareQueryLists(expectedQueryStr, engine.explain(query));
-    }
-
-    @Test
     public void testExplainWhereDimsOnly() throws Exception {
         String expectedQueryStr =
                 "SELECT DISTINCT com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
@@ -56,36 +46,19 @@ public class HiveExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
-    public void testExplainWhereMetricsAndDims() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_AND_DIMS.getQuery();
+    public void testExplainWhereAnd() throws Exception {
+        Query query = TestQuery.WHERE_AND.getQuery();
         String expectedQueryStr =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
                         + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
-                        + "AND MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > :XXX) "
-                        + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
-        compareQueryLists(expectedQueryStr, engine.explain(query));
-    }
+                        + "LEFT JOIN countries AS com_yahoo_elide_datastores_aggregation_example_PlayerStats_country "
+                        + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
+                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL AND com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code IN (:XXX)) "
+                        + " GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating\n";
 
-    /*
-     * // TODO: UDFS / Aggregations not allowed in where/groupby clause
-    @Test
-    public void testExplainWhereMetricsAggregation() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_AGGREGATION.getQuery();
-        OrFilterExpression orFilter = ((OrFilterExpression) query.getWhereFilter());
-        List<FilterPredicate.FilterParameter> params = ((FilterPredicate)orFilter.getRight()).getParameters();
-        String expectedQueryStr =
-                "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
-                        + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
-                        + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
-                        + "OR MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > "
-                        + params.get(0).getPlaceholder()
-                        + ") GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
-    */
 
     /* // TODO Group By is needed before a having clause in Hive
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
@@ -60,6 +60,21 @@ public class HiveExplainQueryTest extends SQLUnitTest {
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
 
+    @Test
+    public void textExplainWhereOr() throws Exception {
+        Query query = TestQuery.WHERE_OR.getQuery();
+        String expectedQueryStr =
+                "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
+                        + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
+                        + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
+                        + "LEFT JOIN countries AS com_yahoo_elide_datastores_aggregation_example_PlayerStats_country "
+                        + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
+                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL OR com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code IN (:XXX)) "
+                        + " GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating\n";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+    }
+
     /* // TODO Group By is needed before a having clause in Hive
     @Test
     public void testExplainHavingMetricsOnly() throws Exception {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
@@ -39,16 +39,6 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
-    public void testExplainWhereMetricsOnly() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_ONLY.getQuery();
-        String expectedQueryStr =
-                "SELECT MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) AS lowScore "
-                        + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE MIN(com_yahoo_elide_datastores_aggregation_example_PlayerStats.lowScore) > :XXX";
-        compareQueryLists(expectedQueryStr, engine.explain(query));
-    }
-
-    @Test
     public void testExplainWhereDimsOnly() throws Exception {
         String expectedQueryStr =
                 "SELECT DISTINCT com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
@@ -58,15 +48,17 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
-    public void testExplainWhereMetricsAndDims() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_AND_DIMS.getQuery();
+    public void testExplainWhereAnd() throws Exception {
+        Query query = TestQuery.WHERE_AND.getQuery();
         String expectedQueryStr =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
                         + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
-                        + "AND MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > :XXX) "
-                        + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
+                        + "LEFT JOIN countries AS com_yahoo_elide_datastores_aggregation_example_PlayerStats_country "
+                        + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
+                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL AND com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code IN (:XXX)) "
+                        + " GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating\n";
+
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
 
@@ -82,25 +74,6 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
                         + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
-
-    /*
-     * // TODO: UDFS / Aggregations not allowed in where/groupby clause.
-     @Test
-     public void testExplainWhereMetricsAggregation() throws Exception {
-     Query query = TestQuery.WHERE_METRICS_AGGREGATION);
-     OrFilterExpression orFilter = ((OrFilterExpression) query.getWhereFilter());
-     List<FilterPredicate.FilterParameter> params = ((FilterPredicate) orFilter.getRight()).getParameters();
-     String expectedQueryStr =
-     "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
-     +"com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
-     + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-     + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
-     + "OR MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > "
-     + params.get(0).getPlaceholder()
-     + ") GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
-     compareQueryLists(expectedQueryStr, engine.explain(query));
-     }
-     */
 
     @Test
     public void testExplainHavingMetricsOnly() throws Exception {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoExplainQueryTest.java
@@ -63,15 +63,17 @@ public class PrestoExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
-    public void testExplainWhereMetricsOrDims() throws Exception {
-        Query query = TestQuery.WHERE_METRICS_OR_DIMS.getQuery();
+    public void textExplainWhereOr() throws Exception {
+        Query query = TestQuery.WHERE_OR.getQuery();
         String expectedQueryStr =
                 "SELECT MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) AS highScore,"
                         + "com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating AS overallRating "
                         + "FROM playerStats AS com_yahoo_elide_datastores_aggregation_example_PlayerStats "
-                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL "
-                        + "OR MAX(com_yahoo_elide_datastores_aggregation_example_PlayerStats.highScore) > :XXX) "
-                        + "GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating";
+                        + "LEFT JOIN countries AS com_yahoo_elide_datastores_aggregation_example_PlayerStats_country "
+                        + "ON com_yahoo_elide_datastores_aggregation_example_PlayerStats.country_id = com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.id "
+                        + "WHERE (com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating IS NOT NULL OR com_yahoo_elide_datastores_aggregation_example_PlayerStats_country.iso_code IN (:XXX)) "
+                        + " GROUP BY com_yahoo_elide_datastores_aggregation_example_PlayerStats.overallRating\n";
+
         compareQueryLists(expectedQueryStr, engine.explain(query));
     }
 


### PR DESCRIPTION
Some of the SQL generation tests include scenarios that are not supported by the query engine when the validator is used.  These tests are removed.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
