### PR TITLE
Refactor legacy hooks

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityBinding.java
@@ -12,6 +12,8 @@ import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.ComputedRelationship;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
 import com.yahoo.elide.annotation.ToMany;
 import com.yahoo.elide.annotation.ToOne;
 import com.yahoo.elide.core.PersistentResource;
@@ -103,10 +105,10 @@ public class EntityBinding {
     public final ConcurrentHashMap<String, String> relationshipToInverse = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, CascadeType[]> relationshipToCascadeTypes = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, AccessibleObject> fieldsToValues = new ConcurrentHashMap<>();
-    public final MultiValuedMap<Triple<String, LifeCycleHookBinding.Operation, LifeCycleHookBinding.TransactionPhase>,
-            LifeCycleHook> fieldTriggers = new HashSetValuedHashMap<>();
-    public final MultiValuedMap<Pair<LifeCycleHookBinding.Operation, LifeCycleHookBinding.TransactionPhase>,
-            LifeCycleHook> classTriggers = new HashSetValuedHashMap<>();
+    public final MultiValuedMap<Triple<String, Operation, TransactionPhase>, LifeCycleHook> fieldTriggers =
+            new HashSetValuedHashMap<>();
+    public final MultiValuedMap<Pair<Operation, TransactionPhase>, LifeCycleHook> classTriggers =
+            new HashSetValuedHashMap<>();
     public final ConcurrentHashMap<String, Type<?>> fieldsToTypes = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<String, String> aliasesToFields = new ConcurrentHashMap<>();
     public final ConcurrentHashMap<Method, Boolean> requestScopeableMethods = new ConcurrentHashMap<>();
@@ -116,7 +118,6 @@ public class EntityBinding {
 
     public static final EntityBinding EMPTY_BINDING = new EntityBinding();
     public static final Set<ArgumentType> EMPTY_ATTRIBUTES_ARGS = Collections.unmodifiableSet(new HashSet<>());
-    private static final String ALL_FIELDS = "*";
 
     /* empty binding constructor */
     private EntityBinding() {
@@ -530,11 +531,11 @@ public class EntityBinding {
         }
     }
 
-    public void bindTrigger(LifeCycleHookBinding.Operation operation,
-                            LifeCycleHookBinding.TransactionPhase phase,
+    public void bindTrigger(Operation operation,
+                            TransactionPhase phase,
                             String fieldOrMethodName,
                             LifeCycleHook hook) {
-        Triple<String, LifeCycleHookBinding.Operation, LifeCycleHookBinding.TransactionPhase> key =
+        Triple<String, Operation, TransactionPhase> key =
                 Triple.of(fieldOrMethodName, operation, phase);
 
         fieldTriggers.put(key, hook);
@@ -548,10 +549,10 @@ public class EntityBinding {
         bindTrigger(binding.operation(), binding.phase(), fieldOrMethodName, hook);
     }
 
-    public void bindTrigger(LifeCycleHookBinding.Operation operation,
-                            LifeCycleHookBinding.TransactionPhase phase,
+    public void bindTrigger(Operation operation,
+                            TransactionPhase phase,
                             LifeCycleHook hook) {
-        Pair<LifeCycleHookBinding.Operation, LifeCycleHookBinding.TransactionPhase> key =
+        Pair<Operation, TransactionPhase> key =
                 Pair.of(operation, phase);
 
         classTriggers.put(key, hook);
@@ -569,19 +570,19 @@ public class EntityBinding {
         bindTrigger(binding.operation(), binding.phase(), hook);
     }
 
-    public <A extends Annotation> Collection<LifeCycleHook> getTriggers(LifeCycleHookBinding.Operation op,
-                                                                        LifeCycleHookBinding.TransactionPhase phase,
+    public <A extends Annotation> Collection<LifeCycleHook> getTriggers(Operation op,
+                                                                        TransactionPhase phase,
                                                                         String fieldName) {
-        Triple<String, LifeCycleHookBinding.Operation, LifeCycleHookBinding.TransactionPhase> key =
+        Triple<String, Operation, TransactionPhase> key =
                 Triple.of(fieldName, op, phase);
         Collection<LifeCycleHook> bindings = fieldTriggers.get(key);
         return (bindings == null ? Collections.emptyList() : bindings);
     }
 
-    public <A extends Annotation> Collection<LifeCycleHook> getTriggers(LifeCycleHookBinding.Operation op,
-                                                                        LifeCycleHookBinding.TransactionPhase phase) {
+    public <A extends Annotation> Collection<LifeCycleHook> getTriggers(Operation op,
+                                                                        TransactionPhase phase) {
 
-        Pair<LifeCycleHookBinding.Operation, LifeCycleHookBinding.TransactionPhase> key =
+        Pair<Operation, TransactionPhase> key =
                 Pair.of(op, phase);
         Collection<LifeCycleHook> bindings = classTriggers.get(key);
         return (bindings == null ? Collections.emptyList() : bindings);

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -14,7 +14,8 @@ import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.ComputedRelationship;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
 import com.yahoo.elide.annotation.NonTransferable;
 import com.yahoo.elide.annotation.OnCreatePostCommit;
 import com.yahoo.elide.annotation.OnCreatePreCommit;
@@ -124,6 +125,7 @@ public class EntityDictionary {
 
     public final static String REGULAR_ID_NAME = "id";
     private final static ConcurrentHashMap<Type, String> SIMPLE_NAMES = new ConcurrentHashMap<>();
+    private static final String ALL_FIELDS = "*";
 
     /**
      * Instantiate a new EntityDictionary with the provided set of checks. In addition all of the checks
@@ -209,9 +211,9 @@ public class EntityDictionary {
     }
 
     public EntityDictionary(Map<String, Class<? extends Check>> checks,
-                Injector injector,
-                Function<Class, Serde> serdeLookup,
-                Set<Type<?>> entitiesToExclude) {
+            Injector injector,
+            Function<Class, Serde> serdeLookup,
+            Set<Type<?>> entitiesToExclude) {
         this.serdeLookup = serdeLookup;
         this.checkNames = Maps.synchronizedBiMap(HashBiMap.create(checks));
         this.roleChecks = new HashMap<>();
@@ -1064,15 +1066,15 @@ public class EntityDictionary {
     }
 
     public <A extends Annotation> Collection<LifeCycleHook> getTriggers(Type<?> cls,
-                                                                        LifeCycleHookBinding.Operation op,
-                                                                        LifeCycleHookBinding.TransactionPhase phase,
-                                                                        String fieldName) {
+            Operation op,
+            TransactionPhase phase,
+            String fieldName) {
         return getEntityBinding(cls).getTriggers(op, phase, fieldName);
     }
 
     public <A extends Annotation> Collection<LifeCycleHook> getTriggers(Type<?> cls,
-                                                                        LifeCycleHookBinding.Operation op,
-                                                                        LifeCycleHookBinding.TransactionPhase phase) {
+            Operation op,
+            TransactionPhase phase) {
         return getEntityBinding(cls).getTriggers(op, phase);
     }
 
@@ -1462,10 +1464,10 @@ public class EntityDictionary {
      * @param hook The callback to invoke.
      */
     public void bindTrigger(Class<?> entityClass,
-                            String fieldOrMethodName,
-                            LifeCycleHookBinding.Operation operation,
-                            LifeCycleHookBinding.TransactionPhase phase,
-                            LifeCycleHook hook) {
+            String fieldOrMethodName,
+            Operation operation,
+            TransactionPhase phase,
+            LifeCycleHook hook) {
         bindTrigger(new ClassType<>(entityClass), fieldOrMethodName, operation, phase, hook);
     }
 
@@ -1479,10 +1481,10 @@ public class EntityDictionary {
      * @param hook The callback to invoke.
      */
     public void bindTrigger(Type<?> entityClass,
-                            String fieldOrMethodName,
-                            LifeCycleHookBinding.Operation operation,
-                            LifeCycleHookBinding.TransactionPhase phase,
-                            LifeCycleHook hook) {
+            String fieldOrMethodName,
+            Operation operation,
+            TransactionPhase phase,
+            LifeCycleHook hook) {
         bindIfUnbound(entityClass);
 
         getEntityBinding(entityClass).bindTrigger(operation, phase, fieldOrMethodName, hook);
@@ -1502,10 +1504,10 @@ public class EntityDictionary {
      *                                 CRUD actions on the same model.
      */
     public void bindTrigger(Class<?> entityClass,
-                            LifeCycleHookBinding.Operation operation,
-                            LifeCycleHookBinding.TransactionPhase phase,
-                            LifeCycleHook hook,
-                            boolean allowMultipleInvocations) {
+            Operation operation,
+            TransactionPhase phase,
+            LifeCycleHook hook,
+            boolean allowMultipleInvocations) {
         bindTrigger(new ClassType<>(entityClass), operation, phase, hook, allowMultipleInvocations);
     }
 
@@ -1523,10 +1525,10 @@ public class EntityDictionary {
      *                                 CRUD actions on the same model.
      */
     public void bindTrigger(Type<?> entityClass,
-                            LifeCycleHookBinding.Operation operation,
-                            LifeCycleHookBinding.TransactionPhase phase,
-                            LifeCycleHook hook,
-                            boolean allowMultipleInvocations) {
+            Operation operation,
+            TransactionPhase phase,
+            LifeCycleHook hook,
+            boolean allowMultipleInvocations) {
         bindIfUnbound(entityClass);
 
         if (allowMultipleInvocations) {
@@ -1561,7 +1563,7 @@ public class EntityDictionary {
      * @param <T> The result type.
      * @return The collection of results.
      */
-    public <T> List<T> walkEntityGraph(Set<Type<?>> entities,  Function<Type<?>, T> transform) {
+    public <T> List<T> walkEntityGraph(Set<Type<?>> entities, Function<Type<?>, T> transform) {
         ArrayList<T> results = new ArrayList<>();
         Queue<Type<?>> toVisit = new ArrayDeque<>(entities);
         Set<Type<?>> visited = new HashSet<>();
@@ -1910,83 +1912,85 @@ public class EntityDictionary {
 
     public void bindLegacyHooks(EntityBinding binding) {
         binding.getAllMethods().stream()
+                .map(Method.class::cast)
                 .forEach(method -> {
-                    String annotationField = null;
-                    LifeCycleHookBinding.TransactionPhase phase = null;
-                    LifeCycleHookBinding.Operation operation = null;
                     if (method.isAnnotationPresent(OnCreatePostCommit.class)) {
-                        annotationField = method.getAnnotation(OnCreatePostCommit.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
-                        operation = LifeCycleHookBinding.Operation.CREATE;
-                    } else if (method.isAnnotationPresent(OnCreatePreCommit.class)) {
-                        annotationField = method.getAnnotation(OnCreatePreCommit.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
-                        operation = LifeCycleHookBinding.Operation.CREATE;
-                    } else if (method.isAnnotationPresent(OnCreatePreSecurity.class)) {
-                        annotationField = method.getAnnotation(OnCreatePreSecurity.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.PRESECURITY;
-                        operation = LifeCycleHookBinding.Operation.CREATE;
-                    } else if (method.isAnnotationPresent(OnUpdatePostCommit.class)) {
-                        annotationField = method.getAnnotation(OnUpdatePostCommit.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
-                        operation = LifeCycleHookBinding.Operation.UPDATE;
-                    } else if (method.isAnnotationPresent(OnUpdatePreCommit.class)) {
-                        annotationField = method.getAnnotation(OnUpdatePreCommit.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
-                        operation = LifeCycleHookBinding.Operation.UPDATE;
-                    } else if (method.isAnnotationPresent(OnUpdatePreSecurity.class)) {
-                        annotationField = method.getAnnotation(OnUpdatePreSecurity.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.PRESECURITY;
-                        operation = LifeCycleHookBinding.Operation.UPDATE;
-                    } else if (method.isAnnotationPresent(OnReadPostCommit.class)) {
-                        annotationField = method.getAnnotation(OnReadPostCommit.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
-                        operation = LifeCycleHookBinding.Operation.READ;
-                    } else if (method.isAnnotationPresent(OnReadPreCommit.class)) {
-                        annotationField = method.getAnnotation(OnReadPreCommit.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
-                        operation = LifeCycleHookBinding.Operation.READ;
-                    } else if (method.isAnnotationPresent(OnReadPreSecurity.class)) {
-                        annotationField = method.getAnnotation(OnReadPreSecurity.class).value();
-                        phase = LifeCycleHookBinding.TransactionPhase.PRESECURITY;
-                        operation = LifeCycleHookBinding.Operation.READ;
-                    } else if (method.isAnnotationPresent(OnDeletePostCommit.class)) {
-                        phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT;
-                        operation = LifeCycleHookBinding.Operation.DELETE;
-                    } else if (method.isAnnotationPresent(OnDeletePreCommit.class)) {
-                        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
-                        operation = LifeCycleHookBinding.Operation.DELETE;
-                    } else if (method.isAnnotationPresent(OnDeletePreSecurity.class)) {
-                        phase = LifeCycleHookBinding.TransactionPhase.PRESECURITY;
-                        operation = LifeCycleHookBinding.Operation.DELETE;
+                        bindHookMethod(binding, method, method.getAnnotation(OnCreatePostCommit.class).value(),
+                                TransactionPhase.POSTCOMMIT, Operation.CREATE);
                     }
-
-                    if (operation != null) {
-                        if (annotationField != null && ! annotationField.isEmpty()) {
-                            if (annotationField.equals("*")) {
-                                bindTrigger(binding.entityClass, operation, phase,
-                                        generateHook((Method) method), true);
-                            } else {
-                                bindTrigger(binding.entityClass, annotationField, operation, phase,
-                                        generateHook((Method) method));
-                            }
-                        } else {
-                            bindTrigger(binding.entityClass, operation, phase,
-                                    generateHook((Method) method), false);
-                        }
+                    if (method.isAnnotationPresent(OnCreatePreCommit.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnCreatePreCommit.class).value(),
+                                TransactionPhase.PRECOMMIT, Operation.CREATE);
                     }
-
+                    if (method.isAnnotationPresent(OnCreatePreSecurity.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnCreatePreSecurity.class).value(),
+                                TransactionPhase.PRESECURITY, Operation.CREATE);
+                    }
+                    if (method.isAnnotationPresent(OnUpdatePostCommit.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnUpdatePostCommit.class).value(),
+                                TransactionPhase.POSTCOMMIT, Operation.UPDATE);
+                    }
+                    if (method.isAnnotationPresent(OnUpdatePreCommit.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnUpdatePreCommit.class).value(),
+                                TransactionPhase.PRECOMMIT, Operation.UPDATE);
+                    }
+                    if (method.isAnnotationPresent(OnUpdatePreSecurity.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnUpdatePreSecurity.class).value(),
+                                TransactionPhase.PRESECURITY, Operation.UPDATE);
+                    }
+                    if (method.isAnnotationPresent(OnReadPostCommit.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnReadPostCommit.class).value(),
+                                TransactionPhase.POSTCOMMIT, Operation.READ);
+                    }
+                    if (method.isAnnotationPresent(OnReadPreCommit.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnReadPreCommit.class).value(),
+                                TransactionPhase.PRECOMMIT, Operation.READ);
+                    }
+                    if (method.isAnnotationPresent(OnReadPreSecurity.class)) {
+                        bindHookMethod(binding, method, method.getAnnotation(OnReadPreSecurity.class).value(),
+                                TransactionPhase.PRESECURITY, Operation.READ);
+                    }
+                    if (method.isAnnotationPresent(OnDeletePostCommit.class)) {
+                        bindHookMethod(binding, method, null, TransactionPhase.POSTCOMMIT, Operation.DELETE);
+                    }
+                    if (method.isAnnotationPresent(OnDeletePreCommit.class)) {
+                        bindHookMethod(binding, method, null, TransactionPhase.PRECOMMIT, Operation.DELETE);
+                    }
+                    if (method.isAnnotationPresent(OnDeletePreSecurity.class)) {
+                        bindHookMethod(binding, method, null, TransactionPhase.PRESECURITY, Operation.DELETE);
+                    }
                 });
+    }
+
+    private void bindHookMethod(
+            EntityBinding binding,
+            Method method,
+            String annotationField,
+            TransactionPhase phase,
+            Operation operation) {
+
+        if (StringUtils.isNotEmpty(annotationField)) {
+            if (annotationField.equals(ALL_FIELDS)) {
+                bindTrigger(binding.entityClass, operation, phase,
+                        generateHook(method), true);
+            } else {
+                bindTrigger(binding.entityClass, annotationField, operation, phase,
+                        generateHook(method));
+            }
+        } else {
+            bindTrigger(binding.entityClass, operation, phase,
+                    generateHook(method), false);
+        }
     }
 
     private static LifeCycleHook generateHook(Method method) {
         return new LifeCycleHook() {
             @Override
-            public void execute(LifeCycleHookBinding.Operation operation,
-                                LifeCycleHookBinding.TransactionPhase phase,
-                                Object model,
-                                com.yahoo.elide.core.security.RequestScope scope,
-                                Optional changes) {
+            public void execute(Operation operation,
+                    TransactionPhase phase,
+                    Object model,
+                    com.yahoo.elide.core.security.RequestScope scope,
+                    Optional changes) {
                 try {
                     int paramCount = method.getParameterCount();
                     Class<?>[] paramTypes = method.getParameterTypes();

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -1969,17 +1969,12 @@ public class EntityDictionary {
             TransactionPhase phase,
             Operation operation) {
 
-        if (StringUtils.isNotEmpty(annotationField)) {
-            if (annotationField.equals(ALL_FIELDS)) {
-                bindTrigger(binding.entityClass, operation, phase,
-                        generateHook(method), true);
-            } else {
-                bindTrigger(binding.entityClass, annotationField, operation, phase,
-                        generateHook(method));
-            }
+        if (StringUtils.isEmpty(annotationField)) {
+            bindTrigger(binding.entityClass, operation, phase, generateHook(method), false);
+        } else if (annotationField.equals(ALL_FIELDS)) {
+            bindTrigger(binding.entityClass, operation, phase, generateHook(method), true);
         } else {
-            bindTrigger(binding.entityClass, operation, phase,
-                    generateHook(method), false);
+            bindTrigger(binding.entityClass, annotationField, operation, phase, generateHook(method));
         }
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -479,7 +479,7 @@ public enum Operator {
                             .anyMatch(value -> predicate.test(leftHandSideElement, value)));
         }
         return leftHandSide != null && values.stream()
-                .map(value -> CoerceUtil.coerce(value, valueClass))
+                .map(value -> valueClass == null ? value : CoerceUtil.coerce(value, valueClass))
                 .anyMatch(value -> predicate.test(leftHandSide, value));
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
@@ -9,4 +9,11 @@ package com.yahoo.elide.core.security.checks;
  * Permissions are assigned as a set of checks that grant access to the permission.
  */
 public interface Check {
+
+    /**
+     * Should check run inline or be deferred to Commit
+     */
+    default boolean runInline() {
+        return true;
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
@@ -9,4 +9,13 @@ package com.yahoo.elide.core.security.checks;
  * Permissions are assigned as a set of checks that grant access to the permission.
  */
 public interface Check {
+
+    /**
+     * Should the check forced to be run at transaction commit or not.
+     *
+     * @return true to run at transaction commit
+     */
+    default boolean runAtCommit() {
+        return false;
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
@@ -9,12 +9,4 @@ package com.yahoo.elide.core.security.checks;
  * Permissions are assigned as a set of checks that grant access to the permission.
  */
 public interface Check {
-
-    /**
-     * Should check run inline or be deferred to Commit
-     * @return true to run at commit
-     */
-    default boolean runAtCommit() {
-        return false;
-    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/Check.java
@@ -12,8 +12,9 @@ public interface Check {
 
     /**
      * Should check run inline or be deferred to Commit
+     * @return true to run at commit
      */
-    default boolean runInline() {
-        return true;
+    default boolean runAtCommit() {
+        return false;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/FilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/FilterExpressionCheck.java
@@ -77,6 +77,11 @@ public abstract class FilterExpressionCheck<T> extends OperationCheck<T> {
         }
     }
 
+    @Override
+    public final boolean runAtCommit() {
+        return false;
+    }
+
     /**
      * Converts FieldExpressionPath value to corresponding list of Predicates.
      *

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/OperationCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/OperationCheck.java
@@ -31,4 +31,13 @@ public abstract class OperationCheck<T> implements Check {
      * @return true if security check passed
      */
     public abstract boolean ok(T object, RequestScope requestScope, Optional<ChangeSpec> changeSpec);
+
+    /**
+     * Should check run inline or be deferred to Commit
+     *
+     * @return true to run at commit
+     */
+    public boolean runAtCommit() {
+        return false;
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/OperationCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/OperationCheck.java
@@ -31,13 +31,4 @@ public abstract class OperationCheck<T> implements Check {
      * @return true if security check passed
      */
     public abstract boolean ok(T object, RequestScope requestScope, Optional<ChangeSpec> changeSpec);
-
-    /**
-     * Should check run inline or be deferred to Commit
-     *
-     * @return true to run at commit
-     */
-    public boolean runAtCommit() {
-        return false;
-    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/UserCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/UserCheck.java
@@ -19,4 +19,9 @@ public abstract class UserCheck implements Check {
      * @return True if user check passes, false otherwise
      */
     public abstract boolean ok(User user);
+
+    @Override
+    public final boolean runAtCommit() {
+        return false;
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
@@ -424,9 +424,9 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                     }
                     throw e;
                 }
-            } else {
-                commitCheckQueue.add(new QueuedCheck(expression, annotationClass));
+                return result;
             }
+            commitCheckQueue.add(new QueuedCheck(expression, annotationClass));
             return DEFERRED;
         }
         if (result == FAIL) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/PermissionCondition.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/PermissionCondition.java
@@ -30,14 +30,12 @@ public class PermissionCondition {
     @Getter final Optional<ChangeSpec> changes;
     @Getter final Optional<String> field;
 
-    private static final ImmutableMap<Class<? extends Annotation>, String> PERMISSION_TO_NAME =
-            ImmutableMap.<Class<? extends Annotation>, String>builder()
-                    .put(ReadPermission.class, "READ")
-                    .put(UpdatePermission.class, "UPDATE")
-                    .put(DeletePermission.class, "DELETE")
-                    .put(CreatePermission.class, "CREATE")
-                    .put(NonTransferable.class, "NO TRANSFER")
-                    .build();
+    private static final ImmutableMap<Class<? extends Annotation>, String> PERMISSION_TO_NAME = ImmutableMap.of(
+            ReadPermission.class, "READ",
+            UpdatePermission.class, "UPDATE",
+            DeletePermission.class, "DELETE",
+            CreatePermission.class, "CREATE",
+            NonTransferable.class, "NO TRANSFER");
 
     /**
      * This function attempts to create the appropriate {@link PermissionCondition} based on parameters that may or may

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
@@ -79,8 +79,7 @@ public class CheckExpression implements Expression {
             return result;
         }
 
-        if (mode == EvaluationMode.INLINE_CHECKS_ONLY
-                && check instanceof OperationCheck && ((OperationCheck<?>) check).runAtCommit()) {
+        if (mode == EvaluationMode.INLINE_CHECKS_ONLY && check.runAtCommit()) {
             result = DEFERRED;
             return result;
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
@@ -79,7 +79,7 @@ public class CheckExpression implements Expression {
             return result;
         }
 
-        if (mode == EvaluationMode.INLINE_CHECKS_ONLY && ! check.runInline()) {
+        if (mode == EvaluationMode.INLINE_CHECKS_ONLY && check.runAtCommit()) {
             result = DEFERRED;
             return result;
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
@@ -79,7 +79,8 @@ public class CheckExpression implements Expression {
             return result;
         }
 
-        if (mode == EvaluationMode.INLINE_CHECKS_ONLY && check.runAtCommit()) {
+        if (mode == EvaluationMode.INLINE_CHECKS_ONLY
+                && check instanceof OperationCheck && ((OperationCheck<?>) check).runAtCommit()) {
             result = DEFERRED;
             return result;
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
@@ -79,6 +79,11 @@ public class CheckExpression implements Expression {
             return result;
         }
 
+        if (mode == EvaluationMode.INLINE_CHECKS_ONLY && ! check.runInline()) {
+            result = DEFERRED;
+            return result;
+        }
+
         // If we have a valid change spec, do not cache the result or look for a cached result.
         if (changeSpec.isPresent()) {
             log.trace("-- Check has changespec: {}", changeSpec);

--- a/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LegacyTestModel.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LegacyTestModel.java
@@ -40,39 +40,39 @@ public class LegacyTestModel {
     @Setter
     private String field2;
 
-    @OnCreatePostCommit(value = "field")
+    @OnCreatePostCommit("field")
     public void fieldCreatePostCommit() {
     }
 
-    @OnCreatePreCommit(value = "field")
+    @OnCreatePreCommit("field")
     public void fieldCreatePreCommit() {
     }
 
-    @OnCreatePreSecurity(value = "field")
+    @OnCreatePreSecurity("field")
     public void fieldCreatePreSecurity() {
     }
 
-    @OnUpdatePostCommit(value = "field")
+    @OnUpdatePostCommit("field")
     public void fieldUpdatePostCommit() {
     }
 
-    @OnUpdatePreCommit(value = "field")
+    @OnUpdatePreCommit("field")
     public void fieldUpdatePreCommit() {
     }
 
-    @OnUpdatePreSecurity(value = "field")
+    @OnUpdatePreSecurity("field")
     public void fieldUpdatePreSecurity() {
     }
 
-    @OnReadPostCommit(value = "field")
+    @OnReadPostCommit("field")
     public void fieldReadPostCommit() {
     }
 
-    @OnReadPreCommit(value = "field")
+    @OnReadPreCommit("field")
     public void fieldReadPreCommit() {
     }
 
-    @OnReadPreSecurity(value = "field")
+    @OnReadPreSecurity("field")
     public void fieldReadPreSecurity() {
     }
 
@@ -126,5 +126,32 @@ public class LegacyTestModel {
 
     @OnCreatePreSecurity("*")
     public void classCreatePreCommitAllUpdates() {
+    }
+
+    @OnCreatePostCommit("field")
+    @OnCreatePreCommit
+    @OnCreatePreSecurity("field")
+    @OnReadPostCommit
+    @OnReadPreCommit("field")
+    @OnReadPreSecurity
+    @OnUpdatePostCommit("field")
+    @OnUpdatePreCommit
+    @OnUpdatePreSecurity("field")
+    public void fieldMultiple() {
+    }
+
+    @OnCreatePostCommit
+    @OnCreatePreCommit("field")
+    @OnCreatePreSecurity
+    @OnReadPostCommit("field")
+    @OnReadPreCommit
+    @OnReadPreSecurity("field")
+    @OnUpdatePostCommit
+    @OnUpdatePreCommit("field")
+    @OnUpdatePreSecurity
+    @OnDeletePostCommit
+    @OnDeletePreCommit
+    @OnDeletePreSecurity
+    public void classMultiple() {
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.core.lifecycle;
 
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.DELETE;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.READ;
@@ -55,6 +56,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.UUID;
+import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -150,6 +152,7 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).classCreatePreSecurity();
         verify(mockModel, times(1)).classCreatePreCommit();
         verify(mockModel, times(1)).classCreatePostCommit();
+        verify(mockModel, times(6)).classMultiple();
         verify(mockModel, never()).classUpdatePreCommit();
         verify(mockModel, never()).classUpdatePostCommit();
         verify(mockModel, never()).classUpdatePreSecurity();
@@ -163,6 +166,7 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).fieldCreatePreSecurity();
         verify(mockModel, times(1)).fieldCreatePreCommit();
         verify(mockModel, times(1)).fieldCreatePostCommit();
+        verify(mockModel, times(6)).fieldMultiple();
         verify(mockModel, never()).fieldUpdatePreCommit();
         verify(mockModel, never()).fieldUpdatePostCommit();
         verify(mockModel, never()).fieldUpdatePreSecurity();
@@ -269,6 +273,7 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).classReadPreSecurity();
         verify(mockModel, times(1)).classReadPreCommit();
         verify(mockModel, times(1)).classReadPostCommit();
+        verify(mockModel, times(3)).classMultiple();
         verify(mockModel, never()).classUpdatePreSecurity();
         verify(mockModel, never()).classUpdatePreCommit();
         verify(mockModel, never()).classUpdatePostCommit();
@@ -283,6 +288,7 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).fieldReadPreSecurity();
         verify(mockModel, times(1)).fieldReadPreCommit();
         verify(mockModel, times(1)).fieldReadPostCommit();
+        verify(mockModel, times(3)).fieldMultiple();
         verify(mockModel, never()).fieldUpdatePreSecurity();
         verify(mockModel, never()).fieldUpdatePreCommit();
         verify(mockModel, never()).fieldUpdatePostCommit();
@@ -480,6 +486,7 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).classUpdatePreSecurity();
         verify(mockModel, times(1)).classUpdatePreCommit();
         verify(mockModel, times(1)).classUpdatePostCommit();
+        verify(mockModel, times(3)).classMultiple();
 
         verify(mockModel, never()).fieldReadPreSecurity();
         verify(mockModel, never()).fieldReadPreCommit();
@@ -491,6 +498,7 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).fieldUpdatePreSecurity();
         verify(mockModel, times(1)).fieldUpdatePreCommit();
         verify(mockModel, times(1)).fieldUpdatePostCommit();
+        verify(mockModel, times(3)).fieldMultiple();
 
         verify(tx).preCommit(any());
         verify(tx).save(eq(mockModel), isA(RequestScope.class));
@@ -570,6 +578,7 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).classDeletePreSecurity();
         verify(mockModel, times(1)).classDeletePreCommit();
         verify(mockModel, times(1)).classDeletePostCommit();
+        verify(mockModel, times(3)).classMultiple();
 
         verify(mockModel, never()).fieldUpdatePostCommit();
         verify(mockModel, never()).fieldUpdatePreSecurity();
@@ -580,6 +589,7 @@ public class LifeCycleTest {
         verify(mockModel, never()).fieldCreatePostCommit();
         verify(mockModel, never()).fieldCreatePreSecurity();
         verify(mockModel, never()).fieldCreatePreCommit();
+        verify(mockModel, never()).fieldMultiple();
 
         verify(tx).preCommit(any());
         verify(tx).delete(eq(mockModel), isA(RequestScope.class));
@@ -589,377 +599,321 @@ public class LifeCycleTest {
     }
 
 //TODO - these need to be rewritten for Elide 5.
-//  @Test
-//  public void testElidePatchExtensionCreate() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      FieldTestModel mockModel = mock(FieldTestModel.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      String bookBody = "[{\"op\": \"add\",\"path\": \"/book\",\"value\":{"
-//              + "\"type\":\"book\",\"id\": \"A\",\"attributes\": {\"title\":\"Grapes of Wrath\"}}}]";
-//
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.createNewObject(Book.class)).thenReturn(book);
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
-//      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
-//
-//      /*
-//       * This gets called for :
-//       *  - read pre-security for the book
-//       *  - create pre-security for the book
-//       *  - read pre-commit for the book
-//       *  - create pre-commit for the book
-//       *  - read post-commit for the book
-//       *  - create post-commit for the book
-//       */
-//      verify(callback, times(6)).execute(eq(book), isA(RequestScope.class), any());
-//      verify(tx).accessUser(any());
-//      verify(tx).preCommit(any());
-//      verify(tx, times(1)).createObject(eq(book), isA(RequestScope.class));
-//      verify(tx).flush(isA(RequestScope.class));
-//      verify(tx).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  @Test
-//  public void failElidePatchExtensionCreate() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      Book book = mock(Book.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      String bookBody = "[{\"op\": \"add\",\"path\": \"/book\",\"value\":{"
-//              + "\"type\":\"book\",\"attributes\": {\"title\":\"Grapes of Wrath\"}}}]";
-//
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.createNewObject(Book.class)).thenReturn(book);
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
-//      assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
-//      assertEquals(
-//              "{\"errors\":[{\"detail\":\"JsonPatchExtensionException\"}]}",
-//              response.getBody());
-//
-//      verify(callback, never()).execute(eq(book), isA(RequestScope.class), any());
-//      verify(tx).accessUser(any());
-//      verify(tx, never()).preCommit(any());
-//      verify(tx, never()).flush(isA(RequestScope.class));
-//      verify(tx, never()).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  @Test
-//  public void testElidePatchExtensionUpdate() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      Book book = mock(Book.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      when(book.getId()).thenReturn(1L);
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.loadObject(eq(Book.class), any(), any(), isA(RequestScope.class))).thenReturn(book);
-//
-//      String bookBody = "[{\"op\": \"replace\",\"path\": \"/book/1\",\"value\":{"
-//              + "\"type\":\"book\",\"id\":1,\"attributes\": {\"title\":\"Grapes of Wrath\"}}}]";
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
-//      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
-//      assertEquals("[{\"data\":null}]", response.getBody());
-//
-//      /*
-//       * This gets called for :
-//       *  - read pre-security for the book
-//       *  - update pre-security for the book.title
-//       *  - read pre-commit for the book
-//       *  - update pre-commit for the book.title
-//       *  - read post-commit for the book
-//       *  - update post-commit for the book.title
-//       */
-//      verify(callback, times(6)).execute(eq(book), isA(RequestScope.class), any());
-//      verify(onUpdateImmediateCallback, times(1)).execute(eq(book), isA(RequestScope.class), any());
-//      verify(onUpdateDeferredCallback, times(1)).execute(eq(book), isA(RequestScope.class), any());
-//      verify(onUpdateImmediateCallback, never()).execute(eq(book), isA(RequestScope.class), eq(Optional.empty()));
-//      verify(onUpdateDeferredCallback, never()).execute(eq(book), isA(RequestScope.class), eq(Optional.empty()));
-//      verify(tx).accessUser(any());
-//      verify(tx).preCommit(any());
-//
-//      verify(tx).save(eq(book), isA(RequestScope.class));
-//      verify(tx).flush(isA(RequestScope.class));
-//      verify(tx).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  @Test
-//  public void testElidePatchExtensionDelete() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      Book book = mock(Book.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      when(book.getId()).thenReturn(1L);
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.loadObject(eq(Book.class), any(), any(), isA(RequestScope.class))).thenReturn(book);
-//
-//      String bookBody = "[{\"op\": \"remove\",\"path\": \"/book\",\"value\":{"
-//              + "\"type\":\"book\",\"id\": \"1\"}}]";
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", bookBody, null);
-//      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
-//
-//      /*
-//       * This gets called for :
-//       *  - delete pre-security for the book
-//       *  - delete pre-commit for the book
-//       *  - delete post-commit for the book
-//       */
-//      verify(callback, times(3)).execute(eq(book), isA(RequestScope.class), any());
-//      verify(tx).accessUser(any());
-//      verify(tx).preCommit(any());
-//
-//      verify(tx).delete(eq(book), isA(RequestScope.class));
-//      verify(tx).flush(isA(RequestScope.class));
-//      verify(tx).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  public void testElidePatchFailure() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      FieldTestModel mockModel = mock(FieldTestModel.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      String body = "{\"data\": {\"type\":\"testModel\",\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
-//
-//      dictionary.setValue(mockModel, "id", "1");
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
-//      doThrow(ConstraintViolationException.class).when(tx).flush(any());
-//
-//      String contentType = JSONAPI_CONTENT_TYPE;
-//      ElideResponse response = elide.patch(contentType, contentType, "/testModel/1", body, null, NO_VERSION);
-//      assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
-//      assertEquals(
-//              "{\"errors\":[{\"detail\":\"Constraint violation\"}]}",
-//              response.getBody());
-//
-//      verify(mockModel, never()).classAllFieldsCallback(any(), any());
-//
-//      verify(mockModel, never()).classCallback(eq(READ), any());
-//      verify(mockModel, never()).classCallback(eq(CREATE), any());
-//      verify(mockModel, never()).classCallback(eq(DELETE), any());
-//
-//      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRESECURITY));
-//      verify(mockModel, times(0)).classCallback(eq(UPDATE), eq(PRECOMMIT));
-//      verify(mockModel, times(0)).classCallback(eq(UPDATE), eq(POSTCOMMIT));
-//
-//      verify(mockModel, never()).attributeCallback(eq(READ), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(CREATE), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(PRESECURITY), any());
-//      verify(mockModel, times(0)).attributeCallback(eq(UPDATE), eq(PRECOMMIT), any());
-//      verify(mockModel, times(0)).attributeCallback(eq(UPDATE), eq(POSTCOMMIT), any());
-//
-//      verify(mockModel, never()).relationCallback(eq(READ), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
-//
-//      verify(tx).preCommit(any());
-//      verify(tx).save(eq(mockModel), isA(RequestScope.class));
-//      verify(tx).flush(isA(RequestScope.class));
-//      verify(tx, never()).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  @Test
-//  public void testElidePatchExtensionCreate() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      FieldTestModel mockModel = mock(FieldTestModel.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      String body = "[{\"op\": \"add\",\"path\": \"/testModel\",\"value\":{"
-//              + "\"type\":\"testModel\",\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}]";
-//
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
-//      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
-//
-//      verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
-//      verify(mockModel, times(1)).classCallback(eq(READ), eq(PRECOMMIT));
-//      verify(mockModel, times(1)).classCallback(eq(READ), eq(POSTCOMMIT));
-//      verify(mockModel, times(1)).classCallback(eq(CREATE), eq(PRESECURITY));
-//      verify(mockModel, times(1)).classCallback(eq(CREATE), eq(PRECOMMIT));
-//      verify(mockModel, times(1)).classCallback(eq(CREATE), eq(POSTCOMMIT));
-//      verify(mockModel, never()).classCallback(eq(UPDATE), any());
-//      verify(mockModel, never()).classCallback(eq(DELETE), any());
-//
-//      verify(mockModel, times(2)).classAllFieldsCallback(any(), any());
-//      verify(mockModel, times(2)).classAllFieldsCallback(eq(CREATE), eq(PRECOMMIT));
-//
-//      verify(mockModel, times(1)).attributeCallback(eq(READ), eq(PRESECURITY), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(READ), eq(PRECOMMIT), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(READ), eq(POSTCOMMIT), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(CREATE), eq(PRESECURITY), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(CREATE), eq(PRECOMMIT), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(CREATE), eq(POSTCOMMIT), any());
-//      verify(mockModel, never()).attributeCallback(eq(UPDATE), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
-//
-//      verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRESECURITY), any());
-//      verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRECOMMIT), any());
-//      verify(mockModel, times(1)).relationCallback(eq(READ), eq(POSTCOMMIT), any());
-//      verify(mockModel, times(1)).relationCallback(eq(CREATE), eq(PRESECURITY), any());
-//      verify(mockModel, times(1)).relationCallback(eq(CREATE), eq(PRECOMMIT), any());
-//      verify(mockModel, times(1)).relationCallback(eq(CREATE), eq(POSTCOMMIT), any());
-//      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
-//
-//      verify(tx).preCommit(any());
-//      verify(tx, times(1)).createObject(eq(mockModel), isA(RequestScope.class));
-//      verify(tx).flush(isA(RequestScope.class));
-//      verify(tx).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  @Test
-//  public void failElidePatchExtensionCreate() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      FieldTestModel mockModel = mock(FieldTestModel.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      String body = "[{\"op\": \"add\",\"path\": \"/testModel\",\"value\":{"
-//              + "\"type\":\"testModel\",\"attributes\": {\"field\":\"Foo\"}}}]";
-//
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.createNewObject(FieldTestModel.class)).thenReturn(mockModel);
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
-//      assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
-//      assertEquals(
-//              "[{\"errors\":[{\"detail\":\"Bad Request Body&#39;Patch extension requires all objects to have an assigned ID (temporary or permanent) when assigning relationships.&#39;\",\"status\":\"400\"}]}]",
-//              response.getBody());
-//
-//      verify(tx, never()).preCommit(any());
-//      verify(tx, never()).flush(isA(RequestScope.class));
-//      verify(tx, never()).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  @Test
-//  public void testElidePatchExtensionUpdate() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      FieldTestModel mockModel = mock(FieldTestModel.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      String body = "[{\"op\": \"replace\",\"path\": \"/testModel/1\",\"value\":{"
-//              + "\"type\":\"testModel\",\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}]";
-//
-//      dictionary.setValue(mockModel, "id", "1");
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
-//      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
-//
-//      verify(mockModel, never()).classAllFieldsCallback(any(), any());
-//
-//      verify(mockModel, never()).classCallback(eq(READ), any());
-//      verify(mockModel, never()).classCallback(eq(CREATE), any());
-//      verify(mockModel, never()).classCallback(eq(DELETE), any());
-//      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRESECURITY));
-//      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRECOMMIT));
-//      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(POSTCOMMIT));
-//
-//      verify(mockModel, never()).attributeCallback(eq(READ), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(CREATE), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(PRESECURITY), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(PRECOMMIT), any());
-//      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(POSTCOMMIT), any());
-//
-//      verify(mockModel, never()).relationCallback(eq(READ), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
-//
-//      verify(tx).preCommit(any());
-//      verify(tx).save(eq(mockModel), isA(RequestScope.class));
-//      verify(tx).flush(isA(RequestScope.class));
-//      verify(tx).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
-//
-//  @Test
-//  public void testElidePatchExtensionDelete() throws Exception {
-//      DataStore store = mock(DataStore.class);
-//      DataStoreTransaction tx = mock(DataStoreTransaction.class);
-//      FieldTestModel mockModel = mock(FieldTestModel.class);
-//
-//      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
-//
-//      dictionary.setValue(mockModel, "id", "1");
-//      when(store.beginTransaction()).thenReturn(tx);
-//      when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
-//
-//      String body = "[{\"op\": \"remove\",\"path\": \"/testModel\",\"value\":{"
-//              + "\"type\":\"testModel\",\"id\":\"1\"}}]";
-//
-//      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
-//      ElideResponse response = elide.patch(contentType, contentType, "/", body, null, NO_VERSION);
-//      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
-//
-//      verify(mockModel, never()).classAllFieldsCallback(any(), any());
-//
-//      verify(mockModel, never()).classCallback(eq(UPDATE), any());
-//      verify(mockModel, never()).classCallback(eq(CREATE), any());
-//      verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
-//      verify(mockModel, times(1)).classCallback(eq(READ), eq(PRECOMMIT));
-//      verify(mockModel, times(1)).classCallback(eq(READ), eq(POSTCOMMIT));
-//      verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRESECURITY));
-//      verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRECOMMIT));
-//      verify(mockModel, times(1)).classCallback(eq(DELETE), eq(POSTCOMMIT));
-//
-//      verify(mockModel, never()).attributeCallback(eq(UPDATE), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(CREATE), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(READ), any(), any());
-//      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
-//
-//      //TODO - Read should not be called for a delete.
-//      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
-//      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
-//      verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRESECURITY), any());
-//      verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRECOMMIT), any());
-//      verify(mockModel, times(1)).relationCallback(eq(READ), eq(POSTCOMMIT), any());
-//
-//      verify(tx).preCommit(any());
-//      verify(tx).delete(eq(mockModel), isA(RequestScope.class));
-//      verify(tx).flush(isA(RequestScope.class));
-//      verify(tx).commit(isA(RequestScope.class));
-//      verify(tx).close();
-//  }
+
+    @Test
+    public void testElidePatchExtensionCreate() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel mockModel = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
+
+        String body = "[{\"op\": \"add\",\"path\": \"/testModel\",\"value\":{"
+                + "\"type\":\"testModel\",\"id\": \"1\",\"attributes\": {\"field\":\"Foo\"}}}]";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(new ClassType<>(FieldTestModel.class))).thenReturn(mockModel);
+
+        String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
+        ElideResponse response =
+                elide.patch(baseUrl, contentType, contentType, "/", body, null, NO_VERSION);
+        assertEquals(HttpStatus.SC_OK, response.getResponseCode());
+
+        verify(mockModel, times(1)).classCallback(eq(READ), eq(PRESECURITY));
+        verify(mockModel, times(1)).classCallback(eq(READ), eq(PRECOMMIT));
+        verify(mockModel, times(1)).classCallback(eq(READ), eq(POSTCOMMIT));
+        verify(mockModel, times(1)).classCallback(eq(CREATE), eq(PRESECURITY));
+        verify(mockModel, times(1)).classCallback(eq(CREATE), eq(PRECOMMIT));
+        verify(mockModel, times(1)).classCallback(eq(CREATE), eq(POSTCOMMIT));
+        verify(mockModel, never()).classCallback(eq(UPDATE), any());
+        verify(mockModel, never()).classCallback(eq(DELETE), any());
+
+        verify(mockModel, times(2)).classAllFieldsCallback(any(), any());
+        verify(mockModel, times(2)).classAllFieldsCallback(eq(CREATE), eq(PRECOMMIT));
+
+        verify(mockModel, times(1)).attributeCallback(eq(READ), eq(PRESECURITY), any());
+        verify(mockModel, times(1)).attributeCallback(eq(READ), eq(PRECOMMIT), any());
+        verify(mockModel, times(1)).attributeCallback(eq(READ), eq(POSTCOMMIT), any());
+        verify(mockModel, times(1)).attributeCallback(eq(CREATE), eq(PRESECURITY), any());
+        verify(mockModel, times(1)).attributeCallback(eq(CREATE), eq(PRECOMMIT), any());
+        verify(mockModel, times(1)).attributeCallback(eq(CREATE), eq(POSTCOMMIT), any());
+        verify(mockModel, never()).attributeCallback(eq(UPDATE), any(), any());
+        verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
+
+        verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRESECURITY), any());
+        verify(mockModel, times(1)).relationCallback(eq(READ), eq(PRECOMMIT), any());
+        verify(mockModel, times(1)).relationCallback(eq(READ), eq(POSTCOMMIT), any());
+        verify(mockModel, times(1)).relationCallback(eq(CREATE), eq(PRESECURITY), any());
+        verify(mockModel, times(1)).relationCallback(eq(CREATE), eq(PRECOMMIT), any());
+        verify(mockModel, times(1)).relationCallback(eq(CREATE), eq(POSTCOMMIT), any());
+        verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
+        verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
+
+        verify(tx).preCommit(any());
+        verify(tx, times(1)).createObject(eq(mockModel), isA(RequestScope.class));
+        verify(tx).flush(isA(RequestScope.class));
+        verify(tx).commit(isA(RequestScope.class));
+        verify(tx).close();
+    }
+
+    @Test
+    public void testLegacyElidePatchExtensionCreate() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        LegacyTestModel mockModel = mock(LegacyTestModel.class);
+
+        Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
+
+        String body = "[{\"op\": \"add\",\"path\": \"/legacyTestModel\",\"value\":{"
+                + "\"type\":\"legacyTestModel\",\"id\": \"1\",\"attributes\": {\"field\":\"Foo\"}}}]";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(new ClassType<>(LegacyTestModel.class))).thenReturn(mockModel);
+
+        String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
+        ElideResponse response =
+                elide.patch(baseUrl, contentType, contentType, "/", body, null, NO_VERSION);
+        assertEquals(HttpStatus.SC_OK, response.getResponseCode());
+
+        verify(mockModel, times(1)).classCreatePreSecurity();
+        verify(mockModel, times(1)).classCreatePreCommit();
+        verify(mockModel, times(1)).classCreatePreCommitAllUpdates();
+        verify(mockModel, times(1)).classCreatePostCommit();
+        verify(mockModel, times(1)).classReadPreSecurity();
+        verify(mockModel, times(1)).classReadPreCommit();
+        verify(mockModel, times(1)).classReadPostCommit();
+        verify(mockModel, times(6)).classMultiple();
+        verify(mockModel, never()).classUpdatePreCommit();
+        verify(mockModel, never()).classUpdatePostCommit();
+        verify(mockModel, never()).classUpdatePreSecurity();
+        verify(mockModel, never()).classDeletePreCommit();
+        verify(mockModel, never()).classDeletePostCommit();
+        verify(mockModel, never()).classDeletePreSecurity();
+
+        verify(mockModel, times(1)).fieldCreatePostCommit();
+        verify(mockModel, times(1)).fieldCreatePreCommit();
+        verify(mockModel, times(1)).fieldCreatePreSecurity();
+        verify(mockModel, times(1)).fieldReadPostCommit();
+        verify(mockModel, times(1)).fieldReadPreCommit();
+        verify(mockModel, times(1)).fieldReadPreSecurity();
+        verify(mockModel, times(6)).fieldMultiple();
+        verify(mockModel, never()).fieldUpdatePreCommit();
+        verify(mockModel, never()).fieldUpdatePostCommit();
+        verify(mockModel, never()).fieldUpdatePreSecurity();
+
+        verify(tx).preCommit(any());
+        verify(tx, times(1)).createObject(eq(mockModel), isA(RequestScope.class));
+        verify(tx).flush(isA(RequestScope.class));
+        verify(tx).commit(isA(RequestScope.class));
+        verify(tx).close();
+    }
+
+  @Test
+  public void failElidePatchExtensionCreate() throws Exception {
+      DataStore store = mock(DataStore.class);
+      DataStoreTransaction tx = mock(DataStoreTransaction.class);
+      FieldTestModel mockModel = mock(FieldTestModel.class);
+
+      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
+
+      String body = "[{\"op\": \"add\",\"path\": \"/testModel\",\"value\":{"
+              + "\"type\":\"testModel\",\"attributes\": {\"field\":\"Foo\"}}}]";
+
+      when(store.beginTransaction()).thenReturn(tx);
+      when(tx.createNewObject(new ClassType<>(FieldTestModel.class))).thenReturn(mockModel);
+
+      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
+      ElideResponse response =
+              elide.patch(baseUrl, contentType, contentType, "/", body, null, NO_VERSION);
+      assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
+      assertEquals(
+              "[{\"errors\":[{\"detail\":\"Bad Request Body&#39;Patch extension requires all objects to have an assigned ID (temporary or permanent) when assigning relationships.&#39;\",\"status\":\"400\"}]}]",
+              response.getBody());
+
+      verify(mockModel, never()).classCallback(eq(READ), eq(PRESECURITY));
+      verify(mockModel, never()).classCallback(eq(READ), eq(PRECOMMIT));
+      verify(mockModel, never()).classCallback(eq(READ), eq(POSTCOMMIT));
+      verify(mockModel, never()).classCallback(eq(CREATE), eq(PRESECURITY));
+      verify(mockModel, never()).classCallback(eq(CREATE), eq(PRECOMMIT));
+      verify(mockModel, never()).classCallback(eq(CREATE), eq(POSTCOMMIT));
+      verify(mockModel, never()).classCallback(eq(UPDATE), any());
+      verify(mockModel, never()).classCallback(eq(DELETE), any());
+
+      verify(mockModel, never()).classAllFieldsCallback(any(), any());
+      verify(mockModel, never()).classAllFieldsCallback(eq(CREATE), eq(PRECOMMIT));
+
+      verify(mockModel, never()).attributeCallback(eq(READ), eq(PRESECURITY), any());
+      verify(mockModel, never()).attributeCallback(eq(READ), eq(PRECOMMIT), any());
+      verify(mockModel, never()).attributeCallback(eq(READ), eq(POSTCOMMIT), any());
+      verify(mockModel, never()).attributeCallback(eq(CREATE), eq(PRESECURITY), any());
+      verify(mockModel, never()).attributeCallback(eq(CREATE), eq(PRECOMMIT), any());
+      verify(mockModel, never()).attributeCallback(eq(CREATE), eq(POSTCOMMIT), any());
+      verify(mockModel, never()).attributeCallback(eq(UPDATE), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
+
+      verify(mockModel, never()).relationCallback(eq(READ), eq(PRESECURITY), any());
+      verify(mockModel, never()).relationCallback(eq(READ), eq(PRECOMMIT), any());
+      verify(mockModel, never()).relationCallback(eq(READ), eq(POSTCOMMIT), any());
+      verify(mockModel, never()).relationCallback(eq(CREATE), eq(PRESECURITY), any());
+      verify(mockModel, never()).relationCallback(eq(CREATE), eq(PRECOMMIT), any());
+      verify(mockModel, never()).relationCallback(eq(CREATE), eq(POSTCOMMIT), any());
+      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
+
+      verify(tx, never()).preCommit(any());
+      verify(tx, never()).createObject(eq(mockModel), isA(RequestScope.class));
+      verify(tx, never()).flush(isA(RequestScope.class));
+      verify(tx, never()).commit(isA(RequestScope.class));
+      verify(tx).close();
+  }
+
+  @Test
+  public void testElidePatchExtensionUpdate() throws Exception {
+      DataStore store = mock(DataStore.class);
+      DataStoreTransaction tx = mock(DataStoreTransaction.class);
+      FieldTestModel mockModel = mock(FieldTestModel.class);
+
+      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
+
+      String body = "[{\"op\": \"replace\",\"path\": \"/testModel/1\",\"value\":{"
+              + "\"type\":\"testModel\",\"id\": \"1\",\"attributes\": {\"field\":\"Foo\"}}}]";
+
+      dictionary.setValue(mockModel, "id", "1");
+      when(store.beginTransaction()).thenReturn(tx);
+      when(tx.loadObject(any(), any(), isA(RequestScope.class))).thenReturn(mockModel);
+
+      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
+      ElideResponse response =
+              elide.patch(baseUrl, contentType, contentType, "/", body, null, NO_VERSION);
+      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
+      assertEquals("[{\"data\":null}]", response.getBody());
+
+      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRESECURITY));
+      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRECOMMIT));
+      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(POSTCOMMIT));
+      verify(mockModel, never()).classCallback(eq(READ), any());
+      verify(mockModel, never()).classCallback(eq(CREATE), any());
+      verify(mockModel, never()).classCallback(eq(DELETE), any());
+
+      verify(mockModel, never()).classAllFieldsCallback(any(), any());
+      verify(mockModel, never()).classAllFieldsCallback(eq(CREATE), eq(PRECOMMIT));
+
+      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(PRESECURITY), any());
+      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(PRECOMMIT), any());
+      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(POSTCOMMIT), any());
+      verify(mockModel, never()).attributeCallback(eq(READ), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(CREATE), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
+
+      verify(mockModel, never()).relationCallback(eq(READ), any(), any());
+      verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
+
+      verify(tx).preCommit(any());
+      verify(tx).loadObject(any(), any(), isA(RequestScope.class));
+      verify(tx).flush(isA(RequestScope.class));
+      verify(tx).commit(isA(RequestScope.class));
+      verify(tx).close();
+}
+
+  @Test
+  public void testElidePatchExtensionDelete() throws Exception {
+      DataStore store = mock(DataStore.class);
+      DataStoreTransaction tx = mock(DataStoreTransaction.class);
+      FieldTestModel mockModel = mock(FieldTestModel.class);
+
+      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
+
+      String body = "[{\"op\": \"remove\",\"path\": \"/testModel\",\"value\":{"
+              + "\"type\":\"testModel\",\"id\": \"1\"}}]";
+
+      dictionary.setValue(mockModel, "id", "1");
+      when(store.beginTransaction()).thenReturn(tx);
+      when(tx.loadObject(any(), any(), isA(RequestScope.class))).thenReturn(mockModel);
+
+      String contentType = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
+      ElideResponse response =
+              elide.patch(baseUrl, contentType, contentType, "/", body, null, NO_VERSION);
+      assertEquals(HttpStatus.SC_OK, response.getResponseCode());
+
+      verify(mockModel, never()).classAllFieldsCallback(any(), any());
+
+      verify(mockModel, never()).classCallback(eq(UPDATE), any());
+      verify(mockModel, never()).classCallback(eq(CREATE), any());
+      verify(mockModel, never()).classCallback(eq(READ), any());
+      verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRESECURITY));
+      verify(mockModel, times(1)).classCallback(eq(DELETE), eq(PRECOMMIT));
+      verify(mockModel, times(1)).classCallback(eq(DELETE), eq(POSTCOMMIT));
+
+      verify(mockModel, never()).attributeCallback(eq(UPDATE), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(CREATE), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(READ), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
+
+      // TODO - Read should not be called for a delete.
+      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(READ), any(), any());
+
+      verify(tx).preCommit(any());
+      verify(tx).delete(eq(mockModel), isA(RequestScope.class));
+      verify(tx).flush(isA(RequestScope.class));
+      verify(tx).commit(isA(RequestScope.class));
+      verify(tx).close();
+  }
+
+  public void testElidePatchFailure() throws Exception {
+      DataStore store = mock(DataStore.class);
+      DataStoreTransaction tx = mock(DataStoreTransaction.class);
+      FieldTestModel mockModel = mock(FieldTestModel.class);
+
+      Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
+
+      String body = "{\"data\": {\"type\":\"testModel\",\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
+
+      dictionary.setValue(mockModel, "id", "1");
+      when(store.beginTransaction()).thenReturn(tx);
+      when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
+      doThrow(ConstraintViolationException.class).when(tx).flush(any());
+
+      String contentType = JSONAPI_CONTENT_TYPE;
+      ElideResponse response =
+              elide.patch(baseUrl, contentType, contentType, "/testModel/1", body, null, NO_VERSION);
+      assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
+      assertEquals(
+              "{\"errors\":[{\"detail\":\"Constraint violation\"}]}",
+              response.getBody());
+
+      verify(mockModel, never()).classAllFieldsCallback(any(), any());
+
+      verify(mockModel, never()).classCallback(eq(READ), any());
+      verify(mockModel, never()).classCallback(eq(CREATE), any());
+      verify(mockModel, never()).classCallback(eq(DELETE), any());
+
+      verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRESECURITY));
+      verify(mockModel, never()).classCallback(eq(UPDATE), eq(PRECOMMIT));
+      verify(mockModel, never()).classCallback(eq(UPDATE), eq(POSTCOMMIT));
+
+      verify(mockModel, never()).attributeCallback(eq(READ), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(CREATE), any(), any());
+      verify(mockModel, never()).attributeCallback(eq(DELETE), any(), any());
+      verify(mockModel, times(1)).attributeCallback(eq(UPDATE), eq(PRESECURITY), any());
+      verify(mockModel, never()).attributeCallback(eq(UPDATE), eq(PRECOMMIT), any());
+      verify(mockModel, never()).attributeCallback(eq(UPDATE), eq(POSTCOMMIT), any());
+
+      verify(mockModel, never()).relationCallback(eq(READ), any(), any());
+      verify(mockModel, never()).relationCallback(eq(UPDATE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(CREATE), any(), any());
+      verify(mockModel, never()).relationCallback(eq(DELETE), any(), any());
+
+      verify(tx).preCommit(any());
+      verify(tx).save(eq(mockModel), isA(RequestScope.class));
+      verify(tx).flush(isA(RequestScope.class));
+      verify(tx, never()).commit(isA(RequestScope.class));
+      verify(tx).close();
+  }
 
     @Test
     public void testCreate() {

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
@@ -117,6 +117,23 @@ public class PermissionExecutorTest {
     }
 
     @Test
+    public void testFailRunAtCommitCheck() throws Exception {
+        @Entity
+        @Include(rootLevel = false)
+        @UpdatePermission(expression = "sampleCommit")
+        class Model { }
+
+        PersistentResource resource = newResource(new Model(), Model.class, false);
+        RequestScope requestScope = resource.getRequestScope();
+
+        // Because the check is runAtCommit, the check is DEFERRED.
+        assertEquals(ExpressionResult.DEFERRED,
+                requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource));
+
+        assertThrows(ForbiddenAccessException.class, () -> requestScope.getPermissionExecutor().executeCommitChecks());
+    }
+
+    @Test
     public void testReadFieldAwareSuccessAllAnyField() {
         PersistentResource resource = newResource(SampleBean.class, false);
         RequestScope requestScope = resource.getRequestScope();

--- a/elide-core/src/test/java/example/TestCheckMappings.java
+++ b/elide-core/src/test/java/example/TestCheckMappings.java
@@ -32,6 +32,7 @@ public class TestCheckMappings {
                     .put("privatePermission", PrivatePermission.class)
                     .put("sampleOperation", PermissionExecutorTest.SampleOperationCheck.class)
                     .put("sampleOperationInverse", PermissionExecutorTest.SampleOperationCheckInverse.class)
+                    .put("sampleCommit", PermissionExecutorTest.SampleCommitCheck.class)
                     .put("shouldCache", PermissionExecutorTest.ShouldCache.class)
                     .put("peUserCheck", PermissionExecutorTest.UserCheckTest.class)
                     .put("passingOp", PermissionExecutorTest.PassingOperationCheck.class)

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
@@ -286,7 +286,7 @@ public class FilterTranslator implements FilterOperation<String> {
             throw new BadRequestException("Operator not implemented: " + filterPredicate.getOperator());
         }
 
-        return generator.generate(filterPredicate, aliasGenerator);
+        return generator.generate(filterPredicate, removeThisFromAlias);
     }
 
     private static String greatestClause(List<FilterParameter> params) {


### PR DESCRIPTION
## Description
* Multiple legacy life cycle annotations can be on same method.
* Process "this" placeholder correctly in `FilterTranslator` and `Operator`
* Restore functionality previously available with CommitChecks using `runAtCommit` method in Check.

## Motivation and Context
Fixing issues found in migrating from 4.x to 5.x

## How Has This Been Tested?
Unit testing.  Local testing with own Elide project.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
