### PR TITLE
Upgrading ant on elide-4.x for CVE security fix.

### DIFF
--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -78,7 +78,7 @@
          <dependency>
              <groupId>org.apache.ant</groupId>
              <artifactId>ant</artifactId>
-             <version>1.10.8</version>
+             <version>1.10.9</version>
             <scope>test</scope>
          </dependency>
 


### PR DESCRIPTION

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
