### PR TITLE
Add 2 new filter operators - between and notbetween

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -183,7 +183,19 @@ public enum Operator {
     HASNOMEMBER("hasnomember", true) {
         @Override
         public <T> Predicate<T> contextualize(Path fieldPath, List<Object> values, RequestScope requestScope) {
-            return entiry -> !hasMember(fieldPath, values, requestScope).test(entiry);
+            return entity -> !hasMember(fieldPath, values, requestScope).test(entity);
+        }
+    },
+    BETWEEN("between", true) {
+        @Override
+        public <T> Predicate<T> contextualize(Path fieldPath, List<Object> values, RequestScope requestScope) {
+            return entity -> between(fieldPath, values, requestScope).test(entity);
+        }
+    },
+    NOTBETWEEN("notbetween", true) {
+        @Override
+        public <T> Predicate<T> contextualize(Path fieldPath, List<Object> values, RequestScope requestScope) {
+            return entity -> !between(fieldPath, values, requestScope).test(entity);
         }
     };
 
@@ -210,6 +222,8 @@ public enum Operator {
         NOTEMPTY.negated = ISEMPTY;
         HASMEMBER.negated = HASNOMEMBER;
         HASNOMEMBER.negated = HASMEMBER;
+        BETWEEN.negated = NOTBETWEEN;
+        NOTBETWEEN.negated = BETWEEN;
     }
 
     /**
@@ -345,6 +359,23 @@ public enum Operator {
 
     private static <T> Predicate<T> ge(Path fieldPath, List<Object> values, RequestScope requestScope) {
         return getComparator(fieldPath, values, requestScope, compareResult -> compareResult >= 0);
+    }
+
+    private static <T> Predicate<T> between(Path fieldPath, List<Object> values, RequestScope requestScope) {
+        return (T entity) -> {
+            if (values.size() != 2) {
+                throw new BadRequestException("Between operator expects exactly 2 values");
+            }
+            Object fieldVal = getFieldValue(entity, fieldPath, requestScope);
+
+            if (fieldVal instanceof Collection) {
+                return false;
+            }
+
+            return fieldVal != null
+                    && compare(fieldVal, values.get(0)) >= 0
+                    && compare(fieldVal, values.get(1)) <= 0;
+        };
     }
 
     private static <T> Predicate<T> isTrue() {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -80,6 +80,8 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
     private static final ComparisonOperator ISEMPTY_OP = new ComparisonOperator("=isempty=", false);
     private static final ComparisonOperator HASMEMBER_OP = new ComparisonOperator("=hasmember=", false);
     private static final ComparisonOperator HASNOMEMBER_OP = new ComparisonOperator("=hasnomember=", false);
+    private static final ComparisonOperator BETWEEN_OP = new ComparisonOperator("=between=", true);
+    private static final ComparisonOperator NOTBETWEEN_OP = new ComparisonOperator("=notbetween=", true);
 
     /* Subset of operators that map directly to Elide operators */
     private static final Map<ComparisonOperator, Operator> OPERATOR_MAP =
@@ -90,6 +92,8 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
                     .put(RSQLOperators.LESS_THAN_OR_EQUAL, Operator.LE)
                     .put(HASMEMBER_OP, Operator.HASMEMBER)
                     .put(HASNOMEMBER_OP, Operator.HASNOMEMBER)
+                    .put(BETWEEN_OP, Operator.BETWEEN)
+                    .put(NOTBETWEEN_OP, Operator.NOTBETWEEN)
                     .build();
 
 
@@ -116,6 +120,8 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
         operators.add(ISEMPTY_OP);
         operators.add(HASMEMBER_OP);
         operators.add(HASNOMEMBER_OP);
+        operators.add(BETWEEN_OP);
+        operators.add(NOTBETWEEN_OP);
         return operators;
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -333,6 +333,12 @@ public class OperatorTest {
         fn = Operator.GE.contextualize(constructPath(Author.class, "id"), Arrays.asList("11", "12"), requestScope);
         assertFalse(fn.test(author));
 
+        // between operator
+        fn = Operator.BETWEEN.contextualize(constructPath(Author.class, "id"), Arrays.asList("9", "11"), requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.NOTBETWEEN.contextualize(constructPath(Author.class, "id"), Arrays.asList("9", "11"), requestScope);
+        assertFalse(fn.test(author));
+
         // when val is null
         author.setId(null);
         fn = Operator.LT.contextualize(constructPath(Author.class, "id"), Collections.singletonList("10"), requestScope);
@@ -343,6 +349,7 @@ public class OperatorTest {
         assertFalse(fn.test(author));
         fn = Operator.GE.contextualize(constructPath(Author.class, "id"), Collections.singletonList("10"), requestScope);
         assertFalse(fn.test(author));
+
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -133,6 +133,21 @@ public class DefaultFilterDialectTest {
     }
 
     @Test
+    public void testBetweenOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter[author.books.id][between]",
+                "10,20"
+        );
+
+        Map<String, FilterExpression> expressionMap = dialect.parseTypedExpression("/author", queryParams, NO_VERSION);
+
+        assertEquals(1, expressionMap.size());
+        assertEquals("author.books.id BETWEEN [10, 20]", expressionMap.get("author").toString());
+    }
+
+    @Test
     public void testEmptyOperatorException() throws Exception {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -226,6 +226,23 @@ public class RSQLFilterDialectTest {
     }
 
     @Test
+    public void testBetweenOperator() throws Exception {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+
+        queryParams.add(
+                "filter",
+                "(publishDate=notbetween=(5,10))"
+        );
+
+        FilterExpression expression = dialect.parseGlobalExpression("/book", queryParams, NO_VERSION);
+
+        assertEquals(
+                "book.publishDate NOTBETWEEN [5, 10]",
+                expression.toString()
+        );
+    }
+
+    @Test
     public void testSubstringOperator() throws Exception {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 

--- a/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
+++ b/elide-datastore/elide-datastore-hibernate/src/main/java/com/yahoo/elide/core/filter/FilterTranslator.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core.filter;
 
+import static com.yahoo.elide.core.filter.Operator.BETWEEN;
 import static com.yahoo.elide.core.filter.Operator.FALSE;
 import static com.yahoo.elide.core.filter.Operator.GE;
 import static com.yahoo.elide.core.filter.Operator.GT;
@@ -19,6 +20,7 @@ import static com.yahoo.elide.core.filter.Operator.ISNULL;
 import static com.yahoo.elide.core.filter.Operator.LE;
 import static com.yahoo.elide.core.filter.Operator.LT;
 import static com.yahoo.elide.core.filter.Operator.NOT;
+import static com.yahoo.elide.core.filter.Operator.NOTBETWEEN;
 import static com.yahoo.elide.core.filter.Operator.NOTEMPTY;
 import static com.yahoo.elide.core.filter.Operator.NOTNULL;
 import static com.yahoo.elide.core.filter.Operator.NOT_INSENSITIVE;
@@ -186,6 +188,26 @@ public class FilterTranslator implements FilterOperation<String> {
 
         operatorGenerators.put(NOTEMPTY, (predicate, aliasGenerator) -> {
             return String.format("%s IS NOT EMPTY", aliasGenerator.apply(predicate.getPath()));
+        });
+
+        operatorGenerators.put(BETWEEN, (predicate, aliasGenerator) -> {
+            List<FilterPredicate.FilterParameter> parameters = predicate.getParameters();
+            Preconditions.checkState(!parameters.isEmpty());
+            Preconditions.checkArgument(parameters.size() == 2);
+            return String.format("%s BETWEEN %s AND %s",
+                    aliasGenerator.apply(predicate.getPath()),
+                    parameters.get(0).getPlaceholder(),
+                    parameters.get(1).getPlaceholder());
+        });
+
+        operatorGenerators.put(NOTBETWEEN, (predicate, aliasGenerator) -> {
+            List<FilterPredicate.FilterParameter> parameters = predicate.getParameters();
+            Preconditions.checkState(!parameters.isEmpty());
+            Preconditions.checkArgument(parameters.size() == 2);
+            return String.format("%s NOT BETWEEN %s AND %s",
+                    aliasGenerator.apply(predicate.getPath()),
+                    parameters.get(0).getPlaceholder(),
+                    parameters.get(1).getPlaceholder());
         });
     }
 

--- a/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-hibernate/src/test/java/com/yahoo/elide/core/filter/FilterTranslatorTest.java
@@ -84,6 +84,45 @@ public class FilterTranslatorTest {
     }
 
     @Test
+    public void testBetweenOperator() throws Exception {
+        List<Path.PathElement> authorId = Arrays.asList(
+                new Path.PathElement(Book.class, Author.class, "authors"),
+                new Path.PathElement(Author.class, Long.class, "id")
+        );
+        List<Path.PathElement> publishDate = Arrays.asList(
+                new Path.PathElement(Book.class, Long.class, "publishDate")
+        );
+        FilterPredicate authorPred = new FilterPredicate(new Path(authorId), Operator.BETWEEN, Arrays.asList(1, 15));
+        FilterPredicate publishPred = new FilterPredicate(new Path(publishDate), Operator.NOTBETWEEN, Arrays.asList(1, 15));
+
+
+        AndFilterExpression andFilter = new AndFilterExpression(authorPred, publishPred);
+
+
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
+        String query = filterOp.apply(andFilter, false);
+
+
+        String authorP1 = authorPred.getParameters().get(0).getPlaceholder();
+        String authorP2 = authorPred.getParameters().get(1).getPlaceholder();
+
+
+        String publishP1 = publishPred.getParameters().get(0).getPlaceholder();
+        String publishP2 = publishPred.getParameters().get(1).getPlaceholder();
+
+        String expected = "(authors.id BETWEEN " + authorP1 + " AND " + authorP2 + " AND "
+                + "publishDate NOT BETWEEN " + publishP1 + " AND " + publishP2 + ")";
+        assertEquals(expected, query);
+
+
+        // Assert excepetion if parameter length is not 2
+        assertThrows(IllegalArgumentException.class,
+                () -> filterOp.apply(
+                        new FilterPredicate(new Path(authorId), Operator.BETWEEN, Arrays.asList(3))
+                ));
+    }
+
+    @Test
     public void testMemberOfOperator() throws Exception {
         List<Path.PathElement> path = Arrays.asList(
                 new Path.PathElement(Book.class, String.class, "awards")

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/FilterIT.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
@@ -1569,6 +1570,40 @@ public class FilterIT extends IntegrationTest {
         JsonNode result = getAsNode(String.format("/author/%s/books?filter[book.title][notnull]=true&sort=title", asimovId));
         JsonNode data = result.get("data");
         assertEquals(data.size(), 2);
+    }
+
+    @Test
+    void testBetweenOperatorOnRoot() throws JsonProcessingException {
+        JsonNode result = getAsNode("/book?filter[book.id][between]=2,4");
+        JsonNode data = result.get("data");
+        assertEquals(3, data.size());
+        for (JsonNode book : data) {
+            assertTrue(Arrays.asList(2, 3, 4).contains(book.get("id").asInt()));
+        }
+
+        result = getAsNode("/book?filter=id=notbetween=(2,4);id!=7");
+        data = result.get("data");
+        assertEquals(4, data.size());
+        for (JsonNode book : data) {
+            assertTrue(Arrays.asList(1, 5, 6, 8).contains(book.get("id").asInt()));
+        }
+    }
+
+    @Test
+    void testBetweenOperatorOnNonRoot() throws JsonProcessingException {
+        JsonNode result = getAsNode(String.format("/author/%s/books?filter[book.id][notbetween]=6,7", nullNedId));
+        JsonNode data = result.get("data");
+        assertEquals(1, data.size());
+        for (JsonNode book : data) {
+            assertEquals(8, book.get("id").asInt());
+        }
+
+        result = getAsNode(String.format("/author/%s/books?filter[book]=id=between=(6,7)", nullNedId));
+        data = result.get("data");
+        assertEquals(1, data.size());
+        for (JsonNode book : data) {
+            assertEquals(7, book.get("id").asInt());
+        }
     }
 
 


### PR DESCRIPTION
Resolves #1130

## Description
Added new operators namely `between` and `notbetween`.
```
id=between=(id1, id2) ---> id1 <= id <= id2                  
id=notbetween=(id1, id2) ---> id1 > id < id2
```

## Motivation and Context
filtering over a range is a common use case especially for date dimensions. Having `between` operators simplifies the expression. 

## How Has This Been Tested?
Unit test and IT

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
