### PR TITLE
Async IT cleanup

### DIFF
--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncDelayDataStore.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncDelayDataStore.java
@@ -16,12 +16,9 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 public class AsyncDelayDataStore implements DataStore {
 
     private DataStore delayStore;
-    private Integer testDelay;
 
-    // TODO remove testDelay in this class.
     public AsyncDelayDataStore(DataStore delayStore, Integer testDelay) {
         this.delayStore = delayStore;
-        this.testDelay = testDelay;
     }
 
     public AsyncDelayDataStore(DataStore delayStore) {
@@ -35,11 +32,11 @@ public class AsyncDelayDataStore implements DataStore {
 
     @Override
     public DataStoreTransaction beginTransaction() {
-        return new AsyncDelayStoreTransaction(delayStore.beginTransaction(), testDelay);
+        return new AsyncDelayStoreTransaction(delayStore.beginTransaction());
     }
 
     @Override
     public DataStoreTransaction beginReadTransaction() {
-        return new AsyncDelayStoreTransaction(delayStore.beginReadTransaction(), testDelay);
+        return new AsyncDelayStoreTransaction(delayStore.beginReadTransaction());
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncDelayStoreTransaction.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncDelayStoreTransaction.java
@@ -20,17 +20,6 @@ import java.util.List;
 @Slf4j
 public class AsyncDelayStoreTransaction extends TransactionWrapper {
 
-    // TODO: Update AsyncIT and remove.
-    private Integer testDelay;
-    protected static Boolean sleep = false;
-
-    // TODO: Update AsyncIT and remove.
-    public AsyncDelayStoreTransaction(DataStoreTransaction tx, Integer testDelay) {
-
-        super(tx);
-        this.testDelay = testDelay;
-    }
-
     public AsyncDelayStoreTransaction(DataStoreTransaction tx) {
 
         super(tx);
@@ -44,8 +33,6 @@ public class AsyncDelayStoreTransaction extends TransactionWrapper {
             List<String> sleepTime = scope.getRequestHeaders().get("sleep");
             if (sleepTime != null && !sleepTime.isEmpty()) {
                 Thread.sleep(Integer.parseInt(sleepTime.get(0)));
-            } else if (sleep) {
-                Thread.sleep(testDelay);
             }
         } catch (InterruptedException e) {
             log.debug("Test delay interrupted");

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncIT.java
@@ -50,7 +50,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -180,11 +179,10 @@ public class AsyncIT extends IntegrationTest {
     @Test
     public void jsonApiHappyPath1() throws InterruptedException {
 
-        AsyncDelayStoreTransaction.sleep = true;
-
         //Create Async Request
         given()
                 .contentType(JSONAPI_CONTENT_TYPE)
+                .header("sleep", "1000")
                 .body(
                         data(
                                 resource(
@@ -259,11 +257,10 @@ public class AsyncIT extends IntegrationTest {
     @Test
     public void jsonApiHappyPath2() throws InterruptedException {
 
-        AsyncDelayStoreTransaction.sleep = true;
-
         //Create Async Request
         given()
                 .contentType(JSONAPI_CONTENT_TYPE)
+                .header("sleep", "1000")
                 .body(
                         data(
                                 resource(
@@ -302,7 +299,6 @@ public class AsyncIT extends IntegrationTest {
     @Test
     public void graphQLHappyPath1() throws InterruptedException {
 
-        AsyncDelayStoreTransaction.sleep = true;
         AsyncQuery queryObj = new AsyncQuery();
         queryObj.setId("edc4a871-dff2-4054-804e-d80075cf828e");
         queryObj.setAsyncAfterSeconds(0);
@@ -332,6 +328,7 @@ public class AsyncIT extends IntegrationTest {
         JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
         ValidatableResponse response = given()
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("sleep", "1000")
                 .accept(MediaType.APPLICATION_JSON)
                 .body(graphQLJsonNode)
                 .post("/graphQL")
@@ -385,7 +382,6 @@ public class AsyncIT extends IntegrationTest {
     @Test
     public void graphQLHappyPath2() throws InterruptedException {
 
-        AsyncDelayStoreTransaction.sleep = true;
         AsyncQuery queryObj = new AsyncQuery();
         queryObj.setId("edc4a871-dff2-4054-804e-d80075cf829e");
         queryObj.setAsyncAfterSeconds(7);
@@ -415,6 +411,7 @@ public class AsyncIT extends IntegrationTest {
         JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
         ValidatableResponse response = given()
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("sleep", "1000")
                 .accept(MediaType.APPLICATION_JSON)
                 .body(graphQLJsonNode)
                 .post("/graphQL")
@@ -451,7 +448,6 @@ public class AsyncIT extends IntegrationTest {
     @Test
     public void graphQLTestCreateFailOnQueryStatus() {
 
-        AsyncDelayStoreTransaction.sleep = true;
         AsyncQuery queryObj = new AsyncQuery();
         queryObj.setId("edc4a871-dff2-4054-804e-d80075cf839e");
         queryObj.setAsyncAfterSeconds(0);
@@ -481,6 +477,7 @@ public class AsyncIT extends IntegrationTest {
         JsonNode graphQLJsonNode = toJsonNode(graphQLRequest, null);
         ValidatableResponse response = given()
                 .contentType(MediaType.APPLICATION_JSON)
+                .header("sleep", "1000")
                 .accept(MediaType.APPLICATION_JSON)
                 .body(graphQLJsonNode)
                 .post("/graphQL")
@@ -746,11 +743,11 @@ public class AsyncIT extends IntegrationTest {
     @Test
     public void asyncAfterBeyondMax() throws InterruptedException {
         String expected = "{\"errors\":[{\"detail\":\"Invalid value: Invalid Async After Seconds\"}]}";
-        AsyncDelayStoreTransaction.sleep = true;
 
         //Create Async Request
         given()
                 .contentType(JSONAPI_CONTENT_TYPE)
+                .header("sleep", "1000")
                 .body(
                         data(
                                 resource(
@@ -770,15 +767,6 @@ public class AsyncIT extends IntegrationTest {
                 .statusCode(org.apache.http.HttpStatus.SC_BAD_REQUEST)
                 .body(equalTo(expected));
 
-    }
-
-    /**
-     * Reset sleep delay flag after each test.
-     */
-    @AfterEach
-    public void sleepDelayReset() {
-
-        AsyncDelayStoreTransaction.sleep = false;
     }
 
     private JsonNode toJsonNode(String query, Map<String, Object> variables) {


### PR DESCRIPTION
## Description
Cleanup Delay Logic in the AsyncIT.java

## Motivation and Context
Pass the delay through request headers instead of constructor args.

## How Has This Been Tested?
Existing test cases pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
