### PR TITLE
Replace javax.ws.rs.BadRequestException with com.yahoo.elide.core.exceptions.BadRequestException

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/request/EntityProjection.java
+++ b/elide-core/src/main/java/com/yahoo/elide/request/EntityProjection.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.request;
 
+import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.google.common.collect.Sets;
 import lombok.AllArgsConstructor;
@@ -18,8 +19,6 @@ import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import javax.ws.rs.BadRequestException;
 
 /**
  * Represents a client data request against a subgraph of the entity relationship graph.

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/FragmentResolver.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/FragmentResolver.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.graphql.parser;
 
+import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 
 import graphql.language.Document;
@@ -23,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.ws.rs.BadRequestException;
 
 /**
  * Class that fetch {@link FragmentDefinition}s from graphQL {@link Document} and store them for future reference.

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -18,6 +18,7 @@ import static com.yahoo.elide.graphql.KeyWord.TYPENAME;
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RelationshipType;
+import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.dialect.ParseException;
@@ -51,8 +52,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import javax.ws.rs.BadRequestException;
 
 /**
  * This class converts a GraphQL query string into an Elide {@link EntityProjection} using

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/VariableResolver.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/VariableResolver.java
@@ -6,6 +6,8 @@
 
 package com.yahoo.elide.graphql.parser;
 
+import com.yahoo.elide.core.exceptions.BadRequestException;
+
 import graphql.language.ArrayValue;
 import graphql.language.BooleanValue;
 import graphql.language.EnumValue;
@@ -25,8 +27,6 @@ import graphql.language.VariableReference;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import javax.ws.rs.BadRequestException;
 
 /**
  * Class that contains variables provided in graphql request and can resolve variables based on


### PR DESCRIPTION
## Description
Replace javax.ws.rs.BadRequestException with com.yahoo.elide.core.exceptions.BadRequestException

## Motivation and Context
GraphQL API was returning 400 error code instead of 200 for certain scenarios. 
Per https://elide.io/pages/guide/v4/11-graphql.html, GraphQL API should return 200 error code. So making the behavior consistent. 

## How Has This Been Tested?
Existing test case pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
