### PR TITLE
Fix Config Path to work correctly with Windows

### DIFF
--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/Config.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/Config.java
@@ -5,31 +5,30 @@
  */
 package com.yahoo.elide.modelconfig;
 
-import java.io.File;
 /**
  * Dynamic Config enum.
  */
 public enum Config {
 
     TABLE("table",
-          "models" + File.separator + "tables" + File.separator,
-          File.separator + "elideTableSchema.json"),
+          "models/tables/",
+          "/elideTableSchema.json"),
 
     SECURITY("security",
-             "models" + File.separator + "security.hjson",
-             File.separator + "elideSecuritySchema.json"),
+             "models/security.hjson",
+             "/elideSecuritySchema.json"),
 
     MODELVARIABLE("variable",
-                  "models" + File.separator + "variables.hjson",
-                  File.separator + "elideVariableSchema.json"),
+                  "models/variables.hjson",
+                  "/elideVariableSchema.json"),
 
     DBVARIABLE("variable",
-               "db" + File.separator + "variables.hjson",
-               File.separator + "elideVariableSchema.json"),
+               "db/variables.hjson",
+               "/elideVariableSchema.json"),
 
     SQLDBConfig("sqldbconfig",
-                "db" + File.separator + "sql" + File.separator,
-                File.separator + "elideDBConfigSchema.json");
+                "db/sql/",
+                "/elideDBConfigSchema.json");
 
     private final String configType;
     private final String configPath;

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DynamicConfigHelpers.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DynamicConfigHelpers.java
@@ -17,7 +17,6 @@ import org.hjson.JsonValue;
 import org.hjson.ParseException;
 import lombok.extern.slf4j.Slf4j;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,11 +42,10 @@ public class DynamicConfigHelpers {
      * @return formatted file path.
      */
     public static String formatFilePath(String basePath) {
-        if (isNullOrEmpty(basePath) || basePath.endsWith(File.separator)) {
-            return basePath;
-        } else {
-            return basePath += File.separator;
+        if (!(isNullOrEmpty(basePath) || basePath.endsWith("/"))) {
+            basePath += "/";
         }
+        return basePath;
     }
 
     /**

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
@@ -760,8 +760,8 @@ public class DynamicConfigValidator implements DynamicConfiguration {
      * @return Path to model dir
      */
     public static String formatClassPath(String filePath) {
-        if (filePath.indexOf(RESOURCES + File.separator) > -1) {
-            return filePath.substring(filePath.indexOf(RESOURCES + File.separator) + RESOURCES_LENGTH + 1);
+        if (filePath.indexOf(RESOURCES + "/") > -1) {
+            return filePath.substring(filePath.indexOf(RESOURCES + "/") + RESOURCES_LENGTH + 1);
         } else if (filePath.indexOf(RESOURCES) > -1) {
             return filePath.substring(filePath.indexOf(RESOURCES) + RESOURCES_LENGTH);
         }


### PR DESCRIPTION
It seems getResources function requires unix style path on windows.
So `resolver.getResources("file:C:\\<configDir>\\**\\*.hjson")` doesn't work on Windows but `resolver.getResources("file:C:/<configDir>/**/*.hjson")` works




## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
