### PR TITLE
TimeDimension Grain Arg match check between Having Filter and Projection

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
+import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 
 import java.util.List;
 import java.util.Map;
@@ -83,6 +84,22 @@ public class QueryValidator {
                                     "Dimension field %s must be grouped before filtering in having clause.",
                                     fieldName));
                 }
+            }
+
+            if (queriedTable.getTimeDimensionProjection(fieldName) != null) {
+                dimensionProjections
+                    .stream()
+                    .filter(dim -> dim.getAlias().equals(fieldName)
+                    		&& TimeDimensionProjection.class.isAssignableFrom(dim.getClass()))
+                    .forEach(dim -> {
+                        Object grain = dim.getArguments().get("grain").getValue();
+                        if (last.getArguments().stream().noneMatch(arg -> (arg.getValue()).equals(grain))) {
+                            throw new InvalidOperationException(
+                                    String.format(
+                                            "Time Dimension field %s must use the same grain argument in the projection"
+                                            + " and the having clause.", fieldName));
+                        }
+                    });
             }
         } else if (havingClause instanceof AndFilterExpression) {
             validateHavingClause(((AndFilterExpression) havingClause).getLeft());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryValidator.java
@@ -90,7 +90,7 @@ public class QueryValidator {
                 dimensionProjections
                     .stream()
                     .filter(dim -> dim.getAlias().equals(fieldName)
-                    		&& TimeDimensionProjection.class.isAssignableFrom(dim.getClass()))
+                            && TimeDimensionProjection.class.isAssignableFrom(dim.getClass()))
                     .forEach(dim -> {
                         Object grain = dim.getArguments().get("grain").getValue();
                         if (last.getArguments().stream().noneMatch(arg -> (arg.getValue()).equals(grain))) {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -1235,7 +1235,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                         field(
                                 "orderDetails",
                                 arguments(
-                                        argument("sort", "\"customerRegion\""),
+                                        argument("sort", "\"orderTime\""),
                                         argument("filter", "\"orderTime=='2020-08',orderTotal>50\"") //No Grain Arg passed, but so based on Alias argument is assigned.
                                 ),
                                 selections(
@@ -1254,6 +1254,11 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                         field(
                                 "orderDetails",
                                 selections(
+                                        field("orderTotal", 103.72F),
+                                        field("customerRegion", "Virginia"),
+                                        field("orderTime", "2020-08-30")
+                                ),
+                                selections(
                                         field("orderTotal", 181.47F),
                                         field("customerRegion", "Virginia"),
                                         field("orderTime", "2020-09-08")
@@ -1262,11 +1267,6 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("orderTotal", 78.87F),
                                         field("customerRegion", "Virginia"),
                                         field("orderTime", "2020-09-09")
-                                ),
-                                selections(
-                                        field("orderTotal", 103.72F),
-                                        field("customerRegion", "Virginia"),
-                                        field("orderTime", "2020-08-30")
                                 )
                         )
                 )

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -1176,6 +1176,33 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
     }
 
     @Test
+    public void testTimeDimMismatchArgs() throws Exception {
+
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "orderDetails",
+                                arguments(
+                                        argument("sort", "\"customerRegion\""),
+                                        argument("filter", "\"orderTime[grain:DAY]=='2020-08',orderTotal>50\"")
+                                ),
+                                selections(
+                                        field("orderTotal"),
+                                        field("customerRegion"),
+                                        field("orderTime", arguments(
+                                                argument("grain", TimeGrain.MONTH) // Does not match grain argument in filter
+                                        ))
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = "Exception while fetching data (/orderDetails) : Invalid operation: Time Dimension field orderTime must use the same grain argument in the projection and the having clause.";
+
+        runQueryWithExpectedError(graphQLRequest, expected);
+    }
+
+    @Test
     public void testAdminRole() throws Exception {
 
         String graphQLRequest = document(

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -1236,7 +1236,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "orderDetails",
                                 arguments(
                                         argument("sort", "\"orderTime\""),
-                                        argument("filter", "\"orderTime=='2020-08',orderTotal>50\"") //No Grain Arg passed, but so based on Alias argument is assigned.
+                                        argument("filter", "\"orderTime=='2020-08-01',orderTotal>50\"") //No Grain Arg passed, so works based on Alias's argument in Selection.
                                 ),
                                 selections(
                                         field("orderTotal"),


### PR DESCRIPTION
## Description
Additional Validation to ensure the Grain Argument to a time-dimension in Filter Clause which gets pushed to a Having Filter matches the Grain Argument to a time-dimension in  the Projection 

## Motivation and Context
It may result in some databases throwing errors that the column in HAVING is not present in GROUP BY or is not an aggregate.

## How Has This Been Tested?
Existing and new test cases.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
