### PR TITLE
Add join metadata to SQLTable.

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnVisitor.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 public abstract class ColumnVisitor<T> {
     private static final Pattern REFERENCE_PARENTHESES = Pattern.compile("\\{\\{(.+?)}}");
 
-    private final MetaDataStore metaDataStore;
+    protected final MetaDataStore metaDataStore;
     protected final EntityDictionary dictionary;
 
     public ColumnVisitor(MetaDataStore metaDataStore) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/FormulaValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/FormulaValidator.java
@@ -67,7 +67,7 @@ public class FormulaValidator extends ColumnVisitor<Void> {
             if (source != source.getSource()) {
                 continue;
             } else if (reference.contains(".")) {
-                JoinPath joinToPath = new JoinPath(tableClass, dictionary, reference);
+                JoinPath joinToPath = new JoinPath(tableClass, metaDataStore, reference);
                 Column joinToColumn = getColumn(joinToPath);
                 if (joinToColumn != null) {
                     visitColumn(joinToColumn.getTable().toQueryable(), joinToColumn.toProjection());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -194,8 +194,8 @@ public class MetaDataStore implements DataStore {
      * @param tableClass table class
      * @return meta data table
      */
-    public Table getTable(Type<?> tableClass) {
-        return tables.get(tableClass);
+    public <T extends Table> T getTable(Type<?> tableClass) {
+        return (T) tables.get(tableClass);
     }
 
     /**
@@ -300,7 +300,6 @@ public class MetaDataStore implements DataStore {
      * @return all metadata of given class
      */
     public <T> Set<T> getMetaData(Type<T> cls) {
-
         String version = EntityDictionary.getModelVersion(cls);
         HashMapDataStore hashMapDataStore = hashMapDataStores.computeIfAbsent(version, SERVER_ERROR);
         return hashMapDataStore.get(cls).values().stream().map(obj -> (T) obj).collect(Collectors.toSet());
@@ -322,18 +321,6 @@ public class MetaDataStore implements DataStore {
      */
     public static boolean isMetricField(EntityDictionary dictionary, Type<?> cls, String fieldName) {
         return dictionary.attributeOrRelationAnnotationExists(cls, fieldName, MetricFormula.class);
-    }
-
-    /**
-     * Returns whether a field in a table/entity is actually a JOIN to other table/entity.
-     *
-     * @param cls table/entity class
-     * @param fieldName field name
-     * @param dictionary metadata dictionary
-     * @return True if this field is a table join
-     */
-    public static boolean isTableJoin(Type<?> cls, String fieldName, EntityDictionary dictionary) {
-        return dictionary.getAttributeOrRelationAnnotation(cls, Join.class, fieldName) != null;
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoin.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoin.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata;
+
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.annotation.JoinType;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+/**
+ * Forms relationships between two SQLTables.
+ */
+public class SQLJoin {
+    private String name;
+    private JoinType joinType;
+    private boolean toOne;
+    private Type<?> joinTableType;
+    private String joinExpression;
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoinVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLJoinVisitor.java
@@ -85,8 +85,8 @@ public class SQLJoinVisitor extends ColumnVisitor<Set<JoinPath>> {
         Queryable root = source.getRoot();
 
         JoinPath joinPath = froms.empty()
-                ? new JoinPath(dictionary.getEntityClass(root.getName(), root.getVersion()), dictionary, joinToPath)
-                : froms.peek().extend(joinToPath, dictionary);
+                ? new JoinPath(dictionary.getEntityClass(root.getName(), root.getVersion()), metaDataStore, joinToPath)
+                : froms.peek().extend(joinToPath);
         joinPaths.add(joinPath);
 
         froms.add(joinPath);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -7,7 +7,7 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata;
 
 import static com.yahoo.elide.core.utils.TypeHelper.appendAlias;
 import static com.yahoo.elide.core.utils.TypeHelper.getClassType;
-import static com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore.isTableJoin;
+import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable.isTableJoin;
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
@@ -221,7 +221,7 @@ public class SQLReferenceTable {
             Type<?> parentClass = pathElement.getType();
 
             // Nothing left to join.
-            if (!dictionary.isRelation(parentClass, fieldName) && !isTableJoin(parentClass, fieldName, dictionary)) {
+            if (!dictionary.isRelation(parentClass, fieldName) && !isTableJoin(metaDataStore, parentClass, fieldName)) {
                 return;
             }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -11,7 +11,6 @@ import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.S
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
-import com.yahoo.elide.datastores.aggregation.annotation.Join;
 import com.yahoo.elide.datastores.aggregation.annotation.JoinType;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.ColumnVisitor;
@@ -169,12 +168,10 @@ public class SQLReferenceTable {
             String fieldName = first.getFieldName();
             Type<?> parentClass = first.getType();
 
-            Join join = dictionary.getAttributeOrRelationAnnotation(
-                    parentClass,
-                    Join.class,
-                    fieldName);
+            SQLTable table = metaDataStore.getTable(parentClass);
+            SQLJoin join = table.getJoin(fieldName);
 
-            String joinClause = join.value();
+            String joinClause = join.getJoinExpression();
 
             for (String reference : ColumnVisitor.resolveFormulaReferences(joinClause)) {
                 if (reference.contains(".")) {
@@ -255,16 +252,14 @@ public class SQLReferenceTable {
         // resolve the right hand side of JOIN
         String joinSource = constructTableOrSubselect(joinClass, dialect);
 
-        Join join = dictionary.getAttributeOrRelationAnnotation(
-                fromClass,
-                Join.class,
-                joinField);
+        SQLTable table = metaDataStore.getTable(fromClass);
+        SQLJoin join = table.getJoin(joinField);
 
         String joinKeyword = join == null
                 ? dialect.getJoinKeyword(JoinType.LEFT)
-                : dialect.getJoinKeyword(join.type());
+                : dialect.getJoinKeyword(join.getJoinType());
 
-        if (join != null && join.type().equals(JoinType.CROSS)) {
+        if (join != null && join.getJoinType().equals(JoinType.CROSS)) {
             return String.format("%s %s AS %s",
                     joinKeyword,
                     joinSource,
@@ -280,7 +275,7 @@ public class SQLReferenceTable {
                         dictionary.getAnnotatedColumnName(
                                 joinClass,
                                 dictionary.getIdFieldName(joinClass)))
-                : getJoinClause(fromClass, fromAlias, join.value(), dialect);
+                : getJoinClause(fromClass, fromAlias, join.getJoinExpression(), dialect);
 
         return String.format("%s %s AS %s ON %s",
                 joinKeyword,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceVisitor.java
@@ -142,7 +142,7 @@ public class SQLReferenceVisitor extends ColumnVisitor<String> {
      * @return resolved reference
      */
     private String visitTableJoinToReference(Type<?> tableClass, String joinToPath) {
-        JoinPath joinPath = new JoinPath(tableClass, dictionary, joinToPath);
+        JoinPath joinPath = new JoinPath(tableClass, metaDataStore, joinToPath);
 
         tableAliases.push(extendTypeAlias(tableAliases.peek(), joinPath));
         String result;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.join;
 import com.yahoo.elide.core.dictionary.EntityBinding;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.request.Argument;
@@ -217,8 +218,12 @@ public class SQLTable extends Table implements Queryable {
         return getDimensionProjection(name);
     }
 
+    public SQLJoin getJoin(String joinName) {
+        return joins.get(joinName);
+    }
+
     public SQLTable getJoinTable(MetaDataStore store, String joinName) {
-        SQLJoin join = joins.get(joinName);
+        SQLJoin join = getJoin(joinName);
         if (join == null) {
             return null;
         }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -218,10 +218,21 @@ public class SQLTable extends Table implements Queryable {
         return getDimensionProjection(name);
     }
 
+    /**
+     * Looks up a join by name.
+     * @param joinName The join name.
+     * @return SQLJoin or null.
+     */
     public SQLJoin getJoin(String joinName) {
         return joins.get(joinName);
     }
 
+    /**
+     * Looks up a join by name and returns the corresponding SQLTable being joined to.
+     * @param store The store where all the SQL tables live.
+     * @param joinName The join to lookup.
+     * @return SQLTable or null.
+     */
     public SQLTable getJoinTable(MetaDataStore store, String joinName) {
         SQLJoin join = getJoin(joinName);
         if (join == null) {
@@ -231,6 +242,13 @@ public class SQLTable extends Table implements Queryable {
         return store.getTable(join.getJoinTableType());
     }
 
+    /**
+     * Looks up to see if a given field is a join field or just an attribute.
+     * @param store The metadata store.
+     * @param modelType The model type in question.
+     * @param fieldName The field name in question.
+     * @return True if the field is a join field.  False otherwise.
+     */
     public static boolean isTableJoin(MetaDataStore store, Type<?> modelType, String fieldName) {
         SQLTable table = store.getTable(modelType);
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SubqueryFilterSplitter.java
@@ -68,7 +68,7 @@ public class SubqueryFilterSplitter
         Type<?> tableType = filterPredicate.getEntityType();
         String fieldName = filterPredicate.getField();
 
-        SQLTable table = (SQLTable) metaDataStore.getTable(tableType);
+        SQLTable table = metaDataStore.getTable(tableType);
 
         Set<String> joins = lookupTable.getResolvedJoinExpressions(table, fieldName);
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/JoinPathTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/JoinPathTest.java
@@ -7,32 +7,65 @@ package com.yahoo.elide.datastores.aggregation.core;
 
 import static com.yahoo.elide.core.utils.TypeHelper.getClassType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.example.Country;
 import com.yahoo.elide.datastores.aggregation.example.CountryView;
 import com.yahoo.elide.datastores.aggregation.example.CountryViewNested;
+import com.yahoo.elide.datastores.aggregation.example.Player;
+import com.yahoo.elide.datastores.aggregation.example.PlayerRanking;
+import com.yahoo.elide.datastores.aggregation.example.PlayerStats;
 import com.yahoo.elide.datastores.aggregation.example.PlayerStatsWithView;
+import com.yahoo.elide.datastores.aggregation.example.SubCountry;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialectFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import javax.sql.DataSource;
 
 public class JoinPathTest {
-    private static EntityDictionary dictionary;
+    private static MetaDataStore store;
 
     @BeforeAll
     public static void init() {
-        dictionary = new EntityDictionary(new HashMap<>());
-        dictionary.bindEntity(PlayerStatsWithView.class);
-        dictionary.bindEntity(CountryView.class);
-        dictionary.bindEntity(CountryViewNested.class);
+
+        Set<Type<?>> models = new HashSet<>();
+        models.add(ClassType.of(PlayerStats.class));
+        models.add(ClassType.of(CountryView.class));
+        models.add(ClassType.of(Country.class));
+        models.add(ClassType.of(SubCountry.class));
+        models.add(ClassType.of(Player.class));
+        models.add(ClassType.of(PlayerRanking.class));
+        models.add(ClassType.of(CountryViewNested.class));
+        models.add(ClassType.of(PlayerStatsWithView.class));
+
+        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
+
+        models.stream().forEach(dictionary::bindEntity);
+
+        store = new MetaDataStore(models, true);
+        store.populateEntityDictionary(dictionary);
+
+        DataSource mockDataSource = mock(DataSource.class);
+        //The query engine populates the metadata store with actual tables.
+        new SQLQueryEngine(store, new ConnectionDetails(mockDataSource,
+                SQLDialectFactory.getDefaultDialect()));
     }
 
     @Test
     public void testExtendPath() {
-        JoinPath joinPath = new JoinPath(getClassType(PlayerStatsWithView.class), dictionary, "countryView");
+        JoinPath joinPath = new JoinPath(getClassType(PlayerStatsWithView.class), store, "countryView");
 
-        JoinPath extended = new JoinPath(getClassType(PlayerStatsWithView.class), dictionary, "countryView.nestedView");
+        JoinPath extended = new JoinPath(getClassType(PlayerStatsWithView.class), store, "countryView.nestedView");
 
-        assertEquals(extended, joinPath.extend("countryView.nestedView", dictionary));
+        assertEquals(extended, joinPath.extend("countryView.nestedView"));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/SqlReferenceVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/SqlReferenceVisitorTest.java
@@ -77,7 +77,7 @@ public class SqlReferenceVisitorTest {
     public void testMatchingPhysicalReference() {
         SQLReferenceVisitor visitor = new SQLReferenceVisitor(store, "test_table", getDefaultDialect());
 
-        SQLTable table = (SQLTable) store.getTable(getClassType(TestModel.class));
+        SQLTable table = store.getTable(getClassType(TestModel.class));
         ColumnProjection column = table.getDimensionProjection("dimension1");
 
         String actual = visitor.visitColumn(table, column);
@@ -89,7 +89,7 @@ public class SqlReferenceVisitorTest {
     public void testMismatchingPhysicalReference() {
         SQLReferenceVisitor visitor = new SQLReferenceVisitor(store, "test_table", getDefaultDialect());
 
-        SQLTable table = (SQLTable) store.getTable(getClassType(TestModel.class));
+        SQLTable table = store.getTable(getClassType(TestModel.class));
         ColumnProjection column = table.getDimensionProjection("dimension2");
         String actual = visitor.visitColumn(table, column);
 
@@ -100,7 +100,7 @@ public class SqlReferenceVisitorTest {
     public void testJoinReference() {
         SQLReferenceVisitor visitor = new SQLReferenceVisitor(store, "join_table", getDefaultDialect());
 
-        SQLTable table = (SQLTable) store.getTable(getClassType(TestModel.class));
+        SQLTable table = store.getTable(getClassType(TestModel.class));
         ColumnProjection column = table.getDimensionProjection("dimension3");
 
         String actual = visitor.visitColumn(table, column);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTableTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTableTest.java
@@ -56,7 +56,7 @@ public class SQLReferenceTableTest {
 
         lookupTable = new SQLReferenceTable(metaDataStore);
 
-        playerStats = (SQLTable) metaDataStore.getTable(ClassType.of(PlayerStats.class));
+        playerStats = metaDataStore.getTable(ClassType.of(PlayerStats.class));
     }
 
     @Test


### PR DESCRIPTION
Creates a new class, SQLJoin and adds a set of these to the SQLTable for join metadata.

All references throughout Elide where the Join annotation is referenced at query time have been replaced with the new SQLJoin class.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
