### PR TITLE
Removed the duplicate entry for dependency - javax.persistence-api in 

### DIFF
--- a/elide-datastore/elide-datastore-inmemorydb/pom.xml
+++ b/elide-datastore/elide-datastore-inmemorydb/pom.xml
@@ -71,13 +71,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Removed the duplicate entry for dependency - javax.persistence-api in elide/elide-datastore/elide-datastore-inmemorydb/pom.xml

Resolves #<issue number> (if appropriate)

## Description
Removed duplicate entry for the dependency javax.persistence-api.


## Motivation and Context
The build when ran was giving a warning 

**[WARNING] Some problems were encountered while building the effective model for com.yahoo.elide:elide-datastore-inmemorydb:jar:5.0.0-pr32-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: javax.persistence:javax.persistence-api:jar -> duplicate declaration of version 2.2 @ com.yahoo.elide:elide-datastore-inmemorydb:[unknown-version], elide/elide-datastore/elide-datastore-inmemorydb/pom.xml, line 73, column 21**

## How Has This Been Tested?
After removing this line, the warning did not show up when the build was triggered.

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
