### PR TITLE
Test Cases + Enable Namespace in Standalone and Spring

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackage.java
@@ -29,7 +29,12 @@ public class NamespacePackage implements Package {
     }
 
     public NamespacePackage(String name, String description, String friendlyName) {
-        this(new NamespaceConfig(name, friendlyName, description, EntityDictionary.NO_VERSION));
+        this(NamespaceConfig.builder()
+                .name(name)
+                .friendlyName(friendlyName)
+                .description(description)
+                .apiVersion(EntityDictionary.NO_VERSION)
+                .build());
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
@@ -48,7 +48,7 @@ public class Namespace {
 
         NamespaceMeta meta = pkg.getDeclaredAnnotation(NamespaceMeta.class);
         if (meta != null) {
-            friendlyName = meta.friendlyName();
+            friendlyName = (meta.friendlyName() == null) ? pkg.getName() : meta.friendlyName();
             description = meta.description();
         } else {
             friendlyName = pkg.getName();

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Namespace.java
@@ -48,10 +48,11 @@ public class Namespace {
 
         NamespaceMeta meta = pkg.getDeclaredAnnotation(NamespaceMeta.class);
         if (meta != null) {
-            friendlyName = (meta.friendlyName() == null) ? pkg.getName() : meta.friendlyName();
+            friendlyName = (meta.friendlyName() == null || meta.friendlyName().isEmpty()) ? name
+                    : meta.friendlyName();
             description = meta.description();
         } else {
-            friendlyName = pkg.getName();
+            friendlyName = name;
             description = null;
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackageTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/dynamic/NamespacePackageTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.dynamic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.yahoo.elide.annotation.ApiVersion;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.datastores.aggregation.annotation.NamespaceMeta;
+import com.yahoo.elide.modelconfig.model.NamespaceConfig;
+
+import org.junit.jupiter.api.Test;
+
+public class NamespacePackageTest {
+
+    @Test
+    void testAnnotations() throws Exception {
+        NamespaceConfig testNamespace = NamespaceConfig.builder()
+                .description("A test Namespace")
+                .name("Test")
+                .build();
+
+        NamespacePackage namespace = new NamespacePackage(testNamespace);
+
+        ReadPermission readPermission = (ReadPermission) namespace.getDeclaredAnnotation(ReadPermission.class);
+        assertEquals("Prefab.Role.All", readPermission.expression());
+
+        NamespaceMeta meta = (NamespaceMeta) namespace.getDeclaredAnnotation(NamespaceMeta.class);
+        assertEquals("A test Namespace", meta.description());
+        assertNull(meta.friendlyName());
+
+        ApiVersion apiVersion = (ApiVersion) namespace.getDeclaredAnnotation(ApiVersion.class);
+        assertEquals("", apiVersion.version());
+    }
+
+    @Test
+    void testGet() throws Exception {
+        NamespaceConfig testNamespace = NamespaceConfig.builder()
+                .description("A test Namespace")
+                .name("Test")
+                .build();
+
+        NamespacePackage namespace = new NamespacePackage(testNamespace);
+        assertEquals("Test", namespace.getName());
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
@@ -51,7 +51,8 @@ public class AggregationDataStoreTestHarness implements DataStoreTestHarness {
 
         MetaDataStore metaDataStore;
         if (validator != null) {
-           metaDataStore = new MetaDataStore(validator.getElideTableConfig().getTables(), true);
+           metaDataStore = new MetaDataStore(validator.getElideTableConfig().getTables(),
+                   validator.getElideNamespaceConfig().getNamespaceconfigs(), true);
 
            aggregationDataStoreBuilder.dynamicCompiledClasses(metaDataStore.getDynamicTypes());
         } else {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -96,8 +96,29 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    public void tableMetaDataTest() {
-
+    public void metaDataTest() {
+        given()
+                .accept("application/vnd.api+json")
+                .get("/namespace/SalesNamespace")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.name", equalTo("SalesNamespace"))
+                .body("data.attributes.friendlyName", equalTo("Sales"));
+        given()
+                .accept("application/vnd.api+json")
+                .get("/namespace/DEFault") //"DEFault" namespace overrides "default" namespace
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.name", equalTo("DEFault"))
+                .body("data.attributes.friendlyName", equalTo("DEFAULT"));
+        given()
+                .accept("application/vnd.api+json")
+                .get("/namespace/NoDescriptionNamespace") //"default" namespace added by Agg Store
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.name", equalTo("NoDescriptionNamespace"))
+                .body("data.attributes.friendlyName", equalTo("NoDescriptionNamespace")) //No FriendlyName provided, defaulted to name
+                .body("data.attributes.description", equalTo(null)); // No description provided.
         given()
                .accept("application/vnd.api+json")
                .get("/table/planet")

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -113,12 +113,17 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.attributes.friendlyName", equalTo("DEFAULT"));
         given()
                 .accept("application/vnd.api+json")
+                .get("/namespace/default") //"DEFault" namespace overrides "default" namespace, so "default" not found
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND);
+        given()
+                .accept("application/vnd.api+json")
                 .get("/namespace/NoDescriptionNamespace") //"default" namespace added by Agg Store
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("NoDescriptionNamespace"))
-                .body("data.attributes.friendlyName", equalTo("NoDescriptionNamespace")) //No FriendlyName provided, defaulted to name
-                .body("data.attributes.description", equalTo(null)); // No description provided.
+                .body("data.attributes.friendlyName", equalTo("NoDescriptionNamespace")) // No FriendlyName provided, defaulted to name
+                .body("data.attributes.description", equalTo("NoDescriptionNamespace")); // No description provided, defaulted to name
         given()
                .accept("application/vnd.api+json")
                .get("/table/planet")

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -106,16 +106,12 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.attributes.friendlyName", equalTo("Sales"));
         given()
                 .accept("application/vnd.api+json")
-                .get("/namespace/DEFault") //"DEFault" namespace overrides "default" namespace
+                .get("/namespace/default")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.attributes.name", equalTo("DEFault"))
-                .body("data.attributes.friendlyName", equalTo("DEFAULT"));
-        given()
-                .accept("application/vnd.api+json")
-                .get("/namespace/default") //"DEFault" namespace overrides "default" namespace, so "default" not found
-                .then()
-                .statusCode(HttpStatus.SC_NOT_FOUND);
+                .body("data.attributes.name", equalTo("default"))
+                .body("data.attributes.friendlyName", equalTo("DEFAULT")) // Overridden value
+                .body("data.attributes.description", equalTo("Default Namespace")); // Overridden value
         given()
                 .accept("application/vnd.api+json")
                 .get("/namespace/NoDescriptionNamespace") //"default" namespace added by Agg Store

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/namespaces/namespaces.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/namespaces/namespaces.hjson
@@ -1,0 +1,18 @@
+{
+  namespaces:
+  [
+    {
+      name: SalesNamespace
+      description: Namespace for Sales Schema Tables
+      friendlyName: Sales
+    }
+    {
+      name: NoDescriptionNamespace
+    }
+    {
+      name: DEFault
+      description: Default Namespace
+      friendlyName: DEFAULT
+    }
+  ]
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/namespaces/namespaces.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/namespaces/namespaces.hjson
@@ -10,7 +10,7 @@
       name: NoDescriptionNamespace
     }
     {
-      name: DEFault
+      name: default
       description: Default Namespace
       friendlyName: DEFAULT
     }

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DraftV4LibraryWithElideFormatAttr.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DraftV4LibraryWithElideFormatAttr.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.modelconfig.jsonformats.ElideJDBCUrlFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideJoinKindFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideJoinTypeFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideNameFormatAttr;
+import com.yahoo.elide.modelconfig.jsonformats.ElideNamespaceNameFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideRSQLFilterFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideRoleFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideTimeFieldTypeFormatAttr;
@@ -45,6 +46,8 @@ public class DraftV4LibraryWithElideFormatAttr {
                         .addFormatAttribute(ElideTimeFieldTypeFormatAttr.FORMAT_NAME,
                                         new ElideTimeFieldTypeFormatAttr())
                         .addFormatAttribute(ElideNameFormatAttr.FORMAT_NAME, new ElideNameFormatAttr())
+                        .addFormatAttribute(ElideNamespaceNameFormatAttr.FORMAT_NAME,
+                                        new ElideNamespaceNameFormatAttr())
                         .addFormatAttribute(ElideRSQLFilterFormatAttr.FORMAT_NAME, new ElideRSQLFilterFormatAttr())
                         .addFormatAttribute(JavaClassNameWithExtFormatAttr.FORMAT_NAME,
                                         new JavaClassNameWithExtFormatAttr())

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DynamicConfiguration.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/DynamicConfiguration.java
@@ -7,6 +7,7 @@
 package com.yahoo.elide.modelconfig;
 
 import com.yahoo.elide.modelconfig.model.DBConfig;
+import com.yahoo.elide.modelconfig.model.NamespaceConfig;
 import com.yahoo.elide.modelconfig.model.Table;
 
 import java.util.HashSet;
@@ -39,6 +40,14 @@ public interface DynamicConfiguration {
      * @return a set of database configurations.
      */
     default Set<DBConfig> getDatabaseConfigurations() {
+        return new HashSet<>();
+    }
+
+    /**
+     * Returns a set of Namespace configurations.
+     * @return a set of Namespace configurations.
+     */
+    default Set<NamespaceConfig> getNamespaceConfigurations() {
         return new HashSet<>();
     }
 }

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/MessageBundleWithElideMessages.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/MessageBundleWithElideMessages.java
@@ -55,7 +55,9 @@ public class MessageBundleWithElideMessages {
                                                         ElideTimeFieldTypeFormatAttr.TYPE_MSG)
                                         .put(ElideNameFormatAttr.FORMAT_KEY, ElideNameFormatAttr.FORMAT_MSG)
                                         .put(ElideNamespaceNameFormatAttr.FORMAT_KEY,
-                                                        ElideNamespaceNameFormatAttr.FORMAT_MSG)
+                                                        ElideNamespaceNameFormatAttr.FORMAT_KEY_MSG)
+                                        .put(ElideNamespaceNameFormatAttr.FORMAT_ADDITIONAL_KEY,
+                                                ElideNamespaceNameFormatAttr.FORMAT_ADDITIONAL_KEY_MSG)
                                         .put(ElideRSQLFilterFormatAttr.FORMAT_KEY, ElideRSQLFilterFormatAttr.FORMAT_MSG)
                                         .put(JavaClassNameWithExtFormatAttr.FORMAT_KEY,
                                                         JavaClassNameWithExtFormatAttr.FORMAT_MSG)

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/MessageBundleWithElideMessages.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/MessageBundleWithElideMessages.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.modelconfig.jsonformats.ElideJDBCUrlFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideJoinKindFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideJoinTypeFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideNameFormatAttr;
+import com.yahoo.elide.modelconfig.jsonformats.ElideNamespaceNameFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideRSQLFilterFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideRoleFormatAttr;
 import com.yahoo.elide.modelconfig.jsonformats.ElideTimeFieldTypeFormatAttr;
@@ -53,6 +54,8 @@ public class MessageBundleWithElideMessages {
                                         .put(ElideTimeFieldTypeFormatAttr.TYPE_KEY,
                                                         ElideTimeFieldTypeFormatAttr.TYPE_MSG)
                                         .put(ElideNameFormatAttr.FORMAT_KEY, ElideNameFormatAttr.FORMAT_MSG)
+                                        .put(ElideNamespaceNameFormatAttr.FORMAT_KEY,
+                                                        ElideNamespaceNameFormatAttr.FORMAT_MSG)
                                         .put(ElideRSQLFilterFormatAttr.FORMAT_KEY, ElideRSQLFilterFormatAttr.FORMAT_MSG)
                                         .put(JavaClassNameWithExtFormatAttr.FORMAT_KEY,
                                                         JavaClassNameWithExtFormatAttr.FORMAT_MSG)

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ElideNamespaceNameFormatAttr.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ElideNamespaceNameFormatAttr.java
@@ -26,9 +26,13 @@ public class ElideNamespaceNameFormatAttr extends AbstractFormatAttribute {
 
     public static final String FORMAT_NAME = "elideNamespaceName";
     public static final String FORMAT_KEY = "elideNamespaceName.error.format";
-    public static final String FORMAT_MSG =
+    public static final String FORMAT_ADDITIONAL_KEY = "elideNamespaceName.error.additional";
+    public static final String FORMAT_KEY_MSG =
                     "Name [%s] is not allowed. Name must start with an alphabetic character and can include "
                     + "alaphabets, numbers and '_' only. Name must not be a variant of 'default' with different cases.";
+    public static final String FORMAT_ADDITIONAL_KEY_MSG =
+            "Name [%s] clashes with the 'default' namespace. Either change the case or pick a different namespace "
+            + "name.";
     public static final String DEFAULT_NAME = "default";
 
     public ElideNamespaceNameFormatAttr() {
@@ -45,7 +49,7 @@ public class ElideNamespaceNameFormatAttr extends AbstractFormatAttribute {
         }
 
         if (!input.equals(DEFAULT_NAME) && input.toLowerCase(Locale.ENGLISH).equals(DEFAULT_NAME)) {
-            report.error(newMsg(data, bundle, FORMAT_KEY).putArgument("value", input));
+            report.error(newMsg(data, bundle, FORMAT_ADDITIONAL_KEY).putArgument("value", input));
         }
     }
 }

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ElideNamespaceNameFormatAttr.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ElideNamespaceNameFormatAttr.java
@@ -29,7 +29,7 @@ public class ElideNamespaceNameFormatAttr extends AbstractFormatAttribute {
     public static final String FORMAT_ADDITIONAL_KEY = "elideNamespaceName.error.additional";
     public static final String FORMAT_KEY_MSG =
                     "Name [%s] is not allowed. Name must start with an alphabetic character and can include "
-                    + "alaphabets, numbers and '_' only. Name must not be a variant of 'default' with different cases.";
+                    + "alaphabets, numbers and '_' only.";
     public static final String FORMAT_ADDITIONAL_KEY_MSG =
             "Name [%s] clashes with the 'default' namespace. Either change the case or pick a different namespace "
             + "name.";

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ElideNamespaceNameFormatAttr.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ElideNamespaceNameFormatAttr.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.modelconfig.jsonformats;
+
+import com.github.fge.jackson.NodeType;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.format.AbstractFormatAttribute;
+import com.github.fge.jsonschema.processors.data.FullData;
+import com.github.fge.msgsimple.bundle.MessageBundle;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Format specifier for {@code elideNamespaceName} format attribute.
+ * <p>
+ * This specifier will check if a string instance is a valid Elide Name.
+ * </p>
+ */
+public class ElideNamespaceNameFormatAttr extends AbstractFormatAttribute {
+    public static final Pattern NAME_FORMAT_REGEX = ElideNameFormatAttr.NAME_FORMAT_REGEX;
+
+    public static final String FORMAT_NAME = "elideNamespaceName";
+    public static final String FORMAT_KEY = "elideNamespaceName.error.format";
+    public static final String FORMAT_MSG =
+                    "Name [%s] is not allowed. Name must start with an alphabetic character and can include "
+                    + "alaphabets, numbers and '_' only. Name must not be a variant of 'default' with different cases.";
+    public static final String DEFAULT_NAME = "default";
+
+    public ElideNamespaceNameFormatAttr() {
+        super(FORMAT_NAME, NodeType.STRING);
+    }
+
+    @Override
+    public void validate(final ProcessingReport report, final MessageBundle bundle, final FullData data)
+                    throws ProcessingException {
+        final String input = data.getInstance().getNode().textValue();
+
+        if (!NAME_FORMAT_REGEX.matcher(input).matches()) {
+            report.error(newMsg(data, bundle, FORMAT_KEY).putArgument("value", input));
+        }
+
+        if (!input.equals(DEFAULT_NAME) && input.toLowerCase(Locale.ENGLISH).equals(DEFAULT_NAME)) {
+            report.error(newMsg(data, bundle, FORMAT_KEY).putArgument("value", input));
+        }
+    }
+}

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/NamespaceConfig.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/NamespaceConfig.java
@@ -51,4 +51,13 @@ public class NamespaceConfig implements Named {
     @Builder.Default
     @JsonProperty("apiVersion")
     private String apiVersion = EntityDictionary.NO_VERSION;
+
+    /**
+     * Returns description of the namespace object.
+     * If null, returns the name.
+     * @return description
+     */
+    public String getDescription() {
+        return (this.description == null ? getName() : this.description);
+    }
 }

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/NamespaceConfig.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/NamespaceConfig.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -31,6 +32,7 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode()
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class NamespaceConfig implements Named {
 
     @JsonProperty("name")
@@ -39,19 +41,14 @@ public class NamespaceConfig implements Named {
     @JsonProperty("friendlyName")
     private String friendlyName;
 
+    @Builder.Default
     @JsonProperty("readAccess")
     private String readAccess = "Prefab.Role.All";
 
     @JsonProperty("description")
     private String description;
 
+    @Builder.Default
     @JsonProperty("apiVersion")
     private String apiVersion = EntityDictionary.NO_VERSION;
-
-    public NamespaceConfig(String name, String description, String friendlyName, String apiVersion) {
-        this.name = name;
-        this.friendlyName = friendlyName;
-        this.description = description;
-        this.apiVersion = apiVersion;
-    }
 }

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Table.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Table.java
@@ -69,9 +69,11 @@ public class Table implements Named {
     @JsonProperty("dbConnectionName")
     private String dbConnectionName;
 
+    @Builder.Default
     @JsonProperty("isFact")
     private Boolean isFact = true;
 
+    @Builder.Default
     @JsonProperty("hidden")
     private Boolean hidden = false;
 
@@ -87,9 +89,11 @@ public class Table implements Named {
     @JsonProperty("cardinality")
     private String cardinality;
 
+    @Builder.Default
     @JsonProperty("readAccess")
     private String readAccess = "Prefab.Role.All";
 
+    @Builder.Default
     @JsonProperty("namespace")
     private String namespace = "default";
 
@@ -105,10 +109,12 @@ public class Table implements Named {
     @Singular
     private List<Dimension> dimensions = new ArrayList<>();
 
+    @Builder.Default
     @JsonProperty("tags")
     @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> tags = new LinkedHashSet<>();
 
+    @Builder.Default
     @JsonProperty("hints")
     @JsonDeserialize(as = LinkedHashSet.class)
     private Set<String> hints = new LinkedHashSet<>();

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
@@ -212,6 +212,11 @@ public class DynamicConfigValidator implements DynamicConfiguration {
         return elideSQLDBConfig.getDbconfigs();
     }
 
+    @Override
+    public Set<NamespaceConfig> getNamespaceConfigurations() {
+        return elideNamespaceConfig.getNamespaceconfigs();
+    }
+
     private static void validateInheritance(ElideTableConfig tables) {
         tables.getTables().stream().forEach(table -> validateInheritance(tables, table, new HashSet<>()));
     }

--- a/elide-model-config/src/main/resources/elideNamespaceConfigSchema.json
+++ b/elide-model-config/src/main/resources/elideNamespaceConfigSchema.json
@@ -27,7 +27,7 @@
                         "type": "string",
                         "title": "Namespace Name",
                         "description": "Name of the Namespace. This can used for grouping the tables by subject area.",
-                        "format": "elideName",
+                        "format": "elideNamespaceName",
                         "examples": [
                             "MyNamespace"
                         ]

--- a/elide-model-config/src/main/resources/elideTableSchema.json
+++ b/elide-model-config/src/main/resources/elideTableSchema.json
@@ -69,7 +69,7 @@
                         "title": "Join Namespace",
                         "description": "Namespace for the Join.",
                         "type": "string",
-                        "format": "elideName",
+                        "format": "elideNamespaceName",
                         "default": "default"
                 },
                 "to": {
@@ -416,7 +416,7 @@
                         "title": "Table Namespace",
                         "description": "Namespace for the table.",
                         "type": "string",
-                        "format": "elideName",
+                        "format": "elideNamespaceName",
                         "default": "default"
                     },
                     "joins": {

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -58,7 +58,7 @@ public class DynamicConfigValidatorTest {
 
         assertEquals("default", child.getNamespace()); //PlayerStatsChild -> no namespace was provided, so defaulted
         assertEquals("PlayerNamespace", parent.getNamespace());
-        assertEquals("default", referred.getNamespace()); // Namespace in HJson "default". Matched case insensitively with "default" namespace
+        assertEquals("default", referred.getNamespace()); // Namespace in HJson "default".
     }
 
     @Test

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -58,7 +58,7 @@ public class DynamicConfigValidatorTest {
 
         assertEquals("default", child.getNamespace()); //PlayerStatsChild -> no namespace was provided, so defaulted
         assertEquals("PlayerNamespace", parent.getNamespace());
-        assertEquals("DEfault", referred.getNamespace()); // Namespace in HJson "DEfault". Matched case insensitively with "default" namespace
+        assertEquals("default", referred.getNamespace()); // Namespace in HJson "DEfault". Matched case insensitively with "default" namespace
     }
 
     @Test
@@ -256,6 +256,20 @@ public class DynamicConfigValidatorTest {
         });
 
         assertEquals("Found undefined security checks: [guest, member, user]\n", error);
+    }
+
+    @Test
+    public void testNamespaceBadDefaultName() throws Exception {
+        String error = tapSystemErr(() -> {
+            int exitStatus = catchSystemExit(() ->
+                    DynamicConfigValidator.main(new String[] { "--configDir", "src/test/resources/validator/bad_default_namespace"}));
+            assertEquals(2, exitStatus);
+        });
+
+        String expected = "Schema validation failed for: test_namespace.hjson\n"
+                + "[ERROR]\n"
+                + "Instance[/namespaces/0/name] failed to validate against schema[/properties/namespaces/items/properties/name]. Name [Default] is not allowed. Name must start with an alphabetic character and can include alaphabets, numbers and '_' only. Name must not be a variant of 'default' with different cases.\n";
+        assertEquals(expected, error);
     }
 
     @Test

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -268,7 +268,7 @@ public class DynamicConfigValidatorTest {
 
         String expected = "Schema validation failed for: test_namespace.hjson\n"
                 + "[ERROR]\n"
-                + "Instance[/namespaces/0/name] failed to validate against schema[/properties/namespaces/items/properties/name]. Name [Default] is not allowed. Name must start with an alphabetic character and can include alaphabets, numbers and '_' only. Name must not be a variant of 'default' with different cases.\n";
+                + "Instance[/namespaces/0/name] failed to validate against schema[/properties/namespaces/items/properties/name]. Name [Default] clashes with the 'default' namespace. Either change the case or pick a different namespace name.\n";
         assertEquals(expected, error);
     }
 

--- a/elide-model-config/src/test/resources/validator/bad_default_namespace/models/namespaces/test_namespace.hjson
+++ b/elide-model-config/src/test/resources/validator/bad_default_namespace/models/namespaces/test_namespace.hjson
@@ -1,0 +1,10 @@
+{
+  namespaces:
+  [
+    {
+      name: Default
+      description: Namespace for Test
+      friendlyName: Default
+    }
+  ]
+}

--- a/elide-model-config/src/test/resources/validator/bad_default_namespace/models/tables/namespace_test_model.hjson
+++ b/elide-model-config/src/test/resources/validator/bad_default_namespace/models/tables/namespace_test_model.hjson
@@ -1,0 +1,28 @@
+{
+  tables: [{
+      name: NameSpaceTestModel
+## default namespace
+      table: test
+      category: Table Category
+      cardinality : lARge
+      hidden : false
+
+      measures : [
+          {
+          name : testMeasure
+          friendlyName : Test Measure
+          type : INteGER
+          description : Test Measure
+          definition: 'MAX({{measure}})'
+          tags: ['PUBLIC']
+          }
+      ]
+      dimensions : [
+         {
+           name : datetime
+           type : TIme
+           definition : '{{datetime}}'
+         }
+      ]
+  }]
+}

--- a/elide-model-config/src/test/resources/validator/valid/models/tables/referred_model.hjson
+++ b/elide-model-config/src/test/resources/validator/valid/models/tables/referred_model.hjson
@@ -2,7 +2,7 @@
   tables: [
     {
       name: Country
-      namespace: DEfault
+      namespace: default
       table: country
       cardinality: small
       dimensions:

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -257,7 +257,7 @@ public class ElideAutoConfiguration {
                         SQLDialectFactory.getDialect(settings.getAggregationStore().getDefaultDialect()));
         if (isDynamicConfigEnabled(settings)) {
             MetaDataStore metaDataStore = new MetaDataStore(dynamicConfig.getTables(),
-                    enableMetaDataStore);
+                    dynamicConfig.getNamespaceConfigurations(), enableMetaDataStore);
             Map<String, ConnectionDetails> connectionDetailsMap = new HashMap<>();
 
             dynamicConfig.getDatabaseConfigurations().forEach(dbConfig -> {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AggregationStoreTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AggregationStoreTest.java
@@ -15,7 +15,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.CoreMatchers.equalTo;
 import com.yahoo.elide.core.exceptions.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,5 +123,16 @@ public class AggregationStoreTest extends IntegrationTest {
                 .get("cache.gets")
                 .tags("cache", "elideQueryCache", "result", "hit")
                 .functionCounter().count() > 0);
+    }
+
+    @Test
+    public void metaDataTest() {
+        given()
+                .accept("application/vnd.api+json")
+                .get("/json/namespace/default") //"default" namespace added by Agg Store
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.name", equalTo("default"))
+                .body("data.attributes.friendlyName", equalTo("default"));
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableAggStoreAsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableAggStoreAsyncTest.java
@@ -113,4 +113,13 @@ public class DisableAggStoreAsyncTest extends IntegrationTest {
             assertEquals("PROCESSING", outputResponse, "Async Query has failed.");
         }
     }
+
+    @Test
+    public void metaDataTest() {
+        given()
+                .accept("application/vnd.api+json")
+                .get("/json/namespace/default") //"default" namespace added by Agg Store.
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND); // Metadatastore is disabled, so not found.
+    }
 }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -471,7 +471,7 @@ public interface ElideStandaloneSettings {
         boolean enableMetaDataStore = getAnalyticProperties().enableMetaDataStore();
 
         return dynamicConfiguration
-                .map(dc -> new MetaDataStore(dc.getTables(), enableMetaDataStore))
+                .map(dc -> new MetaDataStore(dc.getTables(), dc.getNamespaceConfigurations(), enableMetaDataStore))
                 .orElseGet(() -> new MetaDataStore(enableMetaDataStore));
     }
 

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -89,4 +89,14 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
         .then()
         .statusCode(HttpStatus.SC_CREATED);
     }
+
+    @Override
+    @Test
+    public void metaDataTest() {
+        given()
+                .accept("application/vnd.api+json")
+                .get("/api/v1/namespace/default") //"default" namespace added by Agg Store.
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND); // Metadatastore is disabled, so not found.
+    }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -61,33 +61,33 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
     @Test
     public void swaggerDocumentTest() {
         when()
-        .get("/swagger/doc/test")
-         .then()
-         .statusCode(200)
-         .body("tags.name", containsInAnyOrder("post", "asyncQuery"));
+                .get("/swagger/doc/test")
+                .then()
+                .statusCode(200)
+                .body("tags.name", containsInAnyOrder("post", "asyncQuery"));
     }
 
     @Override
     @Test
     public void testJsonAPIPost() {
         given()
-        .contentType(JSONAPI_CONTENT_TYPE)
-        .accept(JSONAPI_CONTENT_TYPE)
-        .body(
-            datum(
-                resource(
-                    type("post"),
-                    id("1"),
-                    attributes(
-                        attr("content", "This is my first post. woot."),
-                        attr("date", "2019-01-01T00:00Z")
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(
+                    datum(
+                        resource(
+                            type("post"),
+                            id("1"),
+                            attributes(
+                                attr("content", "This is my first post. woot."),
+                                attr("date", "2019-01-01T00:00Z")
+                            )
+                        )
                     )
                 )
-            )
-        )
-        .post("/api/v1/post")
-        .then()
-        .statusCode(HttpStatus.SC_CREATED);
+                .post("/api/v1/post")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
     }
 
     @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
@@ -5,10 +5,15 @@
  */
 package example;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+
 import com.yahoo.elide.standalone.ElideStandalone;
 import com.yahoo.elide.standalone.config.ElideStandaloneAnalyticSettings;
+
+import org.apache.http.HttpStatus;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -60,5 +65,15 @@ public class ElideStandaloneDisableMetaDataStoreTest extends ElideStandaloneTest
          .then()
          .statusCode(200)
          .body("tags.name", containsInAnyOrder("post", "asyncQuery", "postView"));
+    }
+
+    @Override
+    @Test
+    public void metaDataTest() {
+        given()
+                .accept("application/vnd.api+json")
+                .get("/api/v1/namespace/default") //"default" namespace added by Agg Store.
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND); // Metadatastore is disabled, so not found.
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
@@ -61,10 +61,10 @@ public class ElideStandaloneDisableMetaDataStoreTest extends ElideStandaloneTest
     @Test
     public void swaggerDocumentTest() {
         when()
-        .get("/swagger/doc/test")
-         .then()
-         .statusCode(200)
-         .body("tags.name", containsInAnyOrder("post", "asyncQuery", "postView"));
+                .get("/swagger/doc/test")
+                .then()
+                .statusCode(200)
+                .body("tags.name", containsInAnyOrder("post", "asyncQuery", "postView"));
     }
 
     @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -280,4 +280,15 @@ public class ElideStandaloneTest {
                 .body(containsString(" Not Found"))
                 .body(not(containsString(queryId + " Not Found")));
     }
+
+    @Test
+    public void metaDataTest() {
+        given()
+                .accept("application/vnd.api+json")
+                .get("/api/v1/namespace/default") //"default" namespace added by Agg Store
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.attributes.name", equalTo("default"))
+                .body("data.attributes.friendlyName", equalTo("default"));
+    }
 }


### PR DESCRIPTION
Resolves #2010 

## Description
i) Enable Namespace HJSON Config parsing in Elide Standalone and Spring.
ii) Test cases for Agg Store Changes to add namespace metadata

## Motivation and Context
#2010

## How Has This Been Tested?
Existing and new test cases pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
