### PR TITLE
Refactored AnyFieldExpression logic

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AnyFieldExpression.java
@@ -5,8 +5,6 @@
  */
 package com.yahoo.elide.core.security.permissions.expressions;
 
-import static com.yahoo.elide.core.security.permissions.ExpressionResult.FAIL;
-import static com.yahoo.elide.core.security.permissions.ExpressionResult.PASS;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
 import com.yahoo.elide.core.security.permissions.PermissionCondition;
 
@@ -18,27 +16,18 @@ import com.yahoo.elide.core.security.permissions.PermissionCondition;
  * is accessible, regardless of what any class or package level permissions would permit.
  */
 public class AnyFieldExpression implements Expression {
-    private final Expression entityExpression;
-    private final Expression fieldExpression;
+    private final Expression expression;
     private final PermissionCondition condition;
 
     public AnyFieldExpression(final PermissionCondition condition,
-                              final Expression entityExpression,
-                              final OrExpression fieldExpression) {
+                              final Expression expression) {
         this.condition = condition;
-        this.entityExpression = entityExpression;
-        this.fieldExpression = fieldExpression;
+        this.expression = expression;
     }
 
     @Override
     public ExpressionResult evaluate(EvaluationMode mode) {
-        ExpressionResult fieldResult = fieldExpression.evaluate(mode);
-
-        if (fieldResult != FAIL) {
-            return fieldResult;
-        }
-
-        return (entityExpression == null) ? PASS : entityExpression.evaluate(mode);
+        return expression.evaluate(mode);
     }
 
     @Override
@@ -48,7 +37,7 @@ public class AnyFieldExpression implements Expression {
 
     @Override
     public String toString() {
-        return String.format("%s FOR EXPRESSION [(FIELDS(%s)) OR (ENTITY(%s))]",
-                condition, fieldExpression, entityExpression);
+        return String.format("%s FOR EXPRESSION [%s]",
+                condition, expression);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/permissions/PermissionExpressionBuilderTest.java
@@ -66,20 +66,17 @@ public class PermissionExpressionBuilderTest {
                 ReadPermission.class,
                 null);
 
-        assertEquals(
-                "READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
-                        + "FOR EXPRESSION [(FIELDS(\u001B[31mFAILURE\u001B[m)) OR (ENTITY(((user has all access "
-                        + "\u001B[34mWAS UNEVALUATED\u001B[m)) AND ((user has no access "
-                        + "\u001B[34mWAS UNEVALUATED\u001B[m))))]",
+        assertEquals("READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
+                        + "FOR EXPRESSION [((user has all access \u001B[34mWAS UNEVALUATED\u001B[m)) "
+                        + "AND ((user has no access \u001B[34mWAS UNEVALUATED\u001B[m))]",
                 expression.toString());
 
         expression.evaluate(Expression.EvaluationMode.ALL_CHECKS);
 
         assertEquals(
                 "READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
-                        + "FOR EXPRESSION [(FIELDS(\u001B[31mFAILURE\u001B[m)) OR (ENTITY(((user has all access "
-                        + "\u001B[32mPASSED\u001B[m)) AND ((user has no access "
-                        + "\u001B[31mFAILED\u001B[m))))]",
+                        + "FOR EXPRESSION [((user has all access [32mPASSED[m)) "
+                        + "AND ((user has no access [31mFAILED[m))]",
                 expression.toString());
 
     }


### PR DESCRIPTION
Changes AnyField permission logic from Elide 3 semantics to match current documentation.

## Screenshots (if appropriate):

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
