### PR TITLE
Cleanup unnecessary syntax

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/AsyncAPIHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/AsyncAPIHook.java
@@ -66,11 +66,13 @@ public abstract class AsyncAPIHook<T extends AsyncAPI> implements LifeCycleHook<
             //ReadPreSecurityHook - Those hooks get evaluated in line with the request processing.
             executeAsync(query, queryWorker);
             return;
-        } else if (operation.equals(CREATE)) {
+        }
+        if (operation.equals(CREATE)) {
             if (phase.equals(POSTCOMMIT)) {
                 completeAsync(query, requestScope);
                 return;
-            } else if (phase.equals(PRESECURITY)) {
+            }
+            if (phase.equals(PRESECURITY)) {
                 updatePrincipalName(query, requestScope);
                 return;
             }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncAPIDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncAPIDAO.java
@@ -66,9 +66,7 @@ public class DefaultAsyncAPIDAO implements AsyncAPIDAO {
     @Override
     public <T extends AsyncAPI> Iterable<T> updateStatusAsyncAPIByFilter(FilterExpression filterExpression,
             QueryStatus status, Class<T> type) {
-        return updateAsyncAPIIterable(filterExpression, (asyncAPI) -> {
-            asyncAPI.setStatus(status);
-            }, type);
+        return updateAsyncAPIIterable(filterExpression, asyncAPI -> asyncAPI.setStatus(status), type);
     }
 
     /**

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngine.java
@@ -54,9 +54,8 @@ public class FileResultStorageEngine implements ResultStorageEngine {
                         throwable -> {
                             throw new IllegalStateException(STORE_ERROR, throwable);
                         },
-                        () -> {
-                            writer.flush();
-                        }
+                        () ->
+                            writer.flush()
                 );
         } catch (IOException e) {
             throw new IllegalStateException(STORE_ERROR, e);
@@ -71,31 +70,28 @@ public class FileResultStorageEngine implements ResultStorageEngine {
 
         return Observable.using(
                 () -> getReader(asyncQueryID),
-                reader -> {
-                    return Observable.fromIterable(() -> {
-                        return new Iterator<String>() {
-                            private String record = null;
+                reader -> Observable.fromIterable(() -> new Iterator<String>() {
+                    private String record = null;
 
-                            @Override
-                            public boolean hasNext() {
-                                try {
-                                    record = reader.readLine();
-                                    return record != null;
-                                } catch (IOException e) {
-                                    throw new IllegalStateException(RETRIEVE_ERROR, e);
-                                }
-                            }
+                    @Override
+                    public boolean hasNext() {
+                        try {
+                            record = reader.readLine();
+                            return record != null;
+                        } catch (IOException e) {
+                            throw new IllegalStateException(RETRIEVE_ERROR, e);
+                        }
+                    }
 
-                            @Override
-                            public String next() {
-                                if (record != null) {
-                                    return record;
-                                }
-                                throw new IllegalStateException("null line found.");
-                            }
-                        };
-                    });
-                }, BufferedReader::close);
+                    @Override
+                    public String next() {
+                        if (record != null) {
+                            return record;
+                        }
+                        throw new IllegalStateException("null line found.");
+                    }
+                }),
+                BufferedReader::close);
     }
 
     private BufferedReader getReader(String asyncQueryID) {

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICancelRunnable.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICancelRunnable.java
@@ -89,12 +89,11 @@ public class AsyncAPICancelRunnable implements Runnable {
 
             //AsyncAPI IDs that need to be cancelled
             Set<String> queryIDsToCancel = queryUUIDsToCancel.stream()
-            .map(uuid -> {
-                return StreamSupport.stream(asyncAPIIterable.spliterator(), false)
+            .map(uuid -> StreamSupport
+                .stream(asyncAPIIterable.spliterator(), false)
                 .filter(query -> query.getRequestId().equals(uuid.toString()))
                 .map(T::getId)
-                .findFirst().orElseThrow(IllegalStateException::new);
-            })
+                .findFirst().orElseThrow(IllegalStateException::new))
             .collect(Collectors.toSet());
 
             //Cancel Transactions

--- a/elide-core/src/main/java/com/yahoo/elide/core/Path.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/Path.java
@@ -130,12 +130,12 @@ public class Path {
                 || fieldName.equals(dictionary.getIdFieldName(entityClass))) {
             Type<?> attributeClass = dictionary.getType(entityClass, fieldName);
             return new PathElement(entityClass, attributeClass, fieldName, alias, arguments);
-        } else if ("this".equals(fieldName)) {
-            return new PathElement(entityClass, null, fieldName);
-        } else {
-            String entityAlias = dictionary.getJsonAliasFor(entityClass);
-            throw new InvalidValueException(entityAlias + " does not contain the field " + fieldName);
         }
+        if ("this".equals(fieldName)) {
+            return new PathElement(entityClass, null, fieldName);
+        }
+        String entityAlias = dictionary.getJsonAliasFor(entityClass);
+        throw new InvalidValueException(entityAlias + " does not contain the field " + fieldName);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1331,7 +1331,7 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
      * @return The Resource
      */
     public Resource toResource(EntityProjection projection) {
-        return toResource(() -> { return getRelationships(projection); }, this::getAttributes);
+        return toResource(() -> getRelationships(projection), this::getAttributes);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -322,10 +322,8 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
 
         queryParams.entrySet()
                 .stream()
-                .filter((entry) -> entry.getKey().startsWith("filter"))
-                .forEach((entry) -> {
-                    returnMap.put(entry.getKey(), entry.getValue());
-                });
+                .filter(entry -> entry.getKey().startsWith("filter"))
+                .forEach(entry -> returnMap.put(entry.getKey(), entry.getValue()));
         return returnMap;
     }
 
@@ -506,8 +504,7 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
     public String getRequestHeaderByName(String headerName) {
         if (this.requestHeaders.get(headerName) == null) {
             return null;
-        } else {
-            return this.requestHeaders.get(headerName).get(0);
         }
+        return this.requestHeaders.get(headerName).get(0);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -47,15 +47,17 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
     private static final Comparator<Object> NULL_SAFE_COMPARE = (a, b) -> {
         if (a == null && b == null) {
             return 0;
-        } else if (a == null) {
-            return -1;
-        } else if (b == null) {
-            return 1;
-        } else if (a instanceof Comparable) {
-            return ((Comparable) a).compareTo(b);
-        } else {
-            throw new IllegalStateException("Trying to comparing non-comparable types!");
         }
+        if (a == null) {
+            return -1;
+        }
+        if (b == null) {
+            return 1;
+        }
+        if (a instanceof Comparable) {
+            return ((Comparable) a).compareTo(b);
+        }
+        throw new IllegalStateException("Trying to comparing non-comparable types!");
     };
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -113,9 +113,8 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
         if (projection.getFilterExpression() == null
                 || tx.supportsFiltering(scope, Optional.empty(), projection) == FeatureSupport.FULL) {
             return tx.loadObject(projection, id, scope);
-        } else {
-            return DataStoreTransaction.super.loadObject(projection, id, scope);
         }
+        return DataStoreTransaction.super.loadObject(projection, id, scope);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityBinding.java
@@ -514,9 +514,8 @@ public class EntityBinding {
         Type type;
         if (fieldOrMethod instanceof Field) {
             return ((Field) fieldOrMethod).getParameterizedType(parentClass, index);
-        } else {
-            return ((Method) fieldOrMethod).getParameterizedReturnType(parentClass, index);
         }
+        return ((Method) fieldOrMethod).getParameterizedReturnType(parentClass, index);
     }
 
     private void bindTriggerIfPresent(AccessibleObject fieldOrMethod) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -1832,12 +1832,10 @@ public class EntityDictionary {
         if (column == null || column.length == 0) {
             if (joinColumn == null || joinColumn.length == 0) {
                 return fieldName;
-            } else {
-                return joinColumn[0].name();
             }
-        } else {
-            return column[0].name();
+            return joinColumn[0].name();
         }
+        return column[0].name();
     }
 
     /**
@@ -1870,9 +1868,8 @@ public class EntityDictionary {
         Entity entity = (Entity) getFirstAnnotation(declaringClass, Arrays.asList(Entity.class));
         if (entity == null || "".equals(entity.name())) {
             return StringUtils.uncapitalize(declaringClass.getSimpleName());
-        } else {
-            return entity.name();
         }
+        return entity.name();
     }
 
     public static <T> Type<T> getType(T object) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -444,11 +444,10 @@ public enum Operator {
 
             if (fieldVal instanceof Collection) {
                 return ((Collection) fieldVal).stream()
-                        .anyMatch((fieldValueElement) -> {
-                            return fieldValueElement != null
-                                    && values.stream()
-                                    .anyMatch(testVal -> condition.test(compare(fieldValueElement, testVal)));
-                        });
+                        .anyMatch(fieldValueElement ->
+                            fieldValueElement != null
+                            && values.stream()
+                            .anyMatch(testVal -> condition.test(compare(fieldValueElement, testVal))));
             }
 
             return fieldVal != null
@@ -474,16 +473,14 @@ public enum Operator {
 
         if (leftHandSide instanceof Collection && !valueClass.isAssignableFrom(COLLECTION_TYPE)) {
             return ((Collection) leftHandSide).stream()
-                    .anyMatch((leftHandSideElement) -> {
-                        return values.stream()
-                                .map(value -> CoerceUtil.coerce(value, valueClass))
-                                .anyMatch(value -> predicate.test(leftHandSideElement, value));
-                    });
-        } else {
-            return leftHandSide != null && values.stream()
-                    .map(value -> CoerceUtil.coerce(value, valueClass))
-                    .anyMatch(value -> predicate.test(leftHandSide, value));
+                    .anyMatch(leftHandSideElement ->
+                        values.stream()
+                            .map(value -> CoerceUtil.coerce(value, valueClass))
+                            .anyMatch(value -> predicate.test(leftHandSideElement, value)));
         }
+        return leftHandSide != null && values.stream()
+                .map(value -> CoerceUtil.coerce(value, valueClass))
+                .anyMatch(value -> predicate.test(leftHandSide, value));
     }
 
     public Operator negate() {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -434,13 +434,17 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
                     .collect(Collectors.toList());
             if (op.equals(RSQLOperators.EQUAL) || op.equals(RSQLOperators.IN)) {
                 return equalityExpression(arguments.get(0), path, values, true);
-            } else if (op.equals(INI)) {
+            }
+            if (op.equals(INI)) {
                 return equalityExpression(arguments.get(0), path, values, false);
-            } else if (op.equals(RSQLOperators.NOT_EQUAL) || op.equals(RSQLOperators.NOT_IN)) {
+            }
+            if (op.equals(RSQLOperators.NOT_EQUAL) || op.equals(RSQLOperators.NOT_IN)) {
                 return new NotFilterExpression(equalityExpression(arguments.get(0), path, values, true));
-            } else if (op.equals(NOT_INI)) {
+            }
+            if (op.equals(NOT_INI)) {
                 return new NotFilterExpression(equalityExpression(arguments.get(0), path, values, false));
-            } else if (OPERATOR_MAP.containsKey(op)) {
+            }
+            if (OPERATOR_MAP.containsKey(op)) {
                 return new FilterPredicate(path, OPERATOR_MAP.get(op), values);
             }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -478,8 +478,8 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
             }
 
             Boolean isStringLike = path.lastElement()
-                    .map(e -> e.getFieldType().isAssignableFrom(STRING_TYPE))
-                    .orElse(false);
+                    .filter(e -> e.getFieldType().isAssignableFrom(STRING_TYPE))
+                    .isPresent();
             if (isStringLike) {
                 Operator op = caseSensitive
                         ? caseSensitivityStrategy.mapOperator(Operator.IN)

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -294,9 +294,8 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
             if (attribute != null) {
                 return new Path(rootEntityType, dictionary, attribute.getName(),
                         attribute.getAlias(), attribute.getArguments());
-            } else {
-                return buildPath(rootEntityType, attributeName);
             }
+            return buildPath(rootEntityType, attributeName);
         }
 
         private Path buildPath(Type rootEntityType, String selector) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/AndFilterExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/AndFilterExpression.java
@@ -37,7 +37,8 @@ public class AndFilterExpression implements FilterExpression {
     public static FilterExpression fromPair(FilterExpression left, FilterExpression right) {
         if (left != null && right != null) {
             return new AndFilterExpression(left, right);
-        } else if (left == null) {
+        }
+        if (left == null) {
             return right;
         }
         return left;

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/OrFilterExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/OrFilterExpression.java
@@ -38,7 +38,8 @@ public class OrFilterExpression implements FilterExpression {
     public static FilterExpression fromPair(FilterExpression left, FilterExpression right) {
         if (left != null && right != null) {
             return new OrFilterExpression(left, right);
-        } else if (left == null) {
+        }
+        if (left == null) {
             return right;
         }
         return left;

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/FilterPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/FilterPredicate.java
@@ -61,11 +61,11 @@ public class FilterPredicate implements FilterExpression, Function<RequestScope,
 
     public static boolean isLastPathElementAssignableFrom(EntityDictionary dictionary, Path path, Type<?> clz) {
         return path.lastElement()
-                .map(last ->
+                .filter(last ->
                         clz.isAssignableFrom(
                                 dictionary.getType(last.getType(), last.getFieldName())
                         ))
-                .orElse(false);
+                .isPresent();
     }
 
     public FilterPredicate(PathElement pathElement, Operator op, List<Object> values) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/prefab/Common.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/prefab/Common.java
@@ -25,8 +25,7 @@ public class Common {
     public static class FieldSetToNull<T> extends OperationCheck<T> {
         @Override
         public boolean ok(T record, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
-            return changeSpec.map((c) -> { return c.getModified() == null; })
-                    .orElse(false);
+            return changeSpec.filter(c -> c.getModified() == null).isPresent();
         }
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
@@ -165,13 +165,11 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                                                                                  ChangeSpec changeSpec,
                                                                                  Class<A> annotationClass,
                                                                                  String field) {
-        Supplier<Expression> expressionSupplier = () -> {
-            return expressionBuilder.buildSpecificFieldExpressions(resource, annotationClass, field, changeSpec);
-        };
+        Supplier<Expression> expressionSupplier = () ->
+            expressionBuilder.buildSpecificFieldExpressions(resource, annotationClass, field, changeSpec);
 
-        Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
-            return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
-        };
+        Function<Expression, ExpressionResult> expressionExecutor = expression ->
+            executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
 
         return checkPermissions(
                 resource.getResourceType(),
@@ -202,12 +200,12 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                 ? CreatePermission.class
                 : annotationClass;
 
-        Supplier<Expression> expressionSupplier = () -> {
-                return expressionBuilder.buildSpecificFieldExpressions(resource,
+        Supplier<Expression> expressionSupplier = () ->
+                expressionBuilder.buildSpecificFieldExpressions(
+                        resource,
                         expressionAnnotation,
                         field,
                         changeSpec);
-        };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             if (requestScope.getNewPersistentResources().contains(resource)) {
@@ -234,12 +232,11 @@ public class ActivePermissionExecutor implements PermissionExecutor {
     @Override
     public <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass,
                                                                         Class<A> annotationClass) {
-        Supplier<Expression> expressionSupplier = () -> {
-            return expressionBuilder.buildUserCheckAnyExpression(
+        Supplier<Expression> expressionSupplier = () ->
+            expressionBuilder.buildUserCheckAnyExpression(
                     resourceClass,
                     annotationClass,
                     requestScope);
-        };
 
         return checkOnlyUserPermissions(
                 resourceClass,
@@ -499,13 +496,12 @@ public class ActivePermissionExecutor implements PermissionExecutor {
     public <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass,
                                                                         Class<A> annotationClass,
                                                                         String field) {
-        Supplier<Expression> expressionSupplier = () -> {
-            return expressionBuilder.buildUserCheckFieldExpressions(
+        Supplier<Expression> expressionSupplier = () ->
+            expressionBuilder.buildUserCheckFieldExpressions(
                     resourceClass,
                     requestScope,
                     annotationClass,
                     field);
-        };
 
         return checkOnlyUserPermissions(
                 resourceClass,

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
@@ -95,9 +95,11 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
         FilterExpression expression = visit(ctx.expression());
         if (Objects.equals(expression, TRUE_USER_CHECK_EXPRESSION)) {
             return FALSE_USER_CHECK_EXPRESSION;
-        } else if (Objects.equals(expression, FALSE_USER_CHECK_EXPRESSION)) {
+        }
+        if (Objects.equals(expression, FALSE_USER_CHECK_EXPRESSION)) {
             return TRUE_USER_CHECK_EXPRESSION;
-        } else if (Objects.equals(expression, NO_EVALUATION_EXPRESSION)) {
+        }
+        if (Objects.equals(expression, NO_EVALUATION_EXPRESSION)) {
             return NO_EVALUATION_EXPRESSION;
         }
         return new NotFilterExpression(expression);

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/ClassScanner.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/ClassScanner.java
@@ -75,7 +75,7 @@ public class ClassScanner {
      * @return The classes
      */
     static public Set<Class<?>> getAnnotatedClasses(List<Class<? extends Annotation>> annotations) {
-        return getAnnotatedClasses(annotations, (clazz) -> { return true; });
+        return getAnnotatedClasses(annotations, clazz -> true);
     }
 
     @SafeVarargs

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
@@ -117,11 +117,11 @@ public class CoerceUtil {
             public Converter lookup(Class<?> sourceType, Class<?> targetType) {
                 if (targetType.isEnum()) {
                     return TO_ENUM_CONVERTER;
-                } else if (Map.class.isAssignableFrom(sourceType)) {
-                    return FROM_MAP_CONVERTER;
-                } else {
-                    return super.lookup(sourceType, targetType);
                 }
+                if (Map.class.isAssignableFrom(sourceType)) {
+                    return FROM_MAP_CONVERTER;
+                }
+                return super.lookup(sourceType, targetType);
             }
         });
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/EpochToDateConverter.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/EpochToDateConverter.java
@@ -55,15 +55,17 @@ public class EpochToDateConverter<T extends Date> implements Converter, Serde<Ob
     private static <T> T numberToDate(Class<T> cls, Number epoch) throws ReflectiveOperationException {
         if (ClassUtils.isAssignable(cls, java.sql.Date.class)) {
             return cls.cast(new java.sql.Date(epoch.longValue()));
-        } else if (ClassUtils.isAssignable(cls, Timestamp.class)) {
-            return cls.cast(new Timestamp(epoch.longValue()));
-        } else if (ClassUtils.isAssignable(cls, Time.class)) {
-            return cls.cast(new Time(epoch.longValue()));
-        } else if (ClassUtils.isAssignable(cls, Date.class)) {
-            return cls.cast(new Date(epoch.longValue()));
-        } else {
-            throw new UnsupportedOperationException("Cannot convert to " + cls.getSimpleName());
         }
+        if (ClassUtils.isAssignable(cls, Timestamp.class)) {
+            return cls.cast(new Timestamp(epoch.longValue()));
+        }
+        if (ClassUtils.isAssignable(cls, Time.class)) {
+            return cls.cast(new Time(epoch.longValue()));
+        }
+        if (ClassUtils.isAssignable(cls, Date.class)) {
+            return cls.cast(new Date(epoch.longValue()));
+        }
+        throw new UnsupportedOperationException("Cannot convert to " + cls.getSimpleName());
     }
 
     private static <T> T stringToDate(Class<T> cls, String epoch) throws ReflectiveOperationException {

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/ISO8601DateSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/ISO8601DateSerde.java
@@ -53,13 +53,14 @@ public class ISO8601DateSerde implements Serde<String, Date> {
 
         if (ClassUtils.isAssignable(targetType, java.sql.Date.class)) {
             return new java.sql.Date(date.getTime());
-        } else if (ClassUtils.isAssignable(targetType, java.sql.Timestamp.class)) {
-            return new java.sql.Timestamp(date.getTime());
-        } else if (ClassUtils.isAssignable(targetType, java.sql.Time.class)) {
-            return new java.sql.Time(date.getTime());
-        } else {
-            return date;
         }
+        if (ClassUtils.isAssignable(targetType, java.sql.Timestamp.class)) {
+            return new java.sql.Timestamp(date.getTime());
+        }
+        if (ClassUtils.isAssignable(targetType, java.sql.Time.class)) {
+            return new java.sql.Time(date.getTime());
+        }
+        return date;
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/ToEnumConverter.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/ToEnumConverter.java
@@ -27,11 +27,11 @@ public class ToEnumConverter implements Converter {
         try {
             if (ClassUtils.isAssignable(value.getClass(), String.class)) {
                 return stringToEnum(cls, (String) value);
-            } else if (ClassUtils.isAssignable(value.getClass(), Integer.class, true)) {
-                return intToEnum(cls, (Integer) value);
-            } else {
-               throw new UnsupportedOperationException(value.getClass().getSimpleName() + " to Enum no supported");
             }
+            if (ClassUtils.isAssignable(value.getClass(), Integer.class, true)) {
+                return intToEnum(cls, (Integer) value);
+            }
+            throw new UnsupportedOperationException(value.getClass().getSimpleName() + " to Enum no supported");
         } catch (IndexOutOfBoundsException | ReflectiveOperationException
                 | UnsupportedOperationException | IllegalArgumentException e) {
             throw new InvalidAttributeException("Unknown " + cls.getSimpleName() + " value " + value, e);

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
@@ -119,17 +119,13 @@ public class EntityProjectionMaker
     @Override
     public Function<Type<?>, NamedEntityProjection> visitRootCollectionLoadEntity(
             CoreParser.RootCollectionLoadEntityContext ctx) {
-        return (unused) -> {
-            return ctx.entity().accept(this).apply(null);
-        };
+        return unused -> ctx.entity().accept(this).apply(null);
     }
 
     @Override
     public Function<Type<?>, NamedEntityProjection> visitSubCollectionReadEntity(
             CoreParser.SubCollectionReadEntityContext ctx) {
-        return (parentClass) -> {
-            return ctx.entity().accept(this).apply(parentClass);
-        };
+        return parentClass -> ctx.entity().accept(this).apply(parentClass);
     }
 
     @Override
@@ -181,9 +177,8 @@ public class EntityProjectionMaker
 
         if (aggregate == null) {
             return nextResult;
-        } else {
-            return aggregate;
         }
+        return aggregate;
     }
 
     public EntityProjection visitIncludePath(Path path) {

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/KeySerializer.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/KeySerializer.java
@@ -33,8 +33,7 @@ public class KeySerializer extends StdKeySerializer {
             str = ((Class<?>) value).getName();
         } else if (cls.isEnum()) {
             str = ((Enum<?>) value).name();
-        }
-        else {
+        } else {
             str = value.toString();
         }
         jgen.writeFieldName(str);

--- a/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
@@ -63,8 +63,7 @@ public class TestRequestScope extends RequestScope {
     public Optional<MultivaluedMap<String, String>> getQueryParams() {
         if (queryParamOverrides != null) {
             return Optional.of(queryParamOverrides);
-        } else {
-            return super.getQueryParams();
         }
+        return super.getQueryParams();
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -213,7 +213,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         EntityDictionary testDictionary = new EntityDictionary(
                 new HashMap<>(),
                 null,
-                (unused) -> { return new ISO8601DateSerde(); });
+                unused -> new ISO8601DateSerde());
 
         testDictionary.bindEntity(EntityWithDateId.class);
 
@@ -752,9 +752,9 @@ public class EntityDictionaryTest extends EntityDictionary {
 
         assertEquals(new ClassType(SuperclassBinding.class), getEntityBinding(new ClassType(SubclassBinding.class)).entityClass);
         assertEquals(new ClassType(SuperclassBinding.class), getEntityBinding(new ClassType(SuperclassBinding.class)).entityClass);
-        assertThrows(IllegalArgumentException.class, () -> {
-            getEntityBinding(new ClassType(SubsubclassBinding.class));
-        });
+        assertThrows(IllegalArgumentException.class, () ->
+            getEntityBinding(new ClassType(SubsubclassBinding.class))
+        );
 
         assertEquals(new ClassType(SuperclassBinding.class), lookupIncludeClass(new ClassType(SuperclassBinding.class)));
         assertEquals(new ClassType(SuperclassBinding.class), lookupIncludeClass(new ClassType(SubclassBinding.class)));

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -259,7 +259,8 @@ public class PermissionToFilterExpressionVisitorTest {
             left = or.getLeft();
             right = or.getRight();
             return containsOnlyFilterableExpressions(left) && containsOnlyFilterableExpressions(right);
-        } else if (expr instanceof AndFilterExpression) {
+        }
+        if (expr instanceof AndFilterExpression) {
             AndFilterExpression and = (AndFilterExpression) expr;
             left = and.getLeft();
             right = and.getRight();

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
@@ -69,28 +69,29 @@ public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> 
             AndFilterExpression andB = (AndFilterExpression) b;
 
             return matches(andA.getLeft(), andB.getLeft()) && matches(andA.getRight(), andB.getRight());
-        } else if (a instanceof OrFilterExpression) {
+        }
+        if (a instanceof OrFilterExpression) {
             OrFilterExpression orA = (OrFilterExpression) a;
             OrFilterExpression orB = (OrFilterExpression) b;
 
             return matches(orA.getLeft(), orB.getLeft()) && matches(orA.getRight(), orB.getRight());
-        } else if (a instanceof NotFilterExpression) {
+        }
+        if (a instanceof NotFilterExpression) {
             NotFilterExpression notA = (NotFilterExpression) a;
             NotFilterExpression notB = (NotFilterExpression) b;
 
             return matches(notA.getNegated(), notB.getNegated());
-        } else {
-            FilterPredicate predicateA = (FilterPredicate) a;
-            FilterPredicate predicateB = (FilterPredicate) b;
-
-            boolean valueMatches = predicateA.getValues().equals(predicateB.getValues());
-            boolean usingTemplate = predicateA.getValues().stream()
-                    .anyMatch((value -> value.toString().matches(TEMPLATE_REGEX)));
-
-            return predicateA.getPath().equals(predicateB.getPath())
-                    && predicateA.getOperator().equals(predicateB.getOperator())
-                    && (usingTemplate || valueMatches);
         }
+        FilterPredicate predicateA = (FilterPredicate) a;
+        FilterPredicate predicateB = (FilterPredicate) b;
+
+        boolean valueMatches = predicateA.getValues().equals(predicateB.getValues());
+        boolean usingTemplate = predicateA.getValues().stream()
+                .anyMatch((value -> value.toString().matches(TEMPLATE_REGEX)));
+
+        return predicateA.getPath().equals(predicateB.getPath())
+                && predicateA.getOperator().equals(predicateB.getOperator())
+                && (usingTemplate || valueMatches);
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/SplitFilterExpressionVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/SplitFilterExpressionVisitor.java
@@ -178,21 +178,20 @@ public class SplitFilterExpressionVisitor implements FilterExpressionVisitor<Fil
                             right.getWhereExpression()
                     )
             );
-        }  else {
-            // all of the rests are pure-H
-            return FilterConstraints.pureHaving(
-                    OrFilterExpression.fromPair(
-                            AndFilterExpression.fromPair(
-                                    left.getWhereExpression(),
-                                    left.getHavingExpression()
-                            ),
-                            AndFilterExpression.fromPair(
-                                    right.getWhereExpression(),
-                                    right.getHavingExpression()
-                            )
-                    )
-            );
         }
+        // all of the rests are pure-H
+        return FilterConstraints.pureHaving(
+                OrFilterExpression.fromPair(
+                        AndFilterExpression.fromPair(
+                                left.getWhereExpression(),
+                                left.getHavingExpression()
+                        ),
+                        AndFilterExpression.fromPair(
+                                right.getWhereExpression(),
+                                right.getHavingExpression()
+                        )
+                )
+        );
     }
 
     @Override
@@ -201,21 +200,21 @@ public class SplitFilterExpressionVisitor implements FilterExpressionVisitor<Fil
 
         if (normalized instanceof AndFilterExpression) {
             return visitAndExpression((AndFilterExpression) normalized);
-        } else if (normalized instanceof OrFilterExpression) {
+        }
+        if (normalized instanceof OrFilterExpression) {
             return visitOrExpression((OrFilterExpression) normalized);
-        } else if (normalized instanceof NotFilterExpression) {
+        }
+        if (normalized instanceof NotFilterExpression) {
             FilterConstraints negatedConstraint = visitNotExpression((NotFilterExpression) normalized);
 
             if (negatedConstraint.isPureWhere()) {
                 return FilterConstraints.pureWhere(new NotFilterExpression(negatedConstraint.getWhereExpression()));
-            } else {
-                // It is not possible to have a mixed where/having for a NotFilterExpression after normalization
-                // so this must be a pure HAVING
-                return FilterConstraints.pureHaving(new NotFilterExpression(negatedConstraint.getHavingExpression()));
             }
-        } else {
-            return visitPredicate((FilterPredicate) normalized);
+            // It is not possible to have a mixed where/having for a NotFilterExpression after normalization
+            // so this must be a pure HAVING
+            return FilterConstraints.pureHaving(new NotFilterExpression(negatedConstraint.getHavingExpression()));
         }
+        return visitPredicate((FilterPredicate) normalized);
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -143,23 +143,23 @@ public abstract class Column implements Versioned {
     public static ValueType getValueType(Type<?> tableClass, String fieldName, EntityDictionary dictionary) {
         if (dictionary.isRelation(tableClass, fieldName)) {
             return ValueType.RELATIONSHIP;
-        } else {
-            Type<?> fieldClass = dictionary.getType(tableClass, fieldName);
-
-            if (fieldName.equals(dictionary.getIdFieldName(tableClass))) {
-                return ValueType.ID;
-            } else if (ClassType.DATE_TYPE.isAssignableFrom(fieldClass)) {
-                return ValueType.TIME;
-            } else {
-                return ValueType.getScalarType(fieldClass);
-            }
         }
+        Type<?> fieldClass = dictionary.getType(tableClass, fieldName);
+
+        if (fieldName.equals(dictionary.getIdFieldName(tableClass))) {
+            return ValueType.ID;
+        }
+        if (ClassType.DATE_TYPE.isAssignableFrom(fieldClass)) {
+            return ValueType.TIME;
+        }
+        return ValueType.getScalarType(fieldClass);
     }
 
     private ValueSourceType getValueSourceType() {
         if (values != null && !values.isEmpty()) {
             return ValueSourceType.ENUM;
-        } else if (tableSource != null) {
+        }
+        if (tableSource != null) {
             return ValueSourceType.TABLE;
         }
         return ValueSourceType.NONE;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -169,11 +169,11 @@ public abstract class Table implements Versioned {
                 .map(field -> {
                     if (isMetricField(dictionary, cls, field)) {
                         return constructMetric(field, dictionary);
-                    } else if (dictionary.attributeOrRelationAnnotationExists(cls, field, Temporal.class)) {
-                        return constructTimeDimension(field, dictionary);
-                    } else {
-                        return constructDimension(field, dictionary);
                     }
+                    if (dictionary.attributeOrRelationAnnotationExists(cls, field, Temporal.class)) {
+                        return constructTimeDimension(field, dictionary);
+                    }
+                    return constructDimension(field, dictionary);
                 })
                 .collect(Collectors.toSet());
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
@@ -23,12 +23,12 @@ public class ImmutablePagination implements Pagination {
     public static ImmutablePagination from(Pagination src) {
         if (src instanceof ImmutablePagination) {
             return (ImmutablePagination) src;
-        } else if (src != null) {
+        }
+        if (src != null) {
             return new ImmutablePagination(
                     src.getOffset(), src.getLimit(), src.isDefaultInstance(), src.returnPageTotals());
-        } else {
-            return null;
         }
+        return null;
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialectFactory.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialectFactory.java
@@ -55,24 +55,28 @@ public class SQLDialectFactory {
     public static SQLDialect getDialect(String type) {
         if (type.equalsIgnoreCase(H2_DIALECT.getDialectType())) {
             return H2_DIALECT;
-        } else if (type.equalsIgnoreCase(HIVE_DIALECT.getDialectType())) {
+        }
+        if (type.equalsIgnoreCase(HIVE_DIALECT.getDialectType())) {
             return HIVE_DIALECT;
-        } else if (type.equalsIgnoreCase(PRESTODB_DIALECT.getDialectType())) {
+        }
+        if (type.equalsIgnoreCase(PRESTODB_DIALECT.getDialectType())) {
             return PRESTODB_DIALECT;
-        } else if (type.equalsIgnoreCase(MYSQL_DIALECT.getDialectType())) {
+        }
+        if (type.equalsIgnoreCase(MYSQL_DIALECT.getDialectType())) {
             return MYSQL_DIALECT;
-        } else if (type.equalsIgnoreCase(POSTGRES_DIALECT.getDialectType())) {
+        }
+        if (type.equalsIgnoreCase(POSTGRES_DIALECT.getDialectType())) {
             return POSTGRES_DIALECT;
-        } else if (type.equalsIgnoreCase(DRUID_DIALECT.getDialectType())) {
+        }
+        if (type.equalsIgnoreCase(DRUID_DIALECT.getDialectType())) {
             return DRUID_DIALECT;
-        } else {
-            try {
-                return (SQLDialect) Class.forName(type).getConstructor().newInstance();
-            } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException("Unsupported SQL Dialect: " + type, e);
-            } catch (Exception e) {
-                throw new IllegalArgumentException("Failed to instantiate SQL Dialect: " + type, e);
-            }
+        }
+        try {
+            return (SQLDialect) Class.forName(type).getConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Unsupported SQL Dialect: " + type, e);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to instantiate SQL Dialect: " + type, e);
         }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -342,11 +342,11 @@ public class SQLReferenceTable {
     private static String applyQuotes(String str, char beginQuote, char endQuote) {
         if (str == null || str.trim().isEmpty()) {
             return str;
-        } else if (str.contains(PERIOD)) {
-            return beginQuote + str.trim().replace(PERIOD, endQuote + PERIOD + beginQuote) + endQuote;
-        } else {
-            return beginQuote + str.trim() + endQuote;
         }
+        if (str.contains(PERIOD)) {
+            return beginQuote + str.trim().replace(PERIOD, endQuote + PERIOD + beginQuote) + endQuote;
+        }
+        return beginQuote + str.trim() + endQuote;
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -171,7 +171,7 @@ public class SQLTable extends Table implements Queryable {
     public Set<ColumnProjection> getColumnProjections() {
         return super.getColumns()
                 .stream()
-                .map((column) -> { return getColumnProjection(column.getName()); })
+                .map(column -> getColumnProjection(column.getName()))
                 .collect(Collectors.toSet());
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
@@ -62,16 +62,17 @@ public class AggregationDataStoreTestHarness implements DataStoreTestHarness {
                 .queryLogger(new Slf4jQueryLogger())
                 .build();
 
-        Consumer<EntityManager> txCancel = (em) -> { em.unwrap(Session.class).cancelQuery(); };
+        Consumer<EntityManager> txCancel = em -> em.unwrap(Session.class).cancelQuery();
 
         DataStore jpaStore = new JpaDataStore(
                 () -> entityManagerFactory.createEntityManager(),
-                (em) -> { return new NonJtaTransaction(em, txCancel); }
+                em -> new NonJtaTransaction(em, txCancel)
         );
 
         return new MultiplexManager(jpaStore, metaDataStore, aggregationDataStore);
     }
 
+    @Override
     public void cleanseTestData() {
 
     }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -103,16 +103,16 @@ public abstract class SQLUnitTest {
 
     // Standard set of test queries used in dialect tests
     protected enum TestQuery {
-        WHERE_DIMS_ONLY (() -> {
-            return Query.builder()
+        WHERE_DIMS_ONLY (() ->
+            Query.builder()
                     .source(playerStatsTable)
                     .dimensionProjection(playerStatsTable.getDimensionProjection("overallRating"))
                     .whereFilter(new FilterPredicate(
                             new Path(PlayerStats.class, dictionary, "overallRating"),
                             Operator.NOTNULL,
                             new ArrayList<Object>()))
-                    .build();
-        }),
+                    .build()
+        ),
         WHERE_AND (() -> {
             FilterPredicate ratingFilter = new FilterPredicate(
                     new Path(PlayerStats.class, dictionary, "overallRating"),
@@ -143,26 +143,26 @@ public abstract class SQLUnitTest {
                     .whereFilter(new OrFilterExpression(ratingFilter, highScoreFilter))
                     .build();
         }),
-        HAVING_METRICS_ONLY (() -> {
-            return Query.builder()
+        HAVING_METRICS_ONLY (() ->
+            Query.builder()
                     .source(playerStatsTable)
                     .metricProjection(playerStatsTable.getMetricProjection("lowScore"))
                     .havingFilter(new FilterPredicate(
                             new Path(PlayerStats.class, dictionary, "lowScore"),
                             Operator.GT,
                             Arrays.asList(9000)))
-                    .build();
-        }),
-        HAVING_DIMS_ONLY (() -> {
-            return Query.builder()
+                    .build()
+        ),
+        HAVING_DIMS_ONLY (() ->
+            Query.builder()
                     .source(playerStatsTable)
                     .dimensionProjection(playerStatsTable.getDimensionProjection("overallRating"))
                     .havingFilter(new FilterPredicate(
                             new Path(PlayerStats.class, dictionary, "overallRating"),
                             Operator.NOTNULL,
                             new ArrayList<Object>()))
-                    .build();
-        }),
+                    .build()
+        ),
         HAVING_METRICS_AND_DIMS (() -> {
             FilterPredicate ratingFilter = new FilterPredicate(
                     new Path(PlayerStats.class, dictionary, "overallRating"),
@@ -193,15 +193,15 @@ public abstract class SQLUnitTest {
                     .havingFilter(new OrFilterExpression(ratingFilter, highScoreFilter))
                     .build();
         }),
-        PAGINATION_TOTAL (() -> {
-            return Query.builder()
+        PAGINATION_TOTAL (() ->
+            Query.builder()
                     .source(playerStatsTable)
                     .metricProjection(playerStatsTable.getMetricProjection("lowScore"))
                     .dimensionProjection(playerStatsTable.getDimensionProjection("overallRating"))
                     .timeDimensionProjection(playerStatsTable.getTimeDimensionProjection("recordedDate"))
                     .pagination(new ImmutablePagination(0, 1, false, true))
-                    .build();
-        }),
+                    .build()
+        ),
         SORT_METRIC_ASC (() -> {
             Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
             sortMap.put("lowScore", Sorting.SortOrder.asc);
@@ -256,13 +256,13 @@ public abstract class SQLUnitTest {
                     .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                     .build();
         }),
-        PAGINATION_METRIC_ONLY (() -> {
-            return Query.builder()
+        PAGINATION_METRIC_ONLY (() ->
+            Query.builder()
                     .source(playerStatsTable)
                     .metricProjection(playerStatsTable.getMetricProjection("lowScore"))
                     .pagination(new ImmutablePagination(10, 5, false, true))
-                    .build();
-        }),
+                    .build()
+        ),
         COMPLICATED (() -> {
             // Sorting
             Map<String, Sorting.SortOrder> sortMap = new TreeMap<>();
@@ -396,30 +396,30 @@ public abstract class SQLUnitTest {
                     .sorting(new SortingImpl(sortMap, playerStatsType, sortAttributes, dictionary))
                     .build();
         }),
-        LEFT_JOIN (() -> {
-            return Query.builder()
+        LEFT_JOIN (() ->
+            Query.builder()
                     .source(videoGameTable)
                     .dimensionProjection(videoGameTable.getDimensionProjection("playerName"))
-                    .build();
-        }),
-        INNER_JOIN (() -> {
-            return Query.builder()
+                    .build()
+        ),
+        INNER_JOIN (() ->
+            Query.builder()
                     .source(videoGameTable)
                     .dimensionProjection(videoGameTable.getDimensionProjection("playerNameInnerJoin"))
-                    .build();
-        }),
-        CROSS_JOIN (() -> {
-            return Query.builder()
+                    .build()
+        ),
+        CROSS_JOIN (() ->
+            Query.builder()
                     .source(videoGameTable)
                     .dimensionProjection(videoGameTable.getDimensionProjection("playerNameCrossJoin"))
-                    .build();
-        }),
-        METRIC_JOIN(() -> {
-            return Query.builder()
+                    .build()
+        ),
+        METRIC_JOIN(() ->
+            Query.builder()
                     .source(videoGameTable)
                     .metricProjection(videoGameTable.getMetricProjection("normalizedHighScore"))
-                    .build();
-        });
+                    .build()
+        );
 
         private Provider<Query> queryProvider;
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -491,7 +491,8 @@ public abstract class SQLUnitTest {
     private static String getCompatabilityMode(String dialectType) {
         if (dialectType.equals(SQLDialectFactory.getMySQLDialect().getDialectType())) {
             return ";MODE=MySQL";
-        } else if (dialectType.equals(SQLDialectFactory.getPostgresDialect().getDialectType())) {
+        }
+        if (dialectType.equals(SQLDialectFactory.getPostgresDialect().getDialectType())) {
             return ";MODE=PostgreSQL";
         }
 
@@ -537,10 +538,14 @@ public abstract class SQLUnitTest {
     protected void compareQueryLists(List<String> expected, List<String> actual) {
         if (expected == null && actual == null) {
             return;
-        } else if (expected == null) {
+        }
+        if (expected == null) {
             fail("Expected a null query List, but actual was non-null");
-        } else if (actual == null) {
+            return;
+        }
+        if (actual == null) {
             fail("Expected a non-null query List, but actual was null");
+            return;
         }
 
         assertEquals(expected.size(), actual.size(), "Query List sizes do not match");

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DaySerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DaySerdeTest.java
@@ -55,8 +55,8 @@ public class DaySerdeTest {
 
         String dateInString = "January-01-2020";
         Serde serde = new Day.DaySerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/HourSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/HourSerdeTest.java
@@ -56,8 +56,8 @@ public class HourSerdeTest {
 
         String dateInString = "00 2020-01-01";
         Serde serde = new Hour.HourSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/ISOWeekSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/ISOWeekSerdeTest.java
@@ -45,9 +45,9 @@ public class ISOWeekSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         ISOWeek timestamp = new ISOWeek(localDate);
         Serde serde = new ISOWeek.ISOWeekSerde();
-        assertThrows(IllegalArgumentException.class, () -> {
-            serde.deserialize(timestamp);
-        });
+        assertThrows(IllegalArgumentException.class, () ->
+            serde.deserialize(timestamp)
+        );
     }
 
     @Test
@@ -65,8 +65,8 @@ public class ISOWeekSerdeTest {
 
         String dateInString = "January-2020-01";
         Serde serde = new ISOWeek.ISOWeekSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MinuteSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MinuteSerdeTest.java
@@ -57,8 +57,8 @@ public class MinuteSerdeTest {
 
         String dateInString = "00:18 2020-01-01";
         Serde serde = new Minute.MinuteSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MonthSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MonthSerdeTest.java
@@ -53,8 +53,8 @@ public class MonthSerdeTest {
     public void testDeserializeDateInvalidFormat() throws ParseException {
         String dateInString = "January-2020";
         Serde serde = new Month.MonthSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/QuarterSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/QuarterSerdeTest.java
@@ -43,9 +43,9 @@ public class QuarterSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(02), 01, 00, 00, 00);
         Quarter quarter = new Quarter(localDate);
         Serde serde = new Quarter.QuarterSerde();
-        assertThrows(IllegalArgumentException.class, () -> {
-            serde.deserialize(quarter);
-        });
+        assertThrows(IllegalArgumentException.class, () ->
+            serde.deserialize(quarter)
+        );
     }
 
     @Test
@@ -63,8 +63,8 @@ public class QuarterSerdeTest {
 
         String dateInString = "January-2020";
         Serde serde = new Quarter.QuarterSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SecondSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SecondSerdeTest.java
@@ -57,8 +57,8 @@ public class SecondSerdeTest {
 
         String dateInString = "00:18:19 2020-01-01";
         Serde serde = new Second.SecondSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/TimeSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/TimeSerdeTest.java
@@ -86,8 +86,8 @@ public class TimeSerdeTest {
     @Test
     public void testInvalidDeserialization() throws ParseException {
         Serde serde = new Time.TimeSerde();
-        assertThrows(IllegalArgumentException.class, () -> {
-            serde.deserialize("2020R1");
-        });
+        assertThrows(IllegalArgumentException.class, () ->
+            serde.deserialize("2020R1")
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/WeekSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/WeekSerdeTest.java
@@ -45,9 +45,9 @@ public class WeekSerdeTest {
 
         Week expectedDate = new Week(localDate);
         Serde serde = new Week.WeekSerde();
-        assertThrows(IllegalArgumentException.class, () -> {
-            serde.deserialize(expectedDate);
-        });
+        assertThrows(IllegalArgumentException.class, () ->
+            serde.deserialize(expectedDate)
+        );
     }
 
     @Test
@@ -66,8 +66,8 @@ public class WeekSerdeTest {
 
         String dateInString = "January-2020-01";
         Serde serde = new Week.WeekSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerdeTest.java
@@ -56,8 +56,8 @@ public class YearSerdeTest {
 
         String dateInString = "January";
         Serde serde = new Year.YearSerde();
-        assertThrows(DateTimeParseException.class, () -> {
-            serde.deserialize(dateInString);
-        });
+        assertThrows(DateTimeParseException.class, () ->
+            serde.deserialize(dateInString)
+        );
     }
 }

--- a/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/AbstractHibernateStore.java
+++ b/elide-datastore/elide-datastore-hibernate5/src/main/java/com/yahoo/elide/datastores/hibernate5/AbstractHibernateStore.java
@@ -95,7 +95,8 @@ public abstract class AbstractHibernateStore implements JPQLDataStore {
         public AbstractHibernateStore build() {
             if (sessionFactory != null) {
                 return new HibernateSessionFactoryStore(sessionFactory, isScrollEnabled, scrollMode);
-            } else if (emf != null) {
+            }
+            if (emf != null) {
                 return new HibernateEntityManagerStore(emf, isScrollEnabled, scrollMode);
             }
             throw new IllegalStateException("Either an EntityManager or SessionFactory is required!");

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreHarness.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreHarness.java
@@ -45,7 +45,7 @@ public class JpaDataStoreHarness implements DataStoreTestHarness {
 
     private DataStore store;
     private MetadataImplementor metadataImplementor;
-    private final Consumer<EntityManager> txCancel = (em) -> { em.unwrap(Session.class).cancelQuery(); };
+    private final Consumer<EntityManager> txCancel = em -> em.unwrap(Session.class).cancelQuery();
 
     public JpaDataStoreHarness() {
         Map<String, Object> options = new HashMap<>();
@@ -99,8 +99,8 @@ public class JpaDataStoreHarness implements DataStoreTestHarness {
         resetSchema();
 
         store = new JpaDataStore(
-                () -> { return emf.createEntityManager(); },
-                (entityManager) -> { return new NonJtaTransaction(entityManager, txCancel); }
+                () -> emf.createEntityManager(),
+                entityManager -> new NonJtaTransaction(entityManager, txCancel)
         );
     }
 

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
@@ -59,7 +59,7 @@ public class JpaDataStoreTest {
         EntityManager managerMock = mock(EntityManager.class);
         when(managerMock.getMetamodel()).thenReturn(mockModel);
 
-        JpaDataStore store = new JpaDataStore(() -> { return managerMock; }, (unused) -> { return null; });
+        JpaDataStore store = new JpaDataStore(() -> managerMock, unused -> null);
         EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
 
 
@@ -90,7 +90,7 @@ public class JpaDataStoreTest {
         EntityManager managerMock = mock(EntityManager.class);
         when(managerMock.getMetamodel()).thenReturn(mockModel);
 
-        JpaDataStore store = new JpaDataStore(() -> { return managerMock; }, (unused) -> { return null; }, getClassType(Test.class));
+        JpaDataStore store = new JpaDataStore(() -> managerMock, unused -> null, getClassType(Test.class));
         EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
         store.populateEntityDictionary(dictionary);
 

--- a/elide-datastore/elide-datastore-search/src/main/java/com/yahoo/elide/datastores/search/SearchDataTransaction.java
+++ b/elide-datastore/elide-datastore-search/src/main/java/com/yahoo/elide/datastores/search/SearchDataTransaction.java
@@ -281,9 +281,8 @@ public class SearchDataTransaction extends TransactionWrapper {
             }
 
             return results.stream()
-                    .map((result) -> {
-                        return result[0];
-                    }).collect(Collectors.toList());
+                    .map(result -> result[0])
+                    .collect(Collectors.toList());
     }
 
     private boolean fieldIsIndexed(Type<?> entityClass, FilterPredicate predicate) {

--- a/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DependencyBinder.java
+++ b/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DependencyBinder.java
@@ -46,12 +46,11 @@ public class DependencyBinder extends ResourceConfig {
                     indexOnStartup = true;
                 }
 
-                Consumer<EntityManager> txCancel = (em) -> { em.unwrap(Session.class).cancelQuery(); };
+                Consumer<EntityManager> txCancel = em -> em.unwrap(Session.class).cancelQuery();
                 EntityManagerFactory emf = Persistence.createEntityManagerFactory("searchDataStoreTest");
                 DataStore jpaStore = new JpaDataStore(
                         emf::createEntityManager,
-                        (em) -> { return new NonJtaTransaction(em, txCancel); }
-                        );
+                        em -> new NonJtaTransaction(em, txCancel));
 
                 EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
@@ -77,7 +77,8 @@ public class GraphQLScalars {
                 public String parseLiteral(Object o) {
                     if (o instanceof StringValue) {
                         return ((StringValue) o).getValue();
-                    } else if (o instanceof IntValue) {
+                    }
+                    if (o instanceof IntValue) {
                         return ((IntValue) o).getValue().toString();
                     }
                     // Unexpected object, try to use the toString.

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -434,14 +434,13 @@ public class PersistentResourceFetcher implements DataFetcher<Object> {
 
         if (!id.isPresent()) {
             throw new BadRequestException("UPDATE data objects must include ids");
-        } else {
-            Set<PersistentResource> loadedResource = fetchObject(
-                    requestScope,
-                    entity.getProjection(),
-                    Optional.of(Collections.singletonList(id.get()))
-            ).getPersistentResources();
-            updatedResource = loadedResource.iterator().next();
         }
+        Set<PersistentResource> loadedResource = fetchObject(
+                requestScope,
+                entity.getProjection(),
+                Optional.of(Collections.singletonList(id.get()))
+        ).getPersistentResources();
+        updatedResource = loadedResource.iterator().next();
 
         return updateAttributes(updatedResource, entity, attributes);
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -262,7 +262,6 @@ public class GraphQLEntityProjectionMaker {
             addRelationship(field, projectionBuilder);
         } else if (TYPENAME.equals(fieldName)) {
             // '__typename' would not be handled by entityProjection
-            return;
         } else if (PAGE_INFO.equals(fieldName)) {
             // only 'totalRecords' needs to be added into the projection's pagination
             if (field.getSelectionSet().getSelections().stream()

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/VariableResolver.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/VariableResolver.java
@@ -89,25 +89,33 @@ class VariableResolver {
     public Object resolveValue(Value value) {
         if (value instanceof BooleanValue) {
             return ((BooleanValue) value).isValue();
-        } else if (value instanceof EnumValue) {
+        }
+        if (value instanceof EnumValue) {
             // TODO
             throw new BadRequestException("Enum value is not supported.");
-        } else if (value instanceof FloatValue) {
+        }
+        if (value instanceof FloatValue) {
             return ((FloatValue) value).getValue();
-        } else if (value instanceof IntValue) {
+        }
+        if (value instanceof IntValue) {
             return ((IntValue) value).getValue();
-        } else if (value instanceof NullValue) {
+        }
+        if (value instanceof NullValue) {
             return null;
-        } else if (value instanceof StringValue) {
+        }
+        if (value instanceof StringValue) {
             return ((StringValue) value).getValue();
-        } else if (value instanceof ObjectValue) {
+        }
+        if (value instanceof ObjectValue) {
             return ((ObjectValue) value).getObjectFields().stream()
                     .collect(Collectors.toMap(ObjectField::getName, ObjectField::getValue));
-        } else if (value instanceof ArrayValue) {
+        }
+        if (value instanceof ArrayValue) {
             return ((ArrayValue) value).getValues().stream()
                     .map(this::resolveValue)
                     .collect(Collectors.toList());
-        } else if (value instanceof VariableReference) {
+        }
+        if (value instanceof VariableReference) {
             String variableName = ((VariableReference) value).getName();
             if (!scopeVariables.containsKey(variableName)) {
                 throw new BadRequestException("Can't resolve variable reference " + variableName);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/VariableResolver.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/VariableResolver.java
@@ -69,10 +69,9 @@ class VariableResolver {
             if (variableType instanceof NonNullType && scopeVariables.get(variableName) == null) {
                 // value of non-null variable must be resolvable
                 throw new BadRequestException("Undefined non-null variable " + variableName);
-            } else {
-                // this would put 'null' for this variable if it is not stored in the map
-                scopeVariables.put(variableName, scopeVariables.get(variableName));
             }
+            // this would put 'null' for this variable if it is not stored in the map
+            scopeVariables.put(variableName, scopeVariables.get(variableName));
         } else {
             if (!scopeVariables.containsKey(variableName)) {
                 // create a new variable with default value

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
@@ -325,33 +325,25 @@ public class DynamicConfigValidator implements DynamicConfiguration {
     }
 
     private String getInheritedSchema(Table table, String schema) {
-        Inheritance action = () -> {
-            return table.getSchema();
-        };
+        Inheritance action = () -> table.getSchema();
 
         return getInheritedAttribute(action, schema);
     }
 
     private String getInheritedConnection(Table table, String connection) {
-        Inheritance action = () -> {
-            return table.getDbConnectionName();
-        };
+        Inheritance action = () -> table.getDbConnectionName();
 
         return getInheritedAttribute(action, connection);
     }
 
     private String getInheritedSql(Table table, String sql) {
-        Inheritance action = () -> {
-            return table.getSql();
-        };
+        Inheritance action = () -> table.getSql();
 
         return getInheritedAttribute(action, sql);
     }
 
     private String getInheritedTable(Table table, String tableName) {
-        Inheritance action = () -> {
-            return table.getTable();
-        };
+        Inheritance action = () -> table.getTable();
 
         return getInheritedAttribute(action, tableName);
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -79,7 +79,7 @@ public class ElideAutoConfiguration {
     @Autowired(required = false)
     private MeterRegistry meterRegistry;
 
-    private final Consumer<EntityManager> txCancel = (em) -> { em.unwrap(Session.class).cancelQuery(); };
+    private final Consumer<EntityManager> txCancel = em -> em.unwrap(Session.class).cancelQuery();
 
     /**
      * Creates dynamic configuration for models, security roles, and database connections.
@@ -295,8 +295,9 @@ public class ElideAutoConfiguration {
                                     @Autowired(required = false) QueryLogger querylogger)
             throws ClassNotFoundException {
 
-        JpaDataStore jpaDataStore = new JpaDataStore(entityManagerFactory::createEntityManager,
-                                                     (em) -> { return new NonJtaTransaction(em, txCancel); });
+        JpaDataStore jpaDataStore = new JpaDataStore(
+                entityManagerFactory::createEntityManager,
+                em -> new NonJtaTransaction(em, txCancel));
 
         if (isAggregationStoreEnabled(settings)) {
             AggregationDataStore.AggregationDataStoreBuilder aggregationDataStoreBuilder =

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -68,7 +68,7 @@ import javax.persistence.EntityManagerFactory;
 public interface ElideStandaloneSettings {
     /* Elide settings */
 
-     public final Consumer<EntityManager> TXCANCEL = (em) -> { em.unwrap(Session.class).cancelQuery(); };
+     public final Consumer<EntityManager> TXCANCEL = em -> em.unwrap(Session.class).cancelQuery();
 
     /**
      * A map containing check mappings for security across Elide. If not provided, then an empty map is used.
@@ -394,8 +394,8 @@ public interface ElideStandaloneSettings {
     default DataStore getDataStore(MetaDataStore metaDataStore, AggregationDataStore aggregationDataStore,
             EntityManagerFactory entityManagerFactory) {
         DataStore jpaDataStore = new JpaDataStore(
-                () -> { return entityManagerFactory.createEntityManager(); },
-                (em) -> { return new NonJtaTransaction(em, TXCANCEL); });
+                () -> entityManagerFactory.createEntityManager(),
+                em -> new NonJtaTransaction(em, TXCANCEL));
 
         DataStore dataStore = new MultiplexManager(jpaDataStore, metaDataStore, aggregationDataStore);
 
@@ -409,8 +409,8 @@ public interface ElideStandaloneSettings {
      */
     default DataStore getDataStore(EntityManagerFactory entityManagerFactory) {
         DataStore jpaDataStore = new JpaDataStore(
-                () -> { return entityManagerFactory.createEntityManager(); },
-                (em) -> { return new NonJtaTransaction(em, TXCANCEL); });
+                () -> entityManagerFactory.createEntityManager(),
+                em -> new NonJtaTransaction(em, TXCANCEL));
 
         return jpaDataStore;
     }

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/SwaggerBuilder.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/SwaggerBuilder.java
@@ -209,8 +209,8 @@ public class SwaggerBuilder {
             Path path = new Path();
 
             /* The path parameter apply for all operations */
-            lineage.stream().forEach(item -> 
-                path.addParameter(item.getPathParameter()));
+            lineage.stream().forEach(item ->
+                    path.addParameter(item.getPathParameter()));
 
             String typeName = dictionary.getJsonAliasFor(type);
 

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/SwaggerBuilder.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/SwaggerBuilder.java
@@ -209,9 +209,8 @@ public class SwaggerBuilder {
             Path path = new Path();
 
             /* The path parameter apply for all operations */
-            lineage.stream().forEach((item) -> {
-                path.addParameter(item.getPathParameter());
-            });
+            lineage.stream().forEach(item -> 
+                path.addParameter(item.getPathParameter()));
 
             String typeName = dictionary.getJsonAliasFor(type);
 
@@ -298,11 +297,8 @@ public class SwaggerBuilder {
             Path path = new Path();
 
             /* The path parameter apply for all operations */
-            if (! lineage.isEmpty()) {
-                lineage.stream().forEach((item) -> {
-                    path.addParameter(item.getPathParameter());
-                });
-            }
+            lineage.stream().forEach(item ->
+                path.addParameter(item.getPathParameter()));
 
             Response okSingularResponse = new Response()
                     .description("Successful response")
@@ -361,9 +357,8 @@ public class SwaggerBuilder {
             Path path = new Path();
 
             /* The path parameter apply for all operations */
-            getFullLineage().stream().forEach((item) -> {
-                path.addParameter(item.getPathParameter());
-            });
+            getFullLineage().stream().forEach(item ->
+                path.addParameter(item.getPathParameter()));
 
             Response okSingularResponse = new Response()
                 .description("Successful response")
@@ -404,9 +399,8 @@ public class SwaggerBuilder {
          * @return the decorated path
          */
         private Path decorateGlobalParameters(Path path) {
-            globalParams.forEach((param) -> {
-                path.addParameter(param);
-            });
+            globalParams.forEach(param ->
+                path.addParameter(param));
             return path;
         }
 


### PR DESCRIPTION
## Description
Reduce code clutter by cleaning up syntax.
A lambda with a single statement does not need a code block.
Removed unnecessary else following a return to improve readability.

## Motivation and Context
Code quality.

## How Has This Been Tested?
Unit testing.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.