### PR TITLE
normalize permission expression before converting to filter expression

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionExpressionNormalizationVisitor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.parsers.expression;
+
+import com.yahoo.elide.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.security.permissions.expressions.Expression;
+import com.yahoo.elide.security.permissions.expressions.ExpressionVisitor;
+import com.yahoo.elide.security.permissions.expressions.NotExpression;
+import com.yahoo.elide.security.permissions.expressions.OrExpression;
+
+/**
+ * Expression Visitor to normalize Permission expression.
+ */
+public class PermissionExpressionNormalizationVisitor implements ExpressionVisitor<Expression> {
+
+    @Override
+    public Expression visitExpression(Expression expression) {
+        return expression;
+    }
+
+    @Override
+    public Expression visitCheckExpression(CheckExpression checkExpression) {
+        return checkExpression;
+    }
+
+    @Override
+    public Expression visitAndExpression(AndExpression andExpression) {
+        Expression left = andExpression.getLeft();
+        Expression right = andExpression.getRight();
+        return new AndExpression(left.accept(this), right.accept(this));
+    }
+
+    @Override
+    public Expression visitOrExpression(OrExpression orExpression) {
+        Expression left = orExpression.getLeft();
+        Expression right = orExpression.getRight();
+        return new OrExpression(left.accept(this), right.accept(this));
+    }
+
+    @Override
+    public Expression visitNotExpression(NotExpression notExpression) {
+        Expression inner = notExpression.getLogical();
+        if (inner instanceof AndExpression) {
+            AndExpression and = (AndExpression) inner;
+            Expression left = new NotExpression(and.getLeft()).accept(this);
+            Expression right = new NotExpression(and.getRight()).accept(this);
+            return new OrExpression(left, right);
+        }
+        if (inner instanceof OrExpression) {
+            OrExpression or = (OrExpression) inner;
+            Expression left = new NotExpression(or.getLeft()).accept(this);
+            Expression right = new NotExpression(or.getRight()).accept(this);
+            return new AndExpression(left, right);
+        }
+        if (inner instanceof NotExpression) {
+            NotExpression not = (NotExpression) inner;
+            return (not.getLogical()).accept(this);
+        }
+        return notExpression;
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
@@ -21,6 +21,12 @@ import com.yahoo.elide.security.FilterExpressionCheck;
 import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.Check;
 import com.yahoo.elide.security.checks.UserCheck;
+import com.yahoo.elide.security.permissions.expressions.AndExpression;
+import com.yahoo.elide.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.security.permissions.expressions.Expression;
+import com.yahoo.elide.security.permissions.expressions.ExpressionVisitor;
+import com.yahoo.elide.security.permissions.expressions.NotExpression;
+import com.yahoo.elide.security.permissions.expressions.OrExpression;
 
 import java.util.Objects;
 
@@ -33,8 +39,7 @@ import java.util.Objects;
  *      1. User define FilterExpressionCheck which returns null in getFilterExpression function.
  *      2. User put a FilterExpressionCheck with a non-userCheck type check in OR relation.
  */
-public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<FilterExpression>
-        implements CheckInstantiator {
+public class PermissionToFilterExpressionVisitor implements ExpressionVisitor<FilterExpression> {
     private final EntityDictionary dictionary;
     private final Class entityClass;
     private final RequestScope requestScope;
@@ -90,8 +95,8 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitNOT(ExpressionParser.NOTContext ctx) {
-        FilterExpression expression = visit(ctx.expression());
+    public FilterExpression visitNotExpression(NotExpression notExpression) {
+        FilterExpression expression = notExpression.getLogical().accept(this);
         if (Objects.equals(expression, TRUE_USER_CHECK_EXPRESSION)) {
             return FALSE_USER_CHECK_EXPRESSION;
         } else if (Objects.equals(expression, FALSE_USER_CHECK_EXPRESSION)) {
@@ -99,13 +104,16 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
         } else if (Objects.equals(expression, NO_EVALUATION_EXPRESSION)) {
             return NO_EVALUATION_EXPRESSION;
         }
+        if (expression instanceof FilterPredicate) {
+            return ((FilterPredicate) expression).negate();
+        }
         return new NotFilterExpression(expression);
     }
 
     @Override
-    public FilterExpression visitOR(ExpressionParser.ORContext ctx) {
-        FilterExpression left = visit(ctx.left);
-        FilterExpression right = visit(ctx.right);
+    public FilterExpression visitOrExpression(OrExpression orExpression) {
+        FilterExpression left = orExpression.getLeft().accept(this);
+        FilterExpression right = orExpression.getRight().accept(this);
 
         if (expressionWillNotFilter(left)) {
             return left;
@@ -131,9 +139,9 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitAND(ExpressionParser.ANDContext ctx) {
-        FilterExpression left = visit(ctx.left);
-        FilterExpression right = visit(ctx.right);
+    public FilterExpression visitAndExpression(AndExpression andExpression) {
+        FilterExpression left = andExpression.getLeft().accept(this);
+        FilterExpression right = andExpression.getRight().accept(this);
 
         // (FALSE_USER_CHECK_EXPRESSION AND FilterExpression) => FALSE_USER_CHECK_EXPRESSION
         // (FALSE_USER_CHECK_EXPRESSION AND NO_EVALUATION_EXPRESSION) => FALSE_USER_CHECK_EXPRESSION
@@ -163,8 +171,8 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitPermissionClass(ExpressionParser.PermissionClassContext ctx) {
-        Check check = getCheck(dictionary, ctx.getText());
+    public FilterExpression visitCheckExpression(CheckExpression checkExpression) {
+        Check check = checkExpression.getCheck();
         if (check instanceof FilterExpressionCheck) {
             FilterExpressionCheck filterCheck = (FilterExpressionCheck) check;
             FilterExpression filterExpression = filterCheck.getFilterExpression(entityClass, requestScope);
@@ -191,7 +199,7 @@ public class PermissionToFilterExpressionVisitor extends ExpressionBaseVisitor<F
     }
 
     @Override
-    public FilterExpression visitPAREN(ExpressionParser.PARENContext ctx) {
-        return visit(ctx.expression());
+    public FilterExpression visitExpression(Expression expression) {
+        return NO_EVALUATION_EXPRESSION;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitor.java
@@ -6,7 +6,6 @@
 
 package com.yahoo.elide.parsers.expression;
 
-import com.yahoo.elide.core.CheckInstantiator;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.FilterPredicate;
 import com.yahoo.elide.core.filter.Operator;
@@ -15,8 +14,6 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
 import com.yahoo.elide.core.filter.expression.NotFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
-import com.yahoo.elide.generated.parsers.ExpressionBaseVisitor;
-import com.yahoo.elide.generated.parsers.ExpressionParser;
 import com.yahoo.elide.security.FilterExpressionCheck;
 import com.yahoo.elide.security.RequestScope;
 import com.yahoo.elide.security.checks.Check;

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/PermissionExpressionBuilder.java
@@ -16,7 +16,6 @@ import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
-import com.yahoo.elide.parsers.expression.FilterExpressionNormalizationVisitor;
 import com.yahoo.elide.parsers.expression.PermissionExpressionNormalizationVisitor;
 import com.yahoo.elide.parsers.expression.PermissionExpressionVisitor;
 import com.yahoo.elide.parsers.expression.PermissionToFilterExpressionVisitor;

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AndExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AndExpression.java
@@ -11,11 +11,15 @@ import static com.yahoo.elide.security.permissions.ExpressionResult.PASS;
 
 import com.yahoo.elide.security.permissions.ExpressionResult;
 
+import lombok.Getter;
+
 /**
  * Representation for an "And" expression.
  */
 public class AndExpression implements Expression {
+    @Getter
     private final Expression left;
+    @Getter
     private final Expression right;
 
     /**
@@ -49,6 +53,11 @@ public class AndExpression implements Expression {
         }
 
         return DEFERRED;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitAndExpression(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/AnyFieldExpression.java
@@ -44,6 +44,11 @@ public class AnyFieldExpression implements Expression {
     }
 
     @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitExpression(this);
+    }
+
+    @Override
     public String toString() {
         return String.format("%s FOR EXPRESSION [(FIELDS(%s)) OR (ENTITY(%s))]",
                 condition, fieldExpression, entityExpression);

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/CheckExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/CheckExpression.java
@@ -20,6 +20,7 @@ import com.yahoo.elide.security.checks.UserCheck;
 import com.yahoo.elide.security.permissions.ExpressionResult;
 import com.yahoo.elide.security.permissions.ExpressionResultCache;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
@@ -30,6 +31,7 @@ import java.util.Optional;
 @Slf4j
 public class CheckExpression implements Expression {
 
+    @Getter
     protected final Check check;
     protected final PersistentResource resource;
     protected final RequestScope requestScope;
@@ -103,6 +105,11 @@ public class CheckExpression implements Expression {
 
         log.trace("-- Check returned with result: {}", result);
         return result;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitCheckExpression(this);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/Expression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/Expression.java
@@ -33,6 +33,8 @@ public interface Expression {
      */
     ExpressionResult evaluate(EvaluationMode mode);
 
+    public <T> T accept(ExpressionVisitor<T> visitor);
+
     /**
      * Static Expressions that return PASS or FAIL.
      */
@@ -44,6 +46,11 @@ public interface Expression {
             }
 
             @Override
+            public <T> T accept(ExpressionVisitor<T> visitor) {
+                return visitor.visitExpression(this);
+            }
+
+            @Override
             public String toString() {
                 return ansi().fg(Ansi.Color.GREEN).a("SUCCESS").reset().toString();
             }
@@ -52,6 +59,11 @@ public interface Expression {
             @Override
             public ExpressionResult evaluate(EvaluationMode ignored) {
                 return ExpressionResult.FAIL;
+            }
+
+            @Override
+            public <T> T accept(ExpressionVisitor<T> visitor) {
+                return visitor.visitExpression(this);
             }
 
             @Override

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/ExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/ExpressionVisitor.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.security.permissions.expressions;
+
+/**
+ * Visitor which walks the permission expression abstract syntax tree.
+ * @param <T> The return type of the visitor
+ */
+public interface ExpressionVisitor<T> {
+    T visitExpression(Expression expression);
+    T visitCheckExpression(CheckExpression checkExpression);
+    T visitAndExpression(AndExpression andExpression);
+    T visitOrExpression(OrExpression orExpression);
+    T visitNotExpression(NotExpression notExpression);
+}

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/NotExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/NotExpression.java
@@ -11,10 +11,13 @@ import static com.yahoo.elide.security.permissions.ExpressionResult.PASS;
 
 import com.yahoo.elide.security.permissions.ExpressionResult;
 
+import lombok.Getter;
+
 /**
  * Representation of a "not" expression.
  */
 public class NotExpression implements Expression {
+    @Getter
     private final Expression logical;
 
     /**
@@ -40,6 +43,11 @@ public class NotExpression implements Expression {
         }
 
         return DEFERRED;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitNotExpression(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/OrExpression.java
@@ -11,11 +11,15 @@ import static com.yahoo.elide.security.permissions.ExpressionResult.PASS;
 
 import com.yahoo.elide.security.permissions.ExpressionResult;
 
+import lombok.Getter;
+
 /**
  * Representation of an "or" expression.
  */
 public class OrExpression implements Expression {
+    @Getter
     private final Expression left;
+    @Getter
     private final Expression right;
 
     public static final OrExpression SUCCESSFUL_EXPRESSION = new OrExpression(Results.SUCCESS, null);
@@ -52,6 +56,11 @@ public class OrExpression implements Expression {
         }
 
         return DEFERRED;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitOrExpression(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/SpecificFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/security/permissions/expressions/SpecificFieldExpression.java
@@ -43,6 +43,11 @@ public class SpecificFieldExpression implements Expression {
         return fieldResult;
     }
 
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitExpression(this);
+    }
+
 
     @Override
     public String toString() {

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionVisitorTest.java
@@ -21,6 +21,7 @@ import com.yahoo.elide.security.checks.UserCheck;
 import com.yahoo.elide.security.checks.prefab.Role;
 import com.yahoo.elide.security.permissions.ExpressionResult;
 import com.yahoo.elide.security.permissions.expressions.Expression;
+import com.yahoo.elide.security.permissions.expressions.ExpressionVisitor;
 
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.junit.jupiter.api.BeforeEach;
@@ -151,6 +152,11 @@ public class PermissionExpressionVisitorTest {
                 return ExpressionResult.PASS;
             }
             return ExpressionResult.FAIL;
+        }
+
+        @Override
+        public <T> T accept(ExpressionVisitor<T> visitor) {
+            return visitor.visitExpression(this);
         }
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionToFilterExpressionVisitorTest.java
@@ -30,6 +30,9 @@ import com.yahoo.elide.security.User;
 import com.yahoo.elide.security.checks.Check;
 import com.yahoo.elide.security.checks.OperationCheck;
 import com.yahoo.elide.security.checks.prefab.Role;
+import com.yahoo.elide.security.permissions.ExpressionResultCache;
+import com.yahoo.elide.security.permissions.expressions.CheckExpression;
+import com.yahoo.elide.security.permissions.expressions.Expression;
 
 import example.Author;
 import example.Book;
@@ -46,13 +49,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 @SuppressWarnings("StringEquality")
 public class PermissionToFilterExpressionVisitorTest {
     private static final Path.PathElement AUTHOR_PATH = new Path.PathElement(Author.class, Book.class, "books");
     private static final Path.PathElement BOOK_PATH = new Path.PathElement(Book.class, String.class, "title");
-    private static final FilterExpressionNormalizationVisitor NORMALIZATION_VISITOR = new FilterExpressionNormalizationVisitor();
+    private static final PermissionExpressionNormalizationVisitor NORMALIZATION_VISITOR = new PermissionExpressionNormalizationVisitor();
 
     private static final FilterExpression IN_PREDICATE = createDummyPredicate(Operator.IN);
     private static final FilterExpression NOT_IN_PREDICATE = createDummyPredicate(Operator.NOT);
@@ -79,6 +83,7 @@ public class PermissionToFilterExpressionVisitorTest {
     private EntityDictionary dictionary;
     private RequestScope requestScope;
     private ElideSettings elideSettings;
+    private ExpressionResultCache cache;
 
     @BeforeEach
     public void setupEntityDictionary() {
@@ -100,6 +105,7 @@ public class PermissionToFilterExpressionVisitorTest {
                 .build();
 
         requestScope = newRequestScope();
+        cache = new ExpressionResultCache();
     }
 
     ///
@@ -159,13 +165,11 @@ public class PermissionToFilterExpressionVisitorTest {
                                             String innerPerm =
                                                     String.format("%s %s %s", innerLeft, innerOp, innerRight);
 
-                                            FilterExpression innerExpr = buildFilter(innerLeft, innerOp, innerRight);
-
                                             return Arguments.of(
                                                     left,
                                                     outerOp,
                                                     innerPerm,
-                                                    buildFilter(left, outerOp, innerExpr));
+                                                    buildFilter(left, outerOp, innerLeft, innerOp, innerRight));
                                         })
                                 ).reduce(Stream.empty(), Stream::concat)
                         ).reduce(Stream.empty(), Stream::concat)
@@ -232,9 +236,14 @@ public class PermissionToFilterExpressionVisitorTest {
     }
 
     private FilterExpression filterExpressionForPermissions(String permission) {
+        Function<Check, Expression> checkFn = (check) ->
+                new CheckExpression(check, null, requestScope, null, cache);
         ParseTree expression = EntityPermissions.parseExpression(permission);
         PermissionToFilterExpressionVisitor fev = new PermissionToFilterExpressionVisitor(dictionary, requestScope, null);
-        return fev.visit(expression).accept(NORMALIZATION_VISITOR);
+        return expression
+                .accept(new PermissionExpressionVisitor(dictionary, checkFn))
+                .accept(NORMALIZATION_VISITOR)
+                .accept(fev);
     }
 
     private static boolean isSpecialCase(FilterExpression expr) {
@@ -331,17 +340,32 @@ public class PermissionToFilterExpressionVisitorTest {
         return null;
     }
 
-    private static FilterExpression buildFilter(String left, String op, FilterExpression rightExpr) {
+    private static FilterExpression buildFilter(String left, String op, String innerLeft, String innerOp, String innerRight) {
         FilterExpression leftExpr = filterFor(left);
         switch (op) {
             case AND:
-                return filterForAndOf(leftExpr, rightExpr);
+                return filterForAndOf(leftExpr, buildFilter(innerLeft, innerOp, innerRight));
             case OR:
-                return filterForOrOf(leftExpr, rightExpr);
+                return filterForOrOf(leftExpr, buildFilter(innerLeft, innerOp, innerRight));
             case AND_NOT:
-                return filterForAndOf(leftExpr, negate(rightExpr));
+                return filterForAndOf(leftExpr, buildNotFilter(innerLeft, innerOp, innerRight));
             case OR_NOT:
-                return filterForOrOf(leftExpr, negate(rightExpr));
+                return filterForOrOf(leftExpr, buildNotFilter(innerLeft, innerOp, innerRight));
+        }
+        return null;
+    }
+
+    private static FilterExpression buildNotFilter(String left, String op, String right) {
+        FilterExpression leftExpr = negate(filterFor(left));
+        switch (op) {
+            case AND:
+                return filterForOrOf(leftExpr, negate(filterFor(right)));
+            case OR:
+                return filterForAndOf(leftExpr, negate(filterFor(right)));
+            case AND_NOT:
+                return filterForOrOf(leftExpr, filterFor(right));
+            case OR_NOT:
+                return filterForAndOf(leftExpr, filterFor(right));
         }
         return null;
     }


### PR DESCRIPTION
## Description
Add Normalization visitor for Permission Expression class.
Change PermissionToFilterExpressionVisitor to work on normalized expression.

## How Has This Been Tested?
Unit Test


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
