### PR TITLE
[HackTogether]Fix Lombok EqualsAndHashCode warnings

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -25,6 +26,7 @@ import javax.persistence.Entity;
 @UpdatePermission(expression = "Prefab.Role.None")
 @DeletePermission(expression = "Prefab.Role.None")
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class AsyncQuery extends AsyncAPI {
     @Embedded
     private AsyncQueryResult result;

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQueryResult.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.async.models;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.Embeddable;
 import javax.persistence.Lob;
@@ -15,6 +16,7 @@ import javax.persistence.Lob;
  */
 @Embeddable
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class AsyncQueryResult extends AsyncAPIResult {
     private Integer contentLength;
 

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/TableExport.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/TableExport.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -29,6 +30,7 @@ import javax.validation.constraints.NotNull;
 @UpdatePermission(expression = "Prefab.Role.None")
 @DeletePermission(expression = "Prefab.Role.None")
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class TableExport extends AsyncAPI {
 
     @Enumerated(EnumType.STRING)

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/TableExportResult.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/TableExportResult.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.async.models;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.net.URL;
 
@@ -17,6 +18,7 @@ import javax.persistence.Lob;
  */
 @Embeddable
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class TableExportResult extends AsyncAPIResult {
     private URL url;
 


### PR DESCRIPTION
Resolves #1888

## Description
Lombok throws a warning when `@Data` annotation is used for classes that extends another because it generates equals/hashcode without the call to super. In this case, it is fixed by explicitly setting `@EqualsAndHashCode(callSuper = true)`

## How Has This Been Tested?
Verified that the warnings logged in the related issue no longer happen. I haven't added any additional tests to verify lombok's functionality, but please let me know if we need additional tests here.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
