### PR TITLE
Add missing default values for ElideAutoConfiguration

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -91,7 +91,7 @@ public class ElideAutoConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnExpression("${elide.aggregation-store.enabled} and ${elide.dynamic-config.enabled}")
+    @ConditionalOnExpression("${elide.aggregation-store.enabled:false} and ${elide.dynamic-config.enabled:false}")
     public DynamicConfiguration buildDynamicConfiguration(ElideConfigProperties settings) throws IOException {
         DynamicConfigValidator validator = new DynamicConfigValidator(settings.getDynamicConfig().getPath());
         validator.readAndValidateConfigs();


### PR DESCRIPTION
Prevents SpelParseException on parsing the expression.

Resolves #2021

## Description
I'm setting a default value for the elide configuration as it doesn't seem to be loaded at this stage
For steps how to reproduce see the issue.



## How Has This Been Tested?
I tested the fix on my project. With pr34 it fails to start, with my local pr35-SNAPSHOT changes it launches.
There is also a reference implementation with the exact same appraoch inside Elide here: https://github.com/yahoo/elide/blob/b126fc12c0102fa8441e5900b81ad95d1b0bb3c3/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ExportController.java#L40


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
