### PR TITLE
Include ISO `T` Date Separator in time dimension formats

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Hour.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Hour.java
@@ -17,7 +17,7 @@ import java.text.SimpleDateFormat;
  */
 public class Hour extends Timestamp {
 
-    public static final String FORMAT = "yyyy-MM-dd HH";
+    public static final String FORMAT = "yyyy-MM-dd'T'HH";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Hour(java.util.Date date) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Minute.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Minute.java
@@ -17,7 +17,7 @@ import java.text.SimpleDateFormat;
  */
 public class Minute extends Timestamp {
 
-    public static final String FORMAT = "yyyy-MM-dd HH:mm";
+    public static final String FORMAT = "yyyy-MM-dd'T'HH:mm";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Minute(java.util.Date date) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Second.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Second.java
@@ -17,7 +17,7 @@ import java.text.SimpleDateFormat;
  */
 public class Second extends Timestamp {
 
-    public static final String FORMAT = "yyyy-MM-dd HH:mm:ss";
+    public static final String FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -977,12 +977,12 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "orderDetails",
                                 selections(
                                         field("courierName", "FEDEX"),
-                                        field("deliveryTime", "2020-09-11 16:30:11"),
-                                        field("deliveryHour", "2020-09-11 16"),
+                                        field("deliveryTime", "2020-09-11T16:30:11"),
+                                        field("deliveryHour", "2020-09-11T16"),
                                         field("deliveryDate", "2020-09-11"),
                                         field("deliveryMonth", "2020-09"),
                                         field("deliveryYear", "2020"),
-                                        field("orderTime", "2020-09-08 16:30:11"),
+                                        field("orderTime", "2020-09-08T16:30:11"),
                                         field("orderDate", "2020-09-08"),
                                         field("orderMonth", "2020-09"),
                                         field("customerRegion", "Virginia"),
@@ -993,12 +993,12 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 ),
                                 selections(
                                         field("courierName", "FEDEX"),
-                                        field("deliveryTime", "2020-09-11 16:30:11"),
-                                        field("deliveryHour", "2020-09-11 16"),
+                                        field("deliveryTime", "2020-09-11T16:30:11"),
+                                        field("deliveryHour", "2020-09-11T16"),
                                         field("deliveryDate", "2020-09-11"),
                                         field("deliveryMonth", "2020-09"),
                                         field("deliveryYear", "2020"),
-                                        field("orderTime", "2020-09-08 16:30:11"),
+                                        field("orderTime", "2020-09-08T16:30:11"),
                                         field("orderDate", "2020-09-08"),
                                         field("orderMonth", "2020-09"),
                                         field("customerRegion", "Virginia"),
@@ -1009,12 +1009,12 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 ),
                                 selections(
                                         field("courierName", "UPS"),
-                                        field("deliveryTime", "2020-09-05 16:30:11"),
-                                        field("deliveryHour", "2020-09-05 16"),
+                                        field("deliveryTime", "2020-09-05T16:30:11"),
+                                        field("deliveryHour", "2020-09-05T16"),
                                         field("deliveryDate", "2020-09-05"),
                                         field("deliveryMonth", "2020-09"),
                                         field("deliveryYear", "2020"),
-                                        field("orderTime", "2020-08-30 16:30:11"),
+                                        field("orderTime", "2020-08-30T16:30:11"),
                                         field("orderDate", "2020-08-30"),
                                         field("orderMonth", "2020-08"),
                                         field("customerRegion", "Virginia"),
@@ -1025,12 +1025,12 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 ),
                                 selections(
                                         field("courierName", "UPS"),
-                                        field("deliveryTime", "2020-09-13 16:30:11"),
-                                        field("deliveryHour", "2020-09-13 16"),
+                                        field("deliveryTime", "2020-09-13T16:30:11"),
+                                        field("deliveryHour", "2020-09-13T16"),
                                         field("deliveryDate", "2020-09-13"),
                                         field("deliveryMonth", "2020-09"),
                                         field("deliveryYear", "2020"),
-                                        field("orderTime", "2020-09-09 16:30:11"),
+                                        field("orderTime", "2020-09-09T16:30:11"),
                                         field("orderDate", "2020-09-09"),
                                         field("orderMonth", "2020-09"),
                                         field("customerRegion", "Virginia"),
@@ -1054,7 +1054,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "orderDetails",
                                 arguments(
                                         argument("sort", "\"customerRegion\""),
-                                        argument("filter", "\"orderTime=='2020-09-08 16:30:11'\"")
+                                        argument("filter", "\"orderTime=='2020-09-08T16:30:11'\"")
                                 ),
                                 selections(
                                         field("orderTotal"),
@@ -1074,7 +1074,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("orderTotal", 181.47F),
                                         field("customerRegion", "Virginia"),
                                         field("orderMonth", "2020-09"),
-                                        field("orderTime", "2020-09-08 16:30:11")
+                                        field("orderTime", "2020-09-08T16:30:11")
                                 )
                         )
                 )

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/HourSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/HourSerdeTest.java
@@ -19,12 +19,12 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class HourSerdeTest {
-    private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH");
+    private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH");
 
     @Test
     public void testDateSerialize() throws ParseException {
 
-        String expected = "2020-01-01 01";
+        String expected = "2020-01-01T01";
         Hour expectedDate = new Hour(formatter.parse(expected));
         Serde serde = new Hour.HourSerde();
         Object actual = serde.serialize(expectedDate);
@@ -34,9 +34,9 @@ public class HourSerdeTest {
     @Test
     public void testDateDeserializeString() throws ParseException {
 
-        String dateInString = "2020-01-01 01";
+        String dateInString = "2020-01-01T01";
         Date expectedDate = new Date(formatter.parse(dateInString).getTime());
-        String actual = "2020-01-01 01:18";
+        String actual = "2020-01-01T01:18";
         Serde serde = new Hour.HourSerde();
         Object actualDate = serde.deserialize(actual);
         assertEquals(expectedDate, actualDate);
@@ -45,7 +45,7 @@ public class HourSerdeTest {
     @Test
     public void testDeserializeTimestamp() throws ParseException {
 
-        String dateInString = "2020-01-01 01";
+        String dateInString = "2020-01-01T01";
         Hour expectedDate = new Hour(formatter.parse(dateInString));
         Timestamp timestamp = new Timestamp(formatter.parse(dateInString).getTime());
         Serde serde = new Hour.HourSerde();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MinuteSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MinuteSerdeTest.java
@@ -19,12 +19,12 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class MinuteSerdeTest {
-    private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+    private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm");
 
     @Test
     public void testDateSerialize() throws ParseException {
 
-        String expected = "2020-01-01 01:18";
+        String expected = "2020-01-01T01:18";
         Minute expectedDate = new Minute(formatter.parse(expected));
         Serde serde = new Minute.MinuteSerde();
         Object actual = serde.serialize(expectedDate);
@@ -34,9 +34,9 @@ public class MinuteSerdeTest {
     @Test
     public void testDateDeserializeString() throws ParseException {
 
-        String dateInString = "2020-01-01 01:18";
+        String dateInString = "2020-01-01T01:18";
         Date expectedDate = new Date(formatter.parse(dateInString).getTime());
-        String actual = "2020-01-01 01:18";
+        String actual = "2020-01-01T01:18";
         Serde serde = new Minute.MinuteSerde();
         Object actualDate = serde.deserialize(actual);
         assertEquals(expectedDate, actualDate);
@@ -45,7 +45,7 @@ public class MinuteSerdeTest {
     @Test
     public void testDeserializeTimestamp() throws ParseException {
 
-        String dateInString = "2020-01-01 01:18";
+        String dateInString = "2020-01-01T01:18";
         Minute expectedDate = new Minute(formatter.parse(dateInString));
         Timestamp timestamp = new Timestamp(formatter.parse(dateInString).getTime());
         Serde serde = new Minute.MinuteSerde();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SecondSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SecondSerdeTest.java
@@ -19,12 +19,12 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public class SecondSerdeTest {
-    private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
     @Test
     public void testDateSerialize() throws ParseException {
 
-        String expected = "2020-01-01 01:18:19";
+        String expected = "2020-01-01T01:18:19";
         Second expectedDate = new Second(formatter.parse(expected));
         Serde serde = new Second.SecondSerde();
         Object actual = serde.serialize(expectedDate);
@@ -34,9 +34,9 @@ public class SecondSerdeTest {
     @Test
     public void testDateDeserializeString() throws ParseException {
 
-        String dateInString = "2020-01-01 01:18:19";
+        String dateInString = "2020-01-01T01:18:19";
         Date expectedDate = new Date(formatter.parse(dateInString).getTime());
-        String actual = "2020-01-01 01:18:19";
+        String actual = "2020-01-01T01:18:19";
         Serde serde = new Second.SecondSerde();
         Object actualDate = serde.deserialize(actual);
         assertEquals(expectedDate, actualDate);
@@ -45,7 +45,7 @@ public class SecondSerdeTest {
     @Test
     public void testDeserializeTimestamp() throws ParseException {
 
-        String dateInString = "2020-01-01 01:18:19";
+        String dateInString = "2020-01-01T01:18:19";
         Second expectedDate = new Second(formatter.parse(dateInString));
         Timestamp timestamp = new Timestamp(formatter.parse(dateInString).getTime());
         Serde serde = new Second.SecondSerde();


### PR DESCRIPTION
## Description
For consistency with default time formats in Elide. Include `T` date separator in the time dimension formats 

## How Has This Been Tested?
Existing test cases were updated.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
