### PR TITLE
Fix handling in filter pushdown extractor

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/FilterPredicatePushdownExtractor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/expression/FilterPredicatePushdownExtractor.java
@@ -51,7 +51,7 @@ public class FilterPredicatePushdownExtractor implements FilterExpressionVisitor
             return left;
         }
 
-        return expression;
+        return new AndFilterExpression(left, right);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class FilterPredicatePushdownExtractor implements FilterExpressionVisitor
         if (left == null || right == null) {
             return null;
         }
-        return expression;
+        return new OrFilterExpression(left, right);
     }
 
     @Override

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/FilterPredicatePushdownExtractorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/FilterPredicatePushdownExtractorTest.java
@@ -83,6 +83,48 @@ public class FilterPredicatePushdownExtractorTest {
     }
 
     @Test
+    public void testAndPartialPredicateExtraction() {
+        FilterExpression dataStoreExpression =
+                new InPredicate(new Path(Book.class, dictionary, "genre"), "Literary Fiction");
+
+        FilterExpression anotherDataStoreExpression =
+                new InPredicate(new Path(Book.class, dictionary, "genre"), "Science Fiction");
+
+        FilterExpression expectedExpression =
+                new AndFilterExpression(dataStoreExpression, anotherDataStoreExpression);
+
+        FilterExpression inMemoryExpression =
+                new InPredicate(new Path(Book.class, dictionary, "editor.firstName"), "Jack");
+
+        FilterExpression finalExpression = new AndFilterExpression(new AndFilterExpression(dataStoreExpression, inMemoryExpression), anotherDataStoreExpression);
+
+        FilterExpression extracted = FilterPredicatePushdownExtractor.extractPushDownPredicate(dictionary, finalExpression);
+
+        assertEquals(expectedExpression, extracted);
+    }
+
+    @Test
+    public void testOrPartialPredicateExtraction() {
+        FilterExpression dataStoreExpression =
+                new InPredicate(new Path(Book.class, dictionary, "genre"), "Literary Fiction");
+
+        FilterExpression anotherDataStoreExpression =
+                new InPredicate(new Path(Book.class, dictionary, "genre"), "Science Fiction");
+
+        FilterExpression expectedExpression =
+                new OrFilterExpression(dataStoreExpression, anotherDataStoreExpression);
+
+        FilterExpression inMemoryExpression =
+                new InPredicate(new Path(Book.class, dictionary, "editor.firstName"), "Jane");
+
+        FilterExpression finalExpression = new OrFilterExpression(new AndFilterExpression(dataStoreExpression, inMemoryExpression), anotherDataStoreExpression);
+
+        FilterExpression extracted = FilterPredicatePushdownExtractor.extractPushDownPredicate(dictionary, finalExpression);
+
+        assertEquals(expectedExpression, extracted);
+    }
+
+    @Test
     public void testInvalidField() {
         InvalidValueException e = assertThrows(
                 InvalidValueException.class,


### PR DESCRIPTION
Resolves #2029

## Description
Modified FilterPredicatePushdownExtractor to return the right FilterExpression.  

## Motivation and Context
Fixes an issue where filtering might not work properly when it involves a computed attribute/relationship, described in the linked issue.

## How Has This Been Tested?
Added new unit tests which before the fix is applied. 

Also tested our application where we were seeing an error due to this and that is resolved as well.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
