### PR TITLE
Revising JPQPredicateGenerator contract to allow for more complex JPQ…

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -433,7 +433,6 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
                             }
                     })
                     .collect(Collectors.toList());
-
             if (op.equals(RSQLOperators.EQUAL) || op.equals(RSQLOperators.IN)) {
                 return equalityExpression(arguments.get(0), path, values, true);
             } else if (op.equals(INI)) {

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/CaseAwareJPQLGenerator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/CaseAwareJPQLGenerator.java
@@ -12,6 +12,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -74,6 +75,7 @@ public class CaseAwareJPQLGenerator implements JPQLPredicateGenerator {
     @Override
     public String generate(FilterPredicate predicate, Function<Path, String> aliasGenerator) {
        String columnAlias = aliasGenerator.apply(predicate.getPath());
+       List<FilterPredicate.FilterParameter> parameters = predicate.getParameters();
 
         if (Strings.isNullOrEmpty(columnAlias)) {
             log.error("columnAlias cannot be NULL or empty");
@@ -81,17 +83,17 @@ public class CaseAwareJPQLGenerator implements JPQLPredicateGenerator {
         }
 
         if (argumentCount == ArgumentCount.MANY) {
-            Preconditions.checkState(!predicate.getParameters().isEmpty());
+            Preconditions.checkState(!parameters.isEmpty());
         } else if (argumentCount == ArgumentCount.ONE) {
-            Preconditions.checkArgument(predicate.getParameters().size() == 1);
+            Preconditions.checkArgument(parameters.size() == 1);
 
-            if (Strings.isNullOrEmpty(predicate.getParameters().get(0).getPlaceholder())) {
+            if (Strings.isNullOrEmpty(parameters.get(0).getPlaceholder())) {
                 log.error("One non-null, non-empty argument was expected.");
                 throw new IllegalStateException(FILTER_ALIAS_NOT_NULL);
             }
         }
 
-        return String.format(jpqlTemplate, upperOrLower.wrap(columnAlias), predicate.getParameters().stream()
+        return String.format(jpqlTemplate, upperOrLower.wrap(columnAlias), parameters.stream()
                 .map(upperOrLower::wrap)
                 .collect(Collectors.joining(COMMA)));
     }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/CaseAwareJPQLGenerator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/CaseAwareJPQLGenerator.java
@@ -5,13 +5,14 @@
  */
 package com.yahoo.elide.core.filter;
 
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -71,7 +72,8 @@ public class CaseAwareJPQLGenerator implements JPQLPredicateGenerator {
     }
 
     @Override
-    public String generate(String columnAlias, List<FilterPredicate.FilterParameter> params) {
+    public String generate(FilterPredicate predicate, Function<Path, String> aliasGenerator) {
+       String columnAlias = aliasGenerator.apply(predicate.getPath());
 
         if (Strings.isNullOrEmpty(columnAlias)) {
             log.error("columnAlias cannot be NULL or empty");
@@ -79,17 +81,17 @@ public class CaseAwareJPQLGenerator implements JPQLPredicateGenerator {
         }
 
         if (argumentCount == ArgumentCount.MANY) {
-            Preconditions.checkState(!params.isEmpty());
+            Preconditions.checkState(!predicate.getParameters().isEmpty());
         } else if (argumentCount == ArgumentCount.ONE) {
-            Preconditions.checkArgument(params.size() == 1);
+            Preconditions.checkArgument(predicate.getParameters().size() == 1);
 
-            if (Strings.isNullOrEmpty(params.get(0).getPlaceholder())) {
+            if (Strings.isNullOrEmpty(predicate.getParameters().get(0).getPlaceholder())) {
                 log.error("One non-null, non-empty argument was expected.");
                 throw new IllegalStateException(FILTER_ALIAS_NOT_NULL);
             }
         }
 
-        return String.format(jpqlTemplate, upperOrLower.wrap(columnAlias), params.stream()
+        return String.format(jpqlTemplate, upperOrLower.wrap(columnAlias), predicate.getParameters().stream()
                 .map(upperOrLower::wrap)
                 .collect(Collectors.joining(COMMA)));
     }

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
@@ -57,10 +57,13 @@ public class FilterTranslator implements FilterOperation<String> {
     private static Map<Operator, JPQLPredicateGenerator> operatorGenerators;
     private static Map<Triple<Operator, Type<?>, String>, JPQLPredicateGenerator> predicateOverrides;
 
-    public static final Function<FilterPredicate, String> GENERATE_HQL_COLUMN_NO_ALIAS = FilterPredicate::getFieldPath;
+    public static final Function<Path, String> GENERATE_HQL_COLUMN_NO_ALIAS = (path) -> path.getPathElements().stream()
+            .map(Path.PathElement::getFieldName)
+            .collect(Collectors.joining("."));
 
-    public static final Function<FilterPredicate, String> GENERATE_HQL_COLUMN_WITH_ALIAS =
-            (predicate) -> getFieldAlias(getPathAlias(predicate.getPath()), predicate.getField());
+    public static final Function<Path, String> GENERATE_HQL_COLUMN_WITH_ALIAS =
+            (path) -> getFieldAlias(getPathAlias(path),
+                    path.lastElement().map(Path.PathElement::getFieldName).orElse(null));
 
     static {
         predicateOverrides = new HashMap<>();
@@ -127,71 +130,75 @@ public class FilterTranslator implements FilterOperation<String> {
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        operatorGenerators.put(LT, (columnAlias, params) -> {
-            Preconditions.checkState(!params.isEmpty());
-            return String.format("%s < %s", columnAlias, params.size() == 1
-                    ? params.get(0).getPlaceholder()
-                    : leastClause(params));
+        operatorGenerators.put(LT, (predicate, aliasGenerator) -> {
+            Preconditions.checkState(!predicate.getParameters().isEmpty());
+            return String.format("%s < %s", aliasGenerator.apply(predicate.getPath()),
+                    predicate.getParameters().size() == 1
+                    ? predicate.getParameters().get(0).getPlaceholder()
+                    : leastClause(predicate.getParameters()));
         });
 
-        operatorGenerators.put(LE, (columnAlias, params) -> {
-            Preconditions.checkState(!params.isEmpty());
-            return String.format("%s <= %s", columnAlias, params.size() == 1
-                    ? params.get(0).getPlaceholder()
-                    : leastClause(params));
+        operatorGenerators.put(LE, (predicate, aliasGenerator) -> {
+            Preconditions.checkState(!predicate.getParameters().isEmpty());
+            return String.format("%s <= %s", aliasGenerator.apply(predicate.getPath()),
+                    predicate.getParameters().size() == 1
+                    ? predicate.getParameters().get(0).getPlaceholder()
+                    : leastClause(predicate.getParameters()));
         });
 
-        operatorGenerators.put(GT, (columnAlias, params) -> {
-            Preconditions.checkState(!params.isEmpty());
-            return String.format("%s > %s", columnAlias, params.size() == 1
-                    ? params.get(0).getPlaceholder()
-                    : greatestClause(params));
+        operatorGenerators.put(GT, (predicate, aliasGenerator) -> {
+            Preconditions.checkState(!predicate.getParameters().isEmpty());
+            return String.format("%s > %s", aliasGenerator.apply(predicate.getPath()),
+                    predicate.getParameters().size() == 1
+                    ? predicate.getParameters().get(0).getPlaceholder()
+                    : greatestClause(predicate.getParameters()));
 
         });
 
-        operatorGenerators.put(GE, (columnAlias, params) -> {
-            Preconditions.checkState(!params.isEmpty());
-            return String.format("%s >= %s", columnAlias, params.size() == 1
-                    ? params.get(0).getPlaceholder()
-                    : greatestClause(params));
+        operatorGenerators.put(GE, (predicate, aliasGenerator) -> {
+            Preconditions.checkState(!predicate.getParameters().isEmpty());
+            return String.format("%s >= %s", aliasGenerator.apply(predicate.getPath()),
+                    predicate.getParameters().size() == 1
+                    ? predicate.getParameters().get(0).getPlaceholder()
+                    : greatestClause(predicate.getParameters()));
         });
 
-        operatorGenerators.put(ISNULL, (columnAlias, params) -> {
-            return String.format("%s IS NULL", columnAlias);
+        operatorGenerators.put(ISNULL, (predicate, aliasGenerator) -> {
+            return String.format("%s IS NULL", aliasGenerator.apply(predicate.getPath()));
         });
 
-        operatorGenerators.put(NOTNULL, (columnAlias, params) -> {
-            return String.format("%s IS NOT NULL", columnAlias);
+        operatorGenerators.put(NOTNULL, (predicate, aliasGenerator) -> {
+            return String.format("%s IS NOT NULL", aliasGenerator.apply(predicate.getPath()));
         });
 
-        operatorGenerators.put(TRUE, (columnAlias, params) -> {
+        operatorGenerators.put(TRUE, (predicate, aliasGenerator) -> {
             return "(1 = 1)";
         });
 
-        operatorGenerators.put(FALSE, (columnAlias, params) -> {
+        operatorGenerators.put(FALSE, (predicate, aliasGenerator) -> {
             return "(1 = 0)";
         });
 
-        operatorGenerators.put(ISEMPTY, (columnAlias, params) -> {
-            return String.format("%s IS EMPTY", columnAlias);
+        operatorGenerators.put(ISEMPTY, (predicate, aliasGenerator) -> {
+            return String.format("%s IS EMPTY", aliasGenerator.apply(predicate.getPath()));
         });
 
-        operatorGenerators.put(NOTEMPTY, (columnAlias, params) -> {
-            return String.format("%s IS NOT EMPTY", columnAlias);
+        operatorGenerators.put(NOTEMPTY, (predicate, aliasGenerator) -> {
+            return String.format("%s IS NOT EMPTY", aliasGenerator.apply(predicate.getPath()));
         });
 
-        operatorGenerators.put(HASMEMBER, (columnAlias, params) -> {
-            Preconditions.checkArgument(params.size() == 1);
+        operatorGenerators.put(HASMEMBER, (predicate, aliasGenerator) -> {
+            Preconditions.checkArgument(predicate.getParameters().size() == 1);
             return String.format("%s MEMBER OF %s",
-                    params.get(0).getPlaceholder(),
-                    columnAlias);
+                    predicate.getParameters().get(0).getPlaceholder(),
+                    aliasGenerator.apply(predicate.getPath()));
         });
 
-        operatorGenerators.put(HASNOMEMBER, (columnAlias, params) -> {
-            Preconditions.checkArgument(params.size() == 1);
+        operatorGenerators.put(HASNOMEMBER, (predicate, aliasGenerator) -> {
+            Preconditions.checkArgument(predicate.getParameters().size() == 1);
             return String.format("%s NOT MEMBER OF %s",
-                    params.get(0).getPlaceholder(),
-                    columnAlias);
+                    predicate.getParameters().get(0).getPlaceholder(),
+                    aliasGenerator.apply(predicate.getPath()));
         });
 
     }
@@ -255,18 +262,19 @@ public class FilterTranslator implements FilterOperation<String> {
     /**
      * Transforms a filter predicate into a JPQL query fragment.
      * @param filterPredicate The predicate to transform.
-     * @param columnGenerator Function which supplies a HQL fragment which represents the column in the predicate.
+     * @param aliasGenerator Function which supplies a HQL fragment which represents the column in the predicate.
      * @return The hql query fragment.
      */
-    protected String apply(FilterPredicate filterPredicate, Function<FilterPredicate, String> columnGenerator) {
-        String fieldPath = columnGenerator.apply(filterPredicate);
+    protected String apply(FilterPredicate filterPredicate, Function<Path, String> aliasGenerator) {
+
+        Function<Path, String> removeThisFromAlias = (path) -> {
+            String fieldPath = aliasGenerator.apply(path);
+
+            //JPQL doesn't support 'this', but it does support aliases.
+            return fieldPath.replaceAll("\\.this", "");
+        };
 
         Path.PathElement last = filterPredicate.getPath().lastElement().get();
-
-        //JPQL doesn't support 'this', but it does support aliases.
-        fieldPath = fieldPath.replaceAll("\\.this", "");
-
-        List<FilterParameter> params = filterPredicate.getParameters();
 
         Operator op = filterPredicate.getOperator();
         JPQLPredicateGenerator generator = lookupJPQLGenerator(op, last.getType(), last.getFieldName());
@@ -279,7 +287,7 @@ public class FilterTranslator implements FilterOperation<String> {
             throw new BadRequestException("Operator not implemented: " + filterPredicate.getOperator());
         }
 
-        return generator.generate(fieldPath, params);
+        return generator.generate(filterPredicate, aliasGenerator);
     }
 
     private static String greatestClause(List<FilterParameter> params) {
@@ -302,22 +310,22 @@ public class FilterTranslator implements FilterOperation<String> {
      * @return A JPQL filter fragment.
      */
     public String apply(FilterExpression filterExpression, boolean prefixWithAlias) {
-        Function<FilterPredicate, String> columnGenerator = GENERATE_HQL_COLUMN_NO_ALIAS;
+        Function<Path, String> aliasGenerator = GENERATE_HQL_COLUMN_NO_ALIAS;
         if (prefixWithAlias) {
-            columnGenerator = GENERATE_HQL_COLUMN_WITH_ALIAS;
+            aliasGenerator = GENERATE_HQL_COLUMN_WITH_ALIAS;
         }
 
-        return apply(filterExpression, columnGenerator);
+        return apply(filterExpression, aliasGenerator);
     }
 
     /**
      * Translates the filterExpression to a JPQL filter fragment.
      * @param filterExpression The filterExpression to translate
-     * @param columnGenerator Generates a HQL fragment that represents a column in the predicate
+     * @param aliasGenerator Generates a HQL fragment that represents a column in the predicate
      * @return A JPQL filter fragment.
      */
-    public String apply(FilterExpression filterExpression, Function<FilterPredicate, String> columnGenerator) {
-        JPQLQueryVisitor visitor = new JPQLQueryVisitor(columnGenerator);
+    public String apply(FilterExpression filterExpression, Function<Path, String> aliasGenerator) {
+        JPQLQueryVisitor visitor = new JPQLQueryVisitor(aliasGenerator);
         return filterExpression.accept(visitor);
     }
 
@@ -325,15 +333,15 @@ public class FilterTranslator implements FilterOperation<String> {
      * Filter expression visitor which builds an JPQL query.
      */
     public class JPQLQueryVisitor implements FilterExpressionVisitor<String> {
-        private Function<FilterPredicate, String> columnGenerator;
+        private Function<Path, String> aliasGenerator;
 
-        public JPQLQueryVisitor(Function<FilterPredicate, String> columnGenerator) {
-            this.columnGenerator = columnGenerator;
+        public JPQLQueryVisitor(Function<Path, String> aliasGenerator) {
+            this.aliasGenerator = aliasGenerator;
         }
 
         @Override
         public String visitPredicate(FilterPredicate filterPredicate) {
-            return apply(filterPredicate, columnGenerator);
+            return apply(filterPredicate, aliasGenerator);
         }
 
         @Override

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/JPQLPredicateGenerator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/JPQLPredicateGenerator.java
@@ -6,14 +6,15 @@
 
 package com.yahoo.elide.core.filter;
 
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
 
-import java.util.List;
+import java.util.function.Function;
 
 /**
  * Converts a JPQL column alias and list of arguments into a JPQL filter predicate fragment.
  */
 @FunctionalInterface
 public interface JPQLPredicateGenerator {
-    String generate(String columnAlias, List<FilterPredicate.FilterParameter> parameters);
+    String generate(FilterPredicate predicate, Function<Path, String> aliasGenerator);
 }

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -131,7 +132,7 @@ public class FilterTranslatorTest {
 
         JPQLPredicateGenerator generator = new JPQLPredicateGenerator() {
             @Override
-            public String generate(String columnAlias, List<FilterPredicate.FilterParameter> parameters) {
+            public String generate(FilterPredicate predicate, Function<Path, String> aliasGenerator) {
                 return "FOO";
             }
         };
@@ -154,7 +155,7 @@ public class FilterTranslatorTest {
 
         JPQLPredicateGenerator generator = new JPQLPredicateGenerator() {
             @Override
-            public String generate(String columnAlias, List<FilterPredicate.FilterParameter> parameters) {
+            public String generate(FilterPredicate predicate, Function<Path, String> aliasGenerator) {
                 return "FOO";
             }
         };

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.annotations.JPQLFilterFragment;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.filter.FilterTranslator;
@@ -21,7 +22,7 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
-import java.util.List;
+import java.util.function.Function;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.Id;
@@ -31,7 +32,7 @@ import javax.persistence.metamodel.Metamodel;
 public class JpaDataStoreTest {
     public static class TestGenerator implements JPQLPredicateGenerator {
         @Override
-        public String generate(String columnAlias, List<FilterPredicate.FilterParameter> parameters) {
+        public String generate(FilterPredicate predicate, Function<Path, String> parameters) {
             return "FOO()";
         }
     }


### PR DESCRIPTION
JPQPredicateGenerator is revised to include the entire predicate along with an alias generator to correctly generate aliases for the target JPQL/SQL generation.

This will allow more complex HASMEMBER operator JPQL generation for #1822.
 
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
