### PR TITLE
Elide boot timing fix by allowing Spring Boot Apps to specify Packages to look for Models

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Set;
 
 public class ClassScannerTest {
@@ -24,7 +25,7 @@ public class ClassScannerTest {
 
     @Test
     public void testGetAnnotatedClasses() {
-        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses("example", ReadPermission.class);
+        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(ReadPermission.class, "example");
         assertEquals(6, classes.size(), "Actual: " + classes);
         classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(ReadPermission.class)));
     }
@@ -38,7 +39,7 @@ public class ClassScannerTest {
 
     @Test
     public void testGetAnyAnnotatedClasses() {
-        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(ReadPermission.class, UpdatePermission.class);
+        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(Arrays.asList(ReadPermission.class, UpdatePermission.class));
         assertEquals(17, classes.size());
         for (Class<?> cls : classes) {
             assertTrue(cls.isAnnotationPresent(ReadPermission.class)

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/compile/ElideDynamicEntityCompiler.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/compile/ElideDynamicEntityCompiler.java
@@ -72,6 +72,7 @@ public class ElideDynamicEntityCompiler {
 
     private static Map<ModelMapKey, ModelMapValue> createMapping() {
         Map<ModelMapKey, ModelMapValue> map = new HashMap<>();
+        // TODO: Add Package Filter here, after PR#1693
         Set<Class<?>> includeClasses = ClassScanner.getAnnotatedClasses(Arrays.asList(Include.class));
         EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
         includeClasses.forEach(dictionary::bindEntity);

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -145,14 +145,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
-            <version>${spring.boot.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${spring.boot.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -214,6 +212,13 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -14,6 +14,10 @@ import lombok.Data;
 @Data
 @ConfigurationProperties(prefix = "elide")
 public class ElideConfigProperties {
+    /**
+     * Optional Package name for models to scan for.
+     */
+    private String modelPackage;
 
     /**
      * Settings for the JSON-API controller.

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
-        <spring.boot.version>2.3.5.RELEASE</spring.boot.version>
+        <spring.boot.version>2.4.0</spring.boot.version>
         <groovy.version>3.0.6</groovy.version>
     </properties>
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/Util.java
@@ -131,11 +131,16 @@ public class Util {
     public static List<String> combineModelEntities(Optional<ElideDynamicEntityCompiler> optionalCompiler,
             String modelPackageName, boolean includeAsyncModel) {
 
-        List<String> modelEntities = getAllEntities(modelPackageName);
+        List<String> packageNamesList = new ArrayList<String>();
+        packageNamesList.add(modelPackageName);
 
         if (includeAsyncModel) {
-            modelEntities.addAll(getAllEntities(AsyncQuery.class.getPackage().getName()));
+            packageNamesList.add(AsyncQuery.class.getPackage().getName());
         }
+
+        List<String> modelEntities = new ArrayList<String>();
+
+        modelEntities.addAll(getAllEntities(modelEntities.toArray(new String[0])));
 
         if (optionalCompiler.isPresent()) {
             try {
@@ -153,8 +158,8 @@ public class Util {
      * @param packageName Package name
      * @return All entities found in package.
      */
-    public static List<String> getAllEntities(String packageName) {
-        return ClassScanner.getAnnotatedClasses(packageName, Entity.class).stream()
+    public static List<String> getAllEntities(String... packageName) {
+        return ClassScanner.getAnnotatedClasses(Entity.class, packageName).stream()
                 .map(Class::getName)
                 .collect(Collectors.toList());
     }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -427,7 +427,7 @@ public interface ElideStandaloneSettings {
 
         if (optionalCompiler.isPresent()) {
             try {
-                metaDataStore = new MetaDataStore(optionalCompiler.get(), enableMetaDataStore);
+                metaDataStore = new MetaDataStore(optionalCompiler.get(), enableMetaDataStore, getModelPackageName());
             } catch (ClassNotFoundException e) {
                 throw new IllegalStateException(e);
             }


### PR DESCRIPTION
## Description
Spring Boot Applications use ClassScanner to find the models in the whole project including lib and jars. This change allows users to specify packagename to look for models. That will improve the boot time for application. 

## How Has This Been Tested?
Existing test case pass. Tested through the example app.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
