### PR TITLE
refactor datastore to provide permission executor

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncAPIDAO.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncAPIDAO.java
@@ -164,7 +164,7 @@ public class DefaultAsyncAPIDAO implements AsyncAPIDAO {
         try (DataStoreTransaction tx = dataStore.beginTransaction()) {
             JsonApiDocument jsonApiDoc = new JsonApiDocument();
             MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-            RequestScope scope = new RequestScope("", "query", NO_VERSION, jsonApiDoc,
+            RequestScope scope = new RequestScope("", "asyncQuery", NO_VERSION, jsonApiDoc,
                     tx, null, queryParams, Collections.emptyMap(), UUID.randomUUID(), elideSettings);
             result = action.execute(tx, scope);
             tx.flush(scope);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICancelRunnable.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncAPICancelRunnable.java
@@ -103,7 +103,7 @@ public class AsyncAPICancelRunnable implements Runnable {
                    if (runningTransaction != null) {
                        JsonApiDocument jsonApiDoc = new JsonApiDocument();
                        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-                       RequestScope scope = new RequestScope("", "query", NO_VERSION, jsonApiDoc,
+                       RequestScope scope = new RequestScope("", "asyncQuery", NO_VERSION, jsonApiDoc,
                                runningTransaction, null, queryParams, Collections.emptyMap(),
                                uuid, elide.getElideSettings());
                        runningTransaction.cancel(scope);

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -5,14 +5,12 @@
  */
 package com.yahoo.elide;
 
-import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.audit.AuditLogger;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.graphql.FilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.JoinFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.SubqueryFilterDialect;
-import com.yahoo.elide.core.security.PermissionExecutor;
 import com.yahoo.elide.core.utils.coerce.converters.Serde;
 import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.jsonapi.links.JSONApiLinks;
@@ -21,7 +19,6 @@ import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Object containing general Elide settings passed to RequestScope.
@@ -32,7 +29,6 @@ public class ElideSettings {
     @Getter private final DataStore dataStore;
     @Getter private final EntityDictionary dictionary;
     @Getter private final JsonApiMapper mapper;
-    @Getter private final Function<RequestScope, PermissionExecutor> permissionExecutor;
     @Getter private final List<JoinFilterDialect> joinFilterDialects;
     @Getter private final List<SubqueryFilterDialect> subqueryFilterDialects;
     @Getter private final FilterDialect graphqlDialect;

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide;
 
-import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.audit.AuditLogger;
 import com.yahoo.elide.core.audit.Slf4jLogger;
 import com.yahoo.elide.core.datastore.DataStore;
@@ -17,9 +16,6 @@ import com.yahoo.elide.core.filter.dialect.jsonapi.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.JoinFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.SubqueryFilterDialect;
 import com.yahoo.elide.core.pagination.PaginationImpl;
-import com.yahoo.elide.core.security.PermissionExecutor;
-import com.yahoo.elide.core.security.executors.ActivePermissionExecutor;
-import com.yahoo.elide.core.security.executors.VerbosePermissionExecutor;
 import com.yahoo.elide.core.utils.coerce.converters.EpochToDateConverter;
 import com.yahoo.elide.core.utils.coerce.converters.ISO8601DateSerde;
 import com.yahoo.elide.core.utils.coerce.converters.Serde;
@@ -32,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.function.Function;
 
 /**
  * Builder for ElideSettings.
@@ -42,7 +37,6 @@ public class ElideSettingsBuilder {
     private AuditLogger auditLogger;
     private JsonApiMapper jsonApiMapper;
     private EntityDictionary entityDictionary = new EntityDictionary(new HashMap<>());
-    private Function<RequestScope, PermissionExecutor> permissionExecutorFunction = ActivePermissionExecutor::new;
     private List<JoinFilterDialect> joinFilterDialects;
     private List<SubqueryFilterDialect> subqueryFilterDialects;
     private FilterDialect graphqlFilterDialect;
@@ -98,7 +92,6 @@ public class ElideSettingsBuilder {
                 dataStore,
                 entityDictionary,
                 jsonApiMapper,
-                permissionExecutorFunction,
                 joinFilterDialects,
                 subqueryFilterDialects,
                 graphqlFilterDialect,
@@ -175,10 +168,10 @@ public class ElideSettingsBuilder {
         return this;
     }
 
-    public ElideSettingsBuilder withVerboseErrors() {
-        permissionExecutorFunction = VerbosePermissionExecutor::new;
-        return this;
-    }
+//    public ElideSettingsBuilder withVerboseErrors() {
+//        // Set Verbose Permission Executor in datastore
+//        return this;
+//    }
 
     public ElideSettingsBuilder withISO8601Dates(String dateFormat, TimeZone tz) {
         serdes.put(Date.class, new ISO8601DateSerde(dateFormat, tz));

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -168,10 +168,10 @@ public class ElideSettingsBuilder {
         return this;
     }
 
-//    public ElideSettingsBuilder withVerboseErrors() {
-//        // Set Verbose Permission Executor in datastore
-//        return this;
-//    }
+    public ElideSettingsBuilder withVerboseErrors() {
+        // Set Verbose Permission Executor in datastore
+        return this;
+    }
 
     public ElideSettingsBuilder withISO8601Dates(String dateFormat, TimeZone tz) {
         serdes.put(Date.class, new ISO8601DateSerde(dateFormat, tz));

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStore.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStore.java
@@ -5,7 +5,12 @@
  */
 package com.yahoo.elide.core.datastore;
 
+import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.security.PermissionExecutor;
+import com.yahoo.elide.core.security.executors.ActivePermissionExecutor;
+
+import java.util.function.Function;
 
 /**
  * Database interface library.
@@ -33,5 +38,9 @@ public interface DataStore {
      */
     default DataStoreTransaction beginReadTransaction() {
         return beginTransaction();
+    }
+
+    default Function<RequestScope, PermissionExecutor> getPermissionExecutorFunction() {
+        return ActivePermissionExecutor::new;
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
@@ -765,10 +765,7 @@ public class EntityProjectionMakerTest {
         queryParams.add("fields[book]", "publisher,bookTitle,bookName"); // Invalid Fields: bookTitle & bookName
         String path = "/book";
 
-        RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
-        EntityProjectionMaker maker = new EntityProjectionMaker(dictionary, scope);
-
-        Exception e = assertThrows(InvalidValueException.class, () -> maker.parsePath(path));
+        Exception e = assertThrows(InvalidValueException.class, () -> new TestRequestScope(dictionary, path, queryParams));
         assertEquals("Invalid value: book does not contain the fields: [bookTitle, bookName]", e.getMessage());
     }
 
@@ -780,10 +777,7 @@ public class EntityProjectionMakerTest {
         queryParams.add("include", "publisher");
         String path = "/book";
 
-        RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
-        EntityProjectionMaker maker = new EntityProjectionMaker(dictionary, scope);
-
-        Exception e = assertThrows(InvalidValueException.class, () -> maker.parsePath(path));
+        Exception e = assertThrows(InvalidValueException.class, () -> new TestRequestScope(dictionary, path, queryParams));
         assertEquals("Invalid value: publisher does not contain the fields: [cost]", e.getMessage());
     }
 

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/JpaDataStore.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/JpaDataStore.java
@@ -119,6 +119,11 @@ public class JpaDataStore implements JPQLDataStore {
         return transaction;
     }
 
+    @Override
+    public Function<RequestScope, PermissionExecutor> getPermissionExecutorFunction() {
+        return permissionExecutorFunction;
+    }
+
     /**
      * Functional interface for describing a method to supply EntityManager.
      */

--- a/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DependencyBinder.java
+++ b/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DependencyBinder.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.DefaultFilterDialect;
 import com.yahoo.elide.core.pagination.PaginationImpl;
+import com.yahoo.elide.core.security.executors.VerbosePermissionExecutor;
 import com.yahoo.elide.datastores.jpa.JpaDataStore;
 import com.yahoo.elide.datastores.jpa.transaction.NonJtaTransaction;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -50,7 +51,8 @@ public class DependencyBinder extends ResourceConfig {
                 EntityManagerFactory emf = Persistence.createEntityManagerFactory("searchDataStoreTest");
                 DataStore jpaStore = new JpaDataStore(
                         emf::createEntityManager,
-                        em -> new NonJtaTransaction(em, txCancel));
+                        em -> new NonJtaTransaction(em, txCancel),
+                        VerbosePermissionExecutor::new);
 
                 EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
 
@@ -61,7 +63,6 @@ public class DependencyBinder extends ResourceConfig {
                 Elide elide = new Elide(new ElideSettingsBuilder(searchStore)
                         .withAuditLogger(new Slf4jLogger())
                         .withEntityDictionary(dictionary)
-                        .withVerboseErrors()
                         .withDefaultMaxPageSize(PaginationImpl.MAX_PAGE_LIMIT)
                         .withDefaultPageSize(PaginationImpl.DEFAULT_PAGE_LIMIT)
                         .withISO8601Dates("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"))


### PR DESCRIPTION
## Description
Permission Executor should be provided by each datastore since the permission plan will differ for each datastore. 
## Motivation and Context
Aggregation datastore should have a new permission executor which does not run permission filter in memory. 

## How Has This Been Tested?
Unit test, IT.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
