### PR TITLE
Migrate metadatacalls to metadata store

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.datastores.aggregation.cache.QueryKeyExtractor;
 import com.yahoo.elide.datastores.aggregation.core.QueryLogger;
 import com.yahoo.elide.datastores.aggregation.core.QueryResponse;
 import com.yahoo.elide.datastores.aggregation.filter.visitor.MatchesTemplateVisitor;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.QueryResult;
@@ -37,7 +38,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
     private final Cache cache;
     private final QueryEngine.Transaction queryEngineTransaction;
     private final QueryLogger queryLogger;
-    private final
+    private final MetaDataStore metaDataStore;
 
     public AggregationDataStoreTransaction(QueryEngine queryEngine, Cache cache,
                                            QueryLogger queryLogger) {
@@ -45,6 +46,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
         this.cache = cache;
         this.queryEngineTransaction = queryEngine.beginTransaction();
         this.queryLogger = queryLogger;
+        this.metaDataStore = queryEngine.metaDataStore;
     }
 
     @Override
@@ -122,7 +124,10 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
 
     @VisibleForTesting
     Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
-        Table table = queryEngine.getTable(scope.getDictionary().getJsonAliasFor(entityProjection.getType()));
+        Table table = metaDataStore.getTable(
+                scope.getDictionary().getJsonAliasFor(entityProjection.getType()),
+                scope.getApiVersion());
+
         EntityProjectionTranslator translator = new EntityProjectionTranslator(
                 queryEngine,
                 table,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -46,7 +46,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
         this.cache = cache;
         this.queryEngineTransaction = queryEngine.beginTransaction();
         this.queryLogger = queryLogger;
-        this.metaDataStore = queryEngine.metaDataStore;
+        this.metaDataStore = queryEngine.getMetaDataStore();
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -37,6 +37,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
     private final Cache cache;
     private final QueryEngine.Transaction queryEngineTransaction;
     private final QueryLogger queryLogger;
+    private final
 
     public AggregationDataStoreTransaction(QueryEngine queryEngine, Cache cache,
                                            QueryLogger queryLogger) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -21,13 +21,10 @@ import com.yahoo.elide.datastores.aggregation.query.QueryResult;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.request.Argument;
 
-import com.google.common.base.Functions;
-
 import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 /**
  * A {@link QueryEngine} is an abstraction that an AggregationDataStore leverages to run analytic queries (OLAP style)
  * against an underlying persistence layer.
@@ -73,8 +70,6 @@ public abstract class QueryEngine {
 
     protected EntityDictionary metadataDictionary;
 
-    protected Map<String, Table> tables;
-
     protected QueryEngine() {
     }
     /**
@@ -87,8 +82,6 @@ public abstract class QueryEngine {
         this.metaDataStore = metaDataStore;
         this.metadataDictionary = metaDataStore.getMetadataDictionary();
         populateMetaData(metaDataStore);
-        this.tables = metaDataStore.getMetaData(Table.class).stream()
-                .collect(Collectors.toMap(Table::getId, Functions.identity()));
     }
 
     /**
@@ -187,15 +180,6 @@ public abstract class QueryEngine {
      * @return a version token, or null if not available.
      */
     public abstract String getTableVersion(Table table, Transaction transaction);
-
-    /**
-     * Returns the schema for a given entity class.
-     * @param classAlias json type alias for that class
-     * @return The schema that represents the provided entity.
-     */
-    public Table getTable(String classAlias) {
-        return tables.get(classAlias);
-    }
 
     /**
      * Returns the actual query string(s) that would be executed for the input {@link Query}.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -150,6 +150,19 @@ public class MetaDataStore implements DataStore {
     }
 
     /**
+     * Returns the table for a given name and version.
+     * @param name The name of the table
+     * @param version The version of the table.
+     * @return The table that matches or null.
+     */
+    public Table getTable(String name, String version) {
+        return tables.values().stream()
+                .filter(table -> table.getName().equals(name) && table.getVersion().equals(version))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
      * Get a {@link Column} from a table.
      *
      * @param tableClass table class

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -40,7 +40,6 @@ import com.yahoo.elide.request.Argument;
 import com.yahoo.elide.request.Pagination;
 import com.yahoo.elide.utils.coerce.CoerceUtil;
 
-import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 
 import lombok.Getter;
@@ -99,8 +98,6 @@ public class SQLQueryEngine extends QueryEngine {
         this.metaDataStore = metaDataStore;
         this.metadataDictionary = metaDataStore.getMetadataDictionary();
         populateMetaData(metaDataStore);
-        this.tables = metaDataStore.getMetaData(Table.class).stream()
-                        .collect(Collectors.toMap(Table::getId, Functions.identity()));
         this.referenceTable = new SQLReferenceTable(metaDataStore);
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.framework;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -230,7 +231,7 @@ public abstract class SQLUnitTest {
                     .build();
         }),
         SUBQUERY (() -> {
-            SQLTable playerStatsViewTable = (SQLTable) engine.getTable("playerStatsView");
+            SQLTable playerStatsViewTable = (SQLTable) metaDataStore.getTable("playerStatsView", NO_VERSION);
             return Query.builder()
                     .source(playerStatsViewTable)
                     .metricProjection(playerStatsViewTable.getMetricProjection("highScore"))
@@ -378,7 +379,7 @@ public abstract class SQLUnitTest {
 
         engine = new SQLQueryEngine(metaDataStore, new ConnectionDetails(dataSource, sqlDialect));
 
-        playerStatsTable = (SQLTable) engine.getTable("playerStats");
+        playerStatsTable = (SQLTable) metaDataStore.getTable("playerStats", NO_VERSION);
 
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.queryengines.sql;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.core.Path;
@@ -40,7 +41,7 @@ public class QueryEngineTest extends SQLUnitTest {
     @BeforeAll
     public static void init() {
         SQLUnitTest.init();
-        playerStatsViewTable = (SQLTable) engine.getTable("playerStatsView");
+        playerStatsViewTable = (SQLTable) engine.getMetaDataStore().getTable("playerStatsView", NO_VERSION);
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/ViewTest.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.datastores.aggregation.queryengines.sql;
 
+import static com.yahoo.elide.core.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -29,7 +30,8 @@ public class ViewTest extends SQLUnitTest {
     @BeforeAll
     public static void init() {
         SQLUnitTest.init();
-        playerStatsWithViewSchema = (SQLTable) engine.getTable("playerStatsWithView");
+        playerStatsWithViewSchema =
+                (SQLTable) engine.getMetaDataStore().getTable("playerStatsWithView", NO_VERSION);
     }
 
     @Test


### PR DESCRIPTION
Small cleanup for QueryEngine to remove a metadata method that belongs in the MetadataStore.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
