### PR TITLE
Boost swagger boot time

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -304,6 +304,7 @@ public class ElideAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "elide.swagger.enabled", havingValue = "true")
     public Swagger buildSwagger(EntityDictionary dictionary, ElideConfigProperties settings) {
         Info info = new Info()
                 .title(settings.getSwagger().getName())

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/model/Data.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/model/Data.java
@@ -23,7 +23,7 @@ public class Data extends ModelImpl {
 
     /**
      * Used to construct a collection of resource identifiers.
-     * @param relationship is added as a property of 'data'
+     * @param relationship is added as a property of 'data'.
      */
     public Data(Relationship relationship) {
         super();

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/model/Datum.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/model/Datum.java
@@ -24,7 +24,7 @@ public class Datum extends ModelImpl {
     /**
      * Constructs a singular resource identifier.
      *
-     * @param relationship added as a property of 'data'
+     * @param relationship added as a property of 'data'.
      */
     public Datum(Relationship relationship) {
         super();

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/property/Data.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/property/Data.java
@@ -24,7 +24,7 @@ public class Data extends ObjectProperty {
     }
 
     /**
-     * Used to construct a collection of resources (referenced by the resource type)
+     * Used to construct a collection of resources (referenced by the resource type).
      * @param definitionName The swagger model to reference in 'data'
      * @param included Whether or not to add the 'included' property to the schema.
      */

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/property/Datum.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/property/Datum.java
@@ -25,7 +25,7 @@ public class Datum extends ObjectProperty {
     }
 
     /**
-     * Constructs a singular resource (referenced by type)
+     * Constructs a singular resource (referenced by type).
      * @param definitionName The swagger model to reference in 'data'.
      * @param included Whether or not to add the 'included' property to the schema.
      */

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/property/Relationship.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/property/Relationship.java
@@ -14,8 +14,8 @@ import io.swagger.models.properties.StringProperty;
 public class Relationship extends ObjectProperty {
 
     /**
-     * Constructs a singular resource identifier
-     * @param relationshipType the type of resource
+     * Constructs a singular resource identifier.
+     * @param relationshipType the type of resource.
      */
     public Relationship(String relationshipType) {
         super();

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/SwaggerBuilderTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/SwaggerBuilderTest.java
@@ -85,9 +85,6 @@ public class SwaggerBuilderTest {
         assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors"));
         assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}"));
         assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/relationships/exclusiveAuthors"));
-        assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}/books"));
-        assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}/books/{bookId}"));
-        assertTrue(swagger.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}/relationships/books"));
 
         assertTrue(swagger.getPaths().containsKey("/book"));
         assertTrue(swagger.getPaths().containsKey("/book/{bookId}"));
@@ -95,15 +92,12 @@ public class SwaggerBuilderTest {
         assertTrue(swagger.getPaths().containsKey("/book/{bookId}/authors"));
         assertTrue(swagger.getPaths().containsKey("/book/{bookId}/authors/{authorId}"));
         assertTrue(swagger.getPaths().containsKey("/book/{bookId}/relationships/authors"));
-        assertTrue(swagger.getPaths().containsKey("/book/{bookId}/authors/{authorId}/publisher"));
-        assertTrue(swagger.getPaths().containsKey("/book/{bookId}/authors/{authorId}/publisher/{publisherId}"));
-        assertTrue(swagger.getPaths().containsKey("/book/{bookId}/authors/{authorId}/relationships/publisher"));
 
         assertTrue(swagger.getPaths().containsKey("/book/{bookId}/publisher"));
         assertTrue(swagger.getPaths().containsKey("/book/{bookId}/publisher/{publisherId}"));
         assertTrue(swagger.getPaths().containsKey("/book/{bookId}/relationships/publisher"));
 
-        assertEquals(22, swagger.getPaths().size());
+        assertEquals(16, swagger.getPaths().size());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>29.0-jre</version>
+                <version>30.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -22,6 +22,13 @@ jobs:
     steps:
       - build: mvn -B clean verify coveralls:report
 
+  elide-4-build:
+    requires: [~pr:elide-4.x, ~commit:elide-4.x]
+    secrets:
+        - COVERALLS_REPO_TOKEN
+    steps:
+      - build: mvn -B clean verify coveralls:report
+
   release:
     secrets:
         - BINTRAY_USER


### PR DESCRIPTION
## Description
1. Swagger document is only constructed if the controller is enabled in Spring.
2. Fixed a number of bottlenecks during construction.

## Motivation and Context
For large APIs (many models), the boot time was impacted by swagger document construction.

## How Has This Been Tested?
Existing unit tests plus manual profiling.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
