### PR TITLE
Add context to supports filtering

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/export/TableExporter.java
@@ -76,7 +76,7 @@ public class TableExporter {
                 results = PersistentResource.loadRecords(projection, Collections.emptyList(), requestScope);
             }
 
-            tx.preCommit();
+            tx.preCommit(requestScope);
             requestScope.runQueuedPreSecurityTriggers();
             requestScope.getPermissionExecutor().executeCommitChecks();
 

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -361,7 +361,7 @@ public class Elide {
             RequestScope requestScope = result.getRequestScope();
             isVerbose = requestScope.getPermissionExecutor().isVerbose();
             Supplier<Pair<Integer, JsonNode>> responder = result.getResponder();
-            tx.preCommit();
+            tx.preCommit(requestScope);
             requestScope.runQueuedPreSecurityTriggers();
             requestScope.getPermissionExecutor().executeCommitChecks();
             if (!isReadOnly) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
@@ -73,7 +73,7 @@ public interface DataStoreTransaction extends Closeable {
      * 4. transaction.flush();
      * 5. transaction.commit();
      */
-    default void preCommit() {
+    default void preCommit(RequestScope scope) {
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
@@ -20,6 +20,7 @@ import com.yahoo.elide.core.request.Sorting;
 import java.io.Closeable;
 import java.io.Serializable;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Set;
 /**
  * Wraps the Database Transaction type.
@@ -239,31 +240,40 @@ public interface DataStoreTransaction extends Closeable {
 
     /**
      * Whether or not the transaction can filter the provided class with the provided expression.
-     * @param entityClass The class to filter
-     * @param expression The filter expression
+     * @param scope The request scope
+     * @param projection The projection being loaded
+     * @param parent Are we filtering a root collection or a relationship
      * @return FULL, PARTIAL, or NONE
      */
-    default FeatureSupport supportsFiltering(Class<?> entityClass, FilterExpression expression) {
+    default FeatureSupport supportsFiltering(RequestScope scope,
+                                             Optional<Object> parent,
+                                             EntityProjection projection) {
         return FeatureSupport.FULL;
     }
 
     /**
      * Whether or not the transaction can sort the provided class.
-     * @param entityClass The model type
-     * @param sorting Whether or not the store supports sorting for the given model
+     * @param scope The request scope
+     * @param projection The projection being loaded
+     * @param parent Are we filtering a root collection or a relationship
      * @return true if sorting is possible
      */
-    default boolean supportsSorting(Class<?> entityClass, Sorting sorting) {
+    default boolean supportsSorting(RequestScope scope,
+                                    Optional<Object> parent,
+                                    EntityProjection projection) {
         return true;
     }
 
     /**
      * Whether or not the transaction can paginate the provided class.
-     * @param entityClass The entity class that is being paged.
-     * @param expression The filter expression
+     * @param scope The request scope
+     * @param projection The projection being loaded
+     * @param parent Are we filtering a root collection or a relationship
      * @return true if pagination is possible
      */
-    default boolean supportsPagination(Class<?> entityClass, FilterExpression expression) {
+    default boolean supportsPagination(RequestScope scope,
+                                       Optional<Object> parent,
+                                       EntityProjection projection) {
         return true;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
@@ -15,7 +15,6 @@ import com.yahoo.elide.core.filter.predicates.InPredicate;
 import com.yahoo.elide.core.request.Attribute;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.Relationship;
-import com.yahoo.elide.core.request.Sorting;
 
 import java.io.Closeable;
 import java.io.Serializable;

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/HashMapStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/HashMapStoreTransaction.java
@@ -9,10 +9,8 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.TransactionException;
-import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.Relationship;
-import com.yahoo.elide.core.request.Sorting;
 import com.yahoo.elide.core.utils.coerce.converters.Serde;
 
 import java.io.IOException;
@@ -20,6 +18,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.persistence.GeneratedValue;
 
@@ -164,17 +163,17 @@ public class HashMapStoreTransaction implements DataStoreTransaction {
     }
 
     @Override
-    public FeatureSupport supportsFiltering(Class<?> entityClass, FilterExpression expression) {
+    public FeatureSupport supportsFiltering(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
         return FeatureSupport.NONE;
     }
 
     @Override
-    public boolean supportsSorting(Class<?> entityClass, Sorting sorting) {
+    public boolean supportsSorting(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
         return false;
     }
 
     @Override
-    public boolean supportsPagination(Class<?> entityClass, FilterExpression expression) {
+    public boolean supportsPagination(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
         return false;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -149,8 +149,8 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
     }
 
     @Override
-    public void preCommit() {
-        tx.preCommit();
+    public void preCommit(RequestScope scope) {
+        tx.preCommit(scope);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
@@ -28,8 +28,8 @@ public abstract class TransactionWrapper implements DataStoreTransaction {
     protected DataStoreTransaction tx;
 
     @Override
-    public void preCommit() {
-        tx.preCommit();
+    public void preCommit(RequestScope scope) {
+        tx.preCommit(scope);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
@@ -18,6 +18,7 @@ import lombok.Data;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -75,18 +76,18 @@ public abstract class TransactionWrapper implements DataStoreTransaction {
     }
 
     @Override
-    public FeatureSupport supportsFiltering(Class<?> entityClass, FilterExpression expression) {
-        return tx.supportsFiltering(entityClass, expression);
+    public FeatureSupport supportsFiltering(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
+        return tx.supportsFiltering(scope, parent, projection);
     }
 
     @Override
-    public boolean supportsSorting(Class<?> entityClass, Sorting sorting) {
-        return tx.supportsSorting(entityClass, sorting);
+    public boolean supportsSorting(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
+        return tx.supportsSorting(scope, parent, projection);
     }
 
     @Override
-    public boolean supportsPagination(Class<?> entityClass, FilterExpression expression) {
-        return tx.supportsPagination(entityClass, expression);
+    public boolean supportsPagination(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
+        return tx.supportsPagination(scope, parent, projection);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
@@ -8,11 +8,9 @@ package com.yahoo.elide.core.datastore.wrapped;
 
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
-import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.request.Attribute;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.Relationship;
-import com.yahoo.elide.core.request.Sorting;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/DataStoreTransactionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/DataStoreTransactionTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Optional;
 
 public class DataStoreTransactionTest implements DataStoreTransaction {
     private static final String NAME = "name";
@@ -56,19 +57,19 @@ public class DataStoreTransactionTest implements DataStoreTransaction {
 
     @Test
     public void testSupportsSorting() {
-        boolean actual = supportsSorting(null, null);
+        boolean actual = supportsSorting(null, Optional.empty(), null);
         assertTrue(actual);
     }
 
     @Test
     public void testSupportsPagination() {
-        boolean actual = supportsPagination(null, null);
+        boolean actual = supportsPagination(null, Optional.empty(), null);
         assertTrue(actual);
     }
 
     @Test
     public void testSupportsFiltering() {
-        DataStoreTransaction.FeatureSupport actual = supportsFiltering(null, null);
+        DataStoreTransaction.FeatureSupport actual = supportsFiltering(null, Optional.empty(), null);
         assertEquals(DataStoreTransaction.FeatureSupport.FULL, actual);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/DataStoreTransactionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/DataStoreTransactionTest.java
@@ -45,7 +45,7 @@ public class DataStoreTransactionTest implements DataStoreTransaction {
 
     @Test
     public void testPreCommit() {
-        preCommit();
+        preCommit(scope);
         verify(scope, never()).getDictionary();
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
@@ -300,7 +300,7 @@ public class InMemoryStoreTransactionTest {
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
         when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
-        when(wrappedTransaction.supportsSorting(scope, any(), eq(projection))).thenReturn(false);
+        when(wrappedTransaction.supportsSorting(eq(scope), any(), eq(projection))).thenReturn(false);
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
         Collection<Object> loaded = (Collection<Object>) inMemoryStoreTransaction.loadObjects(

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
@@ -139,7 +139,7 @@ public class InMemoryStoreTransactionTest {
                 .filterExpression(expression)
                 .build();
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class), any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
         when(wrappedTransaction.loadObjects(eq(projection), eq(scope))).thenReturn(books);
 
         Collection<Object> loaded = (Collection<Object>) inMemoryStoreTransaction.loadObjects(projection, scope);
@@ -169,8 +169,7 @@ public class InMemoryStoreTransactionTest {
         ArgumentCaptor<Relationship> relationshipArgument = ArgumentCaptor.forClass(Relationship.class);
 
         when(scope.getNewPersistentResources()).thenReturn(Sets.newHashSet(mock(PersistentResource.class)));
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(relationship.getProjection()))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
         when(wrappedTransaction.getRelation(eq(inMemoryStoreTransaction), eq(author), any(), eq(scope))).thenReturn(books);
 
         Collection<Object> loaded = (Collection<Object>) inMemoryStoreTransaction.getRelation(
@@ -203,8 +202,7 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.NONE);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.NONE);
 
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
@@ -237,8 +235,7 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.PARTIAL);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.PARTIAL);
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
         Collection<Object> loaded = (Collection<Object>) inMemoryStoreTransaction.loadObjects(
@@ -270,10 +267,8 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
-        when(wrappedTransaction.supportsSorting(eq(Book.class),
-                any())).thenReturn(true);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        when(wrappedTransaction.supportsSorting(eq(scope), any(), eq(projection))).thenReturn(true);
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
         Collection<Object> loaded = (Collection<Object>) inMemoryStoreTransaction.loadObjects(
@@ -304,10 +299,8 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
-        when(wrappedTransaction.supportsSorting(eq(Book.class),
-                any())).thenReturn(false);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        when(wrappedTransaction.supportsSorting(scope, any(), eq(projection))).thenReturn(false);
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
         Collection<Object> loaded = (Collection<Object>) inMemoryStoreTransaction.loadObjects(
@@ -345,10 +338,8 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.NONE);
-        when(wrappedTransaction.supportsSorting(eq(Book.class),
-                any())).thenReturn(true);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.NONE);
+        when(wrappedTransaction.supportsSorting(eq(scope), any(), eq(projection))).thenReturn(true);
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
         Collection<Object> loaded = (Collection<Object>) inMemoryStoreTransaction.loadObjects(
@@ -379,9 +370,8 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
-        when(wrappedTransaction.supportsPagination(eq(Book.class), any())).thenReturn(true);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        when(wrappedTransaction.supportsPagination(eq(scope), any(), eq(projection))).thenReturn(true);
 
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
@@ -410,9 +400,8 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
-        when(wrappedTransaction.supportsPagination(eq(Book.class), any())).thenReturn(false);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        when(wrappedTransaction.supportsPagination(eq(scope), any(), eq(projection))).thenReturn(false);
 
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
@@ -448,9 +437,8 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.NONE);
-        when(wrappedTransaction.supportsPagination(eq(Book.class), any())).thenReturn(true);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.NONE);
+        when(wrappedTransaction.supportsPagination(eq(scope), any(), eq(projection))).thenReturn(true);
 
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 
@@ -487,11 +475,9 @@ public class InMemoryStoreTransactionTest {
 
         ArgumentCaptor<EntityProjection> projectionArgument = ArgumentCaptor.forClass(EntityProjection.class);
 
-        when(wrappedTransaction.supportsFiltering(eq(Book.class),
-                any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
-        when(wrappedTransaction.supportsSorting(eq(Book.class),
-                any())).thenReturn(false);
-        when(wrappedTransaction.supportsPagination(eq(Book.class), any())).thenReturn(true);
+        when(wrappedTransaction.supportsFiltering(eq(scope), any(), eq(projection))).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        when(wrappedTransaction.supportsSorting(eq(scope), any(), eq(projection))).thenReturn(false);
+        when(wrappedTransaction.supportsPagination(eq(scope), any(), eq(projection))).thenReturn(true);
 
         when(wrappedTransaction.loadObjects(any(), eq(scope))).thenReturn(books);
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapperTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapperTest.java
@@ -34,8 +34,8 @@ public class TransactionWrapperTest {
         DataStoreTransaction wrapped = mock(DataStoreTransaction.class);
         DataStoreTransaction wrapper = new TestTransactionWrapper(wrapped);
 
-        wrapper.preCommit();
-        verify(wrapped, times(1)).preCommit();
+        wrapper.preCommit(null);
+        verify(wrapped, times(1)).preCommit(any());
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapperTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapperTest.java
@@ -19,6 +19,8 @@ import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.request.Attribute;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 public class TransactionWrapperTest {
 
     private class TestTransactionWrapper extends TransactionWrapper {
@@ -129,10 +131,10 @@ public class TransactionWrapperTest {
         DataStoreTransaction wrapped = mock(DataStoreTransaction.class);
         DataStoreTransaction wrapper = new TestTransactionWrapper(wrapped);
 
-        when(wrapped.supportsSorting(any(), any())).thenReturn(true);
-        boolean actual = wrapper.supportsSorting(null, null);
+        when(wrapped.supportsSorting(any(), any(), any())).thenReturn(true);
+        boolean actual = wrapper.supportsSorting(null, Optional.empty(), null);
 
-        verify(wrapped, times(1)).supportsSorting(any(), any());
+        verify(wrapped, times(1)).supportsSorting(any(), any(), any());
         assertTrue(actual);
     }
 
@@ -141,10 +143,10 @@ public class TransactionWrapperTest {
         DataStoreTransaction wrapped = mock(DataStoreTransaction.class);
         DataStoreTransaction wrapper = new TestTransactionWrapper(wrapped);
 
-        when(wrapped.supportsPagination(any(), any())).thenReturn(true);
-        boolean actual = wrapper.supportsPagination(null, null);
+        when(wrapped.supportsPagination(any(), any(), any())).thenReturn(true);
+        boolean actual = wrapper.supportsPagination(null, Optional.empty(), null);
 
-        verify(wrapped, times(1)).supportsPagination(any(), any());
+        verify(wrapped, times(1)).supportsPagination(any(), any(), any());
         assertTrue(actual);
     }
 
@@ -153,10 +155,10 @@ public class TransactionWrapperTest {
         DataStoreTransaction wrapped = mock(DataStoreTransaction.class);
         DataStoreTransaction wrapper = new TestTransactionWrapper(wrapped);
 
-        when(wrapped.supportsFiltering(any(), any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
-        DataStoreTransaction.FeatureSupport actual = wrapper.supportsFiltering(null, null);
+        when(wrapped.supportsFiltering(any(), any(), any())).thenReturn(DataStoreTransaction.FeatureSupport.FULL);
+        DataStoreTransaction.FeatureSupport actual = wrapper.supportsFiltering(null, Optional.empty(), null);
 
-        verify(wrapped, times(1)).supportsFiltering(any(), any());
+        verify(wrapped, times(1)).supportsFiltering(any(), any(), any());
         assertEquals(DataStoreTransaction.FeatureSupport.FULL, actual);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
@@ -118,7 +118,7 @@ public class LifeCycleTest {
         verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
         verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
 
-        verify(tx).preCommit();
+        verify(tx).preCommit(any());
         verify(tx, times(1)).createObject(eq(mockModel), isA(RequestScope.class));
         verify(tx).flush(isA(RequestScope.class));
         verify(tx).commit(isA(RequestScope.class));
@@ -150,7 +150,7 @@ public class LifeCycleTest {
         verify(mockModel, never()).relationCallback(any(), any(), any());
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
 
-        verify(tx, never()).preCommit();
+        verify(tx, never()).preCommit(any());
         verify(tx, never()).createObject(eq(mockModel), isA(RequestScope.class));
         verify(tx, never()).flush(isA(RequestScope.class));
         verify(tx, never()).commit(isA(RequestScope.class));
@@ -195,7 +195,7 @@ public class LifeCycleTest {
         verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
         verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
         verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
-        verify(tx).preCommit();
+        verify(tx).preCommit(any());
         verify(tx).flush(any());
         verify(tx).commit(any());
         verify(tx).close();
@@ -236,7 +236,7 @@ public class LifeCycleTest {
 
         verify(mockModel, never()).relationCallback(any(), any(), any());
 
-        verify(tx).preCommit();
+        verify(tx).preCommit(any());
         verify(tx).flush(any());
         verify(tx).commit(any());
         verify(tx).close();
@@ -283,7 +283,7 @@ public class LifeCycleTest {
         verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
         verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
 
-        verify(tx).preCommit();
+        verify(tx).preCommit(any());
         verify(tx).flush(any());
         verify(tx).commit(any());
         verify(tx).close();
@@ -328,7 +328,7 @@ public class LifeCycleTest {
         verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
         verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
 
-        verify(tx).preCommit();
+        verify(tx).preCommit(any());
         verify(tx).save(eq(mockModel), isA(RequestScope.class));
         verify(tx).flush(isA(RequestScope.class));
         verify(tx).commit(isA(RequestScope.class));
@@ -370,7 +370,7 @@ public class LifeCycleTest {
         verify(mockModel, never()).relationCallback(eq(READ), any(), any());
         verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
 
-        verify(tx).preCommit();
+        verify(tx).preCommit(any());
         verify(tx).delete(eq(mockModel), isA(RequestScope.class));
         verify(tx).flush(isA(RequestScope.class));
         verify(tx).commit(isA(RequestScope.class));
@@ -407,7 +407,7 @@ public class LifeCycleTest {
 //       */
 //      verify(callback, times(6)).execute(eq(book), isA(RequestScope.class), any());
 //      verify(tx).accessUser(any());
-//      verify(tx).preCommit();
+//      verify(tx).preCommit(any());
 //      verify(tx, times(1)).createObject(eq(book), isA(RequestScope.class));
 //      verify(tx).flush(isA(RequestScope.class));
 //      verify(tx).commit(isA(RequestScope.class));
@@ -437,7 +437,7 @@ public class LifeCycleTest {
 //
 //      verify(callback, never()).execute(eq(book), isA(RequestScope.class), any());
 //      verify(tx).accessUser(any());
-//      verify(tx, never()).preCommit();
+//      verify(tx, never()).preCommit(any());
 //      verify(tx, never()).flush(isA(RequestScope.class));
 //      verify(tx, never()).commit(isA(RequestScope.class));
 //      verify(tx).close();
@@ -478,7 +478,7 @@ public class LifeCycleTest {
 //      verify(onUpdateImmediateCallback, never()).execute(eq(book), isA(RequestScope.class), eq(Optional.empty()));
 //      verify(onUpdateDeferredCallback, never()).execute(eq(book), isA(RequestScope.class), eq(Optional.empty()));
 //      verify(tx).accessUser(any());
-//      verify(tx).preCommit();
+//      verify(tx).preCommit(any());
 //
 //      verify(tx).save(eq(book), isA(RequestScope.class));
 //      verify(tx).flush(isA(RequestScope.class));
@@ -513,7 +513,7 @@ public class LifeCycleTest {
 //       */
 //      verify(callback, times(3)).execute(eq(book), isA(RequestScope.class), any());
 //      verify(tx).accessUser(any());
-//      verify(tx).preCommit();
+//      verify(tx).preCommit(any());
 //
 //      verify(tx).delete(eq(book), isA(RequestScope.class));
 //      verify(tx).flush(isA(RequestScope.class));
@@ -564,7 +564,7 @@ public class LifeCycleTest {
 //      verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
 //      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
 //
-//      verify(tx).preCommit();
+//      verify(tx).preCommit(any());
 //      verify(tx).save(eq(mockModel), isA(RequestScope.class));
 //      verify(tx).flush(isA(RequestScope.class));
 //      verify(tx, never()).commit(isA(RequestScope.class));
@@ -619,7 +619,7 @@ public class LifeCycleTest {
 //      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
 //      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
 //
-//      verify(tx).preCommit();
+//      verify(tx).preCommit(any());
 //      verify(tx, times(1)).createObject(eq(mockModel), isA(RequestScope.class));
 //      verify(tx).flush(isA(RequestScope.class));
 //      verify(tx).commit(isA(RequestScope.class));
@@ -647,7 +647,7 @@ public class LifeCycleTest {
 //              "[{\"errors\":[{\"detail\":\"Bad Request Body&#39;Patch extension requires all objects to have an assigned ID (temporary or permanent) when assigning relationships.&#39;\",\"status\":\"400\"}]}]",
 //              response.getBody());
 //
-//      verify(tx, never()).preCommit();
+//      verify(tx, never()).preCommit(any());
 //      verify(tx, never()).flush(isA(RequestScope.class));
 //      verify(tx, never()).commit(isA(RequestScope.class));
 //      verify(tx).close();
@@ -693,7 +693,7 @@ public class LifeCycleTest {
 //      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
 //      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
 //
-//      verify(tx).preCommit();
+//      verify(tx).preCommit(any());
 //      verify(tx).save(eq(mockModel), isA(RequestScope.class));
 //      verify(tx).flush(isA(RequestScope.class));
 //      verify(tx).commit(isA(RequestScope.class));
@@ -743,7 +743,7 @@ public class LifeCycleTest {
 //      verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRECOMMIT), any());
 //      verify(mockModel, times(1)).relationCallback(eq(READ), eq(POSTCOMMIT), any());
 //
-//      verify(tx).preCommit();
+//      verify(tx).preCommit(any());
 //      verify(tx).delete(eq(mockModel), isA(RequestScope.class));
 //      verify(tx).flush(isA(RequestScope.class));
 //      verify(tx).commit(isA(RequestScope.class));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStoreTransaction.java
@@ -10,14 +10,13 @@ import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.datastore.inmemory.HashMapDataStore;
 import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
-import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.Relationship;
-import com.yahoo.elide.core.request.Sorting;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -94,17 +93,17 @@ public class MetaDataStoreTransaction implements DataStoreTransaction {
     }
 
     @Override
-    public FeatureSupport supportsFiltering(Class<?> entityClass, FilterExpression expression) {
+    public FeatureSupport supportsFiltering(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
         return FeatureSupport.NONE;
     }
 
     @Override
-    public boolean supportsSorting(Class<?> entityClass, Sorting sorting) {
+    public boolean supportsSorting(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
         return false;
     }
 
     @Override
-    public boolean supportsPagination(Class<?> entityClass, FilterExpression expression) {
+    public boolean supportsPagination(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
         return false;
     }
 

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
@@ -217,18 +217,21 @@ public abstract class MultiplexTransaction implements DataStoreTransaction {
     }
 
     @Override
-    public FeatureSupport supportsFiltering(Class<?> entityClass, FilterExpression expression) {
-        return getTransaction(entityClass).supportsFiltering(entityClass, expression);
+    public FeatureSupport supportsFiltering(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
+        Class<?> entityClass = projection.getType();
+        return getTransaction(entityClass).supportsFiltering(scope, parent, projection);
     }
 
     @Override
-    public boolean supportsSorting(Class<?> entityClass, Sorting sorting) {
-        return getTransaction(entityClass).supportsSorting(entityClass, sorting);
+    public boolean supportsSorting(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
+        Class<?> entityClass = projection.getType();
+        return getTransaction(entityClass).supportsSorting(scope, parent, projection);
     }
 
     @Override
-    public boolean supportsPagination(Class<?> entityClass, FilterExpression expression) {
-        return getTransaction(entityClass).supportsPagination(entityClass, expression);
+    public boolean supportsPagination(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
+        Class<?> entityClass = projection.getType();
+        return getTransaction(entityClass).supportsPagination(scope, parent, projection);
     }
 
     private Serializable extractId(FilterExpression filterExpression,

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
@@ -74,10 +74,10 @@ public abstract class MultiplexTransaction implements DataStoreTransaction {
     }
 
     @Override
-    public void preCommit() {
+    public void preCommit(RequestScope scope) {
         transactions.values().stream()
                 .filter(dataStoreTransaction -> dataStoreTransaction != null)
-                .forEach(DataStoreTransaction::preCommit);
+                .forEach(tx -> tx.preCommit(scope));
     }
 
     @Override

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexTransactionTest.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexTransactionTest.java
@@ -6,9 +6,11 @@
 package com.yahoo.elide.datastores.multiplex;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import org.junit.jupiter.api.Test;
@@ -24,6 +26,7 @@ public class MultiplexTransactionTest {
         DataStore store2 =  mock(DataStore.class);
         DataStoreTransaction tx1 = mock(DataStoreTransaction.class);
         DataStoreTransaction tx2 = mock(DataStoreTransaction.class);
+        RequestScope scope = mock(RequestScope.class);
 
         when(store1.beginReadTransaction()).thenReturn(tx1);
         when(store2.beginReadTransaction()).thenReturn(tx2);
@@ -32,12 +35,12 @@ public class MultiplexTransactionTest {
 
         DataStoreTransaction multiplexTx = store.beginReadTransaction();
 
-        multiplexTx.preCommit();
+        multiplexTx.preCommit(scope);
 
         // Since transactions are lazy initialized,
         // preCommit will not be called on individual transactions.
-        verify(tx1, Mockito.times(0)).preCommit();
-        verify(tx2, Mockito.times(0)).preCommit();
+        verify(tx1, Mockito.times(0)).preCommit(any());
+        verify(tx2, Mockito.times(0)).preCommit(any());
 
         MultiplexReadTransaction multiplexReadTx = (MultiplexReadTransaction) multiplexTx;
 

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableRedisStore.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/bridgeable/BridgeableRedisStore.java
@@ -228,7 +228,7 @@ public class BridgeableRedisStore implements DataStore {
         }
 
         @Override
-        public void preCommit() {
+        public void preCommit(RequestScope scope) {
 
         }
 

--- a/elide-datastore/elide-datastore-search/src/main/java/com/yahoo/elide/datastores/search/SearchDataTransaction.java
+++ b/elide-datastore/elide-datastore-search/src/main/java/com/yahoo/elide/datastores/search/SearchDataTransaction.java
@@ -167,13 +167,15 @@ public class SearchDataTransaction extends TransactionWrapper {
     }
 
     @Override
-    public FeatureSupport supportsFiltering(Class<?> entityClass, FilterExpression expression) {
+    public FeatureSupport supportsFiltering(RequestScope scope, Optional<Object> parent, EntityProjection projection) {
+        Class<?> entityClass = projection.getType();
+        FilterExpression expression = projection.getFilterExpression();
 
         /* Return the least support among all the predicates */
         FeatureSupport support = canSearch(entityClass, expression);
 
         if (support == NONE) {
-            return super.supportsFiltering(entityClass, expression);
+            return super.supportsFiltering(scope, parent, projection);
         }
 
         return support;

--- a/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DataStoreSupportsFilteringTest.java
+++ b/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DataStoreSupportsFilteringTest.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.datastores.search;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -22,6 +23,7 @@ import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
+import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.utils.coerce.CoerceUtil;
 import com.yahoo.elide.core.utils.coerce.converters.ISO8601DateSerde;
 import com.yahoo.elide.datastores.search.models.Item;
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Optional;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
@@ -89,7 +92,13 @@ public class DataStoreSupportsFilteringTest {
         FilterExpression filter = filterParser.parseFilterExpression("name==*rum*",
                 Item.class, false);
 
-        assertEquals(DataStoreTransaction.FeatureSupport.FULL, testTransaction.supportsFiltering(Item.class, filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(DataStoreTransaction.FeatureSupport.FULL,
+                testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
     }
 
     @Test
@@ -99,7 +108,13 @@ public class DataStoreSupportsFilteringTest {
         FilterExpression filter = filterParser.parseFilterExpression("description==*rum*",
                 Item.class, false);
 
-        assertEquals(DataStoreTransaction.FeatureSupport.FULL, testTransaction.supportsFiltering(Item.class, filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(DataStoreTransaction.FeatureSupport.FULL,
+                testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
     }
 
     @Test
@@ -109,8 +124,14 @@ public class DataStoreSupportsFilteringTest {
         FilterExpression filter = filterParser.parseFilterExpression("price==123",
                 Item.class, false);
 
-        assertEquals(null, testTransaction.supportsFiltering(Item.class, filter));
-        verify(wrappedTransaction, times(1)).supportsFiltering(eq(Item.class), eq(filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(null, testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
+        verify(wrappedTransaction, times(1))
+                .supportsFiltering(eq(mockScope), any(), eq(projection));
     }
 
     @Test
@@ -119,7 +140,13 @@ public class DataStoreSupportsFilteringTest {
         FilterPredicate filter = (FilterPredicate) filterParser.parseFilterExpression("description==*ru*",
                 Item.class, false);
 
-        assertThrows(InvalidValueException.class, () -> testTransaction.supportsFiltering(Item.class, filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertThrows(InvalidValueException.class,
+                () -> testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
     }
 
     @Test
@@ -128,7 +155,13 @@ public class DataStoreSupportsFilteringTest {
         FilterPredicate filter = (FilterPredicate) filterParser.parseFilterExpression("description==*abcdefghijk*",
                 Item.class, false);
 
-        assertThrows(InvalidValueException.class, () -> testTransaction.supportsFiltering(Item.class, filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertThrows(InvalidValueException.class,
+                () -> testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
     }
 
     @Test
@@ -137,8 +170,15 @@ public class DataStoreSupportsFilteringTest {
         FilterPredicate filter = (FilterPredicate) filterParser.parseFilterExpression("description==abcdefghijk",
                 Item.class, false);
 
-        assertEquals(null, testTransaction.supportsFiltering(Item.class, filter));
-        verify(wrappedTransaction, times(1)).supportsFiltering(eq(Item.class), eq(filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(null, testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
+
+        verify(wrappedTransaction, times(1))
+                .supportsFiltering(eq(mockScope), any(), eq(projection));
     }
 
     @Test
@@ -147,7 +187,13 @@ public class DataStoreSupportsFilteringTest {
         FilterPredicate filter = (FilterPredicate) filterParser.parseFilterExpression("description==*ruabc*",
                 Item.class, false);
 
-        assertEquals(DataStoreTransaction.FeatureSupport.FULL, testTransaction.supportsFiltering(Item.class, filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(DataStoreTransaction.FeatureSupport.FULL,
+                testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
     }
 
     @Test
@@ -156,7 +202,13 @@ public class DataStoreSupportsFilteringTest {
         FilterPredicate filter = (FilterPredicate) filterParser.parseFilterExpression("name==*rum*",
                 Item.class, false);
 
-        assertEquals(DataStoreTransaction.FeatureSupport.FULL, testTransaction.supportsFiltering(Item.class, filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(DataStoreTransaction.FeatureSupport.FULL,
+                testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
     }
 
     @Test
@@ -165,7 +217,13 @@ public class DataStoreSupportsFilteringTest {
         FilterPredicate filter = (FilterPredicate) filterParser.parseFilterExpression("name==drum*",
                 Item.class, false);
 
-        assertEquals(DataStoreTransaction.FeatureSupport.PARTIAL, testTransaction.supportsFiltering(Item.class, filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(DataStoreTransaction.FeatureSupport.PARTIAL,
+                testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
     }
 
     @Test
@@ -174,7 +232,13 @@ public class DataStoreSupportsFilteringTest {
         FilterPredicate filter = (FilterPredicate) filterParser.parseFilterExpression("name==drum",
                 Item.class, false);
 
-        assertEquals(null, testTransaction.supportsFiltering(Item.class, filter));
-        verify(wrappedTransaction, times(1)).supportsFiltering(eq(Item.class), eq(filter));
+        EntityProjection projection = EntityProjection.builder()
+                .type(Item.class)
+                .filterExpression(filter)
+                .build();
+
+        assertEquals(null, testTransaction.supportsFiltering(mockScope, Optional.empty(), projection));
+        verify(wrappedTransaction, times(1))
+                .supportsFiltering(eq(mockScope), any(), eq(projection));
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -254,7 +254,7 @@ public class QueryRunner {
 
             ExecutionResult result = api.execute(executionInput);
 
-            tx.preCommit();
+            tx.preCommit(requestScope);
             requestScope.runQueuedPreSecurityTriggers();
             requestScope.getPermissionExecutor().executeCommitChecks();
             if (isMutation(query)) {

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -140,7 +140,8 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals("Inheriting from table 'B' creates an illegal cyclic dependency.\n", error);
+        assertTrue(error.contains("Inheriting from table"));
+        assertTrue(error.contains("creates an illegal cyclic dependency."));
     }
 
     @Test

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -8,12 +8,12 @@
         <cve>CVE-2019-14540</cve>
     </suppress>
     <!-- Invalid web socket CVE (flagging wrong package) -->
-    <suppress until="2020-12-01Z">
+    <suppress until="2021-12-01Z">
         <cve>CVE-2020-11050</cve>
     </suppress>
 
     <!-- Invalid Spring Security CVE -->
-    <suppress until="2020-12-01Z">
+    <suppress until="2021-12-01Z">
         <cve>CVE-2018-1258</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
Adds additional context parameters to DataStoreTransaction interfaces:
 - precommit takes a RequestScope
 - supportsFiltering, supportsSorting, and supportsPagination all take a request scope, an optional parent entity, and the entity projection.

The latter changes are required to implement an N+1 optimization.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
