### PR TITLE
Aggregation Store: Namespace Metadata changes

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -144,8 +144,8 @@ public abstract class QueryEngine {
      */
     protected void populateMetaData(MetaDataStore metaDataStore) {
         metaDataStore.getNamespacesToBind().stream()
-        .map(namespace -> constructNamespace(namespace))
-        .forEach(metaDataStore::addNamespace);
+                .map(namespace -> constructNamespace(namespace))
+                .forEach(metaDataStore::addNamespace);
 
         metaDataStore.getModelsToBind()
                 .forEach(model -> {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -92,9 +92,7 @@ public abstract class QueryEngine {
      * @param namespacePackage NamespacePackage Type
      * @return constructed Namespace
      */
-    protected Namespace constructNamespace(com.yahoo.elide.core.type.Package namespacePackage) {
-        return new Namespace(namespacePackage);
-    }
+    protected abstract Namespace constructNamespace(com.yahoo.elide.core.type.Package namespacePackage);
 
     /**
      * Construct Table metadata for an entity.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Namespace;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
@@ -86,6 +87,16 @@ public abstract class QueryEngine {
     }
 
     /**
+     * Construct namespace metadata.
+     *
+     * @param namespacePackage NamespacePackage Type
+     * @return constructed Namespace
+     */
+    protected Namespace constructNamespace(com.yahoo.elide.core.type.Package namespacePackage) {
+        return new Namespace(namespacePackage);
+    }
+
+    /**
      * Construct Table metadata for an entity.
      *
      * @param entityClass entity class
@@ -132,6 +143,10 @@ public abstract class QueryEngine {
      * @param metaDataStore metadata store to populate
      */
     protected void populateMetaData(MetaDataStore metaDataStore) {
+        metaDataStore.getNamespacesToBind().stream()
+        .map(namespace -> constructNamespace(namespace))
+        .forEach(metaDataStore::addNamespace);
+
         metaDataStore.getModelsToBind()
                 .forEach(model -> {
                     if (!metadataDictionary.isJPAEntity(model)

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/annotation/NamespaceMeta.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/annotation/NamespaceMeta.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the specified namespace has a configured long name and field description for human to read on UI.
+ */
+@Documented
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NamespaceMeta {
+
+    String friendlyName() default "";
+    String description() default "";
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.dynamic;
+
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.core.type.Package;
+import com.yahoo.elide.datastores.aggregation.annotation.NamespaceMeta;
+import com.yahoo.elide.modelconfig.model.NamespaceConfig;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A dynamic Elide model that wraps a deserialized HJSON Namespace.
+ */
+public class NamespacePackage implements Package {
+    protected NamespaceConfig namespace;
+    private Map<Class<? extends Annotation>, Annotation> annotations;
+
+    public NamespacePackage(NamespaceConfig namespace) {
+        this.namespace = namespace;
+        this.annotations = buildAnnotations(namespace);
+    }
+
+    @Override
+    public <A extends Annotation> A getDeclaredAnnotation(Class<A> annotationClass) {
+        if (annotations.containsKey(annotationClass)) {
+            return (A) annotations.get(annotationClass);
+        }
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return namespace.getName();
+    }
+
+    public String getDescription() {
+        return namespace.getDescription();
+    }
+
+    public String getFriendlyName() {
+        return namespace.getFriendlyName();
+    }
+
+    @Override
+    public Package getParentPackage() {
+        return null;
+    }
+
+    private static Map<Class<? extends Annotation>, Annotation> buildAnnotations(NamespaceConfig namespace) {
+        Map<Class<? extends Annotation>, Annotation> annotations = new HashMap<>();
+
+        annotations.put(ReadPermission.class, new ReadPermission() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ReadPermission.class;
+            }
+
+            @Override
+            public String expression() {
+                return namespace.getReadAccess();
+            }
+
+        });
+
+        annotations.put(NamespaceMeta.class, new NamespaceMeta() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return NamespaceMeta.class;
+            }
+
+            @Override
+            public String friendlyName() {
+                return namespace.getFriendlyName();
+            }
+
+            @Override
+            public String description() {
+                return namespace.getDescription();
+            }
+        });
+        return annotations;
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
@@ -39,14 +39,6 @@ public class NamespacePackage implements Package {
         return namespace.getName();
     }
 
-    public String getDescription() {
-        return namespace.getDescription();
-    }
-
-    public String getFriendlyName() {
-        return namespace.getFriendlyName();
-    }
-
     @Override
     public Package getParentPackage() {
         return null;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
@@ -5,7 +5,9 @@
  */
 package com.yahoo.elide.datastores.aggregation.dynamic;
 
+import com.yahoo.elide.annotation.ApiVersion;
 import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Package;
 import com.yahoo.elide.datastores.aggregation.annotation.NamespaceMeta;
 import com.yahoo.elide.modelconfig.model.NamespaceConfig;
@@ -24,6 +26,10 @@ public class NamespacePackage implements Package {
     public NamespacePackage(NamespaceConfig namespace) {
         this.namespace = namespace;
         this.annotations = buildAnnotations(namespace);
+    }
+
+    public NamespacePackage(String name, String description, String friendlyName) {
+        this(new NamespaceConfig(name, friendlyName, description, EntityDictionary.NO_VERSION));
     }
 
     @Override
@@ -78,6 +84,19 @@ public class NamespacePackage implements Package {
                 return namespace.getDescription();
             }
         });
+
+        annotations.put(ApiVersion.class, new ApiVersion() {
+            @Override
+            public String version() {
+                return namespace.getApiVersion();
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ApiVersion.class;
+            }
+        });
+
         return annotations;
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -30,7 +30,6 @@ import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
-import com.yahoo.elide.modelconfig.model.NamespaceConfig;
 
 import org.hibernate.annotations.Subselect;
 import lombok.Getter;
@@ -115,12 +114,8 @@ public class MetaDataStore implements DataStore {
         // Add default namespace if not present.
         if (namespaces.stream().noneMatch(namespace ->
                 namespace.getName().toLowerCase(Locale.ENGLISH).equals("default"))) {
-            // add "default"
-            NamespaceConfig namespaceConfig = new NamespaceConfig();
-            namespaceConfig.setName("default");
-            namespaceConfig.setDescription("Default Namespace");
-            namespaceConfig.setFriendlyName("default");
-            NamespacePackage namespacePackage = new NamespacePackage(namespaceConfig);
+            // add "default" namespace with default ApiVersion = ""
+            NamespacePackage namespacePackage = new NamespacePackage("default", "Default Namespace", "default");
             this.namespacesToBind.add(namespacePackage);
         }
 
@@ -239,8 +234,8 @@ public class MetaDataStore implements DataStore {
      * @param namespace Namespace metadata
      */
     public void addNamespace(Namespace namespace) {
-        // Add/Replicate Namespace for each version
-        hashMapDataStores.keySet().forEach(version -> addMetaData(namespace, version));
+        String version = namespace.getVersion();
+        addMetaData(namespace, version);
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -20,14 +20,18 @@ import com.yahoo.elide.core.utils.ClassScanner;
 import com.yahoo.elide.datastores.aggregation.AggregationDataStore;
 import com.yahoo.elide.datastores.aggregation.annotation.Join;
 import com.yahoo.elide.datastores.aggregation.annotation.MetricFormula;
+import com.yahoo.elide.datastores.aggregation.dynamic.NamespacePackage;
 import com.yahoo.elide.datastores.aggregation.dynamic.TableType;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Argument;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Namespace;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
+import com.yahoo.elide.modelconfig.model.NamespaceConfig;
+
 import org.hibernate.annotations.Subselect;
 import lombok.Getter;
 
@@ -38,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -62,6 +67,9 @@ public class MetaDataStore implements DataStore {
     private final Set<Type<?>> modelsToBind;
 
     @Getter
+    private final Set<com.yahoo.elide.core.type.Package> namespacesToBind;
+
+    @Getter
     private boolean enableMetaDataStore = false;
 
     private Map<Type<?>, Table> tables = new HashMap<>();
@@ -75,6 +83,12 @@ public class MetaDataStore implements DataStore {
     private final Set<Class<?>> metadataModelClasses;
 
     public MetaDataStore(Collection<com.yahoo.elide.modelconfig.model.Table> tables, boolean enableMetaDataStore) {
+        this(tables, new HashSet<>(), enableMetaDataStore);
+    }
+
+    public MetaDataStore(Collection<com.yahoo.elide.modelconfig.model.Table> tables,
+            Collection<com.yahoo.elide.modelconfig.model.NamespaceConfig> namespaces,
+            boolean enableMetaDataStore) {
         this(getClassType(getAllAnnotatedClasses()), enableMetaDataStore);
 
         Map<String, Type<?>> typeMap = new HashMap<>();
@@ -90,6 +104,25 @@ public class MetaDataStore implements DataStore {
                 joinNames.add(join.getTo())
             );
         });
+
+        //Convert namespaces into packages.
+        namespaces.stream().forEach(namespace -> {
+            NamespacePackage namespacePackage = new NamespacePackage(namespace);
+            this.namespacesToBind.add(namespacePackage);
+
+        });
+
+        // Add default namespace if not present.
+        if (namespaces.stream().noneMatch(namespace ->
+                namespace.getName().toLowerCase(Locale.ENGLISH).equals("default"))) {
+            // add "default"
+            NamespaceConfig namespaceConfig = new NamespaceConfig();
+            namespaceConfig.setName("default");
+            namespaceConfig.setDescription("Default Namespace");
+            namespaceConfig.setFriendlyName("default");
+            NamespacePackage namespacePackage = new NamespacePackage(namespaceConfig);
+            this.namespacesToBind.add(namespacePackage);
+        }
 
         //Built a list of static types referenced from joins in the dynamic types.
         metadataDictionary.getBindings().stream()
@@ -134,8 +167,21 @@ public class MetaDataStore implements DataStore {
      * Construct MetaDataStore with data models.
      *
      * @param modelsToBind models to bind
+     * @param enableMetaDataStore If Enable MetaDataStore
      */
     public MetaDataStore(Set<Type<?>> modelsToBind, boolean enableMetaDataStore) {
+        this(modelsToBind, new HashSet<>(), enableMetaDataStore);
+    }
+
+    /**
+     * Construct MetaDataStore with data models, namespaces.
+     *
+     * @param modelsToBind models to bind
+     * @param namespacesToBind namespaces to bind
+     * @param enableMetaDataStore If Enable MetaDataStore
+     */
+    public MetaDataStore(Set<Type<?>> modelsToBind, Set<com.yahoo.elide.core.type.Package> namespacesToBind,
+            boolean enableMetaDataStore) {
         this.metadataModelClasses = ClassScanner.getAllClasses(META_DATA_PACKAGE.getName());
         this.enableMetaDataStore = enableMetaDataStore;
 
@@ -150,6 +196,7 @@ public class MetaDataStore implements DataStore {
 
         // bind external data models in the package.
         this.modelsToBind = modelsToBind;
+        this.namespacesToBind = namespacesToBind;
     }
 
     @Override
@@ -184,6 +231,16 @@ public class MetaDataStore implements DataStore {
         table.getColumns().forEach(this::addColumn);
 
         table.getArguments().forEach(arg -> addArgument(arg, version));
+    }
+
+    /**
+     * Add a namespace metadata object.
+     *
+     * @param namespace Namespace metadata
+     */
+    public void addNamespace(Namespace namespace) {
+        // Add/Replicate Namespace for each version
+        hashMapDataStores.keySet().forEach(version -> addMetaData(namespace, version));
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
@@ -42,8 +42,8 @@ public class Namespace {
 
         NamespaceMeta meta = pkg.getDeclaredAnnotation(NamespaceMeta.class);
         if (meta != null) {
-        friendlyName = meta.friendlyName();
-        description = meta.description();
+            friendlyName = meta.friendlyName();
+            description = meta.description();
         } else {
             friendlyName = pkg.getName();
             description = null;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
@@ -5,7 +5,10 @@
  */
 package com.yahoo.elide.datastores.aggregation.metadata.models;
 
+import com.yahoo.elide.annotation.ApiVersion;
+import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.datastores.aggregation.annotation.NamespaceMeta;
 
 import lombok.EqualsAndHashCode;
@@ -33,6 +36,9 @@ public class Namespace {
 
     private final String description;
 
+    @Exclude
+    private final String version;
+
     @OneToMany
     private Set<Table> tables;
 
@@ -48,6 +54,9 @@ public class Namespace {
             friendlyName = pkg.getName();
             description = null;
         }
+
+        ApiVersion apiVersion = pkg.getDeclaredAnnotation(ApiVersion.class);
+        version = (apiVersion == null) ? EntityDictionary.NO_VERSION : apiVersion.version();
     }
 
     public void addTable(Table table) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.metadata.models;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.datastores.aggregation.annotation.NamespaceMeta;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.Set;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+/**
+ * Namespace for organizing related tables together.
+ */
+@Include(type = "namespace")
+@Getter
+@EqualsAndHashCode
+@ToString
+public class Namespace {
+    @Id
+    private final String id;
+
+    private final String name;
+
+    private final String friendlyName;
+
+    private final String description;
+
+    @OneToMany
+    private Set<Table> tables;
+
+    public Namespace(com.yahoo.elide.core.type.Package pkg) {
+        id = pkg.getName();
+        name = pkg.getName();
+
+        NamespaceMeta meta = pkg.getDeclaredAnnotation(NamespaceMeta.class);
+        if (meta != null) {
+        friendlyName = meta.friendlyName();
+        description = meta.description();
+        } else {
+            friendlyName = pkg.getName();
+            description = null;
+        }
+    }
+
+    public void addTable(Table table) {
+        this.tables.add(table);
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.datastores.aggregation.QueryEngine;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Namespace;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
@@ -111,6 +112,11 @@ public class SQLQueryEngine extends QueryEngine {
             throw new IllegalStateException(e);
         }
     };
+
+    @Override
+    protected Namespace constructNamespace(com.yahoo.elide.core.type.Package namespacePackage) {
+        return new Namespace(namespacePackage);
+    }
 
     @Override
     protected Table constructTable(Type<?> entityClass, EntityDictionary metaDataDictionary) {

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/NamespaceConfig.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/NamespaceConfig.java
@@ -5,9 +5,12 @@
  */
 package com.yahoo.elide.modelconfig.model;
 
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -21,7 +24,8 @@ import lombok.NoArgsConstructor;
     "name",
     "friendlyName",
     "readAccess",
-    "description"
+    "description",
+    "apiVersion"
 })
 @Data
 @EqualsAndHashCode()
@@ -40,4 +44,14 @@ public class NamespaceConfig implements Named {
 
     @JsonProperty("description")
     private String description;
+
+    @JsonProperty("apiVersion")
+    private String apiVersion = EntityDictionary.NO_VERSION;
+
+    public NamespaceConfig(String name, String description, String friendlyName, String apiVersion) {
+        this.name = name;
+        this.friendlyName = friendlyName;
+        this.description = description;
+        this.apiVersion = apiVersion;
+    }
 }

--- a/elide-model-config/src/main/resources/elideNamespaceConfigSchema.json
+++ b/elide-model-config/src/main/resources/elideNamespaceConfigSchema.json
@@ -47,6 +47,12 @@
                         "description": "Read permission for the Namespace.",
                         "type": "string",
                         "default": "Prefab.Role.All"
+                    },
+                    "apiVersion": {
+                        "title": "Namespace apiVersion",
+                        "description": "Api Version for the Namespace.",
+                        "type": "string",
+                        "default": ""
                     }
                 }
             }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -290,6 +290,6 @@ public class AsyncTest extends IntegrationTest {
                 .body("tags.name", containsInAnyOrder("group", "argument", "metric",
                         "dimension", "column", "table", "asyncQuery",
                         "timeDimensionGrain", "timeDimension", "product", "playerCountry", "version", "playerStats",
-                        "stats", "tableExport"));
+                        "stats", "tableExport", "namespace"));
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -415,7 +415,7 @@ public class ControllerTest extends IntegrationTest {
                 .body("tags.name", containsInAnyOrder("group", "argument", "metric",
                         "dimension", "column", "table", "asyncQuery",
                         "timeDimensionGrain", "timeDimension", "product", "playerCountry", "version", "playerStats",
-                        "stats"));
+                        "stats", "namespace"));
     }
 
     @Test

--- a/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
@@ -230,6 +230,6 @@ public class ElideStandaloneExportTest {
                 .statusCode(200)
                 .body("tags.name", containsInAnyOrder("post", "argument", "metric",
                         "dimension", "column", "table", "asyncQuery",
-                        "timeDimensionGrain", "timeDimension", "postView", "tableExport"));
+                        "timeDimensionGrain", "timeDimension", "postView", "tableExport", "namespace"));
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -181,7 +181,7 @@ public class ElideStandaloneTest {
                 .statusCode(200)
                 .body("tags.name", containsInAnyOrder("post", "argument", "metric",
                         "dimension", "column", "table", "asyncQuery",
-                        "timeDimensionGrain", "timeDimension", "postView"));
+                        "timeDimensionGrain", "timeDimension", "postView", "namespace"));
     }
 
     @Test


### PR DESCRIPTION
Resolves #2010

## Description
Metadata Model changes to Support namespace.
i) New Metadata Model called `Namespace` has been added.
ii) New Package Type `NamespacePackage` has been added.
iii) Backward compatible changes in `MetaDataStore`
iv) Populating of Namespace Metadata logic added in QueryEngine. 

## Motivation and Context
#2010 

## How Has This Been Tested?
Existing Test cases pass. New test cases to be added later.
## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
