### PR TITLE
Query Plan Optimizer (Part 2)

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -69,7 +69,7 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection, TimeDime
     public String toSQL(Queryable source, SQLReferenceTable table) {
         //TODO - We will likely migrate to a templating language when we support parameterized metrics.
         return grain.getExpression().replaceFirst(TIME_DIMENSION_REPLACEMENT_REGEX,
-                        table.getResolvedReference(source.getSource(), name));
+                        table.getResolvedReference(source, name));
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -69,7 +69,7 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection, TimeDime
     public String toSQL(Queryable source, SQLReferenceTable table) {
         //TODO - We will likely migrate to a templating language when we support parameterized metrics.
         return grain.getExpression().replaceFirst(TIME_DIMENSION_REPLACEMENT_REGEX,
-                        table.getResolvedReference(source, name));
+                        table.getResolvedReference(source.getSource(), name));
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
+
+import com.yahoo.elide.core.filter.expression.AndFilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
+import com.yahoo.elide.core.filter.expression.NotFilterExpression;
+import com.yahoo.elide.core.filter.expression.OrFilterExpression;
+import com.yahoo.elide.core.filter.predicates.FilterPredicate;
+import com.yahoo.elide.core.filter.visitors.FilterExpressionNormalizationVisitor;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Set;
+
+public class SubqueryFilterSplitter
+        implements FilterExpressionVisitor<Pair<FilterExpression, FilterExpression>> {
+
+    private SQLReferenceTable lookupTable;
+    private MetaDataStore metaDataStore;
+
+    public SubqueryFilterSplitter(MetaDataStore metaDataStore, SQLReferenceTable lookupTable) {
+        this.metaDataStore = metaDataStore;
+        this.lookupTable = lookupTable;
+    }
+
+    public static Pair<FilterExpression, FilterExpression> splitFilter(
+            SQLReferenceTable lookupTable,
+            MetaDataStore metaDataStore,
+            FilterExpression expression) {
+        FilterExpressionNormalizationVisitor normalizer = new FilterExpressionNormalizationVisitor();
+        FilterExpression normalizedExpression = expression.accept(normalizer);
+
+        return normalizedExpression.accept(new SubqueryFilterSplitter(metaDataStore, lookupTable));
+    }
+
+    @Override
+    public Pair<FilterExpression, FilterExpression> visitPredicate(FilterPredicate filterPredicate) {
+        Type<?> tableType = filterPredicate.getFieldType();
+        String fieldName = filterPredicate.getField();
+
+        SQLTable table = (SQLTable) metaDataStore.getTable(tableType);
+
+        Set<String> joins = lookupTable.getResolvedJoinExpressions(table, fieldName);
+
+        if (joins.size() > 0) {
+            return Pair.of(filterPredicate, null);
+        } else {
+            return Pair.of(null, filterPredicate);
+        }
+    }
+
+    @Override
+    public Pair<FilterExpression, FilterExpression> visitAndExpression(AndFilterExpression expression) {
+        Pair<FilterExpression, FilterExpression> lhs = expression.getLeft().accept(this);
+        Pair<FilterExpression, FilterExpression> rhs = expression.getLeft().accept(this);
+
+        return Pair.of(
+                AndFilterExpression.fromPair(lhs.getLeft(), rhs.getLeft()),
+                AndFilterExpression.fromPair(lhs.getRight(), rhs.getRight())
+        );
+    }
+
+    @Override
+    public Pair<FilterExpression, FilterExpression> visitOrExpression(OrFilterExpression expression) {
+        Pair<FilterExpression, FilterExpression> lhs = expression.getLeft().accept(this);
+        Pair<FilterExpression, FilterExpression> rhs = expression.getLeft().accept(this);
+
+        if (lhs.getLeft() != null || rhs.getLeft() != null) {
+            FilterExpression combined = OrFilterExpression.fromPair(
+                    AndFilterExpression.fromPair(lhs.getLeft(), lhs.getRight()),
+                    AndFilterExpression.fromPair(rhs.getLeft(), rhs.getRight()));
+
+            return Pair.of(combined, null);
+        } else {
+            return Pair.of(null,
+                    OrFilterExpression.fromPair(lhs.getRight(), rhs.getRight())
+            );
+        }
+    }
+
+    @Override
+    public Pair<FilterExpression, FilterExpression> visitNotExpression(NotFilterExpression expression) {
+        Pair<FilterExpression, FilterExpression> inner = expression.getNegated().accept(this);
+
+        return Pair.of(
+                inner.getLeft() == null ? null : new NotFilterExpression(inner.getLeft()),
+                inner.getRight() == null ? null : new NotFilterExpression(inner.getRight())
+        );
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
@@ -44,7 +44,7 @@ public class SubqueryFilterSplitter
 
     @Override
     public Pair<FilterExpression, FilterExpression> visitPredicate(FilterPredicate filterPredicate) {
-        Type<?> tableType = filterPredicate.getFieldType();
+        Type<?> tableType = filterPredicate.getEntityType();
         String fieldName = filterPredicate.getField();
 
         SQLTable table = (SQLTable) metaDataStore.getTable(tableType);
@@ -61,7 +61,7 @@ public class SubqueryFilterSplitter
     @Override
     public Pair<FilterExpression, FilterExpression> visitAndExpression(AndFilterExpression expression) {
         Pair<FilterExpression, FilterExpression> lhs = expression.getLeft().accept(this);
-        Pair<FilterExpression, FilterExpression> rhs = expression.getLeft().accept(this);
+        Pair<FilterExpression, FilterExpression> rhs = expression.getRight().accept(this);
 
         return Pair.of(
                 AndFilterExpression.fromPair(lhs.getLeft(), rhs.getLeft()),
@@ -72,7 +72,7 @@ public class SubqueryFilterSplitter
     @Override
     public Pair<FilterExpression, FilterExpression> visitOrExpression(OrFilterExpression expression) {
         Pair<FilterExpression, FilterExpression> lhs = expression.getLeft().accept(this);
-        Pair<FilterExpression, FilterExpression> rhs = expression.getLeft().accept(this);
+        Pair<FilterExpression, FilterExpression> rhs = expression.getRight().accept(this);
 
         if (lhs.getLeft() != null || rhs.getLeft() != null) {
             FilterExpression combined = OrFilterExpression.fromPair(

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
@@ -19,10 +19,20 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLRefer
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 import org.apache.commons.lang3.tuple.Pair;
 
+import lombok.Builder;
+import lombok.Data;
+
 import java.util.Set;
 
 public class SubqueryFilterSplitter
         implements FilterExpressionVisitor<Pair<FilterExpression, FilterExpression>> {
+
+    @Data
+    @Builder
+    public static class SplitFilter {
+        FilterExpression outerQueryFilter;
+        FilterExpression innerQueryFilter;
+    }
 
     private SQLReferenceTable lookupTable;
     private MetaDataStore metaDataStore;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
@@ -17,7 +17,6 @@ import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
-import org.apache.commons.lang3.tuple.Pair;
 
 import lombok.Builder;
 import lombok.Data;

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitterTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitterTest.java
@@ -128,6 +128,30 @@ public class SubqueryFilterSplitterTest {
         assertEquals(expectedInner, splitExpressions.getRight());
     }
 
+    @Test
+    public void testCompoundSplitByOr() throws Exception {
+        FilterExpression expression = parse(
+                "(countryUnSeats>3;overallRating=='Foo'),(overallRating=='Bar';overallRating=='Blah')");
+
+        Pair<FilterExpression, FilterExpression> splitExpressions =
+                SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
+
+        assertEquals(expression, splitExpressions.getLeft());
+        assertNull(splitExpressions.getRight());
+    }
+
+    @Test
+    public void testAllOrsWithNoJoins() throws Exception {
+        FilterExpression expression = parse(
+                "(overallRating=='Foobar',overallRating=='Foo'),(overallRating=='Bar',overallRating=='Blah')");
+
+        Pair<FilterExpression, FilterExpression> splitExpressions =
+                SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
+
+        assertEquals(expression, splitExpressions.getRight());
+        assertNull(splitExpressions.getLeft());
+    }
+
     private FilterExpression parse(String filter) throws ParseException {
         return dialect.parse(PLAYER_STATS_TYPE, new HashSet<>(), filter, NO_VERSION);
     }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitterTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitterTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.queryengines.sql.query;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.ParseException;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.example.Country;
+import com.yahoo.elide.datastores.aggregation.example.Player;
+import com.yahoo.elide.datastores.aggregation.example.PlayerRanking;
+import com.yahoo.elide.datastores.aggregation.example.PlayerStats;
+import com.yahoo.elide.datastores.aggregation.example.SubCountry;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialectFactory;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import javax.sql.DataSource;
+
+public class SubqueryFilterSplitterTest {
+
+    private MetaDataStore metaDataStore;
+    private SQLReferenceTable lookupTable;
+    private RSQLFilterDialect dialect;
+    private static final Type<PlayerStats> PLAYER_STATS_TYPE = ClassType.of(PlayerStats.class);
+
+    public SubqueryFilterSplitterTest() {
+
+        Set<Type<?>> models = new HashSet<>();
+        models.add(ClassType.of(PlayerStats.class));
+        models.add(ClassType.of(Country.class));
+        models.add(ClassType.of(SubCountry.class));
+        models.add(ClassType.of(Player.class));
+        models.add(ClassType.of(PlayerRanking.class));
+
+        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
+
+        models.stream().forEach(dictionary::bindEntity);
+
+        metaDataStore = new MetaDataStore(models, true);
+        metaDataStore.populateEntityDictionary(dictionary);
+
+        DataSource mockDataSource = mock(DataSource.class);
+        //The query engine populates the metadata store with actual tables.
+        new SQLQueryEngine(metaDataStore, new ConnectionDetails(mockDataSource,
+                SQLDialectFactory.getDefaultDialect()));
+
+        lookupTable = new SQLReferenceTable(metaDataStore);
+        dialect = new RSQLFilterDialect(dictionary);
+    }
+
+
+    @Test
+    public void testSinglePredicateNoJoin() throws Exception {
+        FilterExpression expression = parse("overallRating=='Foo'");
+
+        Pair<FilterExpression, FilterExpression> splitExpressions =
+                SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
+
+        assertNull(splitExpressions.getLeft());
+        assertEquals(expression, splitExpressions.getRight());
+    }
+
+    @Test
+    public void testSinglePredicateWithJoin() throws Exception {
+        FilterExpression expression = parse("countryUnSeats>3");
+
+        Pair<FilterExpression, FilterExpression> splitExpressions =
+                SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
+
+        assertNull(splitExpressions.getRight());
+        assertEquals(expression, splitExpressions.getLeft());
+    }
+
+    @Test
+    public void testSplitByAnd() throws Exception {
+        FilterExpression expression = parse("countryUnSeats>3;overallRating=='Foo'");
+        FilterExpression expectedOuter = parse("countryUnSeats>3");
+        FilterExpression expectedInner = parse("overallRating=='Foo'");
+
+        Pair<FilterExpression, FilterExpression> splitExpressions =
+                SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
+
+        assertEquals(expectedOuter, splitExpressions.getLeft());
+        assertEquals(expectedInner, splitExpressions.getRight());
+    }
+
+    @Test
+    public void testSplitByOr() throws Exception {
+        FilterExpression expression = parse("countryUnSeats>3,overallRating=='Foo'");
+
+        Pair<FilterExpression, FilterExpression> splitExpressions =
+                SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
+
+        assertEquals(expression, splitExpressions.getLeft());
+        assertNull(splitExpressions.getRight());
+    }
+
+    @Test
+    public void testCompoundSplitByAnd() throws Exception {
+        FilterExpression expression = parse(
+                "(countryUnSeats>3,overallRating=='Foo');(overallRating=='Bar',overallRating=='Blah')");
+
+        FilterExpression expectedOuter = parse("countryUnSeats>3,overallRating=='Foo'");
+        FilterExpression expectedInner = parse("overallRating=='Bar',overallRating=='Blah'");
+
+        Pair<FilterExpression, FilterExpression> splitExpressions =
+                SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
+
+        assertEquals(expectedOuter, splitExpressions.getLeft());
+        assertEquals(expectedInner, splitExpressions.getRight());
+    }
+
+    private FilterExpression parse(String filter) throws ParseException {
+        return dialect.parse(PLAYER_STATS_TYPE, new HashSet<>(), filter, NO_VERSION);
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitterTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitterTest.java
@@ -26,7 +26,6 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialectFactory;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -71,22 +70,22 @@ public class SubqueryFilterSplitterTest {
     public void testSinglePredicateNoJoin() throws Exception {
         FilterExpression expression = parse("overallRating=='Foo'");
 
-        Pair<FilterExpression, FilterExpression> splitExpressions =
+        SubqueryFilterSplitter.SplitFilter splitExpressions =
                 SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
 
-        assertNull(splitExpressions.getLeft());
-        assertEquals(expression, splitExpressions.getRight());
+        assertNull(splitExpressions.getOuter());
+        assertEquals(expression, splitExpressions.getInner());
     }
 
     @Test
     public void testSinglePredicateWithJoin() throws Exception {
         FilterExpression expression = parse("countryUnSeats>3");
 
-        Pair<FilterExpression, FilterExpression> splitExpressions =
+        SubqueryFilterSplitter.SplitFilter splitExpressions =
                 SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
 
-        assertNull(splitExpressions.getRight());
-        assertEquals(expression, splitExpressions.getLeft());
+        assertNull(splitExpressions.getInner());
+        assertEquals(expression, splitExpressions.getOuter());
     }
 
     @Test
@@ -95,22 +94,22 @@ public class SubqueryFilterSplitterTest {
         FilterExpression expectedOuter = parse("countryUnSeats>3");
         FilterExpression expectedInner = parse("overallRating=='Foo'");
 
-        Pair<FilterExpression, FilterExpression> splitExpressions =
+        SubqueryFilterSplitter.SplitFilter splitExpressions =
                 SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
 
-        assertEquals(expectedOuter, splitExpressions.getLeft());
-        assertEquals(expectedInner, splitExpressions.getRight());
+        assertEquals(expectedOuter, splitExpressions.getOuter());
+        assertEquals(expectedInner, splitExpressions.getInner());
     }
 
     @Test
     public void testSplitByOr() throws Exception {
         FilterExpression expression = parse("countryUnSeats>3,overallRating=='Foo'");
 
-        Pair<FilterExpression, FilterExpression> splitExpressions =
+        SubqueryFilterSplitter.SplitFilter splitExpressions =
                 SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
 
-        assertEquals(expression, splitExpressions.getLeft());
-        assertNull(splitExpressions.getRight());
+        assertEquals(expression, splitExpressions.getOuter());
+        assertNull(splitExpressions.getInner());
     }
 
     @Test
@@ -121,11 +120,11 @@ public class SubqueryFilterSplitterTest {
         FilterExpression expectedOuter = parse("countryUnSeats>3,overallRating=='Foo'");
         FilterExpression expectedInner = parse("overallRating=='Bar',overallRating=='Blah'");
 
-        Pair<FilterExpression, FilterExpression> splitExpressions =
+        SubqueryFilterSplitter.SplitFilter splitExpressions =
                 SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
 
-        assertEquals(expectedOuter, splitExpressions.getLeft());
-        assertEquals(expectedInner, splitExpressions.getRight());
+        assertEquals(expectedOuter, splitExpressions.getOuter());
+        assertEquals(expectedInner, splitExpressions.getInner());
     }
 
     @Test
@@ -133,11 +132,11 @@ public class SubqueryFilterSplitterTest {
         FilterExpression expression = parse(
                 "(countryUnSeats>3;overallRating=='Foo'),(overallRating=='Bar';overallRating=='Blah')");
 
-        Pair<FilterExpression, FilterExpression> splitExpressions =
+        SubqueryFilterSplitter.SplitFilter splitExpressions =
                 SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
 
-        assertEquals(expression, splitExpressions.getLeft());
-        assertNull(splitExpressions.getRight());
+        assertEquals(expression, splitExpressions.getOuter());
+        assertNull(splitExpressions.getInner());
     }
 
     @Test
@@ -145,11 +144,11 @@ public class SubqueryFilterSplitterTest {
         FilterExpression expression = parse(
                 "(overallRating=='Foobar',overallRating=='Foo'),(overallRating=='Bar',overallRating=='Blah')");
 
-        Pair<FilterExpression, FilterExpression> splitExpressions =
+        SubqueryFilterSplitter.SplitFilter splitExpressions =
                 SubqueryFilterSplitter.splitFilter(lookupTable, metaDataStore, expression);
 
-        assertEquals(expression, splitExpressions.getRight());
-        assertNull(splitExpressions.getLeft());
+        assertEquals(expression, splitExpressions.getInner());
+        assertNull(splitExpressions.getOuter());
     }
 
     private FilterExpression parse(String filter) throws ParseException {


### PR DESCRIPTION
This is part 2 of a new query plan optimizer for the Aggregation data store.

The goal is to rewrite queries of the form:

```
SELECT SUM(factTable.measure), factTable.dimensionA 
FROM factTable LEFT JOIN dimTableB 
ON factTable.dimensionB = dimTableB.id 
GROUP BY factTable.dimensionA
WHERE dimTableB.otherField > 0 AND factTable.anotherField = 0;
```

Into an optimized query like:

```
SELECT SUM(subquery.measure), subquery.dimensionA 
FROM 
   (SELECT SUM(factTable.measure), factTable.dimensionA, factTable.dimensionB 
    FROM factTable 
    GROUP BY factTable.dimensionA, factTable.dimensionB 
    WHERE factTable.anotherField = 0) subquery 
LEFT JOIN dimTableB 
ON subquery.dimensionB = dimTableB.id
GROUP BY subquery.dimensionA 
WHERE dimTableB.otherField > 0;
```
This phase adds the logic to split the filter expression between the outer and inner queries based on the presence of joins.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
