### PR TITLE
Add micrometer dependency

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.6</version>
             <optional>true</optional>
         </dependency>
 

--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.5.1</version>
+            <version>1.5.6</version>
         </dependency>
 
         <!-- Jetty -->

--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -109,6 +109,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.5.1</version>
+        </dependency>
+
         <!-- Jetty -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Resolves #<issue number> (if appropriate)

## Description
Add micrometer dependency to spring boot starter pom.xml

## Motivation and Context
Applications that use Elide should not have to add micrometer dependency explicitly
## How Has This Been Tested?
Tested in an application that uses elide, by removing the explicitly added micrometer dependency from its pom.xml
## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
