### PR TITLE
Bug Fix for missed case in isFlag logic

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -144,8 +144,8 @@ public abstract class Table implements Versioned  {
     }
 
     private boolean isFact(Class<?> cls, TableMeta meta) {
-        if (meta != null && meta.isFact()) {
-            return true;
+        if (meta != null) {
+            return meta.isFact();
         }
 
         // If FromTable or FromSubquery Annotation exists then assume its fact table.

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/Planet.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/Planet.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.datastores.aggregation.annotation.TableMeta;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
+
+import lombok.Data;
+
+import javax.persistence.Id;
+
+/**
+ * A root level entity for testing AggregationDataStore.
+ */
+@Data
+@Include
+@FromTable(name = "planets")
+@TableMeta(isFact = false)
+public class Planet {
+    @Id
+    private String id;
+
+    private String name;
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -76,6 +76,12 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
         given()
                .accept("application/vnd.api+json")
+               .get("/table/planet")
+               .then()
+               .statusCode(HttpStatus.SC_OK)
+               .body("data.attributes.isFact", equalTo(false)); //FromTable, TableMeta Present, isFact false
+        given()
+               .accept("application/vnd.api+json")
                .get("/table/continent")
                .then()
                .statusCode(HttpStatus.SC_OK)
@@ -91,7 +97,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .get("/table/country")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.attributes.isFact", equalTo(false)) //TableMeta Present, isFact default true
+                .body("data.attributes.isFact", equalTo(false)) //TableMeta not Present
                 .body("data.attributes.cardinality", equalTo("SMALL"))
                 .body("data.relationships.columns.data.id", hasItems("country.id", "country.name", "country.isoCode"));
         given()

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_tables.sql
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_tables.sql
@@ -72,3 +72,13 @@ CREATE TABLE IF NOT EXISTS continents
 TRUNCATE TABLE continents;
 INSERT INTO continents VALUES (1, 'Asia');
 INSERT INTO continents VALUES (2, 'North America');
+
+CREATE TABLE IF NOT EXISTS planets
+    (
+      id BIGINT,
+      name VARCHAR(255)
+    );
+TRUNCATE TABLE planets;
+INSERT INTO planets VALUES (1, 'Mercury');
+INSERT INTO planets VALUES (2, 'Venus');
+INSERT INTO planets VALUES (3, 'Earth');


### PR DESCRIPTION
## Description
Fixes the logic for isFlag property. Missing a case when it was set to false in TableMeta for FromTable and FromSubSelect Annotated models. 

## How Has This Been Tested?
Existing and New test cases.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
