### PR TITLE
Metadatastore Models Permission

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -185,10 +185,10 @@ public class PersistenceResourceTestSetup extends PersistentResource {
     /* ChangeSpec-specific test elements */
     @Entity
     @Include(rootLevel = false)
-    @CreatePermission(expression = "allow all")
-    @ReadPermission(expression = "allow all")
+    @CreatePermission(expression = "Prefab.Role.All")
+    @ReadPermission(expression = "Prefab.Role.All")
     @UpdatePermission(expression = "Prefab.Role.None")
-    @DeletePermission(expression = "allow all")
+    @DeletePermission(expression = "Prefab.Role.All")
     public static final class ChangeSpecModel {
         @Id
         public long id;
@@ -220,10 +220,10 @@ public class PersistenceResourceTestSetup extends PersistentResource {
     @Include(rootLevel = false)
     @EqualsAndHashCode
     @AllArgsConstructor
-    @CreatePermission(expression = "allow all")
-    @ReadPermission(expression = "allow all")
-    @UpdatePermission(expression = "allow all")
-    @DeletePermission(expression = "allow all")
+    @CreatePermission(expression = "Prefab.Role.All")
+    @ReadPermission(expression = "Prefab.Role.All")
+    @UpdatePermission(expression = "Prefab.Role.All")
+    @DeletePermission(expression = "Prefab.Role.All")
     public static final class ChangeSpecChild {
         @Id
         public long id;

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
@@ -262,7 +262,7 @@ public class PermissionExecutorTest {
             @Id
             public Long id;
 
-            @UpdatePermission(expression = "allow all AND FailOp")
+            @UpdatePermission(expression = "Prefab.Role.All AND FailOp")
             public String field = "some data";
         }
 
@@ -297,12 +297,12 @@ public class PermissionExecutorTest {
     public void testFailAllSpecificFieldAwareSuccessOperationFailCommit() {
         @Entity
         @Include(rootLevel = false)
-        @UpdatePermission(expression = "allow all")
+        @UpdatePermission(expression = "Prefab.Role.All")
         class Model {
             @Id
             public Long id;
 
-            @UpdatePermission(expression = "allow all AND FailOp")
+            @UpdatePermission(expression = "Prefab.Role.All AND FailOp")
             public String field = "some data";
         }
 
@@ -494,14 +494,14 @@ public class PermissionExecutorTest {
         @Id
         public Long id;
 
-        @ReadPermission(expression = "allow all AND sampleOperation")
-        @UpdatePermission(expression = "allow all AND sampleOperation")
+        @ReadPermission(expression = "Prefab.Role.All AND sampleOperation")
+        @UpdatePermission(expression = "Prefab.Role.All AND sampleOperation")
         public String allVisible = "You should see me!";
 
         public String defaultHidden = "I'm invisible. muwahaha...";
 
-        @ReadPermission(expression = "allow all AND Prefab.Role.None")
-        @UpdatePermission(expression = "allow all AND Prefab.Role.None")
+        @ReadPermission(expression = "Prefab.Role.All AND Prefab.Role.None")
+        @UpdatePermission(expression = "Prefab.Role.All AND Prefab.Role.None")
         public String cannotSeeMe = "hidden";
 
         @ReadPermission(expression = "sampleOperation")
@@ -509,8 +509,8 @@ public class PermissionExecutorTest {
         public String mayFailInCommit = "aw :(";
     }
 
-    @ReadPermission(expression = "allow all")
-    @UpdatePermission(expression = "allow all")
+    @ReadPermission(expression = "Prefab.Role.All")
+    @UpdatePermission(expression = "Prefab.Role.All")
     @Include(rootLevel = false)
     @Entity
     public static final class OpenBean {
@@ -519,8 +519,8 @@ public class PermissionExecutorTest {
 
         public String open;
 
-        @ReadPermission(expression = "allow all AND sampleOperation")
-        @UpdatePermission(expression = "allow all AND sampleOperation")
+        @ReadPermission(expression = "Prefab.Role.All AND sampleOperation")
+        @UpdatePermission(expression = "Prefab.Role.All AND sampleOperation")
         public String openAll = "all";
 
         @ReadPermission(expression = "Prefab.Role.None OR sampleOperation")

--- a/elide-core/src/test/java/example/FirstClassFields.java
+++ b/elide-core/src/test/java/example/FirstClassFields.java
@@ -32,10 +32,10 @@ public class FirstClassFields {
     public Left private2;
 
     // Public vars
-    @ReadPermission(expression = "allow all")
+    @ReadPermission(expression = "Prefab.Role.All")
     public String public1;
 
-    @ReadPermission(expression = "allow all")
+    @ReadPermission(expression = "Prefab.Role.All")
     @OneToOne
     public Left public2;
 }

--- a/elide-core/src/test/java/example/FunWithPermissions.java
+++ b/elide-core/src/test/java/example/FunWithPermissions.java
@@ -25,10 +25,10 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
-@CreatePermission(expression = "allow all")
-@ReadPermission(expression = "allow all")
-@UpdatePermission(expression = "Prefab.Role.None OR allow all")
-@DeletePermission(expression = "Prefab.Role.None AND allow all")
+@CreatePermission(expression = "Prefab.Role.All")
+@ReadPermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.None OR Prefab.Role.All")
+@DeletePermission(expression = "Prefab.Role.None AND Prefab.Role.All")
 @Include(type = "fun") // optional here because class has this name
 @Entity
 @Table(name = "fun")
@@ -147,7 +147,7 @@ public class FunWithPermissions {
         this.field1 = field1;
     }
 
-    @ReadPermission(expression = "allow all")
+    @ReadPermission(expression = "Prefab.Role.All")
     public String getField2() {
         return field2;
     }
@@ -174,7 +174,7 @@ public class FunWithPermissions {
 
     private String field5;
 
-    @ReadPermission(expression = "allow all OR negativeIntegerUser")
+    @ReadPermission(expression = "Prefab.Role.All OR negativeIntegerUser")
     public String getField5() {
         return field5;
     }
@@ -185,7 +185,7 @@ public class FunWithPermissions {
 
     private String field6;
 
-    @ReadPermission(expression = "negativeIntegerUser AND allow all")
+    @ReadPermission(expression = "negativeIntegerUser AND Prefab.Role.All")
     public String getField6() {
         return field6;
     }
@@ -197,7 +197,7 @@ public class FunWithPermissions {
     private String field7;
 
     /* Verifies a chain of checks where the last can fail. */
-    @ReadPermission(expression = "allow all AND Prefab.Role.None")
+    @ReadPermission(expression = "Prefab.Role.All AND Prefab.Role.None")
     public String getField7() {
         return field7;
     }

--- a/elide-core/src/test/java/example/Parent.java
+++ b/elide-core/src/test/java/example/Parent.java
@@ -26,10 +26,10 @@ import javax.persistence.ManyToMany;
 import javax.persistence.PrePersist;
 import javax.validation.constraints.NotNull;
 
-@CreatePermission(expression = "parentInitCheck OR allow all")
-@ReadPermission(expression = "parentInitCheck OR allow all")
-@UpdatePermission(expression = "parentInitCheck OR allow all OR Prefab.Role.None")
-@DeletePermission(expression = "parentInitCheck OR allow all OR Prefab.Role.None")
+@CreatePermission(expression = "parentInitCheck OR Prefab.Role.All")
+@ReadPermission(expression = "parentInitCheck OR Prefab.Role.All")
+@UpdatePermission(expression = "parentInitCheck OR Prefab.Role.All OR Prefab.Role.None")
+@DeletePermission(expression = "parentInitCheck OR Prefab.Role.All OR Prefab.Role.None")
 @Include(type = "parent") // optional here because class has this name
 @Entity
 @ToString
@@ -45,8 +45,8 @@ public class Parent extends BaseId {
         init = true;
     }
 
-    @ReadPermission(expression = "allow all OR Prefab.Role.None")
-    @UpdatePermission(expression = "allow all OR Prefab.Role.None")
+    @ReadPermission(expression = "Prefab.Role.All OR Prefab.Role.None")
+    @UpdatePermission(expression = "Prefab.Role.All OR Prefab.Role.None")
     // Hibernate
     @ManyToMany(
             targetEntity = Child.class,

--- a/elide-core/src/test/java/example/Post.java
+++ b/elide-core/src/test/java/example/Post.java
@@ -15,10 +15,10 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Entity;
 
-@CreatePermission(expression = "allow all")
-@ReadPermission(expression = "allow all")
-@UpdatePermission(expression = "allow all OR Prefab.Role.None")
-@DeletePermission(expression = "allow all OR Prefab.Role.None")
+@CreatePermission(expression = "Prefab.Role.All")
+@ReadPermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All OR Prefab.Role.None")
+@DeletePermission(expression = "Prefab.Role.All OR Prefab.Role.None")
 @Include(type = "post") // optional here because class has this name
 @Entity
 public class Post extends BaseId {

--- a/elide-core/src/test/java/example/Right.java
+++ b/elide-core/src/test/java/example/Right.java
@@ -38,7 +38,7 @@ public class Right {
             cascade = { CascadeType.PERSIST, CascadeType.MERGE },
             targetEntity = Left.class
     )
-    @UpdatePermission(expression = "allow all")
+    @UpdatePermission(expression = "Prefab.Role.All")
     public Left getOne2one() {
         return one2one;
     }
@@ -98,7 +98,7 @@ public class Right {
     @ManyToMany(
             cascade = { CascadeType.PERSIST, CascadeType.MERGE }
     )
-    @UpdatePermission(expression = "allow all")
+    @UpdatePermission(expression = "Prefab.Role.All")
     public Set<Left> getAllowDeleteAtFieldLevel() {
         return allowDeleteAtFieldLevel;
     }

--- a/elide-core/src/test/java/example/TestCheckMappings.java
+++ b/elide-core/src/test/java/example/TestCheckMappings.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 public class TestCheckMappings {
     public static final ImmutableMap<String, Class<? extends Check>> MAPPINGS =
             ImmutableMap.<String, Class<? extends Check>>builder()
-                    .put("allow all", Role.ALL.class)
+                    .put("Prefab.Role.All", Role.ALL.class)
                     .put("changeSpecCollection", PersistentResourceTest.ChangeSpecCollection.class)
                     .put("changeSpecNonCollection", PersistentResourceTest.ChangeSpecNonCollection.class)
                     .put("initCheck", Child.InitCheck.class)

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/package-info.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+/**
+ * Models Package.
+ */
+@ReadPermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.None")
+@DeletePermission(expression = "Prefab.Role.None")
+@CreatePermission(expression = "Prefab.Role.None")
+package com.yahoo.elide.datastores.aggregation.metadata.models;
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/HibernateUser.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/HibernateUser.java
@@ -26,10 +26,10 @@ import javax.persistence.Transient;
  */
 @Include
 @Entity
-@CreatePermission(expression = "allow all")
-@ReadPermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
-@DeletePermission(expression = "allow all")
+@CreatePermission(expression = "Prefab.Role.All")
+@ReadPermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
+@DeletePermission(expression = "Prefab.Role.All")
 public class HibernateUser {
     private Long id;
     private String firstName;

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/hbase/beans/RedisActions.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/hbase/beans/RedisActions.java
@@ -19,10 +19,10 @@ import javax.persistence.Id;
  */
 @Include(rootLevel = false)
 @Entity
-@CreatePermission(expression = "allow all")
-@ReadPermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
-@DeletePermission(expression = "allow all")
+@CreatePermission(expression = "Prefab.Role.All")
+@ReadPermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
+@DeletePermission(expression = "Prefab.Role.All")
 public class RedisActions {
     private String id;
     private String description;

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLTest.java
@@ -28,7 +28,7 @@ public abstract class GraphQLTest {
 
     public GraphQLTest() {
         Map<String, Class<? extends Check>> checks = new HashMap<>();
-        checks.put("allow all", com.yahoo.elide.core.security.checks.prefab.Role.ALL.class);
+        checks.put("Prefab.Role.All", com.yahoo.elide.core.security.checks.prefab.Role.ALL.class);
 
         dictionary = new EntityDictionary(checks);
 

--- a/elide-integration-tests/src/test/java/example/AuditEntity.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntity.java
@@ -22,10 +22,10 @@ import javax.persistence.OneToOne;
         logStatement = "Created with value: {0}",
         logExpressions = {"${auditEntity.value}"})
 @Include
-@ReadPermission(expression = "allow all")
-@CreatePermission(expression = "allow all")
-@DeletePermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
+@ReadPermission(expression = "Prefab.Role.All")
+@CreatePermission(expression = "Prefab.Role.All")
+@DeletePermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
 public class AuditEntity extends BaseId {
     private AuditEntity otherEntity;
     private String value;

--- a/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
+++ b/elide-integration-tests/src/test/java/example/AuditEntityInverse.java
@@ -18,10 +18,10 @@ import javax.persistence.ManyToMany;
 
 @Entity
 @Include
-@ReadPermission(expression = "allow all")
-@CreatePermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
-@DeletePermission(expression = "allow all")
+@ReadPermission(expression = "Prefab.Role.All")
+@CreatePermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
+@DeletePermission(expression = "Prefab.Role.All")
 public class AuditEntityInverse extends BaseId {
     private List<AuditEntity> entities;
 

--- a/elide-integration-tests/src/test/java/example/CreateButNoRead.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoRead.java
@@ -23,7 +23,7 @@ import javax.persistence.OneToMany;
  */
 @Include
 @Entity
-@CreatePermission(expression = "allow all")
+@CreatePermission(expression = "Prefab.Role.All")
 public class CreateButNoRead extends BaseId {
     private Set<CreateButNoReadChild> otherObjects;
 

--- a/elide-integration-tests/src/test/java/example/CreateButNoReadChild.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoReadChild.java
@@ -17,12 +17,12 @@ import javax.persistence.ManyToOne;
  */
 @Include
 @Entity
-@CreatePermission(expression = "allow all")
+@CreatePermission(expression = "Prefab.Role.All")
 public class CreateButNoReadChild extends BaseId {
     private CreateButNoRead otherObject;
 
     @ManyToOne()
-    @ReadPermission(expression = "allow all")
+    @ReadPermission(expression = "Prefab.Role.All")
     public CreateButNoRead getOtherObject() {
         return otherObject;
     }

--- a/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
+++ b/elide-integration-tests/src/test/java/example/CreateButNoUpdate.java
@@ -17,8 +17,8 @@ import javax.persistence.Entity;
  */
 @Include
 @Entity
-@CreatePermission(expression = "allow all")
-@ReadPermission(expression = "allow all")
+@CreatePermission(expression = "Prefab.Role.All")
+@ReadPermission(expression = "Prefab.Role.All")
 @UpdatePermission(expression = "Prefab.Role.None")
 public class CreateButNoUpdate extends BaseId {
     private String textValue;

--- a/elide-integration-tests/src/test/java/example/FunWithPermissions.java
+++ b/elide-integration-tests/src/test/java/example/FunWithPermissions.java
@@ -23,10 +23,10 @@ import javax.persistence.Table;
 /**
  * Permission checks test bean.
  */
-@CreatePermission(expression = "allow all")
-@ReadPermission(expression = "allow all")
-@UpdatePermission(expression = "Prefab.Role.None OR allow all")
-@DeletePermission(expression = "Prefab.Role.None AND allow all")
+@CreatePermission(expression = "Prefab.Role.All")
+@ReadPermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.None OR Prefab.Role.All")
+@DeletePermission(expression = "Prefab.Role.None AND Prefab.Role.All")
 @Include(type = "fun") // optional here because class has this name
 // Hibernate
 @Entity
@@ -92,7 +92,7 @@ public class FunWithPermissions extends BaseId {
         this.field1 = field1;
     }
 
-    @ReadPermission(expression = "allow all")
+    @ReadPermission(expression = "Prefab.Role.All")
     public String getField2() {
         return field2;
     }
@@ -117,7 +117,7 @@ public class FunWithPermissions extends BaseId {
 
     private String field5;
 
-    @ReadPermission(expression = "allow all OR negativeIntegerUser")
+    @ReadPermission(expression = "Prefab.Role.All OR negativeIntegerUser")
     public String getField5() {
         return field5;
     }
@@ -128,7 +128,7 @@ public class FunWithPermissions extends BaseId {
 
     private String field6;
 
-    @ReadPermission(expression = "negativeIntegerUser AND allow all")
+    @ReadPermission(expression = "negativeIntegerUser AND Prefab.Role.All")
     public String getField6() {
         return field6;
     }
@@ -140,7 +140,7 @@ public class FunWithPermissions extends BaseId {
     private String field7;
 
     /* Verifies a chain of checks where the last can fail. */
-    @ReadPermission(expression = "allow all AND Prefab.Role.None")
+    @ReadPermission(expression = "Prefab.Role.All AND Prefab.Role.None")
     public String getField7() {
         return field7;
     }

--- a/elide-integration-tests/src/test/java/example/NoCommitEntity.java
+++ b/elide-integration-tests/src/test/java/example/NoCommitEntity.java
@@ -21,8 +21,8 @@ import javax.persistence.Table;
 /**
  * No Update test bean.
  */
-@CreatePermission(expression = "allow all AND noCommit")
-@UpdatePermission(expression = "allow all AND noCommit")
+@CreatePermission(expression = "Prefab.Role.All AND noCommit")
+@UpdatePermission(expression = "Prefab.Role.All AND noCommit")
 @Include(type = "nocommit")
 // Hibernate
 @Entity

--- a/elide-integration-tests/src/test/java/example/NotIncludedResource.java
+++ b/elide-integration-tests/src/test/java/example/NotIncludedResource.java
@@ -11,9 +11,9 @@ import com.yahoo.elide.annotation.UpdatePermission;
 
 import javax.persistence.Entity;
 
-@ReadPermission(expression = "allow all")
-@CreatePermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
+@ReadPermission(expression = "Prefab.Role.All")
+@CreatePermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
 @Entity
 public class NotIncludedResource extends BaseId {
     private String someParams;

--- a/elide-integration-tests/src/test/java/example/OneToOneNonRoot.java
+++ b/elide-integration-tests/src/test/java/example/OneToOneNonRoot.java
@@ -16,9 +16,9 @@ import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 
 @Include(rootLevel = false)
-@ReadPermission(expression = "allow all")
-@CreatePermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
+@ReadPermission(expression = "Prefab.Role.All")
+@CreatePermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
 @Entity
 public class OneToOneNonRoot extends BaseId {
     private String test;

--- a/elide-integration-tests/src/test/java/example/OneToOneRoot.java
+++ b/elide-integration-tests/src/test/java/example/OneToOneRoot.java
@@ -15,9 +15,9 @@ import javax.persistence.FetchType;
 import javax.persistence.OneToOne;
 
 @Include
-@ReadPermission(expression = "allow all")
-@CreatePermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
+@ReadPermission(expression = "Prefab.Role.All")
+@CreatePermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
 @Entity
 public class OneToOneRoot extends BaseId {
     private String name;

--- a/elide-integration-tests/src/test/java/example/Parent.java
+++ b/elide-integration-tests/src/test/java/example/Parent.java
@@ -28,10 +28,10 @@ import javax.validation.constraints.NotNull;
 /**
  * Parent test bean.
  */
-@CreatePermission(expression = "parentInitCheck OR allow all")
-@ReadPermission(expression = "parentInitCheck OR allow all")
-@UpdatePermission(expression = "parentInitCheck OR allow all OR Prefab.Role.None")
-@DeletePermission(expression = "parentInitCheck OR allow all OR Prefab.Role.None")
+@CreatePermission(expression = "parentInitCheck OR Prefab.Role.All")
+@ReadPermission(expression = "parentInitCheck OR Prefab.Role.All")
+@UpdatePermission(expression = "parentInitCheck OR Prefab.Role.All OR Prefab.Role.None")
+@DeletePermission(expression = "parentInitCheck OR Prefab.Role.All OR Prefab.Role.None")
 @Include(type = "parent") // optional here because class has this name
 @Paginate(maxLimit = 100000)
 // Hibernate
@@ -48,8 +48,8 @@ public class Parent extends BaseId {
         init = true;
     }
 
-    @ReadPermission(expression = "allow all OR Prefab.Role.None")
-    @UpdatePermission(expression = "allow all OR Prefab.Role.None")
+    @ReadPermission(expression = "Prefab.Role.All OR Prefab.Role.None")
+    @UpdatePermission(expression = "Prefab.Role.All OR Prefab.Role.None")
     // Hibernate
     @ManyToMany(
             targetEntity = Child.class

--- a/elide-integration-tests/src/test/java/example/Post.java
+++ b/elide-integration-tests/src/test/java/example/Post.java
@@ -16,10 +16,10 @@ import javax.persistence.Entity;
 /**
  * Post test bean.
  */
-@CreatePermission(expression = "allow all")
-@ReadPermission(expression = "allow all")
-@UpdatePermission(expression = "allow all OR Prefab.Role.None")
-@DeletePermission(expression = "allow all OR Prefab.Role.None")
+@CreatePermission(expression = "Prefab.Role.All")
+@ReadPermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All OR Prefab.Role.None")
+@DeletePermission(expression = "Prefab.Role.All OR Prefab.Role.None")
 @Include(type = "post") // optional here because class has this name
 // Hibernate
 @Entity

--- a/elide-integration-tests/src/test/java/example/ResourceWithInvalidRelationship.java
+++ b/elide-integration-tests/src/test/java/example/ResourceWithInvalidRelationship.java
@@ -14,9 +14,9 @@ import javax.persistence.Entity;
 import javax.persistence.OneToOne;
 
 @Include
-@ReadPermission(expression = "allow all")
-@CreatePermission(expression = "allow all")
-@UpdatePermission(expression = "allow all")
+@ReadPermission(expression = "Prefab.Role.All")
+@CreatePermission(expression = "Prefab.Role.All")
+@UpdatePermission(expression = "Prefab.Role.All")
 @Entity
 public class ResourceWithInvalidRelationship extends BaseId {
     private String name;

--- a/elide-integration-tests/src/test/java/example/SpecialRead.java
+++ b/elide-integration-tests/src/test/java/example/SpecialRead.java
@@ -22,7 +22,7 @@ import javax.persistence.ManyToOne;
 @Include(type = "specialread")
 @ReadPermission(expression = "specialValue")
 @UpdatePermission(expression = "Prefab.Role.None")
-@CreatePermission(expression = "allow all")
+@CreatePermission(expression = "Prefab.Role.All")
 public class SpecialRead extends BaseId {
     private String value;
     private Child child;

--- a/elide-integration-tests/src/test/java/example/TestCheckMappings.java
+++ b/elide-integration-tests/src/test/java/example/TestCheckMappings.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 public class TestCheckMappings {
     public static final HashMap<String, Class<? extends Check>> MAPPINGS =
             new HashMap<>(ImmutableMap.<String, Class<? extends Check>>builder()
-                    .put("allow all", Role.ALL.class)
+                    .put("Prefab.Role.All", Role.ALL.class)
                     .put("Prefab.Role.None", Role.NONE.class)
                     .put("adminRoleCheck", User.AdminRoleCheck.class)
                     .put("initCheck", Child.InitCheck.class)

--- a/elide-integration-tests/src/test/java/example/YetAnotherPermission.java
+++ b/elide-integration-tests/src/test/java/example/YetAnotherPermission.java
@@ -11,7 +11,7 @@ import com.yahoo.elide.annotation.ReadPermission;
 
 import javax.persistence.Entity;
 
-@CreatePermission(expression = "allow all")
+@CreatePermission(expression = "Prefab.Role.All")
 @ReadPermission(expression = "Prefab.Role.None")
 @Include
 @Entity
@@ -27,7 +27,7 @@ public class YetAnotherPermission extends BaseId {
         this.hiddenName = hiddenName;
     }
 
-    @ReadPermission(expression = "allow all")
+    @ReadPermission(expression = "Prefab.Role.All")
     public String getYouShouldBeAbleToRead() {
         return youShouldBeAbleToRead;
     }


### PR DESCRIPTION
## Description
Add permissions on Metadatastore models to make them read-only.

## Motivation and Context
Add permissions on Metadatastore models to make them read-only.

## How Has This Been Tested?
Existing tests pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
