### PR TITLE
Tweak Cleaner Thread Delays

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
@@ -44,7 +44,7 @@ public class AsyncCleanerService {
         // Since there will be multiple hosts running the elide service,
         // setting up random delays to avoid all of them trying to cleanup at the same time.
         Random random = new Random();
-        int initialDelayMinutes = random.ints(5, maxInitialDelayMinutes).limit(1).findFirst().getAsInt();
+        int initialDelayMinutes = random.ints(0, maxInitialDelayMinutes).limit(1).findFirst().getAsInt();
         log.debug("Initial Delay for cleaner service is {}", initialDelayMinutes);
 
         //Having a delay of at least DEFAULT_CLEANUP_DELAY between two cleanup attempts.
@@ -60,7 +60,7 @@ public class AsyncCleanerService {
         AsyncAPICancelThread cancelTask = new AsyncAPICancelThread(maxRunTimeSeconds,
                 elide, asyncQueryDao);
 
-        cancellation.scheduleWithFixedDelay(cancelTask, 300, cancelDelaySeconds, TimeUnit.SECONDS);
+        cancellation.scheduleWithFixedDelay(cancelTask, 0, cancelDelaySeconds, TimeUnit.SECONDS);
     }
 
     /**

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncCleanerService.java
@@ -25,7 +25,7 @@ import javax.inject.Inject;
 @Slf4j
 public class AsyncCleanerService {
 
-    private final int defaultCleanupDelayMinutes = 360;
+    private final int defaultCleanupDelayMinutes = 120;
     private final int maxInitialDelayMinutes = 100;
     private static AsyncCleanerService asyncCleanerService = null;
 
@@ -44,7 +44,7 @@ public class AsyncCleanerService {
         // Since there will be multiple hosts running the elide service,
         // setting up random delays to avoid all of them trying to cleanup at the same time.
         Random random = new Random();
-        int initialDelayMinutes = random.ints(0, maxInitialDelayMinutes).limit(1).findFirst().getAsInt();
+        int initialDelayMinutes = random.ints(5, maxInitialDelayMinutes).limit(1).findFirst().getAsInt();
         log.debug("Initial Delay for cleaner service is {}", initialDelayMinutes);
 
         //Having a delay of at least DEFAULT_CLEANUP_DELAY between two cleanup attempts.
@@ -60,7 +60,7 @@ public class AsyncCleanerService {
         AsyncAPICancelThread cancelTask = new AsyncAPICancelThread(maxRunTimeSeconds,
                 elide, asyncQueryDao);
 
-        cancellation.scheduleWithFixedDelay(cancelTask, 0, cancelDelaySeconds, TimeUnit.SECONDS);
+        cancellation.scheduleWithFixedDelay(cancelTask, 300, cancelDelaySeconds, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
## Description
Changes the default run time for the Cleaner thread from 360 Minutes to 120 Minutes. The cleaner thread is responsible for updating the status of interrupted async queries (due to app crash or restart) to TIMEDOUT from PROCESSING. It is also responsible for cleaning up history. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
