### PR TITLE
New isFact flag for Analytical Models

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/annotation/TableMeta.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/annotation/TableMeta.java
@@ -29,4 +29,10 @@ public @interface TableMeta {
      * @return The required filter template.
      */
     String filterTemplate() default "";
+
+    /**
+     * Whether or not this table is a fact table.
+     * @return true or false.
+     */
+    boolean isFact() default true;
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -24,6 +24,7 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSu
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
 
 import com.yahoo.elide.utils.TypeHelper;
+
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -65,6 +66,8 @@ public abstract class Table implements Versioned  {
     private final CardinalitySize cardinality;
 
     private final String requiredFilter;
+
+    private final boolean isFact;
 
     @OneToMany
     @ToString.Exclude
@@ -151,6 +154,20 @@ public abstract class Table implements Versioned  {
         } else {
             this.cardinality = null;
         }
+
+        this.isFact = isFact(cls, meta);
+    }
+
+    private boolean isFact(Class<?> cls, TableMeta meta) {
+        if (meta != null && meta.isFact()) {
+            return true;
+        }
+
+        // If FromTable or FromSubquery Annotation exists then assume its fact table.
+        boolean existsAggAnnotations = (cls.getAnnotation(FromTable.class) != null
+                || cls.getAnnotation(FromSubquery.class) != null);
+
+        return existsAggAnnotations;
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/Continent.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/Continent.java
@@ -8,6 +8,8 @@ package com.yahoo.elide.datastores.aggregation.example;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.datastores.aggregation.annotation.Cardinality;
 import com.yahoo.elide.datastores.aggregation.annotation.CardinalitySize;
+import com.yahoo.elide.datastores.aggregation.annotation.TableMeta;
+
 import lombok.Data;
 
 import javax.persistence.Entity;
@@ -18,6 +20,7 @@ import javax.persistence.Table;
 @Entity
 @Include
 @Table(name = "continents")
+@TableMeta(isFact = false)
 @Cardinality(size = CardinalitySize.SMALL)
 public class Continent {
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -65,17 +65,31 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
     public void tableMetaDataTest() {
 
         given()
+               .accept("application/vnd.api+json")
+               .get("/table/continent")
+               .then()
+               .statusCode(HttpStatus.SC_OK)
+               .body("data.attributes.isFact", equalTo(false)); //TableMeta Present, isFact false
+        given()
                 .accept("application/vnd.api+json")
                 .get("/table/country")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.isFact", equalTo(false)) //TableMeta Present, isFact default true
                 .body("data.attributes.cardinality", equalTo("SMALL"))
                 .body("data.relationships.columns.data.id", hasItems("country.id", "country.name", "country.isoCode"));
+        given()
+                .accept("application/vnd.api+json")
+                .get("/table/playerStatsView")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.isFact", equalTo(true)); //FromSubquery
         given()
                 .accept("application/vnd.api+json")
                 .get("/table/playerStats")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.isFact", equalTo(true)) //FromTable
                 .body("data.attributes.cardinality", equalTo("LARGE"))
                 .body("data.attributes.category", equalTo("Sports Category"))
                 .body("data.attributes.tags", hasItems("Statistics", "Game"))

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
-        <spring.boot.version>2.3.4.RELEASE</spring.boot.version>
+        <spring.boot.version>2.3.5.RELEASE</spring.boot.version>
         <groovy.version>3.0.5</groovy.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <!-- dependency versions -->
         <version.antlr4>4.8-1</version.antlr4>
         <version.logback>1.2.3</version.logback>
-        <version.jetty>9.4.31.v20200723</version.jetty>
+        <version.jetty>9.4.33.v20201020</version.jetty>
         <version.restassured>4.3.1</version.restassured>
         <version.jackson>2.11.2</version.jackson>
         <version.jersey>2.31</version.jersey>


### PR DESCRIPTION
Resolves https://github.com/yahoo/elide/issues/1544

## Description
Not all `@Table` and `@Subselect` Annotated Models satisfy the Analytics/Aggregated Model requirement. So we should be able to flag them.

* `@TableMeta` annotation introduces a new property `isFact` with default value 'true' which can be used to mark the flag. 
* `FromTable` and `FromSubquery` annotated models will always default to isFact = true unless marked otherwise. 
* `@Table` and `@Subselect` annotated models will always default to isFact = false unless marked otherwise. 

## Motivation and Context
Not all `@table` and `@Subselect` Annotated Models satisfy the Analytics/Aggregated Model requirements. The UI will use the isFact flag to filter the non-supported models.

## How Has This Been Tested?
New and existing test cases work.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
