### PR TITLE
LOB for ResponseBody

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.async.models;
 import lombok.Data;
 
 import javax.persistence.Embeddable;
+import javax.persistence.Lob;
 
 /**
  * Model for Async Query Result.
@@ -17,5 +18,6 @@ import javax.persistence.Embeddable;
 public class AsyncQueryResult extends AsyncAPIResult {
     private Integer contentLength;
 
+    @Lob
     private String responseBody;  //URL or Response body
 }


### PR DESCRIPTION

## Description
Use LOB for responseBody so that its not limited by varchar size.

## How Has This Been Tested?
Existing Test case and example App passed.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
