### PR TITLE
use pipeline cache

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 cache:
-   event: ["~/.m2"]
+   pipeline: ["~/.m2"]
 
 shared:
    annotations:


### PR DESCRIPTION
## Description
Elide build has no build pipelines so effectively there is no [cache](https://docs.screwdriver.cd/user-guide/configuration/build-cache.html).

## Motivation and Context
Build optimization.

## How Has This Been Tested?
Building

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
