### PR TITLE
Generate shade jar to enable dynamic config validation from command line.

### DIFF
--- a/elide-model-config/README.md
+++ b/elide-model-config/README.md
@@ -7,7 +7,9 @@ To build and run:
 1. mvn clean install
 2. Execute Jar File :
    a) java -cp elide-spring/elide-spring-boot-autoconfigure/target/elide-spring-boot-autoconfigure-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --configDir <Path for Config Directory>
+      java -cp elide-standalone/target/elide-standalone-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --configDir <Path for Config Directory>
    b) java -cp elide-standalone/target/elide-standalone-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
+      java -cp elide-spring/elide-spring-boot-autoconfigure/target/elide-spring-boot-autoconfigure-*.jar         com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
 ```
 Expected Configs Directory Structure:
 ```text

--- a/elide-model-config/README.md
+++ b/elide-model-config/README.md
@@ -8,8 +8,8 @@ To build and run:
 2. Execute Jar File :
    a) java -cp elide-spring/elide-spring-boot-autoconfigure/target/elide-spring-boot-autoconfigure-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --configDir <Path for Config Directory>
       java -cp elide-standalone/target/elide-standalone-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --configDir <Path for Config Directory>
-   b) java -cp elide-standalone/target/elide-standalone-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
-      java -cp elide-spring/elide-spring-boot-autoconfigure/target/elide-spring-boot-autoconfigure-*.jar         com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
+   b) java -cp elide-spring/elide-spring-boot-autoconfigure/target/elide-spring-boot-autoconfigure-*.jar       com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
+      java -cp elide-standalone/target/elide-standalone-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
 ```
 Expected Configs Directory Structure:
 ```text

--- a/elide-model-config/README.md
+++ b/elide-model-config/README.md
@@ -6,8 +6,8 @@ To build and run:
 ```text
 1. mvn clean install
 2. Execute Jar File :
-   a) java -cp elide-contrib/elide-dynamic-config-helpers/target/elide-dynamic-config-*-jar-with-dependencies.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --configDir <Path for Config Directory>
-   b) java -cp elide-contrib/elide-dynamic-config-helpers/target/elide-dynamic-config-*-jar-with-dependencies.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
+   a) java -cp elide-spring/elide-spring-boot-autoconfigure/target/elide-spring-boot-autoconfigure-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --configDir <Path for Config Directory>
+   b) java -cp elide-standalone/target/elide-standalone-*.jar com.yahoo.elide.contrib.dynamicconfighelpers.validator.DynamicConfigValidator --help
 ```
 Expected Configs Directory Structure:
 ```text

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -240,20 +240,17 @@
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -239,6 +239,22 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -254,26 +254,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
-                        <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.4</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>com.yahoo.elide:elide-model-config</include>
-                </includes>
-              </artifactSet>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -254,6 +254,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
+                        <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.yahoo.elide:elide-model-config</include>
+                </includes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Description
Generate shade jar to enable dynamic config validation from command line.
## Motivation and Context
Command line validation of dynamic config hjson files
## How Has This Been Tested?
Tested command line validation of hjson files using the new shaded jars
## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
