### PR TITLE
Correct exception logging

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncAPIUpdateOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncAPIUpdateOperation.java
@@ -40,10 +40,10 @@ public class AsyncAPIUpdateOperation implements Runnable {
             asyncAPIDao.updateAsyncAPIResult(queryResultObj, queryObj.getId(), queryObj.getClass());
 
         } catch (InterruptedException e) {
-            log.error("InterruptedException: {}", e);
+            log.error("InterruptedException: {}", e.toString());
             asyncAPIDao.updateStatus(queryObj.getId(), QueryStatus.FAILURE, queryObj.getClass());
         } catch (Exception e) {
-            log.error("Exception: {}", e);
+            log.error("Exception: {}", e.toString());
             asyncAPIDao.updateStatus(queryObj.getId(), QueryStatus.FAILURE, queryObj.getClass());
         }
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncAPIUpdateOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncAPIUpdateOperation.java
@@ -40,6 +40,7 @@ public class AsyncAPIUpdateOperation implements Runnable {
             asyncAPIDao.updateAsyncAPIResult(queryResultObj, queryObj.getId(), queryObj.getClass());
 
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.error("InterruptedException: {}", e.toString());
             asyncAPIDao.updateStatus(queryObj.getId(), QueryStatus.FAILURE, queryObj.getClass());
         } catch (Exception e) {

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
@@ -87,16 +87,16 @@ public class AsyncExecutorService {
             queryObj.setStatus(QueryStatus.COMPLETE);
             queryObj.setUpdatedOn(new Date());
         } catch (InterruptedException e) {
-            log.error("InterruptedException: {}", e);
+            log.error("InterruptedException: {}", e.toString());
             queryObj.setStatus(QueryStatus.FAILURE);
         } catch (ExecutionException e) {
-            log.error("ExecutionException: {}", e);
+            log.error("ExecutionException: {}", e.toString());
             queryObj.setStatus(QueryStatus.FAILURE);
         } catch (TimeoutException e) {
-            log.error("TimeoutException: {}", e);
+            log.error("TimeoutException: {}", e.toString());
             resultFuture.setSynchronousTimeout(true);
         } catch (Exception e) {
-            log.error("Exception: {}", e);
+            log.error("Exception: {}", e.toString());
             queryObj.setStatus(QueryStatus.FAILURE);
         } finally {
             asyncResultFutureThreadLocal.set(resultFuture);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncExecutorService.java
@@ -87,6 +87,7 @@ public class AsyncExecutorService {
             queryObj.setStatus(QueryStatus.COMPLETE);
             queryObj.setUpdatedOn(new Date());
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.error("InterruptedException: {}", e.toString());
             queryObj.setStatus(QueryStatus.FAILURE);
         } catch (ExecutionException e) {

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncAPIDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncAPIDAO.java
@@ -170,7 +170,7 @@ public class DefaultAsyncAPIDAO implements AsyncAPIDAO {
             tx.flush(scope);
             tx.commit(scope);
         } catch (IOException e) {
-            log.error("IOException: {}", e);
+            log.error("IOException: {}", e.toString());
             throw new IllegalStateException(e);
         }
         return result;
@@ -193,7 +193,7 @@ public class DefaultAsyncAPIDAO implements AsyncAPIDAO {
                 return loaded;
             });
         } catch (Exception e) {
-            log.error("Exception: {}", e);
+            log.error("Exception: {}", e.toString());
             throw new IllegalStateException(e);
         }
         return asyncAPIList;

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICancelRunnable.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICancelRunnable.java
@@ -119,7 +119,7 @@ public class AsyncAPICancelRunnable implements Runnable {
                         type);
             }
         } catch (Exception e) {
-            log.error("Exception in scheduled cancellation: {}", e);
+            log.error("Exception in scheduled cancellation: {}", e.toString());
         }
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICleanerRunnable.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICleanerRunnable.java
@@ -58,7 +58,7 @@ public class AsyncAPICleanerRunnable implements Runnable {
             FilterExpression fltDeleteExp = new LEPredicate(createdOnPathElement, cleanupDate);
             asyncAPIDao.deleteAsyncAPIAndResultByFilter(fltDeleteExp, type);
         } catch (Exception e) {
-            log.error("Exception in scheduled cleanup: {}", e);
+            log.error("Exception in scheduled cleanup: {}", e.toString());
         }
     }
 
@@ -79,7 +79,7 @@ public class AsyncAPICleanerRunnable implements Runnable {
             AndFilterExpression fltTimeoutExp = new AndFilterExpression(inPredicate, lePredicate);
             asyncAPIDao.updateStatusAsyncAPIByFilter(fltTimeoutExp, QueryStatus.TIMEDOUT, type);
         } catch (Exception e) {
-            log.error("Exception in scheduled cleanup: {}", e);
+            log.error("Exception in scheduled cleanup: {}", e.toString());
         }
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityPermissions.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityPermissions.java
@@ -115,7 +115,7 @@ public class EntityPermissions implements CheckInstantiator {
 
             return parseExpression(expression);
         } catch (ReflectiveOperationException e) {
-            log.warn("Unknown permission: {}, {}", annotationClass.getName(), e);
+            log.warn("Unknown permission: {}, {}", annotationClass.getName(), e.toString());
             throw new IllegalArgumentException("Unknown permission '" + annotationClass.getName() + "'", e);
         }
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncDelayStoreTransaction.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/AsyncDelayStoreTransaction.java
@@ -35,6 +35,7 @@ public class AsyncDelayStoreTransaction extends TransactionWrapper {
                 Thread.sleep(Integer.parseInt(sleepTime.get(0)));
             }
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.debug("Test delay interrupted");
         }
         return super.loadObjects(entityProjection, scope);


### PR DESCRIPTION
## Description
Always re-throw or re-interrupt when catching the `InterruptedException`.

When the final argument in a slf4j log message is a throwable, it generates a stack trace and is not one of the formatting arguments.
It appears the code had intended to display only the .toString based on the unused `{}`

> 05:46:51.561 [qtp135639164-244] ERROR c.y.e.a.service.AsyncExecutorService.executeQuery(AsyncExecutorService.java:96) - TimeoutException: {}
java.util.concurrent.TimeoutException: null
	at java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at com.yahoo.elide.async.service.AsyncExecutorService.executeQuery(AsyncExecutorService.java:85)
	at com.yahoo.elide.async.hooks.AsyncAPIHook.executeAsync(AsyncAPIHook.java:100)
	at com.yahoo.elide.async.hooks.AsyncAPIHook.executeHook(AsyncAPIHook.java:67)
	at com.yahoo.elide.async.hooks.AsyncQueryHook.execute(AsyncQueryHook.java:38)
	at com.yahoo.elide.async.hooks.AsyncQueryHook.execute(AsyncQueryHook.java:28)

## Motivation and Context
Incorrect logging

## How Has This Been Tested?
Unit testing

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
