### PR TITLE
Update elide standalone getting started docs

### DIFF
--- a/elide-standalone/README.md
+++ b/elide-standalone/README.md
@@ -278,7 +278,7 @@ Your log4j config should go in `src/main/resources` so log4j can find it.
 With these new classes, you have two options for running your project.  You can either run the `Main` class using your
 favorite IDE, or you can run the service from the command line:
 
-```mvn exec:java -Dexec.mainClass="example.Main"```
+```java -jar target/elide-heroku-example.jar```
 
 Our example requires the following environment variables to be set to work correctly with Heroku and Postgres.  
 
@@ -548,7 +548,3 @@ New health checks can be exposed through the servlet path `/stats/healthcheck` b
 You can add additional configuration by specifying the `applicationConfigurator` method. The class (i.e. the `Consumer`) is fully injectable and will take in the root Jersey `ResourceConfig` for your application.
 
 This method accepts a `ResourceConfig` object so you can continue to modify it as necessary.
-
-## <a name="moredetail"></a>Looking for More?
-
-For a more detailed example containing information about using security and additional features, see our [blog example](https://github.com/DennisMcWherter/elide-example-blog-kotlin).

--- a/elide-standalone/README.md
+++ b/elide-standalone/README.md
@@ -452,7 +452,7 @@ data to help our users is just as easy as it is to add new data. Let’s update 
 
 ### Running Analytic Queries
 
-Analytic queries leverage the same API as reading any other Elide model.  Note that Elide will aggregate the measures selected by the dimensions requested.  Learn more about analytic queries [here](/pages/guide/v{{ page.version }}/04-analytics.html).
+Analytic queries leverage the same API as reading any other Elide model.  Note that Elide will aggregate the measures selected by the dimensions requested.  Learn more about analytic queries [here](https://elide.io/pages/guide/v5/04-analytics.html).
 
 #### JSON-API
 

--- a/elide-standalone/README.md
+++ b/elide-standalone/README.md
@@ -49,6 +49,7 @@ There will two kinds of models:
 
   ```java
   @Include(rootLevel = true, type = "group")
+  @Table(name="ArtifactGroup")
   @Entity
   public class ArtifactGroup {
       @Id
@@ -67,6 +68,7 @@ There will two kinds of models:
 
   ```java
   @Include(type = "product")
+  @Table(name="ArtifactProduct")
   @Entity
   public class ArtifactProduct {
       @Id
@@ -88,6 +90,7 @@ There will two kinds of models:
 
   ```java
   @Include(type = "version")
+  @Table(name="ArtifactVersion")
   @Entity
   public class ArtifactVersion {
       @Id
@@ -208,6 +211,57 @@ Bringing life to our API is trivially easy. We need two new classes: Main and Se
           options.put("javax.persistence.jdbc.password", "");
              
           return options;
+      }
+
+      /**
+       * Enables elide's asynchronous API for analytic queries.
+       */
+      @Override
+      public ElideStandaloneAsyncSettings getAsyncProperties() {
+          return new ElideStandaloneAsyncSettings() {
+  
+              @Override
+              public boolean enabled() {
+                  return true;
+              }
+  
+              @Override
+              public boolean enableCleanup() {
+                  return true;
+              }
+          };
+      }
+
+      /**
+       * Enable HJSON configuration files for analytic models.
+       */
+      @Override
+      public boolean enableDynamicModelConfig() {
+          return true;
+      }
+
+      /**
+       * Enable analytic queries.
+       */
+      @Override
+      public boolean enableAggregationDataStore() {
+          return true;
+      }
+
+      /**
+       * Configure the SQL dialect for analytic queries.
+       */
+      @Override
+      public String getDefaultDialect() {
+          return "h2";
+      }
+
+      /**
+       * Configure the location of HJSON models.
+       */
+      @Override
+      public String getDynamicConfigPath() {
+          return "src/main/resources/analytics";
       }
   } 
   ```


### PR DESCRIPTION
Updated elide-standalone getting started docs for elide 5.  Added an analytic model to the example.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
