### PR TITLE
Adding simple setting to enable JSON-API links

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.Injector;
 import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.contrib.swagger.SwaggerBuilder;
 import com.yahoo.elide.core.DataStore;
+import com.yahoo.elide.core.DefaultJSONApiLinks;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.datastores.jpa.JpaDataStore;
@@ -61,6 +62,19 @@ public class ElideAutoConfiguration {
                 .withBaseUrl(settings.getBaseUrl())
                 .withEncodeErrorResponses(true)
                 .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
+
+        if (settings.getJsonApi() != null
+                && settings.getJsonApi().isEnabled()
+                && settings.getJsonApi().isEnableLinks()) {
+            String baseUrl = settings.getBaseUrl();
+
+            if (baseUrl == null || baseUrl.isEmpty()) {
+                builder.withJSONApiLinks(new DefaultJSONApiLinks());
+            } else {
+                String jsonApiBaseUrl = baseUrl + settings.getJsonApi().getPath() + "/";
+                builder.withJSONApiLinks(new DefaultJSONApiLinks(jsonApiBaseUrl));
+            }
+        }
 
         return new Elide(builder.build());
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -19,7 +19,7 @@ public class ElideConfigProperties {
     /**
      * Settings for the JSON-API controller.
      */
-    private ControllerProperties jsonApi;
+    private JsonApiControllerProperties jsonApi;
 
     /**
      * Settings for the GraphQL controller.

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/JsonApiControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/JsonApiControllerProperties.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import lombok.Data;
+
+/**
+ * Extra controller properties for the JSON-API endpoint.
+ */
+@Data
+public class JsonApiControllerProperties extends ControllerProperties {
+
+    /**
+     * Turns on/off JSON-API links in the API.
+     */
+    boolean enableLinks = false;
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/ControllerTest.java
@@ -35,6 +35,7 @@ import com.yahoo.elide.core.HttpStatus;
 import com.yahoo.elide.spring.controllers.JsonApiController;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
@@ -49,6 +50,11 @@ import javax.ws.rs.core.MediaType;
                 + "\t\t('com.example.repository','Example Repository','The code for this project', false);")
 @Sql(executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD,
         statements = "DELETE FROM ArtifactVersion; DELETE FROM ArtifactProduct; DELETE FROM ArtifactGroup;")
+@TestPropertySource(
+        properties = {
+                "elide.json-api.enableLinks=true"
+        }
+)
 public class ControllerTest extends IntegrationTest {
     private String hostname = "localhost";
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/IntegrationTestSetup.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/tests/IntegrationTestSetup.java
@@ -5,45 +5,9 @@
  */
 package com.yahoo.elide.spring.tests;
 
-import com.yahoo.elide.Elide;
-import com.yahoo.elide.ElideSettingsBuilder;
-import com.yahoo.elide.audit.Slf4jLogger;
-import com.yahoo.elide.core.DataStore;
-import com.yahoo.elide.core.DefaultJSONApiLinks;
-import com.yahoo.elide.core.EntityDictionary;
-import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
-import com.yahoo.elide.spring.config.ElideConfigProperties;
-
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
-
-import java.util.TimeZone;
 
 @TestConfiguration
 public class IntegrationTestSetup {
-
-    @Bean
-    @Primary
-    public Elide initializeElide(EntityDictionary dictionary,
-                                 DataStore dataStore, ElideConfigProperties settings) {
-
-        String baseUrl = "https://elide.io";
-        String jsonApiBaseUrl = baseUrl + settings.getJsonApi().getPath() + "/";
-
-        ElideSettingsBuilder builder = new ElideSettingsBuilder(dataStore)
-                .withEntityDictionary(dictionary)
-                .withDefaultMaxPageSize(settings.getMaxPageSize())
-                .withDefaultPageSize(settings.getPageSize())
-                .withJSONApiLinks(new DefaultJSONApiLinks(jsonApiBaseUrl))
-                .withUseFilterExpressions(true)
-                .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
-                .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
-                .withAuditLogger(new Slf4jLogger())
-                .withEncodeErrorResponses(true)
-                .withBaseUrl(baseUrl)
-                .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
-
-        return new Elide(builder.build());
-    }
+    //Initialize beans here if needed.
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -2,6 +2,7 @@ server:
   port: 4001
 
 elide:
+  baseUrl: 'https://elide.io'
   json-api:
     path: /json
     enabled: true


### PR DESCRIPTION
Makes turning on JSON-API links push button simple.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
