### PR TITLE
issue 1904 - fix lombok build warnings

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ExportControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ExportControllerProperties.java
@@ -6,11 +6,13 @@
 package com.yahoo.elide.spring.config;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * Extra controller properties for the export endpoint.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class ExportControllerProperties extends ControllerProperties {
 
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/JsonApiControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/JsonApiControllerProperties.java
@@ -6,11 +6,13 @@
 package com.yahoo.elide.spring.config;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * Extra controller properties for the JSON-API endpoint.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class JsonApiControllerProperties extends ControllerProperties {
 
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/SwaggerControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/SwaggerControllerProperties.java
@@ -6,11 +6,13 @@
 package com.yahoo.elide.spring.config;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
  * Extra controller properties for the Swagger document endpoint.
  */
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class SwaggerControllerProperties extends ControllerProperties {
 
     /**


### PR DESCRIPTION
Resolves #1904 

## Description
lombok's `@Data` annotation aggregates several functionalities. one is `@EqualsAndHashCode` 
in order to get rid of build warning in extending classes we should explicitly declare `@EqualsAndHashCode`, here with `(callSuper = true)`  option to also include fields from super class when implementing `hashCode()` and `equals()`

## How Has This Been Tested?
in this specific case - no applicative code was changed, so no tests (unless you'd like me to add tests for lombok functionality - not sure what is the agenda for such cases in this repo)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
