### PR TITLE
Source sparse fields from entity projection

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -1790,6 +1790,7 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
         Set<String> filteredSet = new LinkedHashSet<>();
         for (String field : fields) {
             try {
+
                 if (checkIncludeSparseField(requestScope.getSparseFields(), typeName, field)) {
                     checkFieldAwareReadPermissions(field);
                     filteredSet.add(field);

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -339,8 +339,10 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
             throw new InvalidObjectIdentifierException(ids.toString(), dictionary.getJsonAliasFor(loadClass));
         }
 
+        Set<String> requestedFields = projection.getRequestedFields();
+
         if (pagination != null && !pagination.isDefaultInstance()
-                && !CanPaginateVisitor.canPaginate(loadClass, dictionary, requestScope)) {
+                && !CanPaginateVisitor.canPaginate(loadClass, dictionary, requestScope, requestedFields)) {
             throw new BadRequestException(String.format("Cannot paginate %s",
                     dictionary.getJsonAliasFor(loadClass)));
         }
@@ -362,7 +364,7 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
         }
 
         Optional<FilterExpression> permissionFilter = getPermissionFilterExpression(loadClass, requestScope,
-                projection.getRequestedFields());
+                requestedFields);
         if (permissionFilter.isPresent()) {
             if (filterExpression != null) {
                 filterExpression = new AndFilterExpression(filterExpression, permissionFilter.get());
@@ -1073,7 +1075,12 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
         Optional<Pagination> pagination = Optional.ofNullable(relationship.getProjection().getPagination());
 
         if (pagination.filter(Predicates.not(Pagination::isDefaultInstance)).isPresent()
-                && !CanPaginateVisitor.canPaginate(relationClass, dictionary, requestScope)) {
+                && !CanPaginateVisitor.canPaginate(
+                        relationClass,
+                        dictionary,
+                        requestScope,
+                        relationship.getProjection().getRequestedFields())) {
+
             throw new BadRequestException(String.format("Cannot paginate %s",
                     dictionary.getJsonAliasFor(relationClass)));
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -56,6 +56,7 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
     @Getter private final JsonApiMapper mapper;
     @Getter private final AuditLogger auditLogger;
     @Getter private final MultivaluedMap<String, String> queryParams;
+    @Getter private final Map<String, Set<String>> sparseFields;
     @Getter private final Map<String, List<String>> requestHeaders;
     @Getter private final PermissionExecutor permissionExecutor;
     @Getter private final ObjectEntityCache objectEntityCache;
@@ -145,6 +146,8 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
                 : requestHeaders;
         registerPreSecurityObservers();
 
+        this.sparseFields = parseSparseFields(getQueryParams());
+
         if (!this.queryParams.isEmpty()) {
 
             /* Extract any query param that starts with 'filter' */
@@ -218,6 +221,7 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
         this.queuedLifecycleEvents = outerRequestScope.queuedLifecycleEvents;
         this.requestId = outerRequestScope.requestId;
         this.headers = outerRequestScope.headers;
+        this.sparseFields = outerRequestScope.sparseFields;
     }
 
     public Set<com.yahoo.elide.core.security.PersistentResource> getNewResources() {

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -57,7 +57,6 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
     @Getter private final AuditLogger auditLogger;
     @Getter private final MultivaluedMap<String, String> queryParams;
     @Getter private final Map<String, List<String>> requestHeaders;
-    @Getter private final Map<String, Set<String>> sparseFields;
     @Getter private final PermissionExecutor permissionExecutor;
     @Getter private final ObjectEntityCache objectEntityCache;
     @Getter private final Set<PersistentResource> newPersistentResources;
@@ -181,10 +180,6 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
                     }
                 }
             }
-
-            this.sparseFields = parseSparseFields(this.queryParams);
-        } else {
-            this.sparseFields = Collections.emptyMap();
         }
     }
 
@@ -209,7 +204,6 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
         this.auditLogger = outerRequestScope.auditLogger;
         this.queryParams = new MultivaluedHashMap<>();
         this.requestHeaders = Collections.emptyMap();
-        this.sparseFields = Collections.emptyMap();
         this.objectEntityCache = outerRequestScope.objectEntityCache;
         this.newPersistentResources = outerRequestScope.newPersistentResources;
         this.permissionExecutor = outerRequestScope.getPermissionExecutor();

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/EntityProjection.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/EntityProjection.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -45,6 +46,13 @@ public class EntityProjection {
     //TODO: Remove this exclude
     @ToString.Exclude
     private Set<Argument> arguments;
+
+    public Set<String> getRequestedFields() {
+        return Streams.concat(
+                attributes.stream().map(Attribute::getName),
+                relationships.stream().map(Relationship::getName)
+        ).collect(Collectors.toCollection(LinkedHashSet::new));
+    }
 
     /**
      * Creates a builder initialized as a copy of this collection

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
@@ -15,7 +15,9 @@ import com.yahoo.elide.core.security.permissions.ExpressionResult;
 import com.yahoo.elide.core.type.Type;
 
 import java.lang.annotation.Annotation;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Interface describing classes responsible for managing the life-cycle and execution of checks.
@@ -35,7 +37,12 @@ public interface PermissionExecutor {
      * @see com.yahoo.elide.annotation.DeletePermission
      * @return the results of evaluating the permission
      */
-    <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass, PersistentResource resource);
+    default <A extends Annotation> ExpressionResult checkPermission(
+            Class<A> annotationClass,
+            PersistentResource resource
+    ) {
+        return checkPermission(annotationClass, resource, new HashSet<>());
+    }
 
     /**
      * Check permission on class.
@@ -43,16 +50,18 @@ public interface PermissionExecutor {
      * @param <A> type parameter
      * @param annotationClass annotation class
      * @param resource resource
-     * @param changeSpec ChangeSpec
+     * @param requestedFields the list of requested fields
      * @see com.yahoo.elide.annotation.CreatePermission
      * @see com.yahoo.elide.annotation.ReadPermission
      * @see com.yahoo.elide.annotation.UpdatePermission
      * @see com.yahoo.elide.annotation.DeletePermission
      * @return the results of evaluating the permission
      */
-    <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
+    <A extends Annotation> ExpressionResult checkPermission(
+            Class<A> annotationClass,
             PersistentResource resource,
-            ChangeSpec changeSpec);
+            Set<String> requestedFields
+    );
 
     /**
      * Check for permissions on a specific field.
@@ -90,9 +99,14 @@ public interface PermissionExecutor {
      * @param <A> type parameter
      * @param resourceClass Resource class
      * @param annotationClass Annotation class
+     * @param requestedFields The list of client requested fields
      * @return the results of evaluating the permission
      */
-    <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass, Class<A> annotationClass);
+    <A extends Annotation> ExpressionResult checkUserPermissions(
+            Type<?> resourceClass,
+            Class<A> annotationClass,
+            Set<String> requestedFields
+    );
 
     /**
      * Check strictly user permissions on an entity field.
@@ -110,9 +124,10 @@ public interface PermissionExecutor {
      * Get the read filter, if defined.
      *
      * @param resourceClass the class to check for a filter
+     * @param requestedFields the set of requested fields
      * @return the an optional containg the filter
      */
-    Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass);
+    Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass, Set<String> requestedFields);
 
     /**
      * Execute commit checks.

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
@@ -15,7 +15,6 @@ import com.yahoo.elide.core.security.permissions.ExpressionResult;
 import com.yahoo.elide.core.type.Type;
 
 import java.lang.annotation.Annotation;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -41,7 +40,7 @@ public interface PermissionExecutor {
             Class<A> annotationClass,
             PersistentResource resource
     ) {
-        return checkPermission(annotationClass, resource, new HashSet<>());
+        return checkPermission(annotationClass, resource, null);
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -77,47 +78,22 @@ public class ActivePermissionExecutor implements PermissionExecutor {
         this.verbose = verbose;
     }
 
-    /**
-     * Check permission on class.
-     *
-     * @param <A> type parameter
-     * @param annotationClass annotation class
-     * @param resource resource
-     * @see com.yahoo.elide.annotation.CreatePermission
-     * @see com.yahoo.elide.annotation.ReadPermission
-     * @see com.yahoo.elide.annotation.UpdatePermission
-     * @see com.yahoo.elide.annotation.DeletePermission
-     */
     @Override
     public <A extends Annotation> ExpressionResult checkPermission(
-            Class<A> annotationClass, PersistentResource resource) {
-        return checkPermission(annotationClass, resource, null);
-    }
+            Class<A> annotationClass,
+            PersistentResource resource,
+            Set<String> requestedFields
 
-    /**
-     * Check permission on class. Checking on Transferable falls to check ReadPermission.
-     *
-     * @param annotationClass annotation class
-     * @param resource resource
-     * @param changeSpec ChangeSpec
-     * @param <A> type parameter
-     * @see com.yahoo.elide.annotation.CreatePermission
-     * @see com.yahoo.elide.annotation.ReadPermission
-     * @see com.yahoo.elide.annotation.UpdatePermission
-     * @see com.yahoo.elide.annotation.DeletePermission
-     */
-    @Override
-    public <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
-                                                                   PersistentResource resource,
-                                                                   ChangeSpec changeSpec) {
+    ) {
         Supplier<Expression> expressionSupplier = () -> {
             if (NonTransferable.class == annotationClass) {
                 if (requestScope.getDictionary().isTransferable(resource.getResourceType())) {
-                    return expressionBuilder.buildAnyFieldExpressions(resource, ReadPermission.class, changeSpec);
+                    return expressionBuilder.buildAnyFieldExpressions(resource, ReadPermission.class,
+                            requestedFields, null);
                 }
                 return PermissionExpressionBuilder.FAIL_EXPRESSION;
             }
-            return expressionBuilder.buildAnyFieldExpressions(resource, annotationClass, changeSpec);
+            return expressionBuilder.buildAnyFieldExpressions(resource, annotationClass, requestedFields, null);
         };
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
@@ -231,11 +207,13 @@ public class ActivePermissionExecutor implements PermissionExecutor {
      */
     @Override
     public <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass,
-                                                                        Class<A> annotationClass) {
+                                                                        Class<A> annotationClass,
+                                                                        Set<String> requestedFields) {
         Supplier<Expression> expressionSupplier = () ->
             expressionBuilder.buildUserCheckAnyExpression(
                     resourceClass,
                     annotationClass,
+                    requestedFields,
                     requestScope);
 
         return checkOnlyUserPermissions(
@@ -349,12 +327,13 @@ public class ActivePermissionExecutor implements PermissionExecutor {
      * Get permission filter on an entity.
      *
      * @param resourceClass Resource class
+     * @param requestedFields The set of requested fields
      * @return the filter expression for the class, if any
      */
     @Override
-    public Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass) {
+    public Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass, Set<String> requestedFields) {
         FilterExpression filterExpression =
-                expressionBuilder.buildAnyFieldFilterExpression(resourceClass, requestScope);
+                expressionBuilder.buildAnyFieldFilterExpression(resourceClass, requestScope, requestedFields);
 
         return Optional.ofNullable(filterExpression);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/BypassPermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/BypassPermissionExecutor.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.core.type.Type;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Permission executor intended to bypass all security checks. I.e. this is effectively a no-op.
@@ -21,14 +22,8 @@ import java.util.Optional;
 public class BypassPermissionExecutor implements PermissionExecutor {
     @Override
     public <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
-                                                                   PersistentResource resource) {
-        return ExpressionResult.PASS;
-    }
-
-    @Override
-    public <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
                                                                    PersistentResource resource,
-                                                                   ChangeSpec changeSpec) {
+                                                                   Set<String> requestedFields) {
         return ExpressionResult.PASS;
     }
 
@@ -46,12 +41,13 @@ public class BypassPermissionExecutor implements PermissionExecutor {
 
     @Override
     public <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass,
-                                                                        Class<A> annotationClass) {
+                                                                        Class<A> annotationClass,
+                                                                        Set<String> requestedFields) {
         return ExpressionResult.PASS;
     }
 
     @Override
-    public Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass) {
+    public Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass, Set<String> requestedFields) {
         return Optional.empty();
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/MultiplexPermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/MultiplexPermissionExecutor.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * MultiplexPermissionExecutor manages Model to permssion executor mapping.
@@ -41,17 +42,10 @@ public class MultiplexPermissionExecutor implements PermissionExecutor {
 
     @Override
     public <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
-                                                                   PersistentResource resource) {
-        return getPermissionExecutor(resource.getResourceType())
-                .checkPermission(annotationClass, resource);
-    }
-
-    @Override
-    public <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
                                                                    PersistentResource resource,
-                                                                   ChangeSpec changeSpec) {
+                                                                   Set<String> requestedFields) {
         return getPermissionExecutor(resource.getResourceType())
-                .checkPermission(annotationClass, resource, changeSpec);
+                .checkPermission(annotationClass, resource, requestedFields);
     }
 
     @Override
@@ -74,9 +68,10 @@ public class MultiplexPermissionExecutor implements PermissionExecutor {
 
     @Override
     public <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass,
-                                                                        Class<A> annotationClass) {
+                                                                        Class<A> annotationClass,
+                                                                        Set<String> requestedFields) {
         return getPermissionExecutor(resourceClass)
-                .checkUserPermissions(resourceClass, annotationClass);
+                .checkUserPermissions(resourceClass, annotationClass, requestedFields);
     }
 
     @Override
@@ -88,8 +83,8 @@ public class MultiplexPermissionExecutor implements PermissionExecutor {
     }
 
     @Override
-    public Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass) {
-        return getPermissionExecutor(resourceClass).getReadPermissionFilter(resourceClass);
+    public Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass, Set<String> requestedFields) {
+        return getPermissionExecutor(resourceClass).getReadPermissionFilter(resourceClass, requestedFields);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/PermissionExpressionBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/PermissionExpressionBuilder.java
@@ -98,6 +98,7 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
      */
     public <A extends Annotation> Expression buildAnyFieldExpressions(final PersistentResource resource,
                                                                        final Class<A> annotationClass,
+                                                                       Set<String> requestedFields,
                                                                        final ChangeSpec changeSpec) {
 
 
@@ -112,6 +113,7 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
                 (checkFn) -> buildAnyFieldExpression(
                         PermissionCondition.create(annotationClass, resource, (String) null, changeSpec),
                         checkFn,
+                        requestedFields,
                         resource.getRequestScope()
                 );
 
@@ -158,13 +160,15 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
      */
     public <A extends Annotation> Expression buildUserCheckAnyExpression(final Type<?> resourceClass,
                                                                          final Class<A> annotationClass,
+                                                                         Set<String> requestedFields,
                                                                          final RequestScope requestScope) {
 
         final Function<Check, Expression> leafBuilderFn = (check) ->
                 new CheckExpression(check, null, requestScope, null, cache);
 
         return buildAnyFieldExpression(
-                        new PermissionCondition(annotationClass, resourceClass), leafBuilderFn, requestScope);
+                        new PermissionCondition(annotationClass, resourceClass), leafBuilderFn,
+                requestedFields, requestScope);
     }
 
     /**
@@ -195,10 +199,12 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
      * @param condition       The condition which triggered this permission expression check
      * @param checkFn         check function
      * @param scope           RequestScope
+     * @param requestedFields The list of requested fields
      * @return Expressions
      */
     private Expression buildAnyFieldExpression(final PermissionCondition condition,
             final Function<Check, Expression> checkFn,
+            final Set<String> requestedFields,
             final RequestScope scope) {
 
         Type<?> resourceClass = condition.getEntityClass();
@@ -209,13 +215,12 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
 
         OrExpression allFieldsExpression = new OrExpression(FAILURE, null);
         List<String> fields = entityDictionary.getAllFields(resourceClass);
-        Set<String> sparseFields = scope.getSparseFields().get(entityDictionary.getJsonAliasFor(resourceClass));
 
         boolean entityExpressionUsed = false;
         boolean fieldExpressionUsed = false;
 
         for (String field : fields) {
-            if (sparseFields != null && !sparseFields.contains(field)) {
+            if (requestedFields != null && !requestedFields.contains(field)) {
                 continue;
             }
 
@@ -261,7 +266,11 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
      * @param requestScope requestScope
      * @return Expressions
      */
-    public FilterExpression buildAnyFieldFilterExpression(Type<?> forType, RequestScope requestScope) {
+    public FilterExpression buildAnyFieldFilterExpression(
+            Type<?> forType,
+            RequestScope requestScope,
+            Set<String> requestedFields
+    ) {
 
         Class<? extends Annotation> annotationClass = ReadPermission.class;
         ParseTree classPermissions = entityDictionary.getPermissionsForClass(forType, annotationClass);
@@ -274,10 +283,9 @@ public class PermissionExpressionBuilder implements CheckInstantiator {
             entityFilter = null;
         }
 
-        Set<String> sparseFields = requestScope.getSparseFields().get(entityDictionary.getJsonAliasFor(forType));
         FilterExpression allFieldsFilterExpression = entityFilter;
         List<String> fields = entityDictionary.getAllFields(forType).stream()
-                .filter(field -> sparseFields == null || sparseFields.contains(field))
+                .filter(field -> requestedFields == null || requestedFields.contains(field))
                 .collect(Collectors.toList());
 
         for (String field : fields) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/CanPaginateVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/CanPaginateVisitor.java
@@ -144,11 +144,13 @@ public class CanPaginateVisitor
 
     private final EntityDictionary dictionary;
     private final RequestScope scope;
+    private Set<String> requestedFields;
 
 
-    public CanPaginateVisitor(EntityDictionary dictionary, RequestScope scope) {
+    public CanPaginateVisitor(EntityDictionary dictionary, RequestScope scope, Set<String> requestedFields) {
         this.dictionary = dictionary;
         this.scope = scope;
+        this.requestedFields = requestedFields;
     }
 
     @Override
@@ -229,12 +231,17 @@ public class CanPaginateVisitor
      * class for a requested set of fields.
      * @param resourceClass The class of resources that will be paginated
      * @param dictionary Used to look up permissions
-     * @param scope Contains the request info including any sparse fields that were requested
+     * @param scope Contains the user object.
+     * @param requestedFields Contains the request info including any sparse fields that were requested
      * @return true if the data store can paginate.  false otherwise.
      */
-    public static boolean canPaginate(Type<?> resourceClass, EntityDictionary dictionary, RequestScope scope) {
-
-        CanPaginateVisitor visitor = new CanPaginateVisitor(dictionary, scope);
+    public static boolean canPaginate(
+            Type<?> resourceClass,
+            EntityDictionary dictionary,
+            RequestScope scope,
+            Set<String> requestedFields
+    ) {
+        CanPaginateVisitor visitor = new CanPaginateVisitor(dictionary, scope, requestedFields);
 
         Class<? extends Annotation> annotationClass = ReadPermission.class;
         ParseTree classPermissions = dictionary.getPermissionsForClass(resourceClass, annotationClass);
@@ -245,8 +252,6 @@ public class CanPaginateVisitor
         }
 
         List<String> fields = dictionary.getAllFields(resourceClass);
-        String resourceName = dictionary.getJsonAliasFor(resourceClass);
-        Set<String> requestedFields = scope.getSparseFields().getOrDefault(resourceName, Collections.emptySet());
 
         boolean canPaginate = true;
         for (String field : fields) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/CanPaginateVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/CanPaginateVisitor.java
@@ -19,7 +19,6 @@ import com.yahoo.elide.generated.parsers.ExpressionParser;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 import java.lang.annotation.Annotation;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -382,7 +382,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
             Set<PersistentResource> results =
                     PersistentResource.filter(
                             ReadPermission.class,
-                            Optional.empty(), resources).toList(LinkedHashSet::new).blockingGet();
+                            Optional.empty(), ALL_FIELDS, resources).toList(LinkedHashSet::new).blockingGet();
 
             assertEquals(2, results.size(), "Only a subset of the children are readable");
             assertTrue(results.contains(child1Resource), "Readable children includes children with positive IDs");
@@ -400,7 +400,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
                     Observable.fromArray(child1Resource, child2Resource, child3Resource, child4Resource);
 
             Set<PersistentResource> results = PersistentResource.filter(ReadPermission.class,
-                    Optional.empty(), resources).toList(LinkedHashSet::new).blockingGet();
+                    Optional.empty(), ALL_FIELDS, resources).toList(LinkedHashSet::new).blockingGet();
 
             assertEquals(0, results.size(), "No children are readable by an invalid user");
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 public class VerifyFieldAccessFilterExpressionVisitorTest {
 
@@ -118,7 +120,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
         verify(permissionExecutor, times(17)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, NAME);
-        verify(permissionExecutor, times(21)).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, times(21)).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -176,7 +178,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(8)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, HOME);
-        verify(permissionExecutor, times(9)).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, times(9)).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, times(5)).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -201,7 +203,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, GENRE);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -232,11 +234,11 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, AUTHORS);
-        verify(permissionExecutor, never()).getReadPermissionFilter(ClassType.of(Author.class));
+        verify(permissionExecutor, never()).getReadPermissionFilter(ClassType.of(Author.class), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, HOME);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(any(), any(), any(), any());
         verify(permissionExecutor, never()).checkSpecificFieldPermissionsDeferred(any(), any(), any(), any());
-        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }
@@ -264,7 +266,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, GENRE);
         verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -293,7 +295,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, AUTHORS);
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, NAME);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }
@@ -319,7 +321,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
                 .thenReturn(ExpressionResult.PASS);
         when(permissionExecutor.checkSpecificFieldPermissionsDeferred(resource, null, ReadPermission.class, AUTHORS))
                 .thenReturn(ExpressionResult.PASS);
-        when(permissionExecutor.getReadPermissionFilter(ClassType.of(Author.class))).thenReturn(Optional.empty());
+        when(permissionExecutor.getReadPermissionFilter(ClassType.of(Author.class), any())).thenReturn(Optional.empty());
 
         when(permissionExecutor.checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, HOME))
                 .thenReturn(ExpressionResult.DEFERRED);
@@ -334,10 +336,10 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, AUTHORS);
-        verify(permissionExecutor, times(1)).getReadPermissionFilter(ClassType.of(Author.class));
+        verify(permissionExecutor, times(1)).getReadPermissionFilter(ClassType.of(Author.class), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, HOME);
         verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resourceAuthor, null, ReadPermission.class, HOME);
-        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
         verify(tx, times(1)).getRelation(eq(tx), eq(book), any(), eq(scope));
     }
@@ -362,7 +364,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(any(), any(), any(), any());
-        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }
@@ -408,7 +410,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), any());
+        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), isA(Set.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 
 public class VerifyFieldAccessFilterExpressionVisitorTest {
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitorTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -120,7 +121,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         PermissionExecutor permissionExecutor = scope.getPermissionExecutor();
         verify(permissionExecutor, times(17)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, NAME);
-        verify(permissionExecutor, times(21)).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, times(21)).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -178,7 +179,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(8)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(5)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, HOME);
-        verify(permissionExecutor, times(9)).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, times(9)).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, times(5)).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -203,7 +204,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, GENRE);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -234,11 +235,11 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, AUTHORS);
-        verify(permissionExecutor, never()).getReadPermissionFilter(ClassType.of(Author.class), any());
+        verify(permissionExecutor, never()).getReadPermissionFilter(ClassType.of(Author.class), null);
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, HOME);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(any(), any(), any(), any());
         verify(permissionExecutor, never()).checkSpecificFieldPermissionsDeferred(any(), any(), any(), any());
-        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }
@@ -266,7 +267,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, GENRE);
         verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, times(1)).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
     }
 
@@ -295,7 +296,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, AUTHORS);
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, NAME);
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }
@@ -321,7 +322,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
                 .thenReturn(ExpressionResult.PASS);
         when(permissionExecutor.checkSpecificFieldPermissionsDeferred(resource, null, ReadPermission.class, AUTHORS))
                 .thenReturn(ExpressionResult.PASS);
-        when(permissionExecutor.getReadPermissionFilter(ClassType.of(Author.class), any())).thenReturn(Optional.empty());
+        when(permissionExecutor.getReadPermissionFilter(ClassType.of(Author.class), null)).thenReturn(Optional.empty());
 
         when(permissionExecutor.checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, HOME))
                 .thenReturn(ExpressionResult.DEFERRED);
@@ -336,10 +337,10 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Book.class), ReadPermission.class, AUTHORS);
-        verify(permissionExecutor, times(1)).getReadPermissionFilter(ClassType.of(Author.class), any());
+        verify(permissionExecutor, times(1)).getReadPermissionFilter(ClassType.of(Author.class), new HashSet<>());
         verify(permissionExecutor, times(1)).checkUserPermissions(ClassType.of(Author.class), ReadPermission.class, HOME);
         verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resourceAuthor, null, ReadPermission.class, HOME);
-        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, times(2)).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
         verify(tx, times(1)).getRelation(eq(tx), eq(book), any(), eq(scope));
     }
@@ -364,7 +365,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, never()).checkSpecificFieldPermissions(any(), any(), any(), any());
-        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, never()).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }
@@ -410,7 +411,7 @@ public class VerifyFieldAccessFilterExpressionVisitorTest {
 
         verify(permissionExecutor, times(1)).evaluateFilterJoinUserChecks(any(), any());
         verify(permissionExecutor, times(1)).checkSpecificFieldPermissions(resource, null, ReadPermission.class, GENRE);
-        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), isA(Set.class));
+        verify(permissionExecutor, never()).checkUserPermissions(any(), any(), isA(String.class));
         verify(permissionExecutor, times(1)).handleFilterJoinReject(any(), any(), any());
         verify(tx, never()).getRelation(any(), any(), any(), any());
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
@@ -34,12 +34,19 @@ import javax.persistence.Id;
 
 public class PermissionExecutorTest {
 
+    interface SampleOperationModel {
+        default boolean test() {
+            return true;
+        }
+    }
+
     @Test
     public void testSuccessfulOperationCheck() throws Exception {
         @Entity
         @Include(rootLevel = false)
         @UpdatePermission(expression = "sampleOperation")
-        class Model { }
+        class Model implements SampleOperationModel {
+        }
 
         PersistentResource resource = newResource(new Model(), Model.class, false);
         RequestScope requestScope = resource.getRequestScope();
@@ -54,7 +61,7 @@ public class PermissionExecutorTest {
         @Entity
         @Include(rootLevel = false)
         @UpdatePermission(expression = "sampleOperation AND Prefab.Role.None")
-        class Model { }
+        class Model implements SampleOperationModel { }
 
         PersistentResource resource = newResource(new Model(), Model.class, false);
         RequestScope requestScope = resource.getRequestScope();
@@ -68,7 +75,13 @@ public class PermissionExecutorTest {
         @Entity
         @Include(rootLevel = false)
         @UpdatePermission(expression = "sampleOperation")
-        class Model { }
+        class Model implements SampleOperationModel {
+
+            @Override
+            public boolean test() {
+                return false;
+            }
+        }
 
         PersistentResource resource = newResource(new Model(), Model.class, true);
         RequestScope requestScope = resource.getRequestScope();
@@ -85,7 +98,7 @@ public class PermissionExecutorTest {
         @Entity
         @Include(rootLevel = false)
         @UpdatePermission(expression = "sampleOperation")
-        class Model { }
+        class Model implements SampleOperationModel { }
 
         PersistentResource resource = newResource(new Model(), Model.class, true);
         RequestScope requestScope = resource.getRequestScope();
@@ -102,7 +115,7 @@ public class PermissionExecutorTest {
         @Entity
         @Include(rootLevel = false)
         @UpdatePermission(expression = "sampleCommit")
-        class Model { }
+        class Model implements SampleOperationModel { }
 
         PersistentResource resource = newResource(new Model(), Model.class, false);
         RequestScope requestScope = resource.getRequestScope();
@@ -119,7 +132,12 @@ public class PermissionExecutorTest {
         @Entity
         @Include(rootLevel = false)
         @UpdatePermission(expression = "sampleCommit")
-        class Model { }
+        class Model implements SampleOperationModel {
+            @Override
+            public boolean test() {
+                return false;
+            }
+        }
 
         PersistentResource resource = newResource(new Model(), Model.class, false);
         RequestScope requestScope = resource.getRequestScope();
@@ -133,7 +151,9 @@ public class PermissionExecutorTest {
 
     @Test
     public void testReadFieldAwareSuccessAllAnyField() {
-        PersistentResource resource = newResource(SampleBean.class, false);
+        SampleBean sampleBean = new SampleBean();
+        sampleBean.id = 1L;
+        PersistentResource resource = newResource(sampleBean, SampleBean.class, false);
         RequestScope requestScope = resource.getRequestScope();
         assertEquals(ExpressionResult.PASS,
                 requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, ALL_FIELDS));
@@ -152,7 +172,9 @@ public class PermissionExecutorTest {
 
     @Test
     public void testReadFieldAwareSuccessAll() {
-        PersistentResource resource = newResource(SampleBean.class, false);
+        SampleBean sampleBean = new SampleBean();
+        sampleBean.id = 1L;
+        PersistentResource resource = newResource(sampleBean, SampleBean.class, false);
         RequestScope requestScope = resource.getRequestScope();
         assertEquals(ExpressionResult.PASS,
                 requestScope.getPermissionExecutor().checkSpecificFieldPermissions(resource, new ChangeSpec(null, null, null, null), ReadPermission.class, "allVisible"));
@@ -194,7 +216,9 @@ public class PermissionExecutorTest {
 
     @Test
     public void testReadFieldAwareSuccessAny() {
-        PersistentResource resource = newResource(SampleBean.class, false);
+        SampleBean sampleBean = new SampleBean();
+        sampleBean.id = 1L;
+        PersistentResource resource = newResource(sampleBean, SampleBean.class, false);
         RequestScope requestScope = resource.getRequestScope();
         assertEquals(ExpressionResult.PASS,
                 requestScope.getPermissionExecutor().checkSpecificFieldPermissions(resource, new ChangeSpec(null, null, null, null), ReadPermission.class, "mayFailInCommit"));
@@ -214,7 +238,9 @@ public class PermissionExecutorTest {
 
     @Test
     public void testUpdateFieldAwareSuccessAll() {
-        PersistentResource resource = newResource(SampleBean.class, true);
+        SampleBean sampleBean = new SampleBean();
+        sampleBean.id = 1L;
+        PersistentResource resource = newResource(sampleBean, SampleBean.class, true);
         RequestScope requestScope = resource.getRequestScope();
         assertEquals(ExpressionResult.DEFERRED,
                 requestScope.getPermissionExecutor().checkSpecificFieldPermissions(resource, new ChangeSpec(null, null, null, null), UpdatePermission.class, "allVisible"));
@@ -231,7 +257,9 @@ public class PermissionExecutorTest {
 
     @Test
     public void testUpdateFieldAwareSuccessAny() {
-        PersistentResource resource = newResource(SampleBean.class, true);
+        SampleBean sampleBean = new SampleBean();
+        sampleBean.id = 1L;
+        PersistentResource resource = newResource(sampleBean, SampleBean.class, true);
         RequestScope requestScope = resource.getRequestScope();
         assertEquals(ExpressionResult.DEFERRED,
                 requestScope.getPermissionExecutor().checkSpecificFieldPermissions(resource, new ChangeSpec(null, null, null, null), UpdatePermission.class, "mayFailInCommit"));
@@ -248,7 +276,9 @@ public class PermissionExecutorTest {
 
     @Test
     public void testReadFieldAwareEntireOpenBean() {
-        PersistentResource resource = newResource(OpenBean.class, false);
+        OpenBean openBean = new OpenBean();
+        openBean.id = 1L;
+        PersistentResource resource = newResource(openBean, OpenBean.class, false);
         RequestScope requestScope = resource.getRequestScope();
         assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource));
         assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkSpecificFieldPermissions(resource, null, ReadPermission.class, "open"));
@@ -444,6 +474,8 @@ public class PermissionExecutorTest {
 
     @Test
     public void testUserCheckOnFieldSuccess() {
+        OpenBean openBean = new OpenBean();
+        openBean.id = 1L;
         PersistentResource resource = newResource(OpenBean.class, false);
         RequestScope requestScope = resource.getRequestScope();
         ExpressionResult result = requestScope.getPermissionExecutor().checkUserPermissions(ClassType.of(OpenBean.class),
@@ -502,10 +534,10 @@ public class PermissionExecutorTest {
                     .build();
     }
 
-    public static final class SampleOperationCheck extends OperationCheck<Object> {
+    public static final class SampleOperationCheck extends OperationCheck<SampleOperationModel> {
         @Override
-        public boolean ok(Object object, com.yahoo.elide.core.security.RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
-            return changeSpec.isPresent();
+        public boolean ok(SampleOperationModel model, com.yahoo.elide.core.security.RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+            return model.test();
         }
     }
 
@@ -517,16 +549,16 @@ public class PermissionExecutorTest {
         }
     }
 
-    public static final class SampleCommitCheck extends OperationCheck<Object> {
+    public static final class SampleCommitCheck extends OperationCheck<SampleOperationModel> {
         @Override
         public boolean runAtCommit() {
             return true;
         }
 
         @Override
-        public boolean ok(Object object, com.yahoo.elide.core.security.RequestScope requestScope,
+        public boolean ok(SampleOperationModel model, com.yahoo.elide.core.security.RequestScope requestScope,
                 Optional<ChangeSpec> changeSpec) {
-            return changeSpec.isPresent();
+            return model.test();
         }
     }
 
@@ -534,9 +566,14 @@ public class PermissionExecutorTest {
     @UpdatePermission(expression = "Prefab.Role.None")
     @Include(rootLevel = false)
     @Entity
-    public static final class SampleBean {
+    public static final class SampleBean implements SampleOperationModel {
         @Id
         public Long id;
+
+        @Override
+        public boolean test() {
+            return id != null && id == 1L;
+        }
 
         @ReadPermission(expression = "Prefab.Role.All AND sampleOperation")
         @UpdatePermission(expression = "Prefab.Role.All AND sampleOperation")
@@ -557,11 +594,16 @@ public class PermissionExecutorTest {
     @UpdatePermission(expression = "Prefab.Role.All")
     @Include(rootLevel = false)
     @Entity
-    public static final class OpenBean {
+    public static final class OpenBean implements SampleOperationModel {
         @Id
         public Long id;
 
         public String open;
+
+        @Override
+        public boolean test() {
+            return id != null && id == 1L;
+        }
 
         @ReadPermission(expression = "Prefab.Role.All AND sampleOperation")
         @UpdatePermission(expression = "Prefab.Role.All AND sampleOperation")

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/PermissionExecutorTest.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.core.security;
 
+import static com.yahoo.elide.core.PersistentResource.ALL_FIELDS;
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,9 +43,8 @@ public class PermissionExecutorTest {
 
         PersistentResource resource = newResource(new Model(), Model.class, false);
         RequestScope requestScope = resource.getRequestScope();
-        ChangeSpec cspec = new ChangeSpec(null, null, null, null);
         assertEquals(ExpressionResult.PASS,
-                requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, cspec));
+                requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, ALL_FIELDS));
 
         requestScope.getPermissionExecutor().executeCommitChecks();
     }
@@ -89,11 +89,10 @@ public class PermissionExecutorTest {
 
         PersistentResource resource = newResource(new Model(), Model.class, true);
         RequestScope requestScope = resource.getRequestScope();
-        ChangeSpec cspec = new ChangeSpec(null, null, null, null);
 
         // Because the object is newly created, the check is DEFERRED.
         assertEquals(ExpressionResult.DEFERRED,
-                requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, cspec));
+                requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, ALL_FIELDS));
 
         requestScope.getPermissionExecutor().executeCommitChecks();
     }
@@ -107,11 +106,10 @@ public class PermissionExecutorTest {
 
         PersistentResource resource = newResource(new Model(), Model.class, false);
         RequestScope requestScope = resource.getRequestScope();
-        ChangeSpec cspec = new ChangeSpec(null, null, null, null);
 
         // Because the check is runAtCommit, the check is DEFERRED.
         assertEquals(ExpressionResult.DEFERRED,
-                requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, cspec));
+                requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, ALL_FIELDS));
 
         requestScope.getPermissionExecutor().executeCommitChecks();
     }
@@ -138,7 +136,7 @@ public class PermissionExecutorTest {
         PersistentResource resource = newResource(SampleBean.class, false);
         RequestScope requestScope = resource.getRequestScope();
         assertEquals(ExpressionResult.PASS,
-                requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, new ChangeSpec(null, null, null, null)));
+                requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, ALL_FIELDS));
         requestScope.getPermissionExecutor().executeCommitChecks();
     }
 
@@ -425,25 +423,23 @@ public class PermissionExecutorTest {
     public void testNoCache() {
         PersistentResource resource = newResource(AnnotationOnlyRecord.class, false);
         RequestScope requestScope = resource.getRequestScope();
-        ChangeSpec cspec = new ChangeSpec(null, null, null, null);
         assertThrows(
                 ForbiddenAccessException.class,
-                () -> requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, cspec));
+                () -> requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, ALL_FIELDS));
         assertThrows(
                 ForbiddenAccessException.class,
-                () -> requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, cspec));
+                () -> requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, ALL_FIELDS));
     }
 
     @Test
     public void testUserCheckCache() {
         PersistentResource resource = newResource(UserCheckCacheRecord.class, false);
         RequestScope requestScope = resource.getRequestScope();
-        ChangeSpec cspec = new ChangeSpec(null, null, null, null);
         // This should cache for updates, reads, etc.
-        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, cspec));
-        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, cspec));
-        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, cspec));
-        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, cspec));
+        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, ALL_FIELDS));
+        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(UpdatePermission.class, resource, ALL_FIELDS));
+        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, ALL_FIELDS));
+        assertEquals(ExpressionResult.PASS, requestScope.getPermissionExecutor().checkPermission(ReadPermission.class, resource, ALL_FIELDS));
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/permissions/PermissionExpressionBuilderTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/permissions/PermissionExpressionBuilderTest.java
@@ -64,7 +64,7 @@ public class PermissionExpressionBuilderTest {
         Expression expression = builder.buildAnyFieldExpressions(
                 resource,
                 ReadPermission.class,
-                null);
+                null, null);
 
         assertEquals("READ PERMISSION WAS INVOKED ON PersistentResource{type=model, id=null}  "
                         + "FOR EXPRESSION [((user has all access \u001B[34mWAS UNEVALUATED\u001B[m)) "

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/CanPaginateVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/CanPaginateVisitorTest.java
@@ -9,7 +9,6 @@ package com.yahoo.elide.parsers.expression;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.core.RequestScope;
@@ -25,12 +24,12 @@ import com.yahoo.elide.core.security.checks.UserCheck;
 import com.yahoo.elide.core.security.visitors.CanPaginateVisitor;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
-import com.google.common.collect.Sets;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -97,7 +96,7 @@ public class CanPaginateVisitorTest {
 
         RequestScope scope = mock(RequestScope.class);
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -115,7 +114,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -133,7 +132,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -152,7 +151,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -172,7 +171,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -191,7 +190,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -210,7 +209,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -229,7 +228,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -248,7 +247,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -267,7 +266,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -289,7 +288,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -312,7 +311,7 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, new HashSet<>()));
     }
 
     @Test
@@ -337,17 +336,16 @@ public class CanPaginateVisitorTest {
         dictionary.bindEntity(Book.class);
         RequestScope scope = mock(RequestScope.class);
 
-        Map<String, Set<String>> sparseFields = new HashMap<>();
-        when(scope.getSparseFields()).thenReturn(sparseFields);
+        Set<String> sparseFields = new HashSet<>();
 
-        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, sparseFields));
+        sparseFields.add("title");
+        sparseFields.add("publicationDate");
 
-        sparseFields.put("book", Sets.newHashSet("title", "publicationDate"));
+        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, sparseFields));
 
-        assertTrue(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        sparseFields.add("outOfPrint");
 
-        sparseFields.put("book", Sets.newHashSet("outOfPrint"));
-
-        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope));
+        assertFalse(CanPaginateVisitor.canPaginate(ClassType.of(Book.class), dictionary, scope, sparseFields));
     }
 }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -299,7 +299,7 @@ public class GraphQLEndpointTest {
     }
 
     @Test
-    void testCannotReadRestrictedField() throws IOException {
+    void testCannotReadRestrictedField() throws JSONException {
         String graphQLRequest = document(
                 selection(
                         field(
@@ -311,8 +311,11 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
+        //Empty response because the collection is skipped because of failed user check.
+        String expected = "{\"data\":{\"book\":{\"edges\":[]}}}";
+
         Response response = endpoint.post(uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
-        assertHasErrors(response);
+        assert200EqualBody(response, expected);
     }
 
 


### PR DESCRIPTION
Some logic in Elide that examines JSON-API sparse fields is not applied for GraphQL:

- Determining whether a collection can be paginated.
- Building security filters from only the set of requested fields (not the entire entity model).
.
This PR changes Elide core to leverage the EntityProjection to build the list of requested fields (rather than sourcing from sparse fields from the request header) allowing the same logic to be leveraged for both JSON-API and GraphQL

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
