### PR TITLE
Inmemory security filtercheck

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/DatastoreEvalFilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/DatastoreEvalFilterExpressionCheck.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.security.checks;
+
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Optional;
+
+public class DatastoreEvalFilterExpressionCheck<T> extends OperationCheck<T> {
+    @Getter @Setter
+    private boolean executedInMemory;
+    private boolean negated = false;
+    @Getter
+    private FilterExpressionCheck<T> wrappedFilterExpressionCheck;
+
+    public DatastoreEvalFilterExpressionCheck(FilterExpressionCheck<T> wrappedFilterExpressionCheck) {
+        this.wrappedFilterExpressionCheck = wrappedFilterExpressionCheck;
+        this.executedInMemory = false;
+    }
+
+    @Override
+    public boolean ok(T object, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+        if (executedInMemory) {
+            return negated ^ wrappedFilterExpressionCheck.ok(object, requestScope, changeSpec);
+        }
+        return true;
+    }
+
+    public void negate() {
+        negated = !negated;
+    }
+
+    @Override
+    public String toString() {
+        return "DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=" + executedInMemory +
+                ", negated=" + negated +
+                ", wrappedFilterExpressionCheck=" + wrappedFilterExpressionCheck.getClass() +
+                '}';
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/DatastoreEvalFilterExpressionCheck.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/DatastoreEvalFilterExpressionCheck.java
@@ -40,10 +40,10 @@ public class DatastoreEvalFilterExpressionCheck<T> extends OperationCheck<T> {
 
     @Override
     public String toString() {
-        return "DatastoreEvalFilterExpressionCheck{" +
-                "executedInMemory=" + executedInMemory +
-                ", negated=" + negated +
-                ", wrappedFilterExpressionCheck=" + wrappedFilterExpressionCheck.getClass() +
-                '}';
+        return "DatastoreEvalFilterExpressionCheck{"
+                + "executedInMemory=" + executedInMemory
+                + ", negated=" + negated
+                + ", wrappedFilterExpressionCheck=" + wrappedFilterExpressionCheck.getClass()
+                + '}';
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/ExecuteFilterCheckInMemoryVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/ExecuteFilterCheckInMemoryVisitor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.security.visitors;
+
+import com.yahoo.elide.core.security.checks.Check;
+import com.yahoo.elide.core.security.checks.DatastoreEvalFilterExpressionCheck;
+import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
+import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
+import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
+
+public class ExecuteFilterCheckInMemoryVisitor implements ExpressionVisitor<Expression> {
+
+    @Override
+    public Expression visitExpression(Expression expression) {
+        return expression;
+    }
+
+    @Override
+    public Expression visitCheckExpression(CheckExpression checkExpression) {
+        Check check = checkExpression.getCheck();
+        if (check instanceof DatastoreEvalFilterExpressionCheck) {
+            ((DatastoreEvalFilterExpressionCheck) check).setExecutedInMemory(true);
+        }
+        return checkExpression;
+    }
+
+    @Override
+    public Expression visitAndExpression(AndExpression andExpression) {
+        andExpression.getLeft().accept(this);
+        andExpression.getRight().accept(this);
+        return andExpression;
+    }
+
+    @Override
+    public Expression visitOrExpression(OrExpression orExpression) {
+        orExpression.getLeft().accept(this);
+        orExpression.getRight().accept(this);
+        return orExpression;
+    }
+
+    @Override
+    public Expression visitNotExpression(NotExpression notExpression) {
+        notExpression.getLogical().accept(this);
+        return notExpression;
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/InmemoryPermissionExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/InmemoryPermissionExpressionVisitor.java
@@ -7,18 +7,17 @@
 package com.yahoo.elide.core.security.visitors;
 
 import com.yahoo.elide.core.dictionary.EntityDictionary;
-import com.yahoo.elide.core.security.CheckInstantiator;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.DatastoreEvalFilterExpressionCheck;
 import com.yahoo.elide.core.security.checks.FilterExpressionCheck;
 import com.yahoo.elide.core.security.checks.UserCheck;
 import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
 import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
 import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
 import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
-import com.yahoo.elide.generated.parsers.ExpressionBaseVisitor;
-import com.yahoo.elide.generated.parsers.ExpressionParser;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -29,19 +28,21 @@ import java.util.function.Function;
 /**
  * Traverse the Expression Parser and returns the Permission Expression and boolean Pair.
  */
-public class InmemoryPermissionExpressionVisitor extends ExpressionBaseVisitor<Pair<Expression, Boolean>>
-        implements CheckInstantiator {
+public class InmemoryPermissionExpressionVisitor implements ExpressionVisitor<Pair<Expression, Boolean>> {
 
-    public static final Pair<Expression, Boolean> TRUE_EXPRESSION_PAIR = new ImmutablePair<>(Expression.Results.SUCCESS, false);
+    public static final Pair<Expression, Boolean> TRUE_EXPRESSION_PAIR =
+            new ImmutablePair<>(Expression.Results.SUCCESS, false);
 
-    public static final Pair<Expression, Boolean> FALSE_EXPRESSION_PAIR = new ImmutablePair<>(Expression.Results.FAILURE, false);
+    public static final Pair<Expression, Boolean> FALSE_EXPRESSION_PAIR =
+            new ImmutablePair<>(Expression.Results.FAILURE, false);
 
     private final EntityDictionary dictionary;
     private final RequestScope requestScope;
     private final Function<Check, Expression> expressionGenerator;
     private ExecuteFilterCheckInMemoryVisitor executeFilterCheckInMemoryVisitor;
 
-    public InmemoryPermissionExpressionVisitor(EntityDictionary dictionary, RequestScope requestScope, Function<Check, Expression> expressionGenerator) {
+    public InmemoryPermissionExpressionVisitor(EntityDictionary dictionary, RequestScope requestScope,
+                                               Function<Check, Expression> expressionGenerator) {
         this.dictionary = dictionary;
         this.requestScope = requestScope;
         this.expressionGenerator = expressionGenerator;
@@ -49,8 +50,8 @@ public class InmemoryPermissionExpressionVisitor extends ExpressionBaseVisitor<P
     }
 
     @Override
-    public Pair<Expression, Boolean> visitNOT(ExpressionParser.NOTContext ctx) {
-        Pair<Expression, Boolean> expressionPair = visit(ctx.expression());
+    public Pair<Expression, Boolean> visitNotExpression(NotExpression notExpression) {
+        Pair<Expression, Boolean> expressionPair = notExpression.getLogical().accept(this);
         if (Objects.equals(expressionPair, TRUE_EXPRESSION_PAIR)) {
             return FALSE_EXPRESSION_PAIR;
         }
@@ -58,13 +59,21 @@ public class InmemoryPermissionExpressionVisitor extends ExpressionBaseVisitor<P
             return TRUE_EXPRESSION_PAIR;
         }
 
+        if (expressionPair.getKey() instanceof CheckExpression) {
+            CheckExpression checkExpression = (CheckExpression) expressionPair.getKey();
+            if (checkExpression.getCheck() instanceof DatastoreEvalFilterExpressionCheck) {
+                ((DatastoreEvalFilterExpressionCheck) checkExpression.getCheck()).negate();
+                return expressionPair;
+            }
+        }
+
         return new ImmutablePair<>(new NotExpression(expressionPair.getKey()), expressionPair.getValue());
     }
 
     @Override
-    public Pair<Expression, Boolean> visitOR(ExpressionParser.ORContext ctx) {
-        Pair<Expression, Boolean> leftPair = visit(ctx.left);
-        Pair<Expression, Boolean> rightPair = visit(ctx.right);
+    public Pair<Expression, Boolean> visitOrExpression(OrExpression orExpression) {
+        Pair<Expression, Boolean> leftPair = orExpression.getLeft().accept(this);
+        Pair<Expression, Boolean> rightPair = orExpression.getRight().accept(this);
         if (Objects.equals(leftPair, TRUE_EXPRESSION_PAIR) || Objects.equals(rightPair, FALSE_EXPRESSION_PAIR)) {
             return leftPair;
         }
@@ -89,9 +98,9 @@ public class InmemoryPermissionExpressionVisitor extends ExpressionBaseVisitor<P
     }
 
     @Override
-    public Pair<Expression, Boolean> visitAND(ExpressionParser.ANDContext ctx) {
-        Pair<Expression, Boolean> leftPair = visit(ctx.left);
-        Pair<Expression, Boolean> rightPair = visit(ctx.right);
+    public Pair<Expression, Boolean> visitAndExpression(AndExpression andExpression) {
+        Pair<Expression, Boolean> leftPair = andExpression.getLeft().accept(this);
+        Pair<Expression, Boolean> rightPair = andExpression.getRight().accept(this);
 
         if (Objects.equals(leftPair, FALSE_EXPRESSION_PAIR) || Objects.equals(rightPair, FALSE_EXPRESSION_PAIR)) {
             return FALSE_EXPRESSION_PAIR;
@@ -110,14 +119,14 @@ public class InmemoryPermissionExpressionVisitor extends ExpressionBaseVisitor<P
 
 
     @Override
-    public Pair<Expression, Boolean> visitPAREN(ExpressionParser.PARENContext ctx) {
-        return visit(ctx.expression());
+    public Pair<Expression, Boolean> visitExpression(Expression expression) {
+        return FALSE_EXPRESSION_PAIR;
     }
 
 
     @Override
-    public Pair<Expression, Boolean> visitPermissionClass(ExpressionParser.PermissionClassContext ctx) {
-        Check check = getCheck(dictionary, ctx.getText());
+    public Pair<Expression, Boolean> visitCheckExpression(CheckExpression checkExpression) {
+        Check check = checkExpression.getCheck();
         if (check instanceof FilterExpressionCheck) {
             return new ImmutablePair<>(expressionGenerator.apply(
                     new DatastoreEvalFilterExpressionCheck((FilterExpressionCheck) check)), false);
@@ -131,5 +140,4 @@ public class InmemoryPermissionExpressionVisitor extends ExpressionBaseVisitor<P
         //Contains Operation check that has to be evaluated inmemory
         return new ImmutablePair<>(expressionGenerator.apply(check), true);
     }
-
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/InmemoryPermissionExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/InmemoryPermissionExpressionVisitor.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.security.visitors;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.security.CheckInstantiator;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.Check;
+import com.yahoo.elide.core.security.checks.DatastoreEvalFilterExpressionCheck;
+import com.yahoo.elide.core.security.checks.FilterExpressionCheck;
+import com.yahoo.elide.core.security.checks.UserCheck;
+import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
+import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
+import com.yahoo.elide.generated.parsers.ExpressionBaseVisitor;
+import com.yahoo.elide.generated.parsers.ExpressionParser;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Traverse the Expression Parser and returns the Permission Expression and boolean Pair.
+ */
+public class InmemoryPermissionExpressionVisitor extends ExpressionBaseVisitor<Pair<Expression, Boolean>>
+        implements CheckInstantiator {
+
+    public static final Pair<Expression, Boolean> TRUE_EXPRESSION_PAIR = new ImmutablePair<>(Expression.Results.SUCCESS, false);
+
+    public static final Pair<Expression, Boolean> FALSE_EXPRESSION_PAIR = new ImmutablePair<>(Expression.Results.FAILURE, false);
+
+    private final EntityDictionary dictionary;
+    private final RequestScope requestScope;
+    private final Function<Check, Expression> expressionGenerator;
+    private ExecuteFilterCheckInMemoryVisitor executeFilterCheckInMemoryVisitor;
+
+    public InmemoryPermissionExpressionVisitor(EntityDictionary dictionary, RequestScope requestScope, Function<Check, Expression> expressionGenerator) {
+        this.dictionary = dictionary;
+        this.requestScope = requestScope;
+        this.expressionGenerator = expressionGenerator;
+        executeFilterCheckInMemoryVisitor = new ExecuteFilterCheckInMemoryVisitor();
+    }
+
+    @Override
+    public Pair<Expression, Boolean> visitNOT(ExpressionParser.NOTContext ctx) {
+        Pair<Expression, Boolean> expressionPair = visit(ctx.expression());
+        if (Objects.equals(expressionPair, TRUE_EXPRESSION_PAIR)) {
+            return FALSE_EXPRESSION_PAIR;
+        }
+        if (Objects.equals(expressionPair, FALSE_EXPRESSION_PAIR)) {
+            return TRUE_EXPRESSION_PAIR;
+        }
+
+        return new ImmutablePair<>(new NotExpression(expressionPair.getKey()), expressionPair.getValue());
+    }
+
+    @Override
+    public Pair<Expression, Boolean> visitOR(ExpressionParser.ORContext ctx) {
+        Pair<Expression, Boolean> leftPair = visit(ctx.left);
+        Pair<Expression, Boolean> rightPair = visit(ctx.right);
+        if (Objects.equals(leftPair, TRUE_EXPRESSION_PAIR) || Objects.equals(rightPair, FALSE_EXPRESSION_PAIR)) {
+            return leftPair;
+        }
+        if (Objects.equals(rightPair, TRUE_EXPRESSION_PAIR) || Objects.equals(leftPair, FALSE_EXPRESSION_PAIR)) {
+            return rightPair;
+        }
+
+        Expression left = leftPair.getKey();
+        Expression right = rightPair.getKey();
+        if (leftPair.getValue()) {
+            //inmemory check present in left. Change any FilterCheckwrapper to run inmemory in right
+            right = right.accept(executeFilterCheckInMemoryVisitor);
+
+        }
+        if (rightPair.getValue()) {
+            //inmemory check present in right. Change any FilterCheckwrapper to run inmemory in right
+            left = left.accept(executeFilterCheckInMemoryVisitor);
+        }
+
+        return new ImmutablePair<>(new OrExpression(left, right),
+                leftPair.getValue() || rightPair.getValue());
+    }
+
+    @Override
+    public Pair<Expression, Boolean> visitAND(ExpressionParser.ANDContext ctx) {
+        Pair<Expression, Boolean> leftPair = visit(ctx.left);
+        Pair<Expression, Boolean> rightPair = visit(ctx.right);
+
+        if (Objects.equals(leftPair, FALSE_EXPRESSION_PAIR) || Objects.equals(rightPair, FALSE_EXPRESSION_PAIR)) {
+            return FALSE_EXPRESSION_PAIR;
+        }
+
+        if (Objects.equals(leftPair, TRUE_EXPRESSION_PAIR)) {
+            return rightPair;
+        }
+        if (Objects.equals(rightPair, TRUE_EXPRESSION_PAIR)) {
+            return leftPair;
+        }
+
+        return new ImmutablePair<>(new AndExpression(leftPair.getKey(), rightPair.getKey()),
+                leftPair.getValue() || rightPair.getValue());
+    }
+
+
+    @Override
+    public Pair<Expression, Boolean> visitPAREN(ExpressionParser.PARENContext ctx) {
+        return visit(ctx.expression());
+    }
+
+
+    @Override
+    public Pair<Expression, Boolean> visitPermissionClass(ExpressionParser.PermissionClassContext ctx) {
+        Check check = getCheck(dictionary, ctx.getText());
+        if (check instanceof FilterExpressionCheck) {
+            return new ImmutablePair<>(expressionGenerator.apply(
+                    new DatastoreEvalFilterExpressionCheck((FilterExpressionCheck) check)), false);
+        }
+
+        if (check instanceof UserCheck) {
+            boolean userCheckResult = ((UserCheck) check).ok(requestScope.getUser());
+            return userCheckResult ? TRUE_EXPRESSION_PAIR : FALSE_EXPRESSION_PAIR;
+        }
+
+        //Contains Operation check that has to be evaluated inmemory
+        return new ImmutablePair<>(expressionGenerator.apply(check), true);
+    }
+
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/visitors/InmemoryPermissionExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/visitors/InmemoryPermissionExpressionVisitorTest.java
@@ -1,0 +1,346 @@
+package com.yahoo.elide.core.security.visitors;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.dictionary.EntityPermissions;
+import com.yahoo.elide.core.dictionary.TestDictionary;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.predicates.NotNullPredicate;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.checks.Check;
+import com.yahoo.elide.core.security.checks.DatastoreEvalFilterExpressionCheck;
+import com.yahoo.elide.core.security.checks.FilterExpressionCheck;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import com.yahoo.elide.core.security.checks.prefab.Role;
+import com.yahoo.elide.core.security.permissions.ExpressionResult;
+import com.yahoo.elide.core.security.permissions.ExpressionResultCache;
+import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
+import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
+import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
+import com.yahoo.elide.core.type.Type;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import lombok.Value;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.persistence.Entity;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class InmemoryPermissionExpressionVisitorTest {
+    private EntityDictionary dictionary;
+    private ElideSettings elideSettings;
+    private PermissionExpressionNormalizationVisitor normalizationVisitor;
+    private Stringify stringify;
+    private RequestScope requestScope;
+
+    @Entity
+    @Include
+    @Value
+    public class Model {
+        int id;
+        String operationDim;
+        String filterDim;
+    }
+
+    public static class FilterCheck extends FilterExpressionCheck<Model> {
+
+        @Override
+        public FilterExpression getFilterExpression(Type<?> entityClass, com.yahoo.elide.core.security.RequestScope requestScope) {
+            Path path = super.getFieldPath(entityClass, requestScope, "getFilterDim", "filterDim");
+            return new NotNullPredicate(path);
+        }
+    }
+
+    public static class Operationcheck extends OperationCheck<Model> {
+
+        @Override
+        public boolean ok(Model model, com.yahoo.elide.core.security.RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            return model.operationDim != null;
+        }
+    }
+
+    @BeforeAll
+    public void setupEntityDictionary() {
+        Map<String, Class<? extends Check>> checks = new HashMap<>();
+        checks.put("user all", Role.ALL.class);
+        checks.put("user none", Role.NONE.class);
+        checks.put("filter check", FilterCheck.class);
+        checks.put("operation check", Operationcheck.class);
+        dictionary = TestDictionary.getTestDictionary(checks);
+        dictionary.bindEntity(Model.class);
+        elideSettings = new ElideSettingsBuilder(null)
+                .withEntityDictionary(dictionary)
+                .build();
+        requestScope = new RequestScope(null, null, NO_VERSION, null, null, null, null, null, UUID.randomUUID(), elideSettings);
+        stringify = new Stringify();
+        normalizationVisitor = new PermissionExpressionNormalizationVisitor();
+
+
+    }
+
+    @Test
+    public void simpleFilterCheckAndUserCheck() {
+
+        String permissionString;
+        String expectedExpressionToString;
+
+        ParseTree permissions;
+        Pair<Expression, Boolean> expressionPair;
+        Model model = new Model(1, null, null);
+
+        InmemoryPermissionExpressionVisitor inmemoryPermissionVisitor = new InmemoryPermissionExpressionVisitor(dictionary, requestScope,
+                (check) -> new CheckExpression(check, new PersistentResource<>(model, requestScope.getUUIDFor(model), requestScope), requestScope, null, new ExpressionResultCache()));
+
+
+        //Only filter check is present. Should have run in memory
+        permissionString = "filter check";
+        expectedExpressionToString = "DatastoreEvalFilterExpressionCheck{" +
+                        "executedInMemory=false, " +
+                        "negated=false, " +
+                        "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck}";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, false);
+
+        permissionString = "user all or filter check";
+        expectedExpressionToString = "\u001B[32mSUCCESS\u001B[m";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, false);
+
+        permissionString = "user none or filter check";
+        expectedExpressionToString = "DatastoreEvalFilterExpressionCheck{" +
+                        "executedInMemory=false, " +
+                        "negated=false, " +
+                        "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck}";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, false);
+
+        permissionString = "user all and filter check";
+        expectedExpressionToString = "DatastoreEvalFilterExpressionCheck{" +
+                        "executedInMemory=false, " +
+                        "negated=false, " +
+                        "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck}";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, false);
+
+        permissionString = "filter check and user none";
+        expectedExpressionToString = "\u001B[31mFAILURE\u001B[m";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.FAIL, false);
+
+    }
+
+    @Test
+    public void inmemoryExecutorTest() {
+
+        String permissionString;
+        String expectedExpressionToString;
+
+        //When operation check => true and filter check => false
+        Model model = new Model(1, "exist", null);
+
+        InmemoryPermissionExpressionVisitor inmemoryPermissionVisitor = new InmemoryPermissionExpressionVisitor(dictionary, requestScope,
+                (check) -> new CheckExpression(check, new PersistentResource<>(model, requestScope.getUUIDFor(model), requestScope), requestScope, null, new ExpressionResultCache()));
+
+
+        // Filter check is assumed to have evaluated in datastore (though filter dim will evaluate to false in memory - caused by group by operation).
+        // Inmemory filter should evaluate only operation check hence overall result = true
+        permissionString = "operation check and filter check";
+        expectedExpressionToString = "((operation check \u001B[34mWAS UNEVALUATED\u001B[m))" +
+                " AND " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=false, " +
+                "negated=false, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, true);
+
+
+        // Not expression present on filter check should not affect the result as datastore handles it.
+        // Therefore after normalization we should see any change in toString method except negated value in DatastoreEvalFilterExpressionCheck
+        permissionString = "operation check and not filter check";
+        expectedExpressionToString = "((operation check \u001B[34mWAS UNEVALUATED\u001B[m))" +
+                " AND " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=false, " +
+                "negated=true, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, true);
+
+        // Evaluates to (NOT (operationcheck = true)) AND (NOT (filter check))
+        // NOT filter check will be evaluated in datastore and will be true for all records returned from datastore..
+        // => (NOT (operationcheck = true)) AND (true)
+        // => false
+        permissionString = "not operation check and not filter check";
+        expectedExpressionToString = "(NOT ((operation check \u001B[34mWAS UNEVALUATED\u001B[m)))" +
+                " AND " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=false, " +
+                "negated=true, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.FAIL, true);
+
+
+        permissionString = "not (operation check or filter check)";
+        expectedExpressionToString = "(NOT ((operation check \u001B[34mWAS UNEVALUATED\u001B[m))) " +
+                "AND " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=true, " +
+                "negated=true, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.FAIL, true);
+
+
+        // Or expression does not push filter check to memory. Hence we evaluate filter check in memory.
+        // therefore the overall expression evalautes to -
+        // => (operation check = true) OR (filter check = false in memory).
+        // => true
+        permissionString = "operation check or filter check";
+        expectedExpressionToString = "((operation check \u001B[34mWAS UNEVALUATED\u001B[m))" +
+                " OR " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=true, " +
+                "negated=false, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, true);
+
+        // Not expression for operation check changes the result because now we evaluate -
+        // (Not (operation check = true)) OR (filter check = false in memory).
+        // => (NOT (true)) OR false
+        // => false
+        permissionString = "not operation check or filter check";
+        expectedExpressionToString = "(NOT ((operation check \u001B[34mWAS UNEVALUATED\u001B[m)))" +
+                " OR " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=true, " +
+                "negated=false, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.FAIL, true);
+
+
+        // Not on both operation and filter combined with OR.
+        // (Not (operation check = true)) OR (NOT (filter check = false in memory)).
+        // => (NOT (true)) OR (NOT (false))
+        // => true
+        permissionString = "not operation check or not filter check";
+        expectedExpressionToString = "(NOT ((operation check \u001B[34mWAS UNEVALUATED\u001B[m)))" +
+                " OR " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=true, " +
+                "negated=true, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, true);
+
+
+        permissionString = "not (operation check and filter check)";
+        expectedExpressionToString = "(NOT ((operation check \u001B[34mWAS UNEVALUATED\u001B[m)))" +
+                " OR " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=false, " +
+                "negated=true, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck})";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, true);
+    }
+
+
+    @Test
+    public void compositePermissionTest() {
+
+        String permissionString;
+        String expectedExpressionToString;
+        //When operation check => false and filter check => true
+        Model model = new Model(1, null, "exist");
+
+        InmemoryPermissionExpressionVisitor inmemoryPermissionVisitor = new InmemoryPermissionExpressionVisitor(dictionary, requestScope,
+                (check) -> new CheckExpression(check, new PersistentResource<>(model, requestScope.getUUIDFor(model), requestScope), requestScope, null, new ExpressionResultCache()));
+
+
+        permissionString = "user all or (operation check and filter check)";
+        expectedExpressionToString = "\u001B[32mSUCCESS\u001B[m";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.PASS, false);
+
+
+        permissionString = "operation check or (user none and filter check)";
+        expectedExpressionToString = "(operation check \u001B[34mWAS UNEVALUATED\u001B[m)";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.FAIL, true);
+
+
+        // Presence of OR condition changes the filter check to be executed in memory
+        permissionString = "operation check or (operation check and filter check)";
+        expectedExpressionToString = "((operation check \u001B[34mWAS UNEVALUATED\u001B[m)) " +
+                "OR " +
+                "(((operation check \u001B[34mWAS UNEVALUATED\u001B[m)) " +
+                "AND " +
+                "(DatastoreEvalFilterExpressionCheck{" +
+                "executedInMemory=true, " +
+                "negated=false, " +
+                "wrappedFilterExpressionCheck=class com.yahoo.elide.core.security.visitors.InmemoryPermissionExpressionVisitorTest$FilterCheck}))";
+        exececuteAndCheckPermission(permissionString, inmemoryPermissionVisitor, expectedExpressionToString, ExpressionResult.FAIL, true);
+
+
+    }
+
+    private void exececuteAndCheckPermission(String permissionStr,
+                                InmemoryPermissionExpressionVisitor inmemoryPermissionVisitor,
+                                String expectedExpressionToString,
+                                ExpressionResult expectedResult,
+                                boolean containsInmemoryComponent) {
+
+        ParseTree permissions = EntityPermissions.parseExpression(permissionStr);
+        Pair<Expression, Boolean> expressionPair = inmemoryPermissionVisitor.visit(permissions);
+        Expression normalizedExpression = expressionPair.getKey().accept(normalizationVisitor);
+        Assertions.assertEquals(expectedExpressionToString, normalizedExpression.accept(stringify));
+        Assertions.assertEquals(expectedResult, normalizedExpression.evaluate(Expression.EvaluationMode.ALL_CHECKS));
+        Assertions.assertEquals(containsInmemoryComponent, expressionPair.getValue());
+
+    }
+
+    private class Stringify implements ExpressionVisitor<String> {
+
+        @Override
+        public String visitExpression(Expression expression) {
+            return expression.toString();
+        }
+
+        @Override
+        public String visitCheckExpression(CheckExpression checkExpression) {
+            if (checkExpression.getCheck() instanceof DatastoreEvalFilterExpressionCheck) {
+                return checkExpression.getCheck().toString();
+            }
+            return checkExpression.toString();
+        }
+
+        @Override
+        public String visitAndExpression(AndExpression andExpression) {
+            return String.format("(%s) AND (%s)",
+                    andExpression.getLeft().accept(this),
+                    andExpression.getRight().accept(this));
+        }
+
+        @Override
+        public String visitOrExpression(OrExpression orExpression) {
+            return String.format("(%s) OR (%s)",
+                    orExpression.getLeft().accept(this),
+                    orExpression.getRight().accept(this));
+        }
+
+        @Override
+        public String visitNotExpression(NotExpression notExpression) {
+            return String.format("NOT (%s)", notExpression.getLogical().accept(this));
+        }
+    }
+
+}


### PR DESCRIPTION
## Description
Bypass filter expression check if it is executed in datastore. Add visitor that wraps all filter expression check and change its state as it traverses through the expression. 
Add normalization visitor for permission expression. 

## Motivation and Context
FilterCheck that already executed in datastore should not be checked against the records returned by the datastore. With aggregation datastore, this will always evaluate to false if the filter path element is not present in group by dimensions. 

## How Has This Been Tested?
Yet to Test


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
