### PR TITLE
Permission visitor normalization

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AndExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AndExpression.java
@@ -10,11 +10,15 @@ import static com.yahoo.elide.core.security.permissions.ExpressionResult.FAIL;
 import static com.yahoo.elide.core.security.permissions.ExpressionResult.PASS;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
 
+import lombok.Getter;
+
 /**
  * Representation for an "And" expression.
  */
 public class AndExpression implements Expression {
+    @Getter
     private final Expression left;
+    @Getter
     private final Expression right;
 
     /**
@@ -48,6 +52,11 @@ public class AndExpression implements Expression {
         }
 
         return DEFERRED;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitAndExpression(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AnyFieldExpression.java
@@ -43,6 +43,11 @@ public class AnyFieldExpression implements Expression {
     }
 
     @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitExpression(this);
+    }
+
+    @Override
     public String toString() {
         return String.format("%s FOR EXPRESSION [(FIELDS(%s)) OR (ENTITY(%s))]",
                 condition, fieldExpression, entityExpression);

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/CheckExpression.java
@@ -18,6 +18,8 @@ import com.yahoo.elide.core.security.checks.OperationCheck;
 import com.yahoo.elide.core.security.checks.UserCheck;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
 import com.yahoo.elide.core.security.permissions.ExpressionResultCache;
+
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
@@ -28,6 +30,7 @@ import java.util.Optional;
 @Slf4j
 public class CheckExpression implements Expression {
 
+    @Getter
     protected final Check check;
     protected final PersistentResource resource;
     protected final RequestScope requestScope;
@@ -106,6 +109,11 @@ public class CheckExpression implements Expression {
 
         log.trace("-- Check returned with result: {}", result);
         return result;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitCheckExpression(this);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/Expression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/Expression.java
@@ -31,6 +31,8 @@ public interface Expression {
      */
     ExpressionResult evaluate(EvaluationMode mode);
 
+    public <T> T accept(ExpressionVisitor<T> visitor);
+
     /**
      * Static Expressions that return PASS or FAIL.
      */
@@ -42,6 +44,11 @@ public interface Expression {
             }
 
             @Override
+            public <T> T accept(ExpressionVisitor<T> visitor) {
+                return visitor.visitExpression(this);
+            }
+
+            @Override
             public String toString() {
                 return ansi().fg(Ansi.Color.GREEN).a("SUCCESS").reset().toString();
             }
@@ -50,6 +57,11 @@ public interface Expression {
             @Override
             public ExpressionResult evaluate(EvaluationMode ignored) {
                 return ExpressionResult.FAIL;
+            }
+
+            @Override
+            public <T> T accept(ExpressionVisitor<T> visitor) {
+                return visitor.visitExpression(this);
             }
 
             @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
@@ -6,6 +6,10 @@
 
 package com.yahoo.elide.core.security.permissions.expressions;
 
+/**
+ * Visitor which walks the permission expression abstract syntax tree.
+ * @param <T> The return type of the visitor
+ */
 public interface ExpressionVisitor<T> {
     T visitExpression(Expression expression);
     T visitCheckExpression(CheckExpression checkExpression);

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.security.permissions.expressions;
+
+public interface ExpressionVisitor<T> {
+    T visitExpression(Expression expression);
+    T visitCheckExpression(CheckExpression checkExpression);
+    T visitAndExpression(AndExpression andExpression);
+    T visitOrExpression(OrExpression orExpression);
+    T visitNotExpression(NotExpression notExpression);
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/NotExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/NotExpression.java
@@ -10,10 +10,13 @@ import static com.yahoo.elide.core.security.permissions.ExpressionResult.FAIL;
 import static com.yahoo.elide.core.security.permissions.ExpressionResult.PASS;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
 
+import lombok.Getter;
+
 /**
  * Representation of a "not" expression.
  */
 public class NotExpression implements Expression {
+    @Getter
     private final Expression logical;
 
     /**
@@ -39,6 +42,11 @@ public class NotExpression implements Expression {
         }
 
         return DEFERRED;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitNotExpression(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/OrExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/OrExpression.java
@@ -10,11 +10,15 @@ import static com.yahoo.elide.core.security.permissions.ExpressionResult.FAIL;
 import static com.yahoo.elide.core.security.permissions.ExpressionResult.PASS;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
 
+import lombok.Getter;
+
 /**
  * Representation of an "or" expression.
  */
 public class OrExpression implements Expression {
+    @Getter
     private final Expression left;
+    @Getter
     private final Expression right;
 
     public static final OrExpression SUCCESSFUL_EXPRESSION = new OrExpression(Results.SUCCESS, null);
@@ -51,6 +55,11 @@ public class OrExpression implements Expression {
         }
 
         return DEFERRED;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitOrExpression(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/SpecificFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/SpecificFieldExpression.java
@@ -41,6 +41,11 @@ public class SpecificFieldExpression implements Expression {
         return fieldResult;
     }
 
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitExpression(this);
+    }
+
 
     @Override
     public String toString() {

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
@@ -13,6 +13,9 @@ import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
 import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
 import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
 
+/**
+ * Expression Visitor to normalize Permission expression.
+ */
 public class PermissionExpressionNormalizationVisitor implements ExpressionVisitor<Expression> {
     @Override
     public Expression visitExpression(Expression expression) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.security.visitors;
+
+import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
+import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
+import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
+
+public class PermissionExpressionNormalizationVisitor implements ExpressionVisitor<Expression> {
+    @Override
+    public Expression visitExpression(Expression expression) {
+        return expression;
+    }
+
+    @Override
+    public Expression visitCheckExpression(CheckExpression checkExpression) {
+        return checkExpression;
+    }
+
+    @Override
+    public Expression visitAndExpression(AndExpression andExpression) {
+        Expression left = andExpression.getLeft();
+        Expression right = andExpression.getRight();
+        return new AndExpression(left.accept(this), right.accept(this));
+    }
+
+    @Override
+    public Expression visitOrExpression(OrExpression orExpression) {
+        Expression left = orExpression.getLeft();
+        Expression right = orExpression.getRight();
+        return new OrExpression(left.accept(this), right.accept(this));
+    }
+
+    @Override
+    public Expression visitNotExpression(NotExpression notExpression) {
+        Expression inner = notExpression.getLogical();
+        if (inner instanceof AndExpression) {
+            AndExpression and = (AndExpression) inner;
+            Expression left = new NotExpression(and.getLeft()).accept(this);
+            Expression right = new NotExpression(and.getRight()).accept(this);
+            return new OrExpression(left, right);
+        }
+        if (inner instanceof OrExpression) {
+            OrExpression or = (OrExpression) inner;
+            Expression left = new NotExpression(or.getLeft()).accept(this);
+            Expression right = new NotExpression(or.getRight()).accept(this);
+            return new AndExpression(left, right);
+        }
+        if (inner instanceof NotExpression) {
+            NotExpression not = (NotExpression) inner;
+            return (not.getLogical()).accept(this);
+        }
+        return notExpression;
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
@@ -19,6 +19,12 @@ import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.FilterExpressionCheck;
 import com.yahoo.elide.core.security.checks.UserCheck;
+import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
+import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
+import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.generated.parsers.ExpressionBaseVisitor;
 import com.yahoo.elide.generated.parsers.ExpressionParser;
@@ -34,8 +40,7 @@ import java.util.Objects;
  *      1. User define FilterExpressionCheck which returns null in getFilterExpression function.
  *      2. User put a FilterExpressionCheck with a non-userCheck type check in OR relation.
  */
-public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<FilterExpression>
-        implements CheckInstantiator {
+public class PermissionToFilterExpressionVisitor implements ExpressionVisitor<FilterExpression> {
     private final EntityDictionary dictionary;
     private final Type entityClass;
     private final RequestScope requestScope;
@@ -91,8 +96,8 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitNOT(ExpressionParser.NOTContext ctx) {
-        FilterExpression expression = visit(ctx.expression());
+    public FilterExpression visitNotExpression(NotExpression notExpression) {
+        FilterExpression expression = notExpression.getLogical().accept(this);
         if (Objects.equals(expression, TRUE_USER_CHECK_EXPRESSION)) {
             return FALSE_USER_CHECK_EXPRESSION;
         }
@@ -102,13 +107,16 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
         if (Objects.equals(expression, NO_EVALUATION_EXPRESSION)) {
             return NO_EVALUATION_EXPRESSION;
         }
+        if (expression instanceof FilterPredicate) {
+            return ((FilterPredicate) expression).negate();
+        }
         return new NotFilterExpression(expression);
     }
 
     @Override
-    public FilterExpression visitOR(ExpressionParser.ORContext ctx) {
-        FilterExpression left = visit(ctx.left);
-        FilterExpression right = visit(ctx.right);
+    public FilterExpression visitOrExpression(OrExpression orExpression) {
+        FilterExpression left = orExpression.getLeft().accept(this);
+        FilterExpression right = orExpression.getRight().accept(this);
 
         if (expressionWillNotFilter(left)) {
             return left;
@@ -134,9 +142,9 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitAND(ExpressionParser.ANDContext ctx) {
-        FilterExpression left = visit(ctx.left);
-        FilterExpression right = visit(ctx.right);
+    public FilterExpression visitAndExpression(AndExpression andExpression) {
+        FilterExpression left = andExpression.getLeft().accept(this);
+        FilterExpression right = andExpression.getRight().accept(this);
 
         // (FALSE_USER_CHECK_EXPRESSION AND FilterExpression) => FALSE_USER_CHECK_EXPRESSION
         // (FALSE_USER_CHECK_EXPRESSION AND NO_EVALUATION_EXPRESSION) => FALSE_USER_CHECK_EXPRESSION
@@ -166,8 +174,8 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitPermissionClass(ExpressionParser.PermissionClassContext ctx) {
-        Check check = getCheck(dictionary, ctx.getText());
+    public FilterExpression visitCheckExpression(CheckExpression checkExpression) {
+        Check check = checkExpression.getCheck();
         if (check instanceof FilterExpressionCheck) {
             FilterExpressionCheck filterCheck = (FilterExpressionCheck) check;
             FilterExpression filterExpression = filterCheck.getFilterExpression(entityClass, requestScope);
@@ -194,7 +202,7 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitPAREN(ExpressionParser.PARENContext ctx) {
-        return visit(ctx.expression());
+    public FilterExpression visitExpression(Expression expression) {
+        return NO_EVALUATION_EXPRESSION;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
@@ -14,7 +14,6 @@ import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
 import com.yahoo.elide.core.filter.expression.NotFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
-import com.yahoo.elide.core.security.CheckInstantiator;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.FilterExpressionCheck;
@@ -26,8 +25,6 @@ import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
 import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
 import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
 import com.yahoo.elide.core.type.Type;
-import com.yahoo.elide.generated.parsers.ExpressionBaseVisitor;
-import com.yahoo.elide.generated.parsers.ExpressionParser;
 
 import java.util.Objects;
 

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitorTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
 package com.yahoo.elide.parsers.expression;
 
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitorTest.java
@@ -1,0 +1,149 @@
+package com.yahoo.elide.parsers.expression;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.dictionary.EntityPermissions;
+import com.yahoo.elide.core.dictionary.TestDictionary;
+import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.visitors.PermissionExpressionNormalizationVisitor;
+import com.yahoo.elide.core.security.visitors.PermissionExpressionVisitor;
+
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.UUID;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PermissionExpressionNormalizationVisitorTest {
+
+    private PermissionExpressionVisitor permissionExpressionVisitor;
+    private PermissionExpressionNormalizationVisitor normalizationVisitor;
+
+    @BeforeAll
+    public void setUp() {
+        EntityDictionary dictionary = TestDictionary.getTestDictionary();
+        ElideSettings elideSettings = new ElideSettingsBuilder(null)
+                .withEntityDictionary(dictionary)
+                .build();
+        RequestScope requestScope = new RequestScope(null, null, NO_VERSION, null, null, null, null, null, UUID.randomUUID(), elideSettings);
+
+        permissionExpressionVisitor = new PermissionExpressionVisitor(dictionary,
+                (check -> new CheckExpression(check, null, requestScope, null, null)));
+        normalizationVisitor = new PermissionExpressionNormalizationVisitor();
+    }
+
+    @Test
+    public void orExpressionTest() {
+        ParseTree tree;
+        Expression normalizedExpression;
+
+
+        tree = EntityPermissions.parseExpression("not (sampleCommit or sampleOperation)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
+                        "(NOT ((sampleOperation \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+        tree = EntityPermissions.parseExpression("not (Prefab.Role.All or sampleCommit or initCheck)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("((NOT ((Prefab.Role.All \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
+                        "(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
+                        "(NOT ((initCheck \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+
+        tree = EntityPermissions.parseExpression("not (parentInitCheck or passingOp) or (FailOp or shouldCache)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) OR " +
+                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+        tree = EntityPermissions.parseExpression("not (parentInitCheck or passingOp) or not (FailOp or shouldCache)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) OR " +
+                        "((NOT ((FailOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
+                normalizedExpression.toString());
+
+        tree = EntityPermissions.parseExpression("not (not (parentInitCheck or passingOp) or not (FailOp or shouldCache))");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("(((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
+                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+    }
+
+    @Test
+    public void andExpressionTest() {
+        ParseTree tree;
+        Expression normalizedExpression;
+
+
+        tree = EntityPermissions.parseExpression("not (sampleCommit and sampleOperation)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
+                        "(NOT ((sampleOperation \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+        tree = EntityPermissions.parseExpression("not (Prefab.Role.All and sampleCommit and initCheck)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("((NOT ((Prefab.Role.All \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
+                        "(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m)))) OR " +
+                        "(NOT ((initCheck \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+
+        tree = EntityPermissions.parseExpression("not (parentInitCheck and passingOp) and (FailOp and shouldCache)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
+                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+        tree = EntityPermissions.parseExpression("not (parentInitCheck and passingOp) and not (FailOp and shouldCache)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
+                        "((NOT ((FailOp \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
+                normalizedExpression.toString());
+
+        tree = EntityPermissions.parseExpression("not (not (parentInitCheck and passingOp) and not (FailOp and shouldCache))");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("(((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
+                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+    }
+
+    @Test
+    public void normalforms() {
+        ParseTree tree;
+        Expression normalizedExpression;
+
+
+        tree = EntityPermissions.parseExpression("not ((parentInitCheck and passingOp) or shouldCache)");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
+                        "(NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
+                        "(NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+
+        tree = EntityPermissions.parseExpression("not (parentInitCheck and (passingOp or shouldCache))");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("(NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
+                        "((NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
+                        "(NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
+                normalizedExpression.toString());
+
+        tree = EntityPermissions.parseExpression("not parentInitCheck and not passingOp");
+        normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
+        Assertions.assertEquals("(NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
+                        "(NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))",
+                normalizedExpression.toString());
+
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitorTest.java
@@ -54,34 +54,34 @@ public class PermissionExpressionNormalizationVisitorTest {
 
         tree = EntityPermissions.parseExpression("not (sampleCommit or sampleOperation)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
-                        "(NOT ((sampleOperation \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m))) AND "
+                        + "(NOT ((sampleOperation \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
         tree = EntityPermissions.parseExpression("not (Prefab.Role.All or sampleCommit or initCheck)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("((NOT ((Prefab.Role.All \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
-                        "(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
-                        "(NOT ((initCheck \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("((NOT ((Prefab.Role.All \u001B[34mWAS UNEVALUATED\u001B[m))) AND "
+                        + "(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m)))) AND "
+                        + "(NOT ((initCheck \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
 
         tree = EntityPermissions.parseExpression("not (parentInitCheck or passingOp) or (FailOp or shouldCache)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) OR " +
-                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) OR "
+                        + "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
         tree = EntityPermissions.parseExpression("not (parentInitCheck or passingOp) or not (FailOp or shouldCache)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) OR " +
-                        "((NOT ((FailOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) OR "
+                        + "((NOT ((FailOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND (NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
                 normalizedExpression.toString());
 
         tree = EntityPermissions.parseExpression("not (not (parentInitCheck or passingOp) or not (FailOp or shouldCache))");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("(((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
-                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("(((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND "
+                        + "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) OR ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
     }
 
@@ -93,34 +93,34 @@ public class PermissionExpressionNormalizationVisitorTest {
 
         tree = EntityPermissions.parseExpression("not (sampleCommit and sampleOperation)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
-                        "(NOT ((sampleOperation \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m))) OR "
+                        + "(NOT ((sampleOperation \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
         tree = EntityPermissions.parseExpression("not (Prefab.Role.All and sampleCommit and initCheck)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("((NOT ((Prefab.Role.All \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
-                        "(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m)))) OR " +
-                        "(NOT ((initCheck \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("((NOT ((Prefab.Role.All \u001B[34mWAS UNEVALUATED\u001B[m))) OR "
+                        + "(NOT ((sampleCommit \u001B[34mWAS UNEVALUATED\u001B[m)))) OR "
+                        + "(NOT ((initCheck \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
 
         tree = EntityPermissions.parseExpression("not (parentInitCheck and passingOp) and (FailOp and shouldCache)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
-                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND "
+                        + "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
         tree = EntityPermissions.parseExpression("not (parentInitCheck and passingOp) and not (FailOp and shouldCache)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
-                        "((NOT ((FailOp \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND "
+                        + "((NOT ((FailOp \u001B[34mWAS UNEVALUATED\u001B[m))) OR (NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
                 normalizedExpression.toString());
 
         tree = EntityPermissions.parseExpression("not (not (parentInitCheck and passingOp) and not (FailOp and shouldCache))");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("(((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
-                        "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("(((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) OR "
+                        + "(((FailOp \u001B[34mWAS UNEVALUATED\u001B[m)) AND ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
     }
 
@@ -132,23 +132,23 @@ public class PermissionExpressionNormalizationVisitorTest {
 
         tree = EntityPermissions.parseExpression("not ((parentInitCheck and passingOp) or shouldCache)");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
-                        "(NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND " +
-                        "(NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("((NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR "
+                        + "(NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))) AND "
+                        + "(NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
 
         tree = EntityPermissions.parseExpression("not (parentInitCheck and (passingOp or shouldCache))");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("(NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR " +
-                        "((NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
-                        "(NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
+        Assertions.assertEquals("(NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) OR "
+                        + "((NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m))) AND "
+                        + "(NOT ((shouldCache \u001B[34mWAS UNEVALUATED\u001B[m))))",
                 normalizedExpression.toString());
 
         tree = EntityPermissions.parseExpression("not parentInitCheck and not passingOp");
         normalizedExpression = tree.accept(permissionExpressionVisitor).accept(normalizationVisitor);
-        Assertions.assertEquals("(NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND " +
-                        "(NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))",
+        Assertions.assertEquals("(NOT ((parentInitCheck \u001B[34mWAS UNEVALUATED\u001B[m))) AND "
+                        + "(NOT ((passingOp \u001B[34mWAS UNEVALUATED\u001B[m)))",
                 normalizedExpression.toString());
 
     }

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionVisitorTest.java
@@ -21,6 +21,7 @@ import com.yahoo.elide.core.security.checks.UserCheck;
 import com.yahoo.elide.core.security.checks.prefab.Role;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
 import com.yahoo.elide.core.security.permissions.expressions.Expression;
+import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
 import com.yahoo.elide.core.security.visitors.PermissionExpressionVisitor;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
@@ -153,6 +154,11 @@ public class PermissionExpressionVisitorTest {
                 return ExpressionResult.PASS;
             }
             return ExpressionResult.FAIL;
+        }
+
+        @Override
+        public <T> T accept(ExpressionVisitor<T> visitor) {
+            return visitor.visitExpression(this);
         }
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -25,7 +25,6 @@ import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
-import com.yahoo.elide.core.filter.visitors.FilterExpressionNormalizationVisitor;
 import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.TestUser;
 import com.yahoo.elide.core.security.User;


### PR DESCRIPTION

## Description
Add Normalization visitor for Permission Expression class. 
Change PermissionToFilterExpressionVisitor to work on normalized expression. 


## How Has This Been Tested?
Unit Test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
