### PR TITLE
Fixing the regular expression for required filter templates

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
@@ -23,7 +23,7 @@ import lombok.AllArgsConstructor;
  */
 @AllArgsConstructor
 public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> {
-    private static final String TEMPLATE_REGEX = "\\{\\{\\w+}\\}";
+    private static final String TEMPLATE_REGEX = "\\{\\{\\w*\\}\\}";
 
     private FilterExpression expressionToMatch;
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -38,7 +38,7 @@ public class MatchesTemplateVisitorTest {
         FilterExpression clientExpression = dialect.parseFilterExpression("highScore==123",
                 playerStatsType, true);
 
-        FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{variable}}",
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{}}",
                 playerStatsType, false, true);
 
         assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));


### PR DESCRIPTION
MatchesTemplateVisitor.TEMPLATE_REGEX is wrong and we should also allow {{}} for substitution.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
