### PR TITLE
Add 'hasmember' operator support across to-many relationships.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -397,10 +397,8 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
                     if (FilterPredicate.isLastPathElementAssignableFrom(dictionary, path, COLLECTION_TYPE)) {
                         throw new RSQLParseException("Invalid Path: Last Path Element cannot be a collection type");
                     }
-                } else {
-                    if (!FilterPredicate.isLastPathElementAssignableFrom(dictionary, path, COLLECTION_TYPE)) {
-                        throw new RSQLParseException("Invalid Path: Last Path Element has to be a collection type");
-                    }
+                } else if (!FilterPredicate.isLastPathElementAssignableFrom(dictionary, path, COLLECTION_TYPE)) {
+                    throw new RSQLParseException("Invalid Path: Last Path Element has to be a collection type");
                 }
             }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -394,11 +394,13 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
 
             if (op.equals(HASMEMBER_OP) || op.equals(HASNOMEMBER_OP)) {
                 if (FilterPredicate.toManyInPath(dictionary, path)) {
-                    throw new RSQLParseException(
-                            "Invalid toMany join: member of operator cannot be used for toMany relationships");
-                }
-                if (!FilterPredicate.isLastPathElementAssignableFrom(dictionary, path, COLLECTION_TYPE)) {
-                    throw new RSQLParseException("Invalid Path: Last Path Element has to be a collection type");
+                    if (FilterPredicate.isLastPathElementAssignableFrom(dictionary, path, COLLECTION_TYPE)) {
+                        throw new RSQLParseException("Invalid Path: Last Path Element cannot be a collection type");
+                    }
+                } else {
+                    if (!FilterPredicate.isLastPathElementAssignableFrom(dictionary, path, COLLECTION_TYPE)) {
+                        throw new RSQLParseException("Invalid Path: Last Path Element has to be a collection type");
+                    }
                 }
             }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/DefaultFilterDialect.java
@@ -239,10 +239,12 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
 
     private void memberOfOperatorConditions(FilterPredicate filterPredicate) throws ParseException {
         if (FilterPredicate.toManyInPath(dictionary, filterPredicate.getPath())) {
-            throw new ParseException("Invalid toMany join: member of operator cannot be used for toMany relationships");
-        }
-
-        if (!FilterPredicate.isLastPathElementAssignableFrom(dictionary, filterPredicate.getPath(), COLLECTION_TYPE)) {
+            if (FilterPredicate.isLastPathElementAssignableFrom(dictionary,
+                    filterPredicate.getPath(), COLLECTION_TYPE)) {
+                throw new ParseException("Invalid Path: Last Path Element cannot be a collection type");
+            }
+        } else if (!FilterPredicate.isLastPathElementAssignableFrom(dictionary, filterPredicate.getPath(),
+                COLLECTION_TYPE)) {
             throw new ParseException("Invalid Path: Last Path Element has to be a collection type");
         }
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
- * Tests filter query parameter parsing for the default Elide implementation (1.0 and 2.0)
+ * Tests filter query parameter parsing for the default Elide implementation (1.0 and 2.0).
  */
 public class DefaultFilterDialectTest {
 
@@ -204,5 +204,4 @@ public class DefaultFilterDialectTest {
 
         assertEquals("Invalid Path: Last Path Element cannot be a collection type", e.getMessage());
     }
-
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -482,7 +482,7 @@ public class RSQLFilterDialectTest {
     }
 
     @Test
-    public void testMemberOfOperatorException() throws Exception {
+    public void testMemberOfOperatorOnNonCollectionAttributeException() throws Exception {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 
         queryParams.clear();
@@ -491,7 +491,25 @@ public class RSQLFilterDialectTest {
                 "title=hasmember=title11"
         );
 
-        assertThrows(ParseException.class,
+        ParseException e = assertThrows(ParseException.class,
                 () -> dialect.parseGlobalExpression("/book", queryParams, NO_VERSION));
+
+        assertEquals("Invalid Path: Last Path Element has to be a collection type", e.getMessage());
+    }
+
+    @Test
+    public void testMemberOfOperatorOnRelationshipException() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.clear();
+        queryParams.add(
+                "filter",
+                "authors=hasmember=1"
+        );
+
+        ParseException e = assertThrows(ParseException.class,
+                () -> dialect.parseGlobalExpression("/book", queryParams, NO_VERSION));
+
+        assertEquals("Invalid Path: Last Path Element cannot be a collection type", e.getMessage());
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -469,16 +469,21 @@ public class RSQLFilterDialectTest {
     }
 
     @Test
-    public void testMemberOfOperatorException() throws Exception {
+    public void testMemberOfToManyRelationship() throws Exception {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 
         queryParams.add(
                 "filter",
-                "authors.name=hasmember=0"
+                "authors.name=hasmember='0'"
         );
 
-        assertThrows(ParseException.class,
-                () -> dialect.parseTypedExpression("/book", queryParams, NO_VERSION));
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
+        assertEquals("book.authors.name HASMEMBER [0]", expression.toString());
+    }
+
+    @Test
+    public void testMemberOfOperatorException() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 
         queryParams.clear();
         queryParams.add(
@@ -487,6 +492,6 @@ public class RSQLFilterDialectTest {
         );
 
         assertThrows(ParseException.class,
-                () -> dialect.parseTypedExpression("/book", queryParams, NO_VERSION));
+                () -> dialect.parseGlobalExpression("/book", queryParams, NO_VERSION));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
@@ -42,11 +42,13 @@ public class QueryTranslator implements QueryVisitor<SQLQuery.SQLQueryBuilder> {
     private final SQLReferenceTable referenceTable;
     private final EntityDictionary dictionary;
     private final SQLDialect dialect;
+    private FilterTranslator filterTranslator;
 
     public QueryTranslator(SQLReferenceTable referenceTable, SQLDialect sqlDialect) {
         this.referenceTable = referenceTable;
         this.dictionary = referenceTable.getDictionary();
         this.dialect = sqlDialect;
+        this.filterTranslator = new FilterTranslator(dictionary);
     }
 
     @Override
@@ -281,9 +283,7 @@ public class QueryTranslator implements QueryVisitor<SQLQuery.SQLQueryBuilder> {
      */
     private String translateFilterExpression(FilterExpression expression,
                                              Function<Path, String> aliasGenerator) {
-        FilterTranslator filterVisitor = new FilterTranslator();
-
-        return filterVisitor.apply(expression, aliasGenerator);
+        return filterTranslator.apply(expression, aliasGenerator);
     }
 
     /**

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
@@ -60,13 +60,13 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
         //       WHERE _INNER_example_Author.id = example_Book_authors.id AND _INNER_example_Author.id = :%s)
         return String.format("EXISTS (SELECT 1 FROM %s WHERE %s = %s AND %s = %s)",
                 getFromClause(path),
-                getFirstIdReference(path),
-                getOuterQueryJoinReference(path, aliasGenerator),
-                getLastFieldReference(path),
+                getInnerQueryIdField(path),
+                getOuterQueryIdField(path, aliasGenerator),
+                getInnerFilterFieldReference(path),
                 predicate.getParameters().get(0).getPlaceholder());
     }
 
-    private String getOuterQueryJoinReference(Path path, Function<Path, String> aliasGenerator) {
+    private String getOuterQueryIdField(Path path, Function<Path, String> aliasGenerator) {
         Path.PathElement firstElement = path.getPathElements().get(0);
 
         Path firstElementPath = new Path(Arrays.asList(firstElement));
@@ -77,7 +77,7 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
         return aliasGenerator.apply(firstElementPath) + "." + idField;
     }
 
-    private String getFirstIdReference(Path path) {
+    private String getInnerQueryIdField(Path path) {
         Path.PathElement firstElement = path.getPathElements().get(0);
 
         Path firstElementPath = new Path(Arrays.asList(firstElement));
@@ -87,7 +87,7 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
         return INNER + getPathAlias(firstElementPath) + "." + idField;
     }
 
-    private String getLastFieldReference(Path path) {
+    private String getInnerFilterFieldReference(Path path) {
         Path.PathElement lastElement = path.lastElement().get();
         String fieldName = lastElement.getFieldName();
 

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.filter;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.filter.predicates.FilterPredicate;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * Generates JPQL filter fragments for the 'hasmember' and 'hasnomember' operators.
+ */
+public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
+    private final EntityDictionary dictionary;
+    private final boolean negated;
+
+    public HasMemberJPQLGenerator(EntityDictionary dictionary) {
+        this(dictionary, false);
+    }
+
+    public HasMemberJPQLGenerator(EntityDictionary dictionary, boolean negated) {
+        this.dictionary = dictionary;
+        this.negated = negated;
+    }
+
+    @Override
+    public String generate(FilterPredicate predicate, Function<Path, String> aliasGenerator) {
+        Preconditions.checkArgument(predicate.getParameters().size() == 1);
+
+        String notMember = negated ? "NOT" : "";
+
+        if (! FilterPredicate.toManyInPath(dictionary, predicate.getPath())) {
+            return String.format("%s %s MEMBER OF %s",
+                    predicate.getParameters().get(0).getPlaceholder(),
+                    notMember,
+                    aliasGenerator.apply(predicate.getPath()));
+        }
+
+        Path path = predicate.getPath();
+        Preconditions.checkArgument(path.lastElement().isPresent());
+        Preconditions.checkArgument(! (path.lastElement().get().getType() instanceof Collection));
+
+        //EXISTS (SELECT 1 FROM Author a WHERE a.id = example_Book_authors.id AND a.id = %s)
+        return String.format("EXISTS (SELECT 1 FROM %s WHERE %s = %s AND %s = %s");
+    }
+}

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 /**
  * Generates JPQL filter fragments for the 'hasmember' and 'hasnomember' operators.
  */
-public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
+public class HasMemberJPQLGenerator implements JPQLPredicateGenerator {
     private final EntityDictionary dictionary;
     private final boolean negated;
 
@@ -56,8 +56,15 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
         Preconditions.checkArgument(! (path.lastElement().get().getType() instanceof Collection));
 
         //Creates JPQL like:
-        //EXISTS (SELECT 1 FROM example.Book _INNER_example_Book LEFT JOIN _INNER_example_Book.authors _INNER_example_Book_authors
-        //WHERE _INNER_example_Book.id = example_Book.id AND _INNER_example_Book_authors.name = :authors_name_7c02839c_0)
+        //EXISTS (SELECT 1
+        //FROM example.Book
+        //    _INNER_example_Book
+        //LEFT JOIN
+        //    _INNER_example_Book.authors  _INNER_example_Book_authors
+        //WHERE
+        //    _INNER_example_Book.id = example_Book.id
+        //    AND
+        //    _INNER_example_Book_authors.name = :authors_name_7c02839c_0)
         return String.format("%sEXISTS (SELECT 1 FROM %s WHERE %s = %s AND %s = %s)",
                 notMember,
                 getFromClause(path),

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/HasMemberJPQLGenerator.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.core.filter;
 
+import static com.yahoo.elide.core.utils.TypeHelper.appendAlias;
 import static com.yahoo.elide.core.utils.TypeHelper.getPathAlias;
 import static com.yahoo.elide.core.utils.TypeHelper.getTypeAlias;
 import com.yahoo.elide.core.Path;
@@ -15,10 +16,8 @@ import com.yahoo.elide.core.type.Type;
 
 import com.google.common.base.Preconditions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -43,10 +42,10 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
     public String generate(FilterPredicate predicate, Function<Path, String> aliasGenerator) {
         Preconditions.checkArgument(predicate.getParameters().size() == 1);
 
-        String notMember = negated ? "NOT" : "";
+        String notMember = negated ? "NOT " : "";
 
         if (! FilterPredicate.toManyInPath(dictionary, predicate.getPath())) {
-            return String.format("%s %s MEMBER OF %s",
+            return String.format("%s %sMEMBER OF %s",
                     predicate.getParameters().get(0).getPlaceholder(),
                     notMember,
                     aliasGenerator.apply(predicate.getPath()));
@@ -56,9 +55,11 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
         Preconditions.checkArgument(path.lastElement().isPresent());
         Preconditions.checkArgument(! (path.lastElement().get().getType() instanceof Collection));
 
-        //EXISTS (SELECT 1 FROM Author _INNER_example_Author
-        //       WHERE _INNER_example_Author.id = example_Book_authors.id AND _INNER_example_Author.id = :%s)
-        return String.format("EXISTS (SELECT 1 FROM %s WHERE %s = %s AND %s = %s)",
+        //Creates JPQL like:
+        //EXISTS (SELECT 1 FROM example.Book _INNER_example_Book LEFT JOIN _INNER_example_Book.authors _INNER_example_Book_authors
+        //WHERE _INNER_example_Book.id = example_Book.id AND _INNER_example_Book_authors.name = :authors_name_7c02839c_0)
+        return String.format("%sEXISTS (SELECT 1 FROM %s WHERE %s = %s AND %s = %s)",
+                notMember,
                 getFromClause(path),
                 getInnerQueryIdField(path),
                 getOuterQueryIdField(path, aliasGenerator),
@@ -68,13 +69,17 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
 
     private String getOuterQueryIdField(Path path, Function<Path, String> aliasGenerator) {
         Path.PathElement firstElement = path.getPathElements().get(0);
-
-        Path firstElementPath = new Path(Arrays.asList(firstElement));
-
         Type<?> modelType = firstElement.getType();
         String idField = dictionary.getIdFieldName(modelType);
+        Type<?> idFieldType = dictionary.getIdType(modelType);
 
-        return aliasGenerator.apply(firstElementPath) + "." + idField;
+        Path idPath = new Path(Arrays.asList(new Path.PathElement(
+                modelType,
+                idFieldType,
+                idField
+        )));
+
+        return aliasGenerator.apply(idPath);
     }
 
     private String getInnerQueryIdField(Path path) {
@@ -95,20 +100,21 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator{
     }
 
     private String getFromClause(Path path) {
-        List<Path.PathElement> pathElements = new ArrayList<>();
-
         Path.PathElement firstElement = path.getPathElements().get(0);
+        Path.PathElement lastElement = path.lastElement().get();
 
         String entityName = firstElement.getType().getCanonicalName();
         String currentAlias = INNER + getTypeAlias(firstElement.getType());
 
-        String fromClause = String.format("FROM %s %s", entityName, currentAlias);
+        String fromClause = String.format("%s %s", entityName, currentAlias);
 
         for (Path.PathElement element : path.getPathElements()) {
-            pathElements.add(element);
-            Path currentPath = new Path(pathElements);
 
-            String nextAlias = getPathAlias(currentPath);
+            //No need to join the last path segment.
+            if (element == lastElement) {
+                break;
+            }
+            String nextAlias = appendAlias(currentAlias, element.getFieldName());
 
             fromClause += " LEFT JOIN " + currentAlias + "." + element.getFieldName() + " " + nextAlias;
 

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/AbstractHQLQueryBuilder.java
@@ -298,7 +298,7 @@ public abstract class AbstractHQLQueryBuilder {
     /**
      * Returns whether filter expression contains toMany relationship.
      * @param filterExpression
-     * @return
+     * @return true or false
      */
     protected boolean containsOneToMany(FilterExpression filterExpression) {
         PredicateExtractionVisitor visitor = new PredicateExtractionVisitor(new ArrayList<>());

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionFetchQueryBuilder.java
@@ -48,7 +48,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
             Collection<FilterPredicate> predicates = filterExpression.accept(extractor);
 
             //Build the WHERE clause
-            String filterClause = WHERE + new FilterTranslator().apply(filterExpression, USE_ALIAS);
+            String filterClause = WHERE + new FilterTranslator(dictionary).apply(filterExpression, USE_ALIAS);
 
             //Build the JOIN clause
             String joinClause =  getJoinClauseFromFilters(filterExpression)

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/RootCollectionPageTotalsQueryBuilder.java
@@ -57,7 +57,7 @@ public class RootCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilde
             predicates = filterExpression.accept(extractor);
 
             //Build the WHERE clause
-            filterClause = WHERE + new FilterTranslator().apply(filterExpression, USE_ALIAS);
+            filterClause = WHERE + new FilterTranslator(dictionary).apply(filterExpression, USE_ALIAS);
 
             //Build the JOIN clause
             joinClause =  getJoinClauseFromFilters(filterExpression, true);

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionFetchQueryBuilder.java
@@ -74,7 +74,7 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
         if (filterExpression != null) {
             PredicateExtractionVisitor extractor = new PredicateExtractionVisitor();
             Collection<FilterPredicate> predicates = filterExpression.accept(extractor);
-            String filterClause = new FilterTranslator().apply(filterExpression, USE_ALIAS);
+            String filterClause = new FilterTranslator(dictionary).apply(filterExpression, USE_ALIAS);
 
             String joinClause =  getJoinClauseFromFilters(filterExpression)
                     + getJoinClauseFromSort(entityProjection.getSorting())

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/hibernate/hql/SubCollectionPageTotalsQueryBuilder.java
@@ -98,7 +98,7 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
             joinClause = getJoinClauseFromFilters(joinedExpression, true);
 
             //Build the WHERE clause
-            filterClause = new FilterTranslator().apply(joinedExpression, USE_ALIAS);
+            filterClause = new FilterTranslator(dictionary).apply(joinedExpression, USE_ALIAS);
         } else {
 
             //If there is no filter, we still need to explicitly JOIN book and authors.
@@ -109,7 +109,7 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
                     + relationshipAlias
                     + SPACE;
 
-            filterClause = new FilterTranslator().apply(idExpression, USE_ALIAS);
+            filterClause = new FilterTranslator(dictionary).apply(idExpression, USE_ALIAS);
             predicates.add(idExpression);
         }
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.core.filter;
 import static com.yahoo.elide.core.utils.TypeHelper.getClassType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
@@ -20,6 +21,7 @@ import com.yahoo.elide.core.filter.predicates.NotEmptyPredicate;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -29,12 +31,14 @@ import java.util.stream.Collectors;
  */
 public class FilterTranslatorTest {
 
+    @Include
     class Book {
         String name;
         String genre;
         Author author;
     }
 
+    @Include
     class Author {
         String name;
     }
@@ -42,7 +46,8 @@ public class FilterTranslatorTest {
     private EntityDictionary dictionary;
 
     public FilterTranslatorTest() {
-        this.dictionary = dictionary;
+        dictionary = new EntityDictionary(new HashMap<>());
+        dictionary.bindEntity(FilterTranslatorTest.Book.class);
     }
 
     @Test

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -9,6 +9,7 @@ import static com.yahoo.elide.core.utils.TypeHelper.getClassType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.NotFilterExpression;
@@ -36,6 +37,12 @@ public class FilterTranslatorTest {
 
     class Author {
         String name;
+    }
+
+    private EntityDictionary dictionary;
+
+    public FilterTranslatorTest() {
+        this.dictionary = dictionary;
     }
 
     @Test
@@ -66,7 +73,7 @@ public class FilterTranslatorTest {
         AndFilterExpression and2 = new AndFilterExpression(or, and1);
         NotFilterExpression not = new NotFilterExpression(and2);
 
-        FilterTranslator filterOp = new FilterTranslator();
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
         String query = filterOp.apply(not, false);
         query = query.trim().replaceAll(" +", " ");
 
@@ -91,7 +98,7 @@ public class FilterTranslatorTest {
 
         AndFilterExpression and = new AndFilterExpression(p1, p2);
 
-        FilterTranslator filterOp = new FilterTranslator();
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
         String query = filterOp.apply(and, false);
 
         String p1Params = p1.getParameters().stream()
@@ -107,7 +114,7 @@ public class FilterTranslatorTest {
     public void testEmptyFieldOnPrefix() throws Exception {
         FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
                 Operator.PREFIX_CASE_INSENSITIVE, Arrays.asList("value"));
-        FilterTranslator filterOp = new FilterTranslator();
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
     }
 
@@ -115,7 +122,7 @@ public class FilterTranslatorTest {
     public void testEmptyFieldOnInfix() throws Exception {
         FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
                 Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
-        FilterTranslator filterOp = new FilterTranslator();
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
     }
 
@@ -123,7 +130,7 @@ public class FilterTranslatorTest {
     public void testEmptyFieldOnPostfix() throws Exception {
         FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
                 Operator.POSTFIX_CASE_INSENSITIVE, Arrays.asList("value"));
-        FilterTranslator filterOp = new FilterTranslator();
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
     }
 
@@ -143,7 +150,7 @@ public class FilterTranslatorTest {
             FilterPredicate pred = new FilterPredicate(new Path.PathElement(Author.class, String.class, "name"),
                     Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
 
-            String actual = new FilterTranslator().apply(pred);
+            String actual = new FilterTranslator(dictionary).apply(pred);
             assertEquals("FOO", actual);
         } finally {
             FilterTranslator.registerJPQLGenerator(Operator.INFIX_CASE_INSENSITIVE, getClassType(Author.class), "name", null);
@@ -167,7 +174,7 @@ public class FilterTranslatorTest {
             FilterPredicate pred = new FilterPredicate(new Path.PathElement(Author.class, String.class, "name"),
                     Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
 
-            String actual = new FilterTranslator().apply(pred);
+            String actual = new FilterTranslator(dictionary).apply(pred);
             assertEquals("FOO", actual);
         } finally {
             FilterTranslator.registerJPQLGenerator(Operator.INFIX_CASE_INSENSITIVE, old);

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -47,29 +47,29 @@ public class FilterTranslatorTest {
 
     public FilterTranslatorTest() {
         dictionary = new EntityDictionary(new HashMap<>());
-        dictionary.bindEntity(Book.class);
+        dictionary.bindEntity(FilterTranslatorTest.Book.class);
     }
 
     @Test
     public void testHQLQueryVisitor() throws Exception {
         List<Path.PathElement> p0Path = Arrays.asList(
-                new Path.PathElement(Book.class, Author.class, "authors")
+                new Path.PathElement(FilterTranslatorTest.Book.class, Author.class, "authors")
         );
         FilterPredicate p0 = new NotEmptyPredicate(new Path(p0Path));
 
         List<Path.PathElement> p1Path = Arrays.asList(
-                new Path.PathElement(Book.class, Author.class, "authors"),
+                new Path.PathElement(FilterTranslatorTest.Book.class, Author.class, "authors"),
                 new Path.PathElement(Author.class, String.class, "name")
         );
         FilterPredicate p1 = new InPredicate(new Path(p1Path), "foo", "bar");
 
         List<Path.PathElement> p2Path = Arrays.asList(
-                new Path.PathElement(Book.class, String.class, "name")
+                new Path.PathElement(FilterTranslatorTest.Book.class, String.class, "name")
         );
         FilterPredicate p2 = new InPredicate(new Path(p2Path), "blah");
 
         List<Path.PathElement> p3Path = Arrays.asList(
-                new Path.PathElement(Book.class, String.class, "genre")
+                new Path.PathElement(FilterTranslatorTest.Book.class, String.class, "genre")
         );
         FilterPredicate p3 = new InPredicate(new Path(p3Path), "scifi");
 
@@ -96,7 +96,7 @@ public class FilterTranslatorTest {
     @Test
     public void testMemberOfOperator() throws Exception {
         List<Path.PathElement> path = Arrays.asList(
-                new Path.PathElement(Book.class, String.class, "awards")
+                new Path.PathElement(FilterTranslatorTest.Book.class, String.class, "awards")
         );
         FilterPredicate p1 = new FilterPredicate(new Path(path), Operator.HASMEMBER, Arrays.asList("awards1"));
         FilterPredicate p2 = new FilterPredicate(new Path(path), Operator.HASNOMEMBER, Arrays.asList("awards2"));
@@ -117,7 +117,7 @@ public class FilterTranslatorTest {
 
     @Test
     public void testEmptyFieldOnPrefix() throws Exception {
-        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(FilterTranslatorTest.Book.class, String.class, ""),
                 Operator.PREFIX_CASE_INSENSITIVE, Arrays.asList("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
@@ -125,7 +125,7 @@ public class FilterTranslatorTest {
 
     @Test
     public void testEmptyFieldOnInfix() throws Exception {
-        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(FilterTranslatorTest.Book.class, String.class, ""),
                 Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
@@ -133,7 +133,7 @@ public class FilterTranslatorTest {
 
     @Test
     public void testEmptyFieldOnPostfix() throws Exception {
-        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(FilterTranslatorTest.Book.class, String.class, ""),
                 Operator.POSTFIX_CASE_INSENSITIVE, Arrays.asList("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.core.filter;
 import static com.yahoo.elide.core.utils.TypeHelper.getClassType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
@@ -18,6 +17,8 @@ import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
 import com.yahoo.elide.core.filter.predicates.InPredicate;
 import com.yahoo.elide.core.filter.predicates.NotEmptyPredicate;
+import example.Author;
+import example.Book;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -31,45 +32,34 @@ import java.util.stream.Collectors;
  */
 public class FilterTranslatorTest {
 
-    @Include
-    static class Book {
-        String name;
-        String genre;
-        Author author;
-    }
-
-    @Include
-    static class Author {
-        String name;
-    }
-
     private EntityDictionary dictionary;
 
     public FilterTranslatorTest() {
         dictionary = new EntityDictionary(new HashMap<>());
-        dictionary.bindEntity(FilterTranslatorTest.Book.class);
+        dictionary.bindEntity(Book.class);
+        dictionary.bindEntity(Author.class);
     }
 
     @Test
     public void testHQLQueryVisitor() throws Exception {
         List<Path.PathElement> p0Path = Arrays.asList(
-                new Path.PathElement(FilterTranslatorTest.Book.class, Author.class, "authors")
+                new Path.PathElement(Book.class, Author.class, "authors")
         );
         FilterPredicate p0 = new NotEmptyPredicate(new Path(p0Path));
 
         List<Path.PathElement> p1Path = Arrays.asList(
-                new Path.PathElement(FilterTranslatorTest.Book.class, Author.class, "authors"),
+                new Path.PathElement(Book.class, Author.class, "authors"),
                 new Path.PathElement(Author.class, String.class, "name")
         );
         FilterPredicate p1 = new InPredicate(new Path(p1Path), "foo", "bar");
 
         List<Path.PathElement> p2Path = Arrays.asList(
-                new Path.PathElement(FilterTranslatorTest.Book.class, String.class, "name")
+                new Path.PathElement(Book.class, String.class, "name")
         );
         FilterPredicate p2 = new InPredicate(new Path(p2Path), "blah");
 
         List<Path.PathElement> p3Path = Arrays.asList(
-                new Path.PathElement(FilterTranslatorTest.Book.class, String.class, "genre")
+                new Path.PathElement(Book.class, String.class, "genre")
         );
         FilterPredicate p3 = new InPredicate(new Path(p3Path), "scifi");
 
@@ -93,10 +83,10 @@ public class FilterTranslatorTest {
         assertEquals(expected, query);
     }
 
-    //@Test
+    @Test
     public void testMemberOfOperator() throws Exception {
         List<Path.PathElement> path = Arrays.asList(
-                new Path.PathElement(FilterTranslatorTest.Book.class, String.class, "awards")
+                new Path.PathElement(Book.class, String.class, "awards")
         );
         FilterPredicate p1 = new FilterPredicate(new Path(path), Operator.HASMEMBER, Arrays.asList("awards1"));
         FilterPredicate p2 = new FilterPredicate(new Path(path), Operator.HASNOMEMBER, Arrays.asList("awards2"));
@@ -117,7 +107,7 @@ public class FilterTranslatorTest {
 
     @Test
     public void testEmptyFieldOnPrefix() throws Exception {
-        FilterPredicate pred = new FilterPredicate(new Path.PathElement(FilterTranslatorTest.Book.class, String.class, ""),
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
                 Operator.PREFIX_CASE_INSENSITIVE, Arrays.asList("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
@@ -125,7 +115,7 @@ public class FilterTranslatorTest {
 
     @Test
     public void testEmptyFieldOnInfix() throws Exception {
-        FilterPredicate pred = new FilterPredicate(new Path.PathElement(FilterTranslatorTest.Book.class, String.class, ""),
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
                 Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
@@ -133,7 +123,7 @@ public class FilterTranslatorTest {
 
     @Test
     public void testEmptyFieldOnPostfix() throws Exception {
-        FilterPredicate pred = new FilterPredicate(new Path.PathElement(FilterTranslatorTest.Book.class, String.class, ""),
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
                 Operator.POSTFIX_CASE_INSENSITIVE, Arrays.asList("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -47,7 +47,7 @@ public class FilterTranslatorTest {
 
     public FilterTranslatorTest() {
         dictionary = new EntityDictionary(new HashMap<>());
-        dictionary.bindEntity(FilterTranslatorTest.Book.class);
+        dictionary.bindEntity(Book.class);
     }
 
     @Test

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -32,14 +32,14 @@ import java.util.stream.Collectors;
 public class FilterTranslatorTest {
 
     @Include
-    class Book {
+    static class Book {
         String name;
         String genre;
         Author author;
     }
 
     @Include
-    class Author {
+    static class Author {
         String name;
     }
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -93,7 +93,7 @@ public class FilterTranslatorTest {
         assertEquals(expected, query);
     }
 
-    @Test
+    //@Test
     public void testMemberOfOperator() throws Exception {
         List<Path.PathElement> path = Arrays.asList(
                 new Path.PathElement(FilterTranslatorTest.Book.class, String.class, "awards")

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/HasMemberJPQLGeneratorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/HasMemberJPQLGeneratorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.filter;
+
+import static com.yahoo.elide.core.utils.TypeHelper.getFieldAlias;
+import static com.yahoo.elide.core.utils.TypeHelper.getPathAlias;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.predicates.FilterPredicate;
+import com.yahoo.elide.core.type.ClassType;
+import example.Author;
+import example.Book;
+import example.Chapter;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.function.Function;
+
+public class HasMemberJPQLGeneratorTest {
+    private EntityDictionary dictionary;
+    private RSQLFilterDialect dialect;
+    private Function<Path, String> aliasGenerator;
+
+    public HasMemberJPQLGeneratorTest() {
+        dictionary = new EntityDictionary(new HashMap<>());
+        dictionary.bindEntity(Author.class);
+        dictionary.bindEntity(Book.class);
+        dictionary.bindEntity(Chapter.class);
+
+        dialect = new RSQLFilterDialect(dictionary);
+
+        aliasGenerator = (path) -> getFieldAlias(getPathAlias(path),
+                path.lastElement().map(Path.PathElement::getFieldName).orElse(null));
+    }
+
+    @Test
+    void testHasMemberBookAuthorName() throws Exception {
+        HasMemberJPQLGenerator generator = new HasMemberJPQLGenerator(dictionary);
+
+        FilterExpression expression = dialect.parseFilterExpression("authors.name=hasmember='Jon Doe'",
+                new ClassType(Book.class),
+                true);
+
+        String actual = generator.generate((FilterPredicate) expression, aliasGenerator);
+        actual = actual.replaceFirst(":\\w+", ":XXX");
+
+        String expected = "EXISTS (SELECT 1 FROM example.Book _INNER_example_Book LEFT JOIN _INNER_example_Book.authors _INNER_example_Book_authors "
+                + "WHERE _INNER_example_Book.id = example_Book.id AND _INNER_example_Book_authors.name = :XXX)";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testHasNoMemberBookAuthorName() throws Exception {
+        HasMemberJPQLGenerator generator = new HasMemberJPQLGenerator(dictionary, true);
+
+        FilterExpression expression = dialect.parseFilterExpression("authors.name=hasnomember='Jon Doe'",
+                new ClassType(Book.class),
+                true);
+
+        String actual = generator.generate((FilterPredicate) expression, aliasGenerator);
+        actual = actual.replaceFirst(":\\w+", ":XXX");
+
+        String expected = "NOT EXISTS (SELECT 1 FROM example.Book _INNER_example_Book LEFT JOIN _INNER_example_Book.authors _INNER_example_Book_authors "
+                + "WHERE _INNER_example_Book.id = example_Book.id AND _INNER_example_Book_authors.name = :XXX)";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testHasMemberAuthorBookChapterTitle() throws Exception {
+        HasMemberJPQLGenerator generator = new HasMemberJPQLGenerator(dictionary);
+
+        FilterExpression expression = dialect.parseFilterExpression("books.chapters.title=hasmember='A title'",
+                new ClassType(Author.class),
+                true);
+
+        String actual = generator.generate((FilterPredicate) expression, aliasGenerator);
+        actual = actual.replaceFirst(":\\w+", ":XXX");
+
+        String expected = "EXISTS (SELECT 1 FROM example.Author _INNER_example_Author LEFT JOIN _INNER_example_Author.books _INNER_example_Author_books "
+                + "LEFT JOIN _INNER_example_Author_books.chapters _INNER_example_Author_books_chapters WHERE _INNER_example_Author.id = example_Author.id AND _INNER_example_Author_books_chapters.title = :XXX)";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testHasMemberBookAwards() throws Exception {
+        HasMemberJPQLGenerator generator = new HasMemberJPQLGenerator(dictionary);
+
+        FilterExpression expression = dialect.parseFilterExpression("awards=hasmember='Foo'",
+                new ClassType(Book.class),
+                true);
+
+        String actual = generator.generate((FilterPredicate) expression, aliasGenerator);
+        actual = actual.replaceFirst(":\\w+", ":XXX");
+
+        String expected = ":XXX MEMBER OF example_Book.awards";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testHasNoMemberBookAwards() throws Exception {
+        HasMemberJPQLGenerator generator = new HasMemberJPQLGenerator(dictionary, true);
+
+        FilterExpression expression = dialect.parseFilterExpression("awards=hasnomember='Foo'",
+                new ClassType(Book.class),
+                true);
+
+        String actual = generator.generate((FilterPredicate) expression, aliasGenerator);
+        actual = actual.replaceFirst(":\\w+", ":XXX");
+
+        String expected = ":XXX NOT MEMBER OF example_Book.awards";
+
+        assertEquals(expected, actual);
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -1927,22 +1927,22 @@ public class FilterIT extends IntegrationTest {
     void testExceptionOnMemberOfOperator() throws JsonProcessingException {
         JsonNode result;
         // Typed Expression
-        result = getAsNode(String.format("/author/%s/books?filter[book.authors.name][hasmember]", nullNedId), HttpStatus.SC_BAD_REQUEST);
+        result = getAsNode(String.format("/author/%s/books?filter[book.authors][hasmember]", nullNedId), HttpStatus.SC_BAD_REQUEST);
         assertEquals(
-                "Invalid predicate: book.authors.name HASMEMBER []\n"
-                        + "Invalid query parameter: filter[book.authors.name][hasmember]\n"
-                        + "Invalid toMany join: member of operator cannot be used for toMany relationships\n"
-                        + "Invalid query parameter: filter[book.authors.name][hasmember]",
+                "Invalid predicate: book.authors HASMEMBER []\n"
+                        + "Invalid query parameter: filter[book.authors][hasmember]\n"
+                        + "Invalid Path: Last Path Element cannot be a collection type\n"
+                        + "Invalid query parameter: filter[book.authors][hasmember]",
                 result.get("errors").get(0).get("detail").asText()
         );
 
         //RSQL
-        result = getAsNode(String.format("/author/%s/books?filter[book]=authors.name=hasmember=true", nullNedId), HttpStatus.SC_BAD_REQUEST);
+        result = getAsNode(String.format("/author/%s/books?filter[book]=authors=hasmember=true", nullNedId), HttpStatus.SC_BAD_REQUEST);
         assertEquals(
                 "Invalid filter format: filter[book]\n"
                         + "Invalid query parameter: filter[book]\n"
                         + "Invalid filter format: filter[book]\n"
-                        + "Invalid toMany join: member of operator cannot be used for toMany relationships",
+                        + "Invalid Path: Last Path Element cannot be a collection type",
                 result.get("errors").get(0).get("detail").asText()
         );
 
@@ -1970,27 +1970,6 @@ public class FilterIT extends IntegrationTest {
                         + "Invalid query parameter: filter[book.title][hasmember]",
                 result.get("errors").get(0).get("detail").asText()
         );
-
-
-        // Member of one Relationships
-        result = getAsNode("/books?filter[book.authors][hasmember]=1", HttpStatus.SC_BAD_REQUEST);
-        assertEquals(
-                "Invalid predicate: book.authors HASMEMBER [1]\n"
-                        + "Invalid query parameter: filter[book.authors][hasmember]\n"
-                        + "Invalid toMany join: member of operator cannot be used for toMany relationships\n"
-                        + "Invalid query parameter: filter[book.authors][hasmember]",
-                result.get("errors").get(0).get("detail").asText()
-        );
-        //RSQL
-        result = getAsNode("/books?filter[book]=publisher=hasmember=1", HttpStatus.SC_BAD_REQUEST);
-        assertEquals(
-                "Invalid filter format: filter[book]\n"
-                        + "Invalid query parameter: filter[book]\n"
-                        + "Invalid filter format: filter[book]\n"
-                        + "Invalid Path: Last Path Element has to be a collection type",
-                result.get("errors").get(0).get("detail").asText()
-        );
-
     }
 
     @AfterAll

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -9,7 +9,10 @@ package com.yahoo.elide.tests;
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -25,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
@@ -1831,6 +1835,33 @@ public class FilterIT extends IntegrationTest {
                         "data.id", contains(publisherBook.toArray())
                 );
 
+    }
+
+    @Test
+    void testMemberOfToManyRelationship() {
+        /* RSQL Global */
+        when()
+                .get("/book?filter=authors.id=hasmember=1")
+                .then()
+                .body("data.relationships.authors", hasSize(2))
+                .body("data.relationships.authors[0].data.id[0]", equalTo("1"))
+                .body("data.relationships.authors[1].data.id[0]", equalTo("1"));
+
+        /* RSQL Typed */
+        when()
+                .get("/book?filter[book]=authors.id=hasmember=1")
+                .then()
+                .body("data.relationships.authors", hasSize(2))
+                .body("data.relationships.authors[0].data.id[0]", equalTo("1"))
+                .body("data.relationships.authors[1].data.id[0]", equalTo("1"));
+
+        /* Default */
+        when()
+                .get("/book?filter[book.authors.id][hasmember]=1")
+                .then()
+                .body("data.relationships.authors", hasSize(2))
+                .body("data.relationships.authors[0].data.id[0]", equalTo("1"))
+                .body("data.relationships.authors[1].data.id[0]", equalTo("1"));
     }
 
     @Test


### PR DESCRIPTION
Resolves #1822

## Description
Add support for 'hasmember' queries that traverse to-many relationships like:
`/item?filter=tags.id=hasmember='new';tags.id=hasmember='sale'`

## Motivation and Context
See #1822 

## How Has This Been Tested?
New operator unit tests, dialect unit tests, and JSON-API integration tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
