### PR TITLE
Pass Transaction phase to LifeCycleHook Execute.

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/CompleteQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/CompleteQueryHook.java
@@ -26,8 +26,8 @@ public class CompleteQueryHook implements LifeCycleHook<AsyncQuery> {
     }
 
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, AsyncQuery query,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        AsyncQuery query, RequestScope requestScope, Optional<ChangeSpec> changes) {
         asyncExecutorService.completeQuery(query, requestScope.getUser(), requestScope.getApiVersion());
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/ExecuteQueryHook.java
@@ -31,8 +31,8 @@ public class ExecuteQueryHook implements LifeCycleHook<AsyncQuery> {
     }
 
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, AsyncQuery query,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        AsyncQuery query, RequestScope requestScope, Optional<ChangeSpec> changes) {
         validateOptions(query);
         if (query.getStatus() == QueryStatus.QUEUED && query.getResult() == null) {
             asyncExecutorService.executeQuery(query, requestScope.getUser(), requestScope.getApiVersion());

--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/UpdatePrincipalNameHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/UpdatePrincipalNameHook.java
@@ -17,8 +17,8 @@ import java.util.Optional;
 public class UpdatePrincipalNameHook implements LifeCycleHook<AsyncQuery> {
 
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, AsyncQuery query,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        AsyncQuery query, RequestScope requestScope, Optional<ChangeSpec> changes) {
         Principal principal = requestScope.getUser().getPrincipal();
         if (principal != null) {
             query.setPrincipalName(principal.getName());

--- a/elide-core/src/main/java/com/yahoo/elide/core/LifecycleHookInvoker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/LifecycleHookInvoker.java
@@ -58,6 +58,7 @@ public class LifecycleHookInvoker implements Observer<CRUDEvent> {
             hooks.forEach((hook) -> {
                     hook.execute(
                             this.op,
+                            this.phase,
                             event.getResource().getObject(),
                             event.getResource().getRequestScope(),
                             event.getChanges());

--- a/elide-core/src/main/java/com/yahoo/elide/functions/LifeCycleHook.java
+++ b/elide-core/src/main/java/com/yahoo/elide/functions/LifeCycleHook.java
@@ -20,11 +20,13 @@ public interface LifeCycleHook<T> {
     /**
      * Run for a lifecycle event.
      * @param operation CREATE, READ, UPDATE, or DELETE
+     * @param phase PRESECURITY, PRECOMMIT or POSTCOMMIT
      * @param elideEntity The entity that triggered the event
      * @param requestScope The request scope
      * @param changes Optionally, the changes that were made to the entity
      */
     public abstract void execute(LifeCycleHookBinding.Operation operation,
+                                 LifeCycleHookBinding.TransactionPhase phase,
                                  T elideEntity,
                                  RequestScope requestScope,
                                  Optional<ChangeSpec> changes);

--- a/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/LifeCycleTest.java
@@ -124,6 +124,7 @@ class FieldTestModel {
     static class ClassPreSecurityHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -134,6 +135,7 @@ class FieldTestModel {
     static class ClassPreCommitHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -144,6 +146,7 @@ class FieldTestModel {
     static class ClassPreCommitHookEverything implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -154,6 +157,7 @@ class FieldTestModel {
     static class ClassPostCommitHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -164,6 +168,7 @@ class FieldTestModel {
     static class AttributePreSecurityHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -174,6 +179,7 @@ class FieldTestModel {
     static class AttributePreCommitHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -184,6 +190,7 @@ class FieldTestModel {
     static class AttributePostCommitHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -194,6 +201,7 @@ class FieldTestModel {
     static class RelationPreSecurityHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -204,6 +212,7 @@ class FieldTestModel {
     static class RelationPreCommitHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -214,6 +223,7 @@ class FieldTestModel {
     static class RelationPostCommitHook implements LifeCycleHook<FieldTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             FieldTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {
@@ -256,6 +266,7 @@ class PropertyTestModel {
     static class RelationPostCommitHook implements LifeCycleHook<PropertyTestModel> {
         @Override
         public void execute(LifeCycleHookBinding.Operation operation,
+                            LifeCycleHookBinding.TransactionPhase phase,
                             PropertyTestModel elideEntity,
                             com.yahoo.elide.security.RequestScope requestScope,
                             Optional<ChangeSpec> changes) {

--- a/elide-core/src/test/java/example/PublisherUpdateHook.java
+++ b/elide-core/src/test/java/example/PublisherUpdateHook.java
@@ -19,8 +19,8 @@ import java.util.Optional;
 public class PublisherUpdateHook implements LifeCycleHook<Publisher> {
 
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, Publisher elideEntity,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        Publisher elideEntity, RequestScope requestScope, Optional<ChangeSpec> changes) {
         elideEntity.setUpdateHookInvoked(true);
     }
 }

--- a/elide-core/src/test/java/example/models/triggers/InvoiceCompletionHook.java
+++ b/elide-core/src/test/java/example/models/triggers/InvoiceCompletionHook.java
@@ -27,8 +27,8 @@ public class InvoiceCompletionHook implements LifeCycleHook<Invoice> {
     }
 
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, Invoice invoice,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        Invoice invoice, RequestScope requestScope, Optional<ChangeSpec> changes) {
         boolean completeNow = (Boolean) changes.get().getModified();
         boolean completeBefore = (Boolean) changes.get().getOriginal();
 

--- a/elide-graphql/src/test/java/hooks/BookUpdatePostCommitHook.java
+++ b/elide-graphql/src/test/java/hooks/BookUpdatePostCommitHook.java
@@ -20,8 +20,8 @@ import java.util.Optional;
  */
 public class BookUpdatePostCommitHook implements LifeCycleHook<Book> {
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, Book elideEntity,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        Book elideEntity, RequestScope requestScope, Optional<ChangeSpec> changes) {
         GraphQLEndpointTest.User user = (GraphQLEndpointTest.User) requestScope.getUser().getPrincipal();
         user.appendLog("On Title Update Post Commit\n");
     }

--- a/elide-graphql/src/test/java/hooks/BookUpdatePreCommitHook.java
+++ b/elide-graphql/src/test/java/hooks/BookUpdatePreCommitHook.java
@@ -20,8 +20,8 @@ import java.util.Optional;
  */
 public class BookUpdatePreCommitHook implements LifeCycleHook<Book> {
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, Book elideEntity,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                          Book elideEntity, RequestScope requestScope, Optional<ChangeSpec> changes) {
         GraphQLEndpointTest.User user = (GraphQLEndpointTest.User) requestScope.getUser().getPrincipal();
         user.appendLog("On Title Update Pre Commit\n");
     }

--- a/elide-graphql/src/test/java/hooks/BookUpdatePreSecurityHook.java
+++ b/elide-graphql/src/test/java/hooks/BookUpdatePreSecurityHook.java
@@ -20,8 +20,8 @@ import java.util.Optional;
  */
 public class BookUpdatePreSecurityHook implements LifeCycleHook<Book> {
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, Book elideEntity,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        Book elideEntity, RequestScope requestScope, Optional<ChangeSpec> changes) {
         GraphQLEndpointTest.User user = (GraphQLEndpointTest.User) requestScope.getUser().getPrincipal();
         user.appendLog("On Title Update Pre Security\n");
     }

--- a/elide-integration-tests/src/test/java/example/models/triggers/InvoiceCompletionHook.java
+++ b/elide-integration-tests/src/test/java/example/models/triggers/InvoiceCompletionHook.java
@@ -27,8 +27,8 @@ public class InvoiceCompletionHook implements LifeCycleHook<Invoice> {
     }
 
     @Override
-    public void execute(LifeCycleHookBinding.Operation operation, Invoice invoice,
-                        RequestScope requestScope, Optional<ChangeSpec> changes) {
+    public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase,
+                        Invoice invoice, RequestScope requestScope, Optional<ChangeSpec> changes) {
         boolean completeNow = (Boolean) changes.get().getModified();
         boolean completeBefore = (Boolean) changes.get().getOriginal();
 


### PR DESCRIPTION
## Description
Pass Transaction phase to LifeCycleHook Execute.

## Motivation and Context
Pass Transaction phase to LifeCycleHook Execute. Will assist in cases where we want to have the same hook called during different phases with separate logic.

## How Has This Been Tested?
Existing Test Cases Pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
