### PR TITLE
add join expression for all column projection including metrics

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/VideoGame.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/VideoGame.java
@@ -38,7 +38,13 @@ public class VideoGame {
     private Float timeSpentPerGame;
 
     @Setter
+    private Float normalizedHighScore;
+
+    @Setter
     private Player player;
+
+    @Setter
+    private PlayerStats playerStats;
 
     @Setter
     private Player playerInnerJoin;
@@ -81,9 +87,20 @@ public class VideoGame {
         return timeSpentPerGame;
     }
 
+
+    @MetricFormula("{{playerStats.highScore}} / {{timeSpent}}")
+    public Float getNormalizedHighScore() {
+        return normalizedHighScore;
+    }
+
     @Join(value = "{{player_id}} = {{player.id}}", type = JoinType.LEFT)
     public Player getPlayer() {
         return player;
+    }
+
+    @Join(value = "{{player_id}} = {{playerStats.id}}", type = JoinType.LEFT)
+    public PlayerStats getPlayerStats() {
+        return playerStats;
     }
 
     @Join(value = "{{player_id}} = {{playerInnerJoin.id}}", type = JoinType.INNER)

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -346,6 +346,12 @@ public abstract class SQLUnitTest {
                     .source(videoGameTable)
                     .dimensionProjection(videoGameTable.getDimensionProjection("playerNameCrossJoin"))
                     .build();
+        }),
+        METRIC_JOIN(() -> {
+            return Query.builder()
+                    .source(videoGameTable)
+                    .metricProjection(videoGameTable.getMetricProjection("normalizedHighScore"))
+                    .build();
         });
 
         private Provider<Query> queryProvider;

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/DruidExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/DruidExplainQueryTest.java
@@ -478,6 +478,20 @@ public class DruidExplainQueryTest  extends SQLUnitTest {
     }
 
     @Test
+    public void testJoinWithMetrics() throws Exception {
+        Query query = TestQuery.METRIC_JOIN.getQuery();
+
+        String expectedQueryStr = "SELECT "
+                + "MAX(\"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\".\"highScore\") / SUM(\"com_yahoo_elide_datastores_aggregation_example_VideoGame\".\"timeSpent\") AS \"normalizedHighScore\" "
+                + "FROM \"videoGames\" AS \"com_yahoo_elide_datastores_aggregation_example_VideoGame\" "
+                + "LEFT OUTER JOIN \"playerStats\" AS \"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\" "
+                + "ON \"com_yahoo_elide_datastores_aggregation_example_VideoGame\".\"player_id\" = \"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\".\"id\"";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+        testQueryExecution(query);
+    }
+
+    @Test
     public void testPaginationMetricsOnly() throws Exception {
         // pagination query should be empty since there is no dimension projection
         Query query = TestQuery.PAGINATION_METRIC_ONLY.getQuery();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/H2ExplainQueryTest.java
@@ -489,6 +489,20 @@ public class H2ExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
+    public void testJoinWithMetrics() throws Exception {
+        Query query = TestQuery.METRIC_JOIN.getQuery();
+
+        String expectedQueryStr = "SELECT "
+                + "MAX(`com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats`.`highScore`) / SUM(`com_yahoo_elide_datastores_aggregation_example_VideoGame`.`timeSpent`) AS `normalizedHighScore` "
+                + "FROM `videoGames` AS `com_yahoo_elide_datastores_aggregation_example_VideoGame` "
+                + "LEFT OUTER JOIN `playerStats` AS `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats` "
+                + "ON `com_yahoo_elide_datastores_aggregation_example_VideoGame`.`player_id` = `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats`.`id`";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+        testQueryExecution(query);
+    }
+
+    @Test
     public void testPaginationMetricsOnly() throws Exception {
         // pagination query should be empty since there is no dimension projection
         Query query = TestQuery.PAGINATION_METRIC_ONLY.getQuery();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/HiveExplainQueryTest.java
@@ -469,6 +469,20 @@ public class HiveExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
+    public void testJoinWithMetrics() throws Exception {
+        Query query = TestQuery.METRIC_JOIN.getQuery();
+
+        String expectedQueryStr = "SELECT "
+                + "MAX(`com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats`.`highScore`) / SUM(`com_yahoo_elide_datastores_aggregation_example_VideoGame`.`timeSpent`) AS `normalizedHighScore` "
+                + "FROM `videoGames` AS `com_yahoo_elide_datastores_aggregation_example_VideoGame` "
+                + "LEFT OUTER JOIN `playerStats` AS `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats` "
+                + "ON `com_yahoo_elide_datastores_aggregation_example_VideoGame`.`player_id` = `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats`.`id`";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+        testQueryExecution(query);
+    }
+
+    @Test
     public void testPaginationMetricsOnly() throws Exception {
         // pagination query should be empty since there is no dimension projection
         Query query = TestQuery.PAGINATION_METRIC_ONLY.getQuery();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/MySQLExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/MySQLExplainQueryTest.java
@@ -477,6 +477,20 @@ public class MySQLExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
+    public void testJoinWithMetrics() throws Exception {
+        Query query = TestQuery.METRIC_JOIN.getQuery();
+
+        String expectedQueryStr = "SELECT "
+                + "MAX(`com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats`.`highScore`) / SUM(`com_yahoo_elide_datastores_aggregation_example_VideoGame`.`timeSpent`) AS `normalizedHighScore` "
+                + "FROM `videoGames` AS `com_yahoo_elide_datastores_aggregation_example_VideoGame` "
+                + "LEFT OUTER JOIN `playerStats` AS `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats` "
+                + "ON `com_yahoo_elide_datastores_aggregation_example_VideoGame`.`player_id` = `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats`.`id`";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+        testQueryExecution(query);
+    }
+
+    @Test
     public void testPaginationMetricsOnly() throws Exception {
         // pagination query should be empty since there is no dimension projection
         Query query = TestQuery.PAGINATION_METRIC_ONLY.getQuery();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PostgresExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PostgresExplainQueryTest.java
@@ -482,6 +482,20 @@ public class PostgresExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
+    public void testJoinWithMetrics() throws Exception {
+        Query query = TestQuery.METRIC_JOIN.getQuery();
+
+        String expectedQueryStr = "SELECT "
+                + "MAX(\"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\".\"highScore\") / SUM(\"com_yahoo_elide_datastores_aggregation_example_VideoGame\".\"timeSpent\") AS \"normalizedHighScore\" "
+                + "FROM \"videoGames\" AS \"com_yahoo_elide_datastores_aggregation_example_VideoGame\" "
+                + "LEFT OUTER JOIN \"playerStats\" AS \"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\" "
+                + "ON \"com_yahoo_elide_datastores_aggregation_example_VideoGame\".\"player_id\" = \"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\".\"id\"";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+        testQueryExecution(query);
+    }
+
+    @Test
     public void testPaginationMetricsOnly() throws Exception {
         // pagination query should be empty since there is no dimension projection
         Query query = TestQuery.PAGINATION_METRIC_ONLY.getQuery();

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoDBExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/PrestoDBExplainQueryTest.java
@@ -446,6 +446,20 @@ public class PrestoDBExplainQueryTest extends SQLUnitTest {
     }
 
     @Test
+    public void testJoinWithMetrics() throws Exception {
+        Query query = TestQuery.METRIC_JOIN.getQuery();
+
+        String expectedQueryStr = "SELECT "
+                + "MAX(\"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\".\"highScore\") / SUM(\"com_yahoo_elide_datastores_aggregation_example_VideoGame\".\"timeSpent\") AS \"normalizedHighScore\" "
+                + "FROM \"videoGames\" AS \"com_yahoo_elide_datastores_aggregation_example_VideoGame\" "
+                + "LEFT OUTER JOIN \"playerStats\" AS \"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\" "
+                + "ON \"com_yahoo_elide_datastores_aggregation_example_VideoGame\".\"player_id\" = \"com_yahoo_elide_datastores_aggregation_example_VideoGame_playerStats\".\"id\"";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+        testQueryExecution(query);
+    }
+
+    @Test
     public void testPaginationMetricsOnly() throws Exception {
         // pagination query should be empty since there is no dimension projection
         Query query = TestQuery.PAGINATION_METRIC_ONLY.getQuery();

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_tables.sql
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_tables.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS playerStats
     (
+      id VARCHAR(255),
       highScore BIGINT,
       lowScore BIGINT,
       overallRating VARCHAR(255),
@@ -11,9 +12,9 @@ CREATE TABLE IF NOT EXISTS playerStats
       updatedDate DATETIME
     );
 TRUNCATE TABLE playerStats;
-INSERT INTO playerStats VALUES (1234, 35, 'Good', '840', '840', 1, 2, '2019-07-12 00:00:00', '2019-10-12 00:00:00');
-INSERT INTO playerStats VALUES (2412, 241, 'Great', '840', '840', 2, 3, '2019-07-11 00:00:00', '2020-07-12 00:00:00');
-INSERT INTO playerStats VALUES (1000, 72, 'Good', '344', '344', 3, 1, '2019-07-13 00:00:00', '2020-01-12 00:00:00');
+INSERT INTO playerStats VALUES (1, 1234, 35, 'Good', '840', '840', 1, 2, '2019-07-12 00:00:00', '2019-10-12 00:00:00');
+INSERT INTO playerStats VALUES (2, 2412, 241, 'Great', '840', '840', 2, 3, '2019-07-11 00:00:00', '2020-07-12 00:00:00');
+INSERT INTO playerStats VALUES (3, 1000, 72, 'Good', '344', '344', 3, 1, '2019-07-13 00:00:00', '2020-01-12 00:00:00');
 
 
 CREATE TABLE IF NOT EXISTS countries


### PR DESCRIPTION
Resolves #1778

## Description
The JOIN SQL expression needs to be added whenever there is a dimension projection, metric projection, or time dimension that refers to a joined parameter in the Aggregation Store. 

## Motivation and Context
The Aggregation Store currently only generates a JOIN SQL expression for columns that contain a join expression that are referenced in the client query dimensions, filter clauses, and sort clauses.

Metrics might also reference a column requiring a join leading to invalid SQL generation.

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
