### PR TITLE
Add ability to handle conversion of Date instances to ISO8601DateSerde

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerde.java
@@ -62,7 +62,7 @@ public class ISO8601DateSerde implements Serde<Object, Date> {
         if (ClassUtils.isAssignable(targetType, java.sql.Timestamp.class)) {
             return new java.sql.Timestamp(date.getTime());
         }
-         if (ClassUtils.isAssignable(targetType, java.sql.Time.class)) {
+        if (ClassUtils.isAssignable(targetType, java.sql.Time.class)) {
             return new java.sql.Time(date.getTime());
         }
         return date;

--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerde.java
@@ -15,7 +15,7 @@ import java.util.TimeZone;
 /**
  * Serializes ISO8601 Dates to Strings and vice versa.
  */
-public class ISO8601DateSerde implements Serde<String, Date> {
+public class ISO8601DateSerde implements Serde<Object, Date> {
 
     protected FastDateFormat df;
     protected Class<? extends Date> targetType;
@@ -42,24 +42,30 @@ public class ISO8601DateSerde implements Serde<String, Date> {
     }
 
     @Override
-    public Date deserialize(String val) {
+    public Date deserialize(Object val) {
         Date date;
 
         try {
-            date = df.parse(val);
+            if (val instanceof Date) {
+                date = (Date) val;
+            }
+            else {
+                date = df.parse(val.toString());
+            }
         } catch (java.text.ParseException e) {
-            throw new IllegalArgumentException("Date strings must be formated as " + df.getPattern());
+            throw new IllegalArgumentException("Date strings must be formatted as " + df.getPattern());
         }
 
         if (ClassUtils.isAssignable(targetType, java.sql.Date.class)) {
             return new java.sql.Date(date.getTime());
-        } else if (ClassUtils.isAssignable(targetType, java.sql.Timestamp.class)) {
-            return new java.sql.Timestamp(date.getTime());
-        } else if (ClassUtils.isAssignable(targetType, java.sql.Time.class)) {
-            return new java.sql.Time(date.getTime());
-        } else {
-            return date;
         }
+        if (ClassUtils.isAssignable(targetType, java.sql.Timestamp.class)) {
+            return new java.sql.Timestamp(date.getTime());
+        }
+         if (ClassUtils.isAssignable(targetType, java.sql.Time.class)) {
+            return new java.sql.Time(date.getTime());
+        }
+        return date;
     }
 
     @Override

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/CoerceUtilTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/CoerceUtilTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.utils.coerce.converters.EpochToDateConverter;
+import com.yahoo.elide.utils.coerce.converters.ISO8601DateSerde;
 import com.yahoo.elide.utils.coerce.converters.Serde;
 
 import org.junit.jupiter.api.AfterAll;
@@ -26,6 +27,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.UUID;
 
 public class CoerceUtilTest {
@@ -192,6 +194,22 @@ public class CoerceUtilTest {
 
         Time time = CoerceUtil.coerce(0, Time.class);
         assertEquals(new Time(0), time);
+    }
+
+    @Test
+    public void testDateToTimestamp() {
+        String dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        Serde oldDateSerde = CoerceUtil.lookup(Date.class);
+        Serde oldTimestampSerde = CoerceUtil.lookup(java.sql.Timestamp.class);
+        Serde timestampSerde = new ISO8601DateSerde(dateFormat, tz, java.sql.Timestamp.class);
+        CoerceUtil.register(Date.class, new ISO8601DateSerde(dateFormat, tz));
+        CoerceUtil.register(java.sql.Timestamp.class, timestampSerde);
+        Date date = new Date();
+        Timestamp timestamp = CoerceUtil.coerce(date, Timestamp.class);
+        assertEquals(date.getTime(), timestamp.getTime());
+        CoerceUtil.register(Date.class, oldDateSerde);
+        CoerceUtil.register(java.sql.Timestamp.class, oldTimestampSerde);
     }
 
     /**

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerdeTest.java
@@ -72,8 +72,8 @@ public class ISO8601DateSerdeTest {
     public void testDateToSQLTimestampDeserialization() throws Exception {
         ISO8601DateSerde serde =
                 new ISO8601DateSerde("yyyy-MM-dd", TimeZone.getTimeZone("UTC"), java.sql.Timestamp.class);
-        java.sql.Timestamp expected = new Timestamp(0);
-        java.sql.Timestamp actual = (java.sql.Timestamp) serde.deserialize(new Date(0));
+        Timestamp expected = new Timestamp(0);
+        Timestamp actual = (Timestamp) serde.deserialize(new Date(0));
         assertEquals(expected, actual);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/utils/coerce/converters/ISO8601DateSerdeTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -67,6 +68,14 @@ public class ISO8601DateSerdeTest {
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testDateToSQLTimestampDeserialization() throws Exception {
+        ISO8601DateSerde serde =
+                new ISO8601DateSerde("yyyy-MM-dd", TimeZone.getTimeZone("UTC"), java.sql.Timestamp.class);
+        java.sql.Timestamp expected = new Timestamp(0);
+        java.sql.Timestamp actual = (java.sql.Timestamp) serde.deserialize(new Date(0));
+        assertEquals(expected, actual);
+    }
 
     @Test
     public void testInvalidDateDeserialization() {
@@ -81,6 +90,6 @@ public class ISO8601DateSerdeTest {
         IllegalArgumentException e = assertThrows(
                 IllegalArgumentException.class,
                 () -> serde.deserialize("2019-01-01T00:00Z"));
-        assertEquals("Date strings must be formated as yyyy-MM-dd'T'HH:mm:ss'Z'", e.getMessage());
+        assertEquals("Date strings must be formatted as yyyy-MM-dd'T'HH:mm:ss'Z'", e.getMessage());
     }
 }


### PR DESCRIPTION
Resolves #2045

## Description
ISO8601DateSerde can now handle conversion from the different instances of Date class as well.

## Motivation and Context
Details in #2045

## How Has This Been Tested?
Added unit test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
