### PR TITLE
MaxAsyncAfterSeconds Default Value Assignment

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/AsyncQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/AsyncQueryHook.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.async.hooks;
 
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
 import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
 import com.yahoo.elide.async.models.AsyncAPI;
@@ -27,8 +28,8 @@ import java.util.concurrent.Callable;
  */
 public class AsyncQueryHook extends AsyncAPIHook<AsyncQuery> {
 
-    public AsyncQueryHook (AsyncExecutorService asyncExecutorService, Integer maxAsyncAfterSeconds) {
-        super(asyncExecutorService, maxAsyncAfterSeconds);
+    public AsyncQueryHook (AsyncExecutorService asyncExecutorService, ElideSettings elideSettings) {
+        super(asyncExecutorService, elideSettings);
     }
 
     @Override

--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/TableExportHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/TableExportHook.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.async.hooks;
 
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
 import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
 import com.yahoo.elide.async.export.formatter.TableExportFormatter;
@@ -32,9 +33,9 @@ public class TableExportHook extends AsyncAPIHook<TableExport> {
     Map<ResultType, TableExportFormatter> supportedFormatters;
     ResultStorageEngine engine;
 
-    public TableExportHook (AsyncExecutorService asyncExecutorService, Integer maxAsyncAfterSeconds,
+    public TableExportHook (AsyncExecutorService asyncExecutorService, ElideSettings settings,
             Map<ResultType, TableExportFormatter> supportedFormatters, ResultStorageEngine engine) {
-        super(asyncExecutorService, maxAsyncAfterSeconds);
+        super(asyncExecutorService, settings);
         this.supportedFormatters = supportedFormatters;
         this.engine = engine;
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncAPI.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncAPI.java
@@ -60,7 +60,7 @@ public abstract class AsyncAPI implements PrincipalOwned {
 
     @Transient
     @ComputedAttribute
-    private Integer asyncAfterSeconds = 10;
+    private Integer asyncAfterSeconds;
 
     /**
      * Set Async API Result.

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -47,4 +47,5 @@ public class ElideSettings {
     @Getter private final String jsonApiPath;
     @Getter private final String graphQLApiPath;
     @Getter private final String exportApiPath;
+    @Getter private final int maxAsyncAfterSeconds;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -57,6 +57,7 @@ public class ElideSettingsBuilder {
     private String jsonApiPath;
     private String graphQLApiPath;
     private String exportApiPath;
+    private int maxAsyncAfterSeconds = 10;
 
     /**
      * A new builder used to generate Elide instances. Instantiates an {@link EntityDictionary} without
@@ -112,7 +113,8 @@ public class ElideSettingsBuilder {
                 baseUrl,
                 jsonApiPath,
                 graphQLApiPath,
-                exportApiPath);
+                exportApiPath,
+                maxAsyncAfterSeconds);
     }
 
     public ElideSettingsBuilder withAuditLogger(AuditLogger auditLogger) {
@@ -219,6 +221,11 @@ public class ElideSettingsBuilder {
 
     public ElideSettingsBuilder withStrictQueryParams(boolean enabled) {
         this.strictQueryParams = enabled;
+        return this;
+    }
+
+    public ElideSettingsBuilder withMaxAsyncAfterSeconds(int maxAsyncAfterSeconds) {
+        this.maxAsyncAfterSeconds = maxAsyncAfterSeconds;
         return this;
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -101,6 +101,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                         .withEntityDictionary(dictionary)
                         .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", Calendar.getInstance().getTimeZone())
                         .withExportApiPath("/export")
+                        .withMaxAsyncAfterSeconds(10)
                         .build());
                 bind(elide).to(Elide.class).named("elide");
 
@@ -123,8 +124,8 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                     supportedFormatters.put(ResultType.JSON, new JSONExportFormatter(elide));
 
                     // Binding TableExport LifeCycleHook
-                    TableExportHook tableExportHook = new TableExportHook(asyncExecutorService, 10, supportedFormatters,
-                            resultStorageEngine);
+                    TableExportHook tableExportHook = new TableExportHook(asyncExecutorService, elide.getElideSettings(),
+                            supportedFormatters, resultStorageEngine);
                     dictionary.bindTrigger(TableExport.class, READ, PRESECURITY, tableExportHook, false);
                     dictionary.bindTrigger(TableExport.class, CREATE, POSTCOMMIT, tableExportHook, false);
                     dictionary.bindTrigger(TableExport.class, CREATE, PRESECURITY, tableExportHook, false);
@@ -143,7 +144,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                 bind(billingService).to(BillingService.class);
 
                 // Binding AsyncQuery LifeCycleHook
-                AsyncQueryHook asyncQueryHook = new AsyncQueryHook(asyncExecutorService, 10);
+                AsyncQueryHook asyncQueryHook = new AsyncQueryHook(asyncExecutorService, elide.getElideSettings());
 
                 InvoiceCompletionHook invoiceCompletionHook = new InvoiceCompletionHook(billingService);
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -150,10 +150,12 @@ public class ElideAutoConfiguration {
                 .withJsonApiPath(settings.getJsonApi().getPath())
                 .withGraphQLApiPath(settings.getGraphql().getPath());
 
-        if (settings.getAsync() != null
-                && settings.getAsync().getExport() != null
-                && settings.getAsync().getExport().isEnabled()) {
-            builder.withExportApiPath(settings.getAsync().getExport().getPath());
+        if (settings.getAsync() != null) {
+            builder.withMaxAsyncAfterSeconds(settings.getAsync().getMaxAsyncAfterSeconds());
+
+            if (settings.getAsync().getExport() != null && settings.getAsync().getExport().isEnabled()) {
+                builder.withExportApiPath(settings.getAsync().getExport().getPath());
+            }
         }
 
         if (settings.getJsonApi() != null

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -196,8 +196,7 @@ public class ElideResourceConfig extends ResourceConfig {
                     }
 
                     // Binding AsyncQuery LifeCycleHook
-                    AsyncQueryHook asyncQueryHook = new AsyncQueryHook(asyncExecutorService,
-                            asyncProperties.getMaxAsyncAfterSeconds());
+                    AsyncQueryHook asyncQueryHook = new AsyncQueryHook(asyncExecutorService, elideSettings);
 
                     dictionary.bindTrigger(AsyncQuery.class, READ, PRESECURITY, asyncQueryHook, false);
                     dictionary.bindTrigger(AsyncQuery.class, CREATE, POSTCOMMIT, asyncQueryHook, false);
@@ -273,13 +272,12 @@ public class ElideResourceConfig extends ResourceConfig {
     private TableExportHook getTableExportHook(AsyncExecutorService asyncExecutorService,
             ElideStandaloneAsyncSettings asyncProperties, Map<ResultType, TableExportFormatter> supportedFormatters,
             ResultStorageEngine engine) {
+        ElideSettings elideSettings = asyncExecutorService.getElide().getElideSettings();
         TableExportHook tableExportHook = null;
         if (asyncProperties.enableExport()) {
-            tableExportHook = new TableExportHook(asyncExecutorService, asyncProperties.getMaxAsyncAfterSeconds(),
-                    supportedFormatters, engine);
+            tableExportHook = new TableExportHook(asyncExecutorService, elideSettings, supportedFormatters, engine);
         } else {
-            tableExportHook = new TableExportHook(asyncExecutorService, asyncProperties.getMaxAsyncAfterSeconds(),
-                    supportedFormatters, engine) {
+            tableExportHook = new TableExportHook(asyncExecutorService, elideSettings, supportedFormatters, engine) {
                 @Override
                 public void validateOptions(AsyncAPI export, RequestScope requestScope) {
                     throw new InvalidOperationException("TableExport is not supported.");

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -127,6 +127,10 @@ public interface ElideStandaloneSettings {
             builder.withExportApiPath(getAsyncProperties().getExportApiPathSpec().replaceAll("/\\*", ""));
         }
 
+        if (getAsyncProperties().getMaxAsyncAfterSeconds() != null) {
+            builder.withMaxAsyncAfterSeconds(getAsyncProperties().getMaxAsyncAfterSeconds());
+        }
+
         if (enableISO8601Dates()) {
             builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"));
         }


### PR DESCRIPTION
Resolves #1949 

## Description
Fix for "Invalid Max Async After Seconds" error when the configured MaxAsyncAfterSeconds in application.yaml or standalone  settings was less than 10.

## Motivation and Context
Resolves incorrect error message

## How Has This Been Tested?
Existing test case pass.
`
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
