### PR TITLE
TableExportHook Binding

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
@@ -54,4 +54,9 @@ public class AsyncProperties {
      * Whether or not the async feature is enabled.
      */
     private boolean enabled = false;
+
+    /**
+     * Settings for the export controller.
+     */
+    private ExportControllerProperties export;
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -148,6 +148,12 @@ public class ElideAutoConfiguration {
                 .withJsonApiPath(settings.getJsonApi().getPath())
                 .withGraphQLApiPath(settings.getGraphql().getPath());
 
+        if (settings.getAsync() != null
+                && settings.getAsync().getExport() != null
+                && settings.getAsync().getExport().isEnabled()) {
+            builder.withDownloadApiPath(settings.getAsync().getExport().getPath());
+        }
+
         if (settings.getJsonApi() != null
                 && settings.getJsonApi().isEnabled()
                 && settings.getJsonApi().isEnableLinks()) {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ExportControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ExportControllerProperties.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import lombok.Data;
+
+/**
+ * Extra controller properties for the export endpoint.
+ */
+@Data
+public class ExportControllerProperties extends ControllerProperties {
+
+    /**
+     * Skip including Header in CSV formatted export.
+     */
+    private boolean skipCSVHeader = false;
+
+    /**
+     * The URL path prefix for the controller.
+     */
+    private String path = "/export";
+}

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneAsyncSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneAsyncSettings.java
@@ -95,4 +95,31 @@ public interface ElideStandaloneAsyncSettings {
     default ResultStorageEngine getResultStorageEngine() {
         return null;
     }
+
+    /**
+     * API root path specification for the export endpoint
+     *
+     * @return Default: /export
+     */
+    default String getExportApiPathSpec() {
+        return "/export/*";
+    }
+
+    /**
+     * Enable the Export endpoint. If false, the endpoint and export support will be disabled.
+     *
+     * @return Default: False
+     */
+    default boolean enableExport() {
+        return false;
+    }
+
+    /**
+     * Skip generating Header when exporting in CSV format.
+     *
+     * @return Default: False
+     */
+    default boolean skipCSVHeader() {
+        return false;
+    }
 }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -100,8 +100,12 @@ public interface ElideStandaloneSettings {
                 .withGraphQLApiPath(getGraphQLApiPathSpec().replaceAll("/\\*", ""))
                 .withAuditLogger(getAuditLogger());
 
+        if (getAsyncProperties().enableExport()) {
+            builder.withDownloadApiPath(getAsyncProperties().getExportApiPathSpec().replaceAll("/\\*", ""));
+        }
+
         if (enableISO8601Dates()) {
-            builder = builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
+            builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
         }
 
         return builder.build();


### PR DESCRIPTION
## Description
Bind TableExportHook at startup. Other properties update for Table Export.

## How Has This Been Tested?
Existing Tests Pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
