### PR TITLE
Removed entity name from Entity Binding

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityBinding.java
@@ -78,7 +78,6 @@ public class EntityBinding {
     @Getter
     public final Class<?> entityClass;
     public final String jsonApiType;
-    public final String entityName;
     @Getter
     public boolean idGenerated;
     @Getter
@@ -128,7 +127,6 @@ public class EntityBinding {
     private EntityBinding() {
         injected = false;
         jsonApiType = null;
-        entityName = null;
         apiVersion = NO_VERSION;
         apiAttributes = new ArrayList<>();
         apiRelationships = new ArrayList<>();
@@ -147,13 +145,11 @@ public class EntityBinding {
      * @param dictionary Dictionary to use
      * @param cls Entity class
      * @param type Declared Elide type name
-     * @param name Declared Entity name
      */
     public EntityBinding(EntityDictionary dictionary,
                          Class<?> cls,
-                         String type,
-                         String name) {
-        this(dictionary, cls, type, name, NO_VERSION, new HashSet<>());
+                         String type) {
+        this(dictionary, cls, type, NO_VERSION, new HashSet<>());
     }
 
     /**
@@ -162,20 +158,17 @@ public class EntityBinding {
      * @param dictionary Dictionary to use
      * @param cls Entity class
      * @param type Declared Elide type name
-     * @param name Declared Entity name
      * @param hiddenAnnotations Annotations for hiding a field in API
      */
     public EntityBinding(EntityDictionary dictionary,
                          Class<?> cls,
                          String type,
-                         String name,
                          String apiVersion,
                          Set<Class<? extends Annotation>> hiddenAnnotations) {
         this.dictionary = dictionary;
         entityClass = cls;
         jsonApiType = type;
         this.apiVersion = apiVersion;
-        entityName = name;
         inheritedTypes = getInheritedTypes(cls);
 
         // Map id's, attributes, and relationships

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -857,7 +857,7 @@ public class EntityDictionary {
         entityBindings.put(declaredClass, new EntityBinding(this, declaredClass,
                 type, version, hiddenAnnotations));
 
-        Include include = (Include) getFirstAnnotation(declaredClass, Collections.singletonList(Include.class));
+        Include include = declaredClass.getAnnotation(Include.class);
         if (include.rootLevel()) {
             bindEntityRoots.add(declaredClass);
         }
@@ -1141,7 +1141,8 @@ public class EntityDictionary {
      * @param annotationClass The annotation to search for.
      * @return The class which declares the annotation or null.
      */
-    public Class<?> lookupAnnotationDeclarationClass(Class<?> objClass, Class<? extends Annotation> annotationClass) {
+    public static Class<?> lookupAnnotationDeclarationClass(Class<?> objClass,
+                                                            Class<? extends Annotation> annotationClass) {
         for (Class<?> cls = objClass; cls != null; cls = cls.getSuperclass()) {
             if (cls.getDeclaredAnnotation(annotationClass) != null) {
                 return cls;
@@ -1685,18 +1686,24 @@ public class EntityDictionary {
         return (apiVersionAnnotation == null) ? NO_VERSION : apiVersionAnnotation.version();
     }
 
+    /**
+     * Looks up the API model name for a given class.
+     * @param modelClass The model class to lookup.
+     * @return the API name for the model class.
+     */
     public static String getEntityName(Class<?> modelClass) {
-        Include include = (Include) getFirstAnnotation(modelClass, Arrays.asList(Include.class));
+        Class<?> declaringClass = lookupAnnotationDeclarationClass(modelClass, Include.class);
 
-        Preconditions.checkNotNull(include);
+        Preconditions.checkNotNull(declaringClass);
+        Include include = declaringClass.getAnnotation(Include.class);
 
         if (! "".equals(include.type())) {
             return include.type();
         }
 
-        Entity entity = (Entity) getFirstAnnotation(modelClass, Arrays.asList(Entity.class));
+        Entity entity = (Entity) getFirstAnnotation(declaringClass, Arrays.asList(Entity.class));
         if (entity == null || "".equals(entity.name())) {
-            return StringUtils.uncapitalize(modelClass.getSimpleName());
+            return StringUtils.uncapitalize(declaringClass.getSimpleName());
         } else {
             return entity.name();
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityBindingTest.java
@@ -29,7 +29,7 @@ public class EntityBindingTest {
 
     @BeforeAll
     public static void init() {
-        entityBinding = new EntityBinding(entityDictionary, ChildClass.class, "child", "childBinding");
+        entityBinding = new EntityBinding(entityDictionary, ChildClass.class, "childBinding");
     }
 
     @Test
@@ -54,19 +54,19 @@ public class EntityBindingTest {
 
     @Test
     public void testIdGeneratedTrueWhenGenerateValue() throws Exception {
-        final EntityBinding eb = new EntityBinding(entityDictionary, GeneratedValueClass.class, "test", "testBinding");
+        final EntityBinding eb = new EntityBinding(entityDictionary, GeneratedValueClass.class, "testBinding");
         assertTrue(eb.isIdGenerated());
     }
 
     @Test
     public void testIdGeneratedTrueWhenMapsId() throws Exception {
-        final EntityBinding eb = new EntityBinding(entityDictionary, MapsIdClass.class, "test", "testBinding");
+        final EntityBinding eb = new EntityBinding(entityDictionary, MapsIdClass.class, "testBinding");
         assertTrue(eb.isIdGenerated());
     }
 
     @Test
     public void testIdGeneratedFalseWhenBadMapsId() throws Exception {
-        final EntityBinding eb = new EntityBinding(entityDictionary, BadMapsIdClass.class, "test", "testBinding");
+        final EntityBinding eb = new EntityBinding(entityDictionary, BadMapsIdClass.class, "testBinding");
         assertFalse(eb.isIdGenerated());
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/EntityDictionaryTest.java
@@ -606,9 +606,6 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertEquals(SuperclassBinding.class, lookupEntityClass(SubclassBinding.class));
         assertEquals(SuperclassBinding.class, lookupEntityClass(SubsubclassBinding.class));
 
-        assertEquals("superclassBinding", getEntityFor(SubclassBinding.class));
-        assertEquals("superclassBinding", getEntityFor(SuperclassBinding.class));
-
         assertNull(getEntityClass("subclassBinding", NO_VERSION));
         assertEquals(SuperclassBinding.class, getEntityClass("superclassBinding", NO_VERSION));
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
@@ -42,6 +42,6 @@ public class NonEntityDictionary extends EntityDictionary {
             throw new DuplicateMappingException(type + " " + cls.getName() + ":" + duplicate.getName());
         }
 
-        entityBindings.put(cls, new EntityBinding(this, cls, type, type));
+        entityBindings.put(cls, new EntityBinding(this, cls, type));
     }
 }


### PR DESCRIPTION
Cleans up the logic that extracts the model names in elide 5.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
