### PR TITLE
Export Controller Disable on Async Disabled or Export Disabled

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ExportController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ExportController.java
@@ -37,7 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 @Configuration
 @RestController
 @RequestMapping(value = "${elide.async.export.path:/export}")
-@ConditionalOnExpression("${elide.async.export.enabled:false}")
+@ConditionalOnExpression("${elide.async.enabled:false} && ${elide.async.export.enabled:false}")
 public class ExportController {
 
     private ResultStorageEngine resultStorageEngine;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncDisableExportControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncDisableExportControllerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.tests;
+
+import static io.restassured.RestAssured.when;
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Executes Export Controller tests with Async Disabled.
+ */
+@TestPropertySource(
+        properties = {
+                "elide.async.enabled=false"
+        }
+)
+public class AsyncDisableExportControllerTest extends IntegrationTest {
+
+    @Test
+    public void exportControllerTest() {
+    	// A post to export will result in not found, if controller was disabled.
+    	// If controller is enabled, it returns Method Not Allowed. 
+        when()
+                .post("/export/1")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncDisableExportControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncDisableExportControllerTest.java
@@ -22,8 +22,8 @@ public class AsyncDisableExportControllerTest extends IntegrationTest {
 
     @Test
     public void exportControllerTest() {
-    	// A post to export will result in not found, if controller was disabled.
-    	// If controller is enabled, it returns Method Not Allowed. 
+        // A post to export will result in not found, if controller was disabled.
+        // If controller is enabled, it returns Method Not Allowed.
         when()
                 .post("/export/1")
                 .then()

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableExportControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableExportControllerTest.java
@@ -23,8 +23,8 @@ public class DisableExportControllerTest extends IntegrationTest {
 
     @Test
     public void exportControllerTest() {
-    	// A post to export will result in not found, if controller was disabled.
-    	// If controller is enabled, it returns Method Not Allowed. 
+        // A post to export will result in not found, if controller was disabled.
+        // If controller is enabled, it returns Method Not Allowed.
         when()
                 .post("/export/1")
                 .then()

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableExportControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableExportControllerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.tests;
+
+import static io.restassured.RestAssured.when;
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Executes Export Controller tests with Async Enabled but Export Controller Disabled.
+ */
+@TestPropertySource(
+        properties = {
+                "elide.async.enabled=true",
+                "elide.async.export.enabled=false"
+        }
+)
+public class DisableExportControllerTest extends IntegrationTest {
+
+    @Test
+    public void exportControllerTest() {
+    	// A post to export will result in not found, if controller was disabled.
+    	// If controller is enabled, it returns Method Not Allowed. 
+        when()
+                .post("/export/1")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+}


### PR DESCRIPTION


## Description
Currently Spring Export Controller is disabled when Export is disabled. Additional condition is added to make sure to check if Async is enabled or not. 

## Motivation and Context
If Async is disabled and export is enabled, it shouldn't launch the export controller as it can not be used without async components.

## How Has This Been Tested?
New test cases have been added.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
