### PR TITLE
Removing system.out from TableExport

### DIFF
--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/TableExportIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/TableExportIT.java
@@ -591,7 +591,6 @@ public class TableExportIT extends IntegrationTest {
                 .statusCode(org.apache.http.HttpStatus.SC_OK);
 
         String output = response.extract().body().asString();
-        System.out.println(output);
         assertEquals(true, output.contains("errors"));
         assertEquals(true, output.contains("Validation error of type WrongType: argument &#39;data.resultType&#39;"));
     }


### PR DESCRIPTION
Removing system.out from TableExport


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
