### PR TITLE
Removing jetty from spring boot starter

### DIFF
--- a/elide-spring/elide-spring-boot-starter/README.md
+++ b/elide-spring/elide-spring-boot-starter/README.md
@@ -3,8 +3,7 @@
 For more information on Elide, visit [elide.io](https://elide.io).
 
 Opinionated jar which packages dependencies to get started with Elide and Spring Boot.  The starter includes:
-1. Spring Boot Web (minus tomcat)
-2. Spring Boot Jetty
+1. Spring Boot Web
 3. Spring Boot JPA
 4. YAML Configuration
 5. All of the Elide dependencies

--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -71,20 +71,6 @@
             <version>4.6.12-SNAPSHOT</version>
         </dependency>
 
-        <!-- Jetty -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-server-impl</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-spring-boot-autoconfigure</artifactId>
@@ -94,33 +80,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <!-- No Tomcat -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <!-- Let's use Jetty Instead -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jetty</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-servlets</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty.websocket</groupId>
-                    <artifactId>websocket-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.eclipse.jetty.websocket</groupId>
-                    <artifactId>javax-websocket-server-impl</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -138,6 +97,5 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
         </dependency>
-
     </dependencies>
 </project>


### PR DESCRIPTION
## Description
Removes Jetty from spring boot starter to allow other containers to be leveraged.

## Motivation and Context
Elide should not pin the container.

## How Has This Been Tested?
Verified the spring boot example project launches and all tests pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
