### PR TITLE
bump jetty to 9.4.38.v20210224 for CVE-2020-27223

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <!-- dependency versions -->
         <version.antlr4>4.9</version.antlr4>
         <version.logback>1.2.3</version.logback>
-        <version.jetty>9.4.36.v20210114</version.jetty>
+        <version.jetty>9.4.38.v20210224</version.jetty>
         <version.restassured>4.3.3</version.restassured>
         <version.jackson>2.12.1</version.jackson>
         <version.jersey>2.32</version.jersey>


### PR DESCRIPTION
## Description
Update jetty

## Motivation and Context
Pass CVE checks

## How Has This Been Tested?
Unit testing

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
