### PR TITLE
Elide 5.x timegrain inheritance

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Day.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Day.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -16,13 +15,13 @@ import java.text.SimpleDateFormat;
 /**
  * Time Grain class for Day.
  */
-public class Day extends Date {
+public class Day extends Hour {
 
     public static final String FORMAT = "yyyy-MM-dd";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Day(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = Day.class, name = "Day")

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Day.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Day.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
@@ -33,12 +32,13 @@ public class Day extends Hour {
 
             try {
                 if (val instanceof String) {
-                    date = new Day(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Day(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Day(FORMATTER.parse(FORMATTER.format(val)));
                 }
             } catch (ParseException e) {
-                throw new IllegalArgumentException("String must be formatted as " + FORMAT);
+                throw new IllegalArgumentException("String must be formatted as " + FORMAT + " or "
+                        + ISOFormatUtil.ISO_FORMAT);
             }
 
             return date;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Hour.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Hour.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
@@ -33,7 +32,7 @@ public class Hour extends Minute {
 
             try {
                 if (val instanceof String) {
-                    date = new Hour(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Hour(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Hour(FORMATTER.parse(FORMATTER.format(val)));
                 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Hour.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Hour.java
@@ -15,13 +15,13 @@ import java.text.SimpleDateFormat;
 /**
  * Time Grain class for Hour.
  */
-public class Hour extends Timestamp {
+public class Hour extends Minute {
 
     public static final String FORMAT = "yyyy-MM-dd'T'HH";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Hour(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = Hour.class, name = "Hour")

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/ISOFormatUtil.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/ISOFormatUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.timegrains;
+
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+public class ISOFormatUtil {
+
+    public static final String ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    private static final SimpleDateFormat ISO_FORMATTER = new SimpleDateFormat(ISO_FORMAT);
+
+    public static java.util.Date formatDateString(String dateString, SimpleDateFormat toFormat) throws ParseException {
+        try {
+            return new Timestamp(toFormat.parse(dateString).getTime());
+        } catch (ParseException e) {
+            return toFormat.parse(toFormat.format(ISO_FORMATTER.parse(dateString)));
+        }
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/ISOWeek.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/ISOWeek.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -16,13 +15,13 @@ import java.text.SimpleDateFormat;
 /**
  * Time Grain class for ISOWeek.
  */
-public class ISOWeek extends Date {
+public class ISOWeek extends Week {
 
     public static final String FORMAT = "yyyy-MM-dd";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public ISOWeek(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = ISOWeek.class, name = "ISOWeek")

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Minute.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Minute.java
@@ -15,13 +15,13 @@ import java.text.SimpleDateFormat;
 /**
  * Time Grain class for Minute.
  */
-public class Minute extends Timestamp {
+public class Minute extends Second {
 
     public static final String FORMAT = "yyyy-MM-dd'T'HH:mm";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Minute(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = Minute.class, name = "Minute")

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Minute.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Minute.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
@@ -33,12 +32,13 @@ public class Minute extends Second {
 
             try {
                 if (val instanceof String) {
-                    date = new Minute(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Minute(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Minute(FORMATTER.parse(FORMATTER.format(val)));
                 }
             } catch (ParseException e) {
-                throw new IllegalArgumentException("String must be formatted as " + FORMAT);
+                throw new IllegalArgumentException("String must be formatted as " + FORMAT + " or "
+                        + ISOFormatUtil.ISO_FORMAT);
             }
 
             return date;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Month.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Month.java
@@ -8,14 +8,13 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 /**
  * Time Grain class for Month.
  */
-public class Month extends Quarter {
+public class Month extends Day {
 
     public static final String FORMAT = "yyyy-MM";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
@@ -33,12 +32,13 @@ public class Month extends Quarter {
 
             try {
                 if (val instanceof String) {
-                    date = new Month(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Month(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Month(FORMATTER.parse(FORMATTER.format(val)));
                 }
             } catch (ParseException e) {
-                throw new IllegalArgumentException("String must be formatted as " + FORMAT);
+                throw new IllegalArgumentException("String must be formatted as " + FORMAT + " or "
+                        + ISOFormatUtil.ISO_FORMAT);
             }
 
             return date;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Month.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Month.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -16,13 +15,13 @@ import java.text.SimpleDateFormat;
 /**
  * Time Grain class for Month.
  */
-public class Month extends Date {
+public class Month extends Quarter {
 
     public static final String FORMAT = "yyyy-MM";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Month(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = Month.class, name = "Month")

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Quarter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Quarter.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -39,12 +38,13 @@ public class Quarter extends Day {
 
             try {
                 if (val instanceof String) {
-                    date = new Quarter(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Quarter(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Quarter(FORMATTER.parse(FORMATTER.format(val)));
                 }
             } catch (ParseException e) {
-                throw new IllegalArgumentException("String must be formatted as " + FORMAT);
+                throw new IllegalArgumentException("String must be formatted as " + FORMAT + " or "
+                        + ISOFormatUtil.ISO_FORMAT);
             }
 
             if (!QUARTER_MONTHS.contains(MONTH_FORMATTER.format(date))) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Quarter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Quarter.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -19,13 +18,13 @@ import java.util.Set;
 /**
  * Time Grain class for Quarter.
  */
-public class Quarter extends Date {
+public class Quarter extends Day {
 
     public static final String FORMAT = "yyyy-MM";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Quarter(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = Quarter.class, name = "Quarter")

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Second.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Second.java
@@ -20,7 +20,6 @@ public class Second extends Timestamp {
     public static final String FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
-
     public Second(java.util.Date date) {
         super(date.getTime());
     }
@@ -39,12 +38,13 @@ public class Second extends Timestamp {
 
             try {
                 if (val instanceof String) {
-                    date = new Second(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Second(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Second(FORMATTER.parse(FORMATTER.format(val)));
                 }
             } catch (ParseException e) {
-                throw new IllegalArgumentException("String must be formatted as " + FORMAT);
+                throw new IllegalArgumentException("String must be formatted as " + FORMAT + " or "
+                + ISOFormatUtil.ISO_FORMAT);
             }
 
             return date;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Week.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Week.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
@@ -35,12 +34,13 @@ public class Week extends Day {
 
             try {
                 if (val instanceof String) {
-                    date = new Week(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Week(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Week(FORMATTER.parse(FORMATTER.format(val)));
                 }
             } catch (ParseException e) {
-                throw new IllegalArgumentException("String must be formatted as " + FORMAT);
+                throw new IllegalArgumentException("String must be formatted as " + FORMAT + " or "
+                        + ISOFormatUtil.ISO_FORMAT);
             }
 
             if (!WEEKDATE_FORMATTER.format(date).equals("7")) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Week.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Week.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -16,13 +15,13 @@ import java.text.SimpleDateFormat;
 /**
  * Time Grain class for Week.
  */
-public class Week extends Date {
+public class Week extends Day {
 
     public static final String FORMAT = "yyyy-MM-dd";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Week(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = Week.class, name = "Week")

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Year.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Year.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
@@ -33,14 +32,14 @@ public class Year extends Month {
 
             try {
                 if (val instanceof String) {
-                    date = new Year(new Timestamp(FORMATTER.parse((String) val).getTime()));
+                    date = new Year(ISOFormatUtil.formatDateString((String) val, FORMATTER));
                 } else {
                     date = new Year(FORMATTER.parse(FORMATTER.format(val)));
                 }
             } catch (ParseException e) {
-                throw new IllegalArgumentException("String must be formatted as " + FORMAT);
+                throw new IllegalArgumentException("String must be formatted as " + FORMAT + " or "
+                        + ISOFormatUtil.ISO_FORMAT);
             }
-
             return date;
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Year.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/timegrains/Year.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.timegrains;
 import com.yahoo.elide.utils.coerce.converters.ElideTypeConverter;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -16,13 +15,13 @@ import java.text.SimpleDateFormat;
 /**
  * Time Grain class for Year.
  */
-public class Year extends Date {
+public class Year extends Month {
 
     public static final String FORMAT = "yyyy";
     private static final SimpleDateFormat FORMATTER = new SimpleDateFormat(FORMAT);
 
     public Year(java.util.Date date) {
-        super(date.getTime());
+        super(date);
     }
 
     @ElideTypeConverter(type = Year.class, name = "Year")

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerdeTest.java
@@ -53,6 +53,17 @@ public class YearSerdeTest {
     }
 
     @Test
+    public void testDeserializeISOTimestamp() throws ParseException {
+
+        String dateInString = "2020-10-20T11:10:00+01:00";
+        Year expectedDate = new Year(formatter.parse(dateInString));
+        Timestamp timestamp = new Timestamp(formatter.parse(dateInString).getTime());
+        Serde serde = new Year.YearSerde();
+        Object actualDate = serde.deserialize(timestamp);
+        assertEquals(expectedDate, actualDate);
+    }
+
+    @Test
     public void testDeserializeDateInvalidFormat() throws ParseException {
 
         String dateInString = "January";


### PR DESCRIPTION
Resolves #1545 & Inheritance between Time Grains

## Description
Enables ISO date format support and inheritance hierarchy for Time Grains.
Inheritance Hierarchy (Second-> Minute-> Hour -> Day->Quarter->Month->Year
Day->Week->IsoWeek)

## Motivation and Context
Support ISO date format for all Time grains
Enable Time Grain override

## How Has This Been Tested?
Unit tests updated. 


## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
