### PR TITLE
Projection may not have permission for relationshipName

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+**Fixes**
+   * [view commit](https://github.com/yahoo/elide/commit/f2ed4903b05b83b0e82449a43eda49fefc48dc28) NPE when projection has no permission for relationshipName (#1989) 
+
 ## 5.0.0-pr32
 4th public release candidate for Elide 5.0
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RelationshipTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RelationshipTerminalState.java
@@ -60,9 +60,8 @@ public class RelationshipTerminalState extends BaseState {
         Optional<MultivaluedMap<String, String>> queryParams = requestScope.getQueryParams();
 
         Map<String, Relationship> relationships = record.toResource(parentProjection).getRelationships();
-        Relationship relationship = null;
-        if (relationships != null) {
-            relationship = relationships.get(relationshipName);
+        if (relationships != null && relationships.containsKey(relationshipName)) {
+            Relationship relationship = relationships.get(relationshipName);
 
             // Handle valid relationship
 


### PR DESCRIPTION
## Description
I found this error while migrating to Elide 5. 
Fixes NPE if projection does not have permission for provided relationshipName.

## Motivation and Context
NPE caused lookup errors.

## How Has This Been Tested?
Unit testing.  Local project testing.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
