### PR TITLE
try-resource block to avoid resource leak warnings

### DIFF
--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/verify/DynamicConfigVerifier.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/verify/DynamicConfigVerifier.java
@@ -107,10 +107,9 @@ public class DynamicConfigVerifier {
     public static String readTarContents(String archiveFile) throws FileNotFoundException, IOException {
         StringBuffer sb = new StringBuffer();
         BufferedReader br = null;
-        TarArchiveInputStream archiveInputStream = null;
-        try {
-            archiveInputStream = new TarArchiveInputStream(
-                    new GzipCompressorInputStream(new BufferedInputStream(new FileInputStream(archiveFile))));
+
+        try (TarArchiveInputStream archiveInputStream = new TarArchiveInputStream(
+                new GzipCompressorInputStream(new BufferedInputStream(new FileInputStream(archiveFile))))) {
             TarArchiveEntry entry = archiveInputStream.getNextTarEntry();
             while (entry  != null) {
                 br = new BufferedReader(new InputStreamReader(archiveInputStream));
@@ -121,8 +120,9 @@ public class DynamicConfigVerifier {
                 entry = archiveInputStream.getNextTarEntry();
             }
         } finally {
-            archiveInputStream.close();
-            br.close();
+            if (br != null) {
+               br.close();
+            }
         }
 
         return sb.toString();


### PR DESCRIPTION
## Description
Resource Leak warning is shown in DynamicConfigVerifier by the IDE. Replacing with a try-resource block. Also adding a null check before calling close.

## Motivation and Context
Resource Leak warning is shown in DynamicConfigVerifier by the IDE. 

## How Has This Been Tested?
Existing test case pass. IDE not showing the warning any more.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
