### PR TITLE
Remove source from ColumnProjection

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
@@ -80,7 +80,6 @@ public final class QueryKeyExtractor implements FilterExpressionVisitor<Object> 
     }
 
     private void visit(ColumnProjection columnProjection) {
-        visit(columnProjection.getId());
         visit(columnProjection.getAlias());
         visit(columnProjection.getArguments());
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.datastores.aggregation.annotation.MetricFormula;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ColumnType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueSourceType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
+import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -163,6 +164,10 @@ public abstract class Column implements Versioned {
             return ValueSourceType.TABLE;
         }
         return ValueSourceType.NONE;
+    }
+
+    public ColumnProjection toProjection() {
+        return table.toQueryable().getColumnProjection(getName());
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -290,7 +290,9 @@ public abstract class Table implements Versioned {
         return null;
     }
 
-    public abstract ColumnProjection toProjection(Column column);
+    public ColumnProjection toProjection(Column column) {
+        return toQueryable().getColumnProjection(column.getName());
+    }
 
     public abstract Queryable toQueryable();
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ColumnProjection.java
@@ -18,11 +18,6 @@ import java.util.Map;
  * Represents a projected column as an alias in a query.
  */
 public interface ColumnProjection extends Serializable {
-    /**
-     * Get the query source associated with the column.
-     * @return the query source
-     */
-    Queryable getSource();
 
     /**
      * Get the projection alias.
@@ -46,14 +41,6 @@ public interface ColumnProjection extends Serializable {
         } else {
             return createSafeAlias(name, alias);
         }
-    }
-
-    /**
-     * Returns a unique identifier for the column.
-     * @return a unique column ID
-     */
-    default String getId() {
-        return getSource().getName() + "." + getName();
     }
 
     /**
@@ -94,21 +81,11 @@ public interface ColumnProjection extends Serializable {
     int hashCode();
 
     /**
-     * Makes a copy of this column with a new source.
-     * @param source The new source.
-     * @return copy of the column projection.
-     */
-    default ColumnProjection withSource(Queryable source) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * Makes a copy of this column with a new source and expression.
-     * @param source The new source.
      * @param expression The new expression.
      * @return copy of the column projection.
      */
-    default ColumnProjection withSourceAndExpression(Queryable source, String expression) {
+    default ColumnProjection withExpression(String expression) {
         throw new UnsupportedOperationException();
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/DefaultQueryPlanResolver.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/DefaultQueryPlanResolver.java
@@ -10,9 +10,9 @@ package com.yahoo.elide.datastores.aggregation.query;
  */
 public class DefaultQueryPlanResolver implements QueryPlanResolver {
     @Override
-    public QueryPlan resolve(MetricProjection projection) {
+    public QueryPlan resolve(Query source, MetricProjection projection) {
         return QueryPlan.builder()
-                .source(projection.getSource())
+                .source(source.getSource())
                 .metricProjection(projection)
                 .build();
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/MetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/MetricProjection.java
@@ -12,7 +12,8 @@ public interface MetricProjection extends ColumnProjection {
 
     /**
      * Resolves the query plan that would fetch this particular metric.
+     * @param query The parent query
      * @return the resolved query plan.
      */
-    QueryPlan resolve();
+    QueryPlan resolve(Query query);
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryPlan.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryPlan.java
@@ -72,17 +72,17 @@ public class QueryPlan implements Queryable {
         if (!self.isNested()) {
             return QueryPlan.builder()
                     .source(self.getSource())
-                    .metricProjections(withSource(self.getSource(), metrics))
-                    .dimensionProjections(withSource(self.getSource(), dimensions))
-                    .timeDimensionProjections(withSource(self.getSource(), timeDimensions))
+                    .metricProjections(metrics)
+                    .dimensionProjections(dimensions)
+                    .timeDimensionProjections(timeDimensions)
                     .build();
         } else {
             Queryable mergedSource = ((QueryPlan) self.getSource()).merge((QueryPlan) other.getSource());
             return QueryPlan.builder()
                     .source(mergedSource)
-                    .metricProjections(withSource(self.getSource(), metrics))
-                    .dimensionProjections(withSource(self.getSource(), dimensions))
-                    .timeDimensionProjections(withSource(self.getSource(), timeDimensions))
+                    .metricProjections(metrics)
+                    .dimensionProjections(dimensions)
+                    .timeDimensionProjections(timeDimensions)
                     .build();
         }
     }
@@ -90,36 +90,22 @@ public class QueryPlan implements Queryable {
     public QueryPlan nest() {
         return QueryPlan.builder()
                 .source(this)
-                .metricProjections(nestColumnProjection(this, metricProjections))
-                .dimensionProjections(nestColumnProjection(this, dimensionProjections))
-                .timeDimensionProjections(nestColumnProjection(this, timeDimensionProjections))
+                .metricProjections(nestColumnProjection(metricProjections))
+                .dimensionProjections(nestColumnProjection(dimensionProjections))
+                .timeDimensionProjections(nestColumnProjection(timeDimensionProjections))
                 .build();
-    }
-
-    /**
-     * Makes of a copy of a set of columns all with a new source.
-     * @param source The new source.
-     * @param columns The columns to copy.
-     * @param <T> The column projection type.
-     * @return An ordered set of the column copies.
-     */
-    public static <T extends ColumnProjection> Set<T> withSource(Queryable source, Set<T> columns) {
-        return (Set<T>) columns.stream()
-                .map(column -> column.withSource(source))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
      * Makes of a copy of a set of columns that are being nested in a new parent.  The column expressions are
      * changed to reference the columns by name.
-     * @param parentSource The new parent source.
      * @param columns The columns to copy.
      * @param <T> The column projection type.
      * @return An ordered set of the column copies.
      */
-    public static <T extends ColumnProjection> Set<T> nestColumnProjection(Queryable parentSource, Set<T> columns) {
+    public static <T extends ColumnProjection> Set<T> nestColumnProjection(Set<T> columns) {
         return (Set<T>) columns.stream()
-                .map(column -> column.withSourceAndExpression(parentSource, "{{" + column.getSafeAlias() + "}}"))
+                .map(column -> column.withExpression("{{" + column.getSafeAlias() + "}}"))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryPlanResolver.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/QueryPlanResolver.java
@@ -13,8 +13,9 @@ public interface QueryPlanResolver {
 
     /**
      * Resolves a projected metric into a query plan.
+     * @param source The queryable that contains the metric.
      * @param projection The metric being projected.
      * @return A query plan for the particular metric.
      */
-    public QueryPlan resolve(MetricProjection projection);
+    public QueryPlan resolve(Query source, MetricProjection projection);
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -345,7 +345,7 @@ public class SQLQueryEngine extends QueryEngine {
 
         //Expand each metric into its own query plan.  Merge them all together.
         for (MetricProjection metricProjection : query.getMetricProjections()) {
-            QueryPlan queryPlan = metricProjection.resolve();
+            QueryPlan queryPlan = metricProjection.resolve(query);
             if (queryPlan != null) {
                 mergedPlan = queryPlan.merge(mergedPlan);
             }
@@ -412,7 +412,7 @@ public class SQLQueryEngine extends QueryEngine {
                 query.getAllDimensionProjections()
                         .stream()
                         .map(SQLColumnProjection.class::cast)
-                        .map((column) -> column.toSQL(queryReferenceTable))
+                        .map((column) -> column.toSQL(query, queryReferenceTable))
                         .collect(Collectors.joining(", "));
 
         if (groupByDimensions.isEmpty()) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -412,7 +412,7 @@ public class SQLQueryEngine extends QueryEngine {
                 query.getAllDimensionProjections()
                         .stream()
                         .map(SQLColumnProjection.class::cast)
-                        .map((column) -> column.toSQL(query, queryReferenceTable))
+                        .map((column) -> column.toSQL(query.getSource(), queryReferenceTable))
                         .collect(Collectors.joining(", "));
 
         if (groupByDimensions.isEmpty()) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -117,15 +117,16 @@ public class SQLReferenceTable {
 
         queryable.getColumnProjections().forEach(column -> {
             // validate that there is no reference loop
-            validator.visitColumn(column);
+            validator.visitColumn(queryable, column);
 
             String fieldName = column.getName();
 
             resolvedReferences.get(key).put(
                     fieldName,
-                    new SQLReferenceVisitor(metaDataStore, key.getAlias(fieldName), dialect).visitColumn(column));
+                    new SQLReferenceVisitor(metaDataStore, key.getAlias(fieldName), dialect)
+                            .visitColumn(queryable, column));
 
-            Set<JoinPath> joinPaths = joinVisitor.visitColumn(column);
+            Set<JoinPath> joinPaths = joinVisitor.visitColumn(queryable, column);
             resolvedJoinExpressions.get(key).put(fieldName, getJoinClauses(joinPaths, dialect));
         });
     }
@@ -237,14 +238,10 @@ public class SQLReferenceTable {
         SQLReferenceVisitor visitor =
                         new SQLReferenceVisitor(metaDataStore, fromAlias, dialect);
 
-        return visitor.visitFormulaDimension(new SQLColumnProjection() {
+        return visitor.visitFormulaDimension(table, new SQLColumnProjection() {
             @Override
             public ValueType getValueType() {
                 return null;
-            }
-            @Override
-            public Queryable getSource() {
-                return table.getSource();
             }
             @Override
             public String getName() {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -192,20 +192,9 @@ public class SQLTable extends Table implements Queryable {
         }
 
         return new SQLColumnProjection() {
-
-            @Override
-            public Queryable getSource() {
-                return SQLTable.this;
-            }
-
             @Override
             public String getAlias() {
                 return column.getName();
-            }
-
-            @Override
-            public String getId() {
-                return column.getId();
             }
 
             @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryPlanTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryPlanTranslator.java
@@ -7,7 +7,6 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 
 import static com.yahoo.elide.datastores.aggregation.query.QueryPlan.nestColumnProjection;
-import static com.yahoo.elide.datastores.aggregation.query.QueryPlan.withSource;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.QueryVisitor;
@@ -64,13 +63,11 @@ public class QueryPlanTranslator implements QueryVisitor<Query.QueryBuilder> {
         Set<ColumnProjection> dimensions = Streams.concat(plan.getDimensionProjections().stream(),
                 clientQuery.getDimensionProjections().stream())
                 .map(SQLDimensionProjection.class::cast)
-                .map(dim -> dim.withSource(clientQuery.getSource()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Set<TimeDimensionProjection> timeDimensions = Streams.concat(plan.getTimeDimensionProjections().stream(),
                 clientQuery.getTimeDimensionProjections().stream())
                 .map(SQLTimeDimensionProjection.class::cast)
-                .map(dim -> dim.withSource(clientQuery.getSource()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         return Query.builder()
@@ -86,10 +83,9 @@ public class QueryPlanTranslator implements QueryVisitor<Query.QueryBuilder> {
 
         return Query.builder()
                 .source(innerQuery)
-                .metricProjections(withSource(innerQuery, plan.getMetricProjections()))
-                .dimensionProjections(nestColumnProjection(innerQuery, clientQuery.getDimensionProjections()))
-                .timeDimensionProjections(nestColumnProjection(innerQuery,
-                        clientQuery.getTimeDimensionProjections()))
+                .metricProjections(plan.getMetricProjections())
+                .dimensionProjections(nestColumnProjection(clientQuery.getDimensionProjections()))
+                .timeDimensionProjections(nestColumnProjection(clientQuery.getTimeDimensionProjections()))
                 .havingFilter(clientQuery.getHavingFilter())
                 .sorting(clientQuery.getSorting())
                 .pagination(clientQuery.getPagination())
@@ -102,10 +98,9 @@ public class QueryPlanTranslator implements QueryVisitor<Query.QueryBuilder> {
 
         return Query.builder()
                 .source(innerQuery)
-                .metricProjections(withSource(innerQuery, plan.getMetricProjections()))
-                .dimensionProjections(nestColumnProjection(innerQuery, clientQuery.getDimensionProjections()))
-                .timeDimensionProjections(nestColumnProjection(innerQuery,
-                        clientQuery.getTimeDimensionProjections()));
+                .metricProjections(plan.getMetricProjections())
+                .dimensionProjections(nestColumnProjection(clientQuery.getDimensionProjections()))
+                .timeDimensionProjections(nestColumnProjection(clientQuery.getTimeDimensionProjections()));
     }
 
     private Query.QueryBuilder visitUnnestedQueryPlan(Queryable plan)  {
@@ -113,18 +108,16 @@ public class QueryPlanTranslator implements QueryVisitor<Query.QueryBuilder> {
         Set<ColumnProjection> dimensions = Streams.concat(plan.getDimensionProjections().stream(),
             clientQuery.getDimensionProjections().stream())
                 .map(SQLDimensionProjection.class::cast)
-                .map((dim) -> dim.withSource(clientQuery.getSource()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Set<TimeDimensionProjection> timeDimensions = Streams.concat(plan.getTimeDimensionProjections().stream(),
             clientQuery.getTimeDimensionProjections().stream())
                 .map(SQLTimeDimensionProjection.class::cast)
-                .map((dim) -> dim.withSource(clientQuery.getSource()))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         return Query.builder()
                 .source(clientQuery.getSource())
-                .metricProjections(withSource(clientQuery.getSource(), plan.getMetricProjections()))
+                .metricProjections(plan.getMetricProjections())
                 .dimensionProjections(dimensions)
                 .timeDimensionProjections(timeDimensions)
                 .havingFilter(clientQuery.getHavingFilter())

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
@@ -76,7 +76,7 @@ public class QueryTranslator implements QueryVisitor<SQLQuery.SQLQueryBuilder> {
             if (!query.getMetricProjections().isEmpty()) {
                 builder.groupByClause("GROUP BY " + groupByDimensions.stream()
                         .map(SQLColumnProjection.class::cast)
-                        .map((column) -> column.toSQL(referenceTable))
+                        .map((column) -> column.toSQL(query, referenceTable))
                         .collect(Collectors.joining(", ")));
             }
         }
@@ -151,7 +151,7 @@ public class QueryTranslator implements QueryVisitor<SQLQuery.SQLQueryBuilder> {
                 .orElse(null);
 
         if (metric != null) {
-            return metric.toSQL(referenceTable);
+            return metric.toSQL(query, referenceTable);
         } else {
             return generatePredicatePathReference(path, query);
         }
@@ -168,13 +168,13 @@ public class QueryTranslator implements QueryVisitor<SQLQuery.SQLQueryBuilder> {
         // TODO: project metric field using table column reference
         List<String> metricProjections = query.getMetricProjections().stream()
                 .map(SQLMetricProjection.class::cast)
-                .map(invocation -> invocation.toSQL(referenceTable) + " AS "
+                .map(invocation -> invocation.toSQL(query, referenceTable) + " AS "
                                 + applyQuotes(invocation.getSafeAlias()))
                 .collect(Collectors.toList());
 
         List<String> dimensionProjections = query.getAllDimensionProjections().stream()
                 .map(SQLColumnProjection.class::cast)
-                .map(dimension -> dimension.toSQL(referenceTable) + " AS "
+                .map(dimension -> dimension.toSQL(query, referenceTable) + " AS "
                                 + applyQuotes(dimension.getSafeAlias()))
                 .collect(Collectors.toList());
 
@@ -209,7 +209,7 @@ public class QueryTranslator implements QueryVisitor<SQLQuery.SQLQueryBuilder> {
                     String orderByClause = (plan.getColumnProjections().contains(projection)
                             && dialect.useAliasForOrderByClause())
                             ? applyQuotes(projection.getSafeAlias())
-                            : projection.toSQL(referenceTable);
+                            : projection.toSQL(plan, referenceTable);
 
                     return orderByClause + (order.equals(Sorting.SortOrder.desc) ? " DESC" : " ASC");
                 })
@@ -300,7 +300,7 @@ public class QueryTranslator implements QueryVisitor<SQLQuery.SQLQueryBuilder> {
         Map<String, Argument> arguments = last.getArguments().stream()
                         .collect(Collectors.toMap(Argument::getName, Function.identity()));
         SQLColumnProjection projection = fieldToColumnProjection(query, last.getAlias(), arguments);
-        return projection.toSQL(referenceTable);
+        return projection.toSQL(query, referenceTable);
     }
 
     private SQLColumnProjection fieldToColumnProjection(Query query, String fieldName) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -17,11 +17,11 @@ public interface SQLColumnProjection extends ColumnProjection {
 
     /**
      * Generate a SQL fragment for this combination column and client arguments.
-     * @param source the parent query
+     * @param source the queryable that contains the column.
      * @param table symbol table to resolve column name references.
      * @return
      */
     default String toSQL(Queryable source, SQLReferenceTable table) {
-        return table.getResolvedReference(source.getSource(), getName());
+        return table.getResolvedReference(source, getName());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -7,6 +7,7 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
 
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 
 /**
@@ -16,10 +17,11 @@ public interface SQLColumnProjection extends ColumnProjection {
 
     /**
      * Generate a SQL fragment for this combination column and client arguments.
+     * @param source the parent query
      * @param table symbol table to resolve column name references.
      * @return
      */
-    default String toSQL(SQLReferenceTable table) {
-        return table.getResolvedReference(getSource(), getName());
+    default String toSQL(Queryable source, SQLReferenceTable table) {
+        return table.getResolvedReference(source.getSource(), getName());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLDimensionProjection.java
@@ -10,8 +10,6 @@ import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ColumnType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
-import com.yahoo.elide.datastores.aggregation.query.Queryable;
-import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
@@ -25,7 +23,6 @@ import java.util.Map;
 @Builder
 @AllArgsConstructor
 public class SQLDimensionProjection implements SQLColumnProjection {
-    private Queryable source;
     private String name;
     private ValueType valueType;
     private ColumnType columnType;
@@ -36,7 +33,6 @@ public class SQLDimensionProjection implements SQLColumnProjection {
     public SQLDimensionProjection(Dimension dimension,
                                   String alias,
                                   Map<String, Argument> arguments) {
-        this.source = (SQLTable) dimension.getTable();
         this.name = dimension.getName();
         this.expression = dimension.getExpression();
         this.valueType = dimension.getValueType();
@@ -46,22 +42,8 @@ public class SQLDimensionProjection implements SQLColumnProjection {
     }
 
     @Override
-    public SQLDimensionProjection withSource(Queryable source) {
+    public SQLDimensionProjection withExpression(String expression) {
         return SQLDimensionProjection.builder()
-                .source(source)
-                .name(name)
-                .alias(alias)
-                .valueType(valueType)
-                .columnType(columnType)
-                .expression(expression)
-                .arguments(arguments)
-                .build();
-    }
-
-    @Override
-    public SQLDimensionProjection withSourceAndExpression(Queryable source, String expression) {
-        return SQLDimensionProjection.builder()
-                .source(source)
                 .name(name)
                 .alias(alias)
                 .valueType(valueType)

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -12,10 +12,9 @@ import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.query.DefaultQueryPlanResolver;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
+import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.QueryPlan;
 import com.yahoo.elide.datastores.aggregation.query.QueryPlanResolver;
-import com.yahoo.elide.datastores.aggregation.query.Queryable;
-import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -28,7 +27,6 @@ import java.util.Map;
 @Value
 @Builder
 public class SQLMetricProjection implements MetricProjection, SQLColumnProjection {
-    private Queryable source;
     private String name;
     private ValueType valueType;
     private ColumnType columnType;
@@ -40,19 +38,17 @@ public class SQLMetricProjection implements MetricProjection, SQLColumnProjectio
     private QueryPlanResolver queryPlanResolver;
 
     @Override
-    public QueryPlan resolve() {
-        return queryPlanResolver.resolve(this);
+    public QueryPlan resolve(Query query) {
+        return queryPlanResolver.resolve(query, this);
     }
 
-    public SQLMetricProjection(Queryable source,
-                               String name,
+    public SQLMetricProjection(String name,
                                ValueType valueType,
                                ColumnType columnType,
                                String expression,
                                String  alias,
                                Map<String, Argument> arguments,
                                QueryPlanResolver queryPlanResolver) {
-        this.source = source;
         this.name = name;
         this.valueType = valueType;
         this.columnType = columnType;
@@ -65,28 +61,13 @@ public class SQLMetricProjection implements MetricProjection, SQLColumnProjectio
     public SQLMetricProjection(Metric metric,
                                String alias,
                                Map<String, Argument> arguments) {
-        this((SQLTable) metric.getTable(), metric.getName(), metric.getValueType(),
+        this(metric.getName(), metric.getValueType(),
                 metric.getColumnType(), metric.getExpression(), alias, arguments, metric.getQueryPlanResolver());
     }
 
     @Override
-    public SQLMetricProjection withSource(Queryable source) {
+    public SQLMetricProjection withExpression(String expression) {
         return SQLMetricProjection.builder()
-                .source(source)
-                .name(name)
-                .alias(alias)
-                .valueType(valueType)
-                .columnType(columnType)
-                .expression(expression)
-                .arguments(arguments)
-                .queryPlanResolver(queryPlanResolver)
-                .build();
-    }
-
-    @Override
-    public SQLMetricProjection withSourceAndExpression(Queryable source, String expression) {
-        return SQLMetricProjection.builder()
-                .source(source)
                 .name(name)
                 .alias(alias)
                 .valueType(valueType)

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -69,7 +69,7 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection, TimeDime
     public String toSQL(Queryable source, SQLReferenceTable table) {
         //TODO - We will likely migrate to a templating language when we support parameterized metrics.
         return grain.getExpression().replaceFirst(TIME_DIMENSION_REPLACEMENT_REGEX,
-                        table.getResolvedReference(source.getSource(), name));
+                        table.getResolvedReference(source, name));
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
@@ -46,7 +46,7 @@ public class QueryKeyExtractorTest {
                 .metricProjection(playerStatsTable.getMetricProjection("highScore"))
                 .build();
         assertEquals(
-                "com_yahoo_elide_datastores_aggregation_example_PlayerStats;{playerStats.highScore;highScore;{}}{}{};;;;",
+                "com_yahoo_elide_datastores_aggregation_example_PlayerStats;{highScore;{}}{}{};;;;",
                 QueryKeyExtractor.extractKey(query));
     }
 
@@ -68,9 +68,9 @@ public class QueryKeyExtractorTest {
                 .pagination(new ImmutablePagination(0, 2, false, true))
                 .build();
         assertEquals("com_yahoo_elide_datastores_aggregation_example_PlayerStats;" // table name
-                        + "{playerStats.highScore;highScore;{}}" // columns
-                        + "{playerStats.overallRating;overallRating;{}}" // group by
-                        + "{playerStats.recordedDate;recordedDate;{}}" // time dimensions
+                        + "{highScore;{}}" // columns
+                        + "{overallRating;{}}" // group by
+                        + "{recordedDate;{}}" // time dimensions
                         + "{P;{{com.yahoo.elide.datastores.aggregation.example.PlayerStats;java.lang.String;countryNickName;}}IN;9;Uncle Sam;}" // where
                         + "{P;{{com.yahoo.elide.datastores.aggregation.example.PlayerStats;long;highScore;}}GT;3;300;}" // having
                         + "{com.yahoo.elide.datastores.aggregation.example.PlayerStats;{{com.yahoo.elide.datastores.aggregation.example.PlayerStats;java.lang.String;playerName;}}asc;}" // sort

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/SqlReferenceVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/SqlReferenceVisitorTest.java
@@ -80,7 +80,7 @@ public class SqlReferenceVisitorTest {
         SQLTable table = (SQLTable) store.getTable(getClassType(TestModel.class));
         ColumnProjection column = table.getDimensionProjection("dimension1");
 
-        String actual = visitor.visitColumn(column);
+        String actual = visitor.visitColumn(table, column);
 
         assertEquals(applyQuotes("test_table.dimension1", getDefaultDialect()), actual);
     }
@@ -91,7 +91,7 @@ public class SqlReferenceVisitorTest {
 
         SQLTable table = (SQLTable) store.getTable(getClassType(TestModel.class));
         ColumnProjection column = table.getDimensionProjection("dimension2");
-        String actual = visitor.visitColumn(column);
+        String actual = visitor.visitColumn(table, column);
 
         assertEquals(applyQuotes("test_table.someColumn", getDefaultDialect()), actual);
     }
@@ -103,7 +103,7 @@ public class SqlReferenceVisitorTest {
         SQLTable table = (SQLTable) store.getTable(getClassType(TestModel.class));
         ColumnProjection column = table.getDimensionProjection("dimension3");
 
-        String actual = visitor.visitColumn(column);
+        String actual = visitor.visitColumn(table, column);
 
         assertEquals(applyQuotes("join_table_joinModel.dimension3", getDefaultDialect()), actual);
     }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -881,7 +881,6 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                 .accept("application/vnd.api+json")
                 .get("/playerStats")
                 .then()
-                .log().all()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.id", hasItems("0", "1", "2"))
                 .body("data.attributes.highScore", hasItems(1000, 1234, 2412))

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/resolvers/DailyAverageScorePerPeriodResolver.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/resolvers/DailyAverageScorePerPeriodResolver.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
+import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.QueryPlan;
 import com.yahoo.elide.datastores.aggregation.query.QueryPlanResolver;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
@@ -25,8 +26,8 @@ import java.util.Map;
 public class DailyAverageScorePerPeriodResolver implements QueryPlanResolver {
 
     @Override
-    public QueryPlan resolve(MetricProjection projection) {
-        SQLTable table = (SQLTable) projection.getSource();
+    public QueryPlan resolve(Query query, MetricProjection projection) {
+        SQLTable table = (SQLTable) query.getSource();
 
         MetricProjection innerMetric = table.getMetricProjection("highScore");
         TimeDimension innerTimeGrain = table.getTimeDimension("recordedDate");
@@ -34,7 +35,7 @@ public class DailyAverageScorePerPeriodResolver implements QueryPlanResolver {
         arguments.put("grain", Argument.builder().name("grain").value(TimeGrain.DAY).build());
 
         QueryPlan innerQuery = QueryPlan.builder()
-                .source(projection.getSource())
+                .source(query.getSource())
                 .metricProjection(innerMetric)
                 .timeDimensionProjection(new SQLTimeDimensionProjection(
                         innerTimeGrain,
@@ -46,7 +47,6 @@ public class DailyAverageScorePerPeriodResolver implements QueryPlanResolver {
         QueryPlan outerQuery = QueryPlan.builder()
                 .source(innerQuery)
                 .metricProjection(SQLMetricProjection.builder()
-                        .source(innerQuery)
                         .alias(projection.getAlias())
                         .name(projection.getName())
                         .expression(projection.getExpression())


### PR DESCRIPTION
Currently, `ColumnProjection` has a reference to the source `Query`.  This makes using the builder problematic because the association is bidirectional AND both `Query` and the projection classes are lombok `Value` classes (meaning they are immutable).

To make it easier to build queries, we are removing the source field in ColumnProjection (breaking the bi-directional association).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
