### PR TITLE
Instantiate DynamicConfigSchemaValidator once instead of multiple times.

### DIFF
--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DynamicConfigHelpers.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DynamicConfigHelpers.java
@@ -53,13 +53,13 @@ public class DynamicConfigHelpers {
     /**
      * converts variables hjson string to map of variables.
      * @param config
+     * @param schemaValidator JSON schema validator.
      * @return Map of Variables
      * @throws IOException
      */
     @SuppressWarnings("unchecked")
-    public static Map<String, Object> stringToVariablesPojo(String fileName, String config)
-            throws IOException {
-        DynamicConfigSchemaValidator schemaValidator = new DynamicConfigSchemaValidator();
+    public static Map<String, Object> stringToVariablesPojo(String fileName, String config,
+                    DynamicConfigSchemaValidator schemaValidator) throws IOException {
         Map<String, Object> variables = new HashMap<>();
         String jsonConfig = hjsonToJson(config);
         try {
@@ -77,12 +77,12 @@ public class DynamicConfigHelpers {
      * Generates ElideTableConfig Pojo from input String.
      * @param content : input string
      * @param variables : variables to resolve.
+     * @param schemaValidator JSON schema validator.
      * @return ElideTableConfig Pojo
      * @throws IOException
      */
     public static ElideTableConfig stringToElideTablePojo(String fileName, String content,
-                                                          Map<String, Object> variables) throws IOException {
-        DynamicConfigSchemaValidator schemaValidator = new DynamicConfigSchemaValidator();
+                    Map<String, Object> variables, DynamicConfigSchemaValidator schemaValidator) throws IOException {
         ElideTableConfig table = new ElideTableConfig();
         String jsonConfig = hjsonToJson(resolveVariables(content, variables));
         try {
@@ -100,12 +100,12 @@ public class DynamicConfigHelpers {
      * Generates ElideDBConfig Pojo from input String.
      * @param content : input string
      * @param variables : variables to resolve.
+     * @param schemaValidator JSON schema validator.
      * @return ElideDBConfig Pojo
      * @throws IOException
      */
     public static ElideDBConfig stringToElideDBConfigPojo(String fileName, String content,
-                                                          Map<String, Object> variables) throws IOException {
-        DynamicConfigSchemaValidator schemaValidator = new DynamicConfigSchemaValidator();
+                    Map<String, Object> variables, DynamicConfigSchemaValidator schemaValidator) throws IOException {
         ElideDBConfig dbconfig = new ElideDBConfig();
         String jsonConfig = hjsonToJson(resolveVariables(content, variables));
         try {
@@ -123,12 +123,12 @@ public class DynamicConfigHelpers {
      * Generates ElideSecurityConfig Pojo from input String.
      * @param content : input string
      * @param variables : variables to resolve.
+     * @param schemaValidator JSON schema validator.
      * @return ElideSecurityConfig Pojo
      * @throws IOException
      */
     public static ElideSecurityConfig stringToElideSecurityPojo(String fileName, String content,
-                                                                Map<String, Object> variables) throws IOException {
-        DynamicConfigSchemaValidator schemaValidator = new DynamicConfigSchemaValidator();
+                    Map<String, Object> variables, DynamicConfigSchemaValidator schemaValidator) throws IOException {
         String jsonConfig = hjsonToJson(resolveVariables(content, variables));
         try {
             if (schemaValidator.verifySchema(Config.SECURITY, jsonConfig, fileName)) {

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
@@ -13,6 +13,7 @@ import static com.yahoo.elide.modelconfig.parser.handlebars.HandlebarsHelper.REF
 import static java.nio.charset.StandardCharsets.UTF_8;
 import com.yahoo.elide.modelconfig.Config;
 import com.yahoo.elide.modelconfig.DynamicConfigHelpers;
+import com.yahoo.elide.modelconfig.DynamicConfigSchemaValidator;
 import com.yahoo.elide.modelconfig.model.DBConfig;
 import com.yahoo.elide.modelconfig.model.Dimension;
 import com.yahoo.elide.modelconfig.model.ElideDBConfig;
@@ -72,6 +73,7 @@ public class DynamicConfigValidator {
     private Map<String, Object> dbVariables;
     private final ElideDBConfig elideSQLDBConfig = new ElideSQLDBConfig();
     private final String configDir;
+    private final DynamicConfigSchemaValidator schemaValidator = new DynamicConfigSchemaValidator();
     private final Map<String, Resource> resourceMap = new HashMap<>();
     private final PathMatchingResourcePatternResolver resolver;
 
@@ -251,8 +253,8 @@ public class DynamicConfigValidator {
                         .map(entry -> {
                             try {
                                 String content = IOUtils.toString(entry.getValue().getInputStream(), UTF_8);
-                                return DynamicConfigHelpers.stringToVariablesPojo
-                                                (entry.getValue().getFilename(), content);
+                                return DynamicConfigHelpers.stringToVariablesPojo(entry.getValue().getFilename(),
+                                                content, schemaValidator);
                             } catch (IOException e) {
                                 throw new IllegalStateException(e);
                             }
@@ -274,8 +276,8 @@ public class DynamicConfigValidator {
                             try {
                                 String content = IOUtils.toString(entry.getValue().getInputStream(), UTF_8);
                                 validateConfigForMissingVariables(content, this.modelVariables);
-                                return DynamicConfigHelpers.stringToElideSecurityPojo
-                                                (entry.getValue().getFilename(), content, this.modelVariables);
+                                return DynamicConfigHelpers.stringToElideSecurityPojo(entry.getValue().getFilename(),
+                                                content, this.modelVariables, schemaValidator);
                             } catch (IOException e) {
                                 throw new IllegalStateException(e);
                             }
@@ -298,8 +300,8 @@ public class DynamicConfigValidator {
                             try {
                                 String content = IOUtils.toString(entry.getValue().getInputStream(), UTF_8);
                                 validateConfigForMissingVariables(content, this.dbVariables);
-                                return DynamicConfigHelpers.stringToElideDBConfigPojo
-                                                (entry.getValue().getFilename(), content, this.dbVariables);
+                                return DynamicConfigHelpers.stringToElideDBConfigPojo(entry.getValue().getFilename(),
+                                                content, this.dbVariables, schemaValidator);
                             } catch (IOException e) {
                                 throw new IllegalStateException(e);
                             }
@@ -321,8 +323,8 @@ public class DynamicConfigValidator {
                             try {
                                 String content = IOUtils.toString(entry.getValue().getInputStream(), UTF_8);
                                 validateConfigForMissingVariables(content, this.modelVariables);
-                                return DynamicConfigHelpers.stringToElideTablePojo
-                                                (entry.getValue().getFilename(), content, this.modelVariables);
+                                return DynamicConfigHelpers.stringToElideTablePojo(entry.getValue().getFilename(),
+                                                content, this.modelVariables, schemaValidator);
                             } catch (IOException e) {
                                 throw new IllegalStateException(e);
                             }


### PR DESCRIPTION
Instantiate DynamicConfigSchemaValidator once instead of multiple times.


## How Has This Been Tested?
Existing tests pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
