### PR TITLE
Elide Standalone: Default DataSource not reading all config params

### DIFF
--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
@@ -36,30 +36,7 @@ public class Util {
             Optional<ElideDynamicEntityCompiler> optionalCompiler, Properties options) {
 
         // Configure default options for example service
-        if (options.isEmpty()) {
-            options.put("hibernate.show_sql", "true");
-            options.put("hibernate.hbm2ddl.auto", "create");
-            options.put("hibernate.dialect", "org.hibernate.dialect.MySQL5Dialect");
-            options.put("hibernate.current_session_context_class", "thread");
-            options.put("hibernate.jdbc.use_scrollable_resultset", "true");
-
-            // Collection Proxy & JDBC Batching
-            options.put("hibernate.jdbc.batch_size", "50");
-            options.put("hibernate.jdbc.fetch_size", "50");
-            options.put("hibernate.default_batch_fetch_size", "100");
-
-            // Hikari Connection Pool Settings
-            options.putIfAbsent("hibernate.connection.provider_class",
-                    "com.zaxxer.hikari.hibernate.HikariConnectionProvider");
-            options.putIfAbsent("hibernate.hikari.connectionTimeout", "20000");
-            options.putIfAbsent("hibernate.hikari.maximumPoolSize", "30");
-            options.putIfAbsent("hibernate.hikari.idleTimeout", "30000");
-
-            options.put("javax.persistence.jdbc.driver", "com.mysql.jdbc.Driver");
-            options.put("javax.persistence.jdbc.url", "jdbc:mysql://localhost/elide?serverTimezone=UTC");
-            options.put("javax.persistence.jdbc.user", "elide");
-            options.put("javax.persistence.jdbc.password", "elide123");
-        }
+        populateDefaultOptions(options);
 
         ClassLoader classLoader = null;
         //Bind entity classes from classpath to Persistence Unit
@@ -96,20 +73,51 @@ public class Util {
     public static DataSource getDataSource(Properties options) {
 
         // Configure default options for example service
-        if (options.isEmpty()) {
-            options.put("javax.persistence.jdbc.driver", "com.mysql.jdbc.Driver");
-            options.put("javax.persistence.jdbc.url", "jdbc:mysql://localhost/elide?serverTimezone=UTC");
-            options.put("javax.persistence.jdbc.user", "elide");
-            options.put("javax.persistence.jdbc.password", "elide123");
-        }
+        populateDefaultOptions(options);
 
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl(options.getProperty("javax.persistence.jdbc.url"));
         config.setUsername(options.getProperty("javax.persistence.jdbc.user"));
         config.setPassword(options.getProperty("javax.persistence.jdbc.password"));
         config.setDriverClassName(options.getProperty("javax.persistence.jdbc.driver"));
+        if (options.getProperty("hibernate.hikari.connectionTimeout") != null) {
+            config.setConnectionTimeout(new Long(options.getProperty("hibernate.hikari.connectionTimeout")));
+        }
+        if (options.getProperty("hibernate.hikari.idleTimeout") != null) {
+            config.setIdleTimeout(new Long(options.getProperty("hibernate.hikari.idleTimeout")));
+        }
+        if (options.getProperty("hibernate.hikari.maximumPoolSize") != null) {
+            config.setMaximumPoolSize(new Integer(options.getProperty("hibernate.hikari.maximumPoolSize")));
+        }
 
         return new HikariDataSource(config);
+    }
+
+    private static void populateDefaultOptions(Properties options) {
+        if (options.isEmpty()) {
+            options.put("hibernate.show_sql", "true");
+            options.put("hibernate.hbm2ddl.auto", "create");
+            options.put("hibernate.dialect", "org.hibernate.dialect.MySQL5Dialect");
+            options.put("hibernate.current_session_context_class", "thread");
+            options.put("hibernate.jdbc.use_scrollable_resultset", "true");
+
+            // Collection Proxy & JDBC Batching
+            options.put("hibernate.jdbc.batch_size", "50");
+            options.put("hibernate.jdbc.fetch_size", "50");
+            options.put("hibernate.default_batch_fetch_size", "100");
+
+            // Hikari Connection Pool Settings
+            options.putIfAbsent("hibernate.connection.provider_class",
+                    "com.zaxxer.hikari.hibernate.HikariConnectionProvider");
+            options.putIfAbsent("hibernate.hikari.connectionTimeout", "20000");
+            options.putIfAbsent("hibernate.hikari.maximumPoolSize", "30");
+            options.putIfAbsent("hibernate.hikari.idleTimeout", "30000");
+
+            options.put("javax.persistence.jdbc.driver", "com.mysql.jdbc.Driver");
+            options.put("javax.persistence.jdbc.url", "jdbc:mysql://localhost/elide?serverTimezone=UTC");
+            options.put("javax.persistence.jdbc.user", "elide");
+            options.put("javax.persistence.jdbc.password", "elide123");
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Default DataSource not reading all config params

## Motivation and Context
Elide Standalone Example was not able to use the Hikari Pool Settings.

## How Has This Been Tested?
Standalone Example.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
