### PR TITLE
Expose query params on security.RequestScope

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -55,7 +55,7 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
     @Getter protected final EntityDictionary dictionary;
     @Getter private final JsonApiMapper mapper;
     @Getter private final AuditLogger auditLogger;
-    @Getter private final Optional<MultivaluedMap<String, String>> queryParams;
+    @Getter private final MultivaluedMap<String, String> queryParams;
     @Getter private final Map<String, List<String>> requestHeaders;
     @Getter private final Map<String, Set<String>> sparseFields;
     @Getter private final PermissionExecutor permissionExecutor;
@@ -139,19 +139,17 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
                 ? new ActivePermissionExecutor(this)
                 : permissionExecutorGenerator.apply(this);
 
-        this.queryParams = MapUtils.isEmpty(queryParams)
-                ? Optional.empty()
-                : Optional.of(queryParams);
+        this.queryParams = queryParams == null ? new MultivaluedHashMap<>() : queryParams;
 
         this.requestHeaders = MapUtils.isEmpty(requestHeaders)
                 ? Collections.emptyMap()
                 : requestHeaders;
         registerPreSecurityObservers();
 
-        if (this.queryParams.isPresent()) {
+        if (!this.queryParams.isEmpty()) {
 
             /* Extract any query param that starts with 'filter' */
-            MultivaluedMap<String, String> filterParams = getFilterParams(queryParams);
+            MultivaluedMap<String, String> filterParams = getFilterParams(this.queryParams);
 
             String errorMessage = "";
             if (! filterParams.isEmpty()) {
@@ -184,7 +182,7 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
                 }
             }
 
-            this.sparseFields = parseSparseFields(queryParams);
+            this.sparseFields = parseSparseFields(this.queryParams);
         } else {
             this.sparseFields = Collections.emptyMap();
         }
@@ -209,7 +207,7 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
         this.dictionary = outerRequestScope.dictionary;
         this.mapper = outerRequestScope.mapper;
         this.auditLogger = outerRequestScope.auditLogger;
-        this.queryParams = Optional.empty();
+        this.queryParams = new MultivaluedHashMap<>();
         this.requestHeaders = Collections.emptyMap();
         this.sparseFields = Collections.emptyMap();
         this.objectEntityCache = outerRequestScope.objectEntityCache;

--- a/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
@@ -21,7 +21,6 @@ import lombok.ToString;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -175,16 +174,16 @@ public class PaginationImpl implements Pagination {
      * @throws InvalidValueException invalid query parameter
      */
     public static PaginationImpl parseQueryParams(Type<?> entityClass,
-                                                  final Optional<MultivaluedMap<String, String>> queryParams,
+                                                  final MultivaluedMap<String, String> queryParams,
                                                   ElideSettings elideSettings)
             throws InvalidValueException {
 
-        if (! queryParams.isPresent()) {
+        if (queryParams.isEmpty()) {
             return getDefaultPagination(entityClass, elideSettings);
         }
 
         final Map<PaginationKey, Integer> pageData = new HashMap<>();
-        queryParams.get().entrySet()
+        queryParams.entrySet()
                 .forEach(paramEntry -> {
                     final String queryParamKey = paramEntry.getKey();
                     if (PAGE_KEYS.containsKey(queryParamKey)) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/RequestScope.java
@@ -5,8 +5,8 @@
  */
 package com.yahoo.elide.core.security;
 
-import java.util.Optional;
-import javax.ws.rs.core.MultivaluedMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The request scope interface passed to checks.
@@ -16,5 +16,5 @@ public interface RequestScope {
     String getApiVersion();
     String getRequestHeaderByName(String headerName);
     String getBaseUrlEndPoint();
-    Optional<MultivaluedMap<String, String>> getQueryParams();
+    Map<String, List<String>> getQueryParams();
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/RequestScope.java
@@ -5,6 +5,9 @@
  */
 package com.yahoo.elide.core.security;
 
+import java.util.Optional;
+import javax.ws.rs.core.MultivaluedMap;
+
 /**
  * The request scope interface passed to checks.
  */
@@ -13,4 +16,5 @@ public interface RequestScope {
     String getApiVersion();
     String getRequestHeaderByName(String headerName);
     String getBaseUrlEndPoint();
+    Optional<MultivaluedMap<String, String>> getQueryParams();
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.MultivaluedMap;
@@ -162,14 +161,14 @@ public class SortingImpl implements Sorting {
      * @param queryParams The query params on the request.
      * @return The Sorting instance (default or specific).
      */
-    public static Sorting parseQueryParams(final Optional<MultivaluedMap<String, String>> queryParams,
+    public static Sorting parseQueryParams(final MultivaluedMap<String, String> queryParams,
                                            Type<?> type, EntityDictionary dictionary) {
 
-        if (! queryParams.isPresent()) {
+        if (queryParams.isEmpty()) {
             return DEFAULT_EMPTY_INSTANCE;
         }
 
-        List<String> sortRules = queryParams.get().entrySet().stream()
+        List<String> sortRules = queryParams.entrySet().stream()
                 .filter(entry -> entry.getKey().equals("sort"))
                 .map(entry -> entry.getValue().get(0))
                 .collect(Collectors.toList());

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
@@ -65,7 +64,7 @@ public class EntityProjectionMaker
 
     public EntityProjectionMaker(EntityDictionary dictionary, RequestScope scope) {
         this.dictionary = dictionary;
-        this.queryParams = scope.getQueryParams().orElseGet(MultivaluedHashMap::new);
+        this.queryParams = scope.getQueryParams();
         sparseFields = RequestScope.parseSparseFields(queryParams);
         this.scope = scope;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/DocumentProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/DocumentProcessor.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.jsonapi.document.processors;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
-import java.util.Optional;
 import java.util.Set;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -27,7 +26,7 @@ public interface DocumentProcessor {
      * @param queryParams the query params
      */
     void execute(JsonApiDocument jsonApiDocument, PersistentResource resource,
-                 Optional<MultivaluedMap<String, String>> queryParams);
+                 MultivaluedMap<String, String> queryParams);
 
     /**
      * A method for making transformations to the JsonApiDocument.
@@ -37,7 +36,7 @@ public interface DocumentProcessor {
      * @param queryParams the query params
      */
     void execute(JsonApiDocument jsonApiDocument, Set<PersistentResource> resources,
-                 Optional<MultivaluedMap<String, String>> queryParams);
+                 MultivaluedMap<String, String> queryParams);
 
     //TODO Possibly add a something like a 'afterExecute' method to process after the first round of execution
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -35,9 +34,9 @@ public class IncludedProcessor implements DocumentProcessor {
      */
     @Override
     public void execute(JsonApiDocument jsonApiDocument, PersistentResource resource,
-                        Optional<MultivaluedMap<String, String>> queryParams) {
+                        MultivaluedMap<String, String> queryParams) {
         if (isPresent(queryParams, INCLUDE)) {
-            addIncludedResources(jsonApiDocument, resource, queryParams.get().get(INCLUDE));
+            addIncludedResources(jsonApiDocument, resource, queryParams.get(INCLUDE));
         }
     }
 
@@ -47,12 +46,12 @@ public class IncludedProcessor implements DocumentProcessor {
      */
     @Override
     public void execute(JsonApiDocument jsonApiDocument, Set<PersistentResource> resources,
-                        Optional<MultivaluedMap<String, String>> queryParams) {
+                        MultivaluedMap<String, String> queryParams) {
         if (isPresent(queryParams, INCLUDE)) {
 
             // Process include for each resource
             resources.forEach(resource ->
-                    addIncludedResources(jsonApiDocument, resource, queryParams.get().get(INCLUDE)));
+                    addIncludedResources(jsonApiDocument, resource, queryParams.get(INCLUDE)));
         }
     }
 
@@ -107,7 +106,7 @@ public class IncludedProcessor implements DocumentProcessor {
         });
     }
 
-    private static boolean isPresent(Optional<MultivaluedMap<String, String>> queryParams, String key) {
-        return queryParams.isPresent() && queryParams.get().get(key) != null;
+    private static boolean isPresent(MultivaluedMap<String, String> queryParams, String key) {
+        return queryParams != null && queryParams.get(key) != null;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/BaseState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/BaseState.java
@@ -25,7 +25,6 @@ import com.yahoo.elide.jsonapi.models.Resource;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -179,7 +178,7 @@ public abstract class BaseState {
     }
 
     protected static JsonNode getResponseBody(PersistentResource resource, RequestScope requestScope) {
-        Optional<MultivaluedMap<String, String>> queryParams = requestScope.getQueryParams();
+        MultivaluedMap<String, String> queryParams = requestScope.getQueryParams();
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
         //TODO Make this a document processor

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
@@ -70,7 +70,7 @@ public class CollectionTerminalState extends BaseState {
     public Supplier<Pair<Integer, JsonNode>> handleGet(StateContext state) {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
         RequestScope requestScope = state.getRequestScope();
-        Optional<MultivaluedMap<String, String>> queryParams = requestScope.getQueryParams();
+        MultivaluedMap<String, String> queryParams = requestScope.getQueryParams();
 
         Set<PersistentResource> collection =
                 getResourceCollection(requestScope).toList(LinkedHashSet::new).blockingGet();

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RelationshipTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RelationshipTerminalState.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 import javax.ws.rs.core.MultivaluedMap;
@@ -57,7 +56,7 @@ public class RelationshipTerminalState extends BaseState {
         JsonApiDocument doc = new JsonApiDocument();
         RequestScope requestScope = state.getRequestScope();
         JsonApiMapper mapper = requestScope.getMapper();
-        Optional<MultivaluedMap<String, String>> queryParams = requestScope.getQueryParams();
+        MultivaluedMap<String, String> queryParams = requestScope.getQueryParams();
 
         Map<String, Relationship> relationships = record.toResource(parentProjection).getRelationships();
         if (relationships != null && relationships.containsKey(relationshipName)) {

--- a/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
@@ -14,7 +14,6 @@ import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.links.DefaultJSONApiLinks;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
-import java.util.Optional;
 import java.util.UUID;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -60,9 +59,9 @@ public class TestRequestScope extends RequestScope {
     }
 
     @Override
-    public Optional<MultivaluedMap<String, String>> getQueryParams() {
+    public MultivaluedMap<String, String> getQueryParams() {
         if (queryParamOverrides != null) {
-            return Optional.of(queryParamOverrides);
+            return queryParamOverrides;
         }
         return super.getQueryParams();
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/pagination/PaginationImplTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/pagination/PaginationImplTest.java
@@ -17,7 +17,6 @@ import com.yahoo.elide.core.type.ClassType;
 import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
 import javax.ws.rs.core.MultivaluedMap;
 
 /**
@@ -34,7 +33,7 @@ public class PaginationImplTest {
         queryParams.add("page[number]", "2");
 
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings);
+                queryParams, elideSettings);
         // page based strategy uses human readable paging - non-zero index
         // page 2 becomes (1)*10 so 10 since we shift to zero based index
         assertEquals(10, pageData.getOffset());
@@ -48,7 +47,7 @@ public class PaginationImplTest {
         queryParams.add("page[number]", "-2");
 
         assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings));
+                queryParams, elideSettings));
     }
 
     @Test
@@ -58,7 +57,7 @@ public class PaginationImplTest {
         queryParams.add("page[number]", "2");
 
         assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings));
+                queryParams, elideSettings));
     }
 
     @Test
@@ -68,7 +67,7 @@ public class PaginationImplTest {
         queryParams.add("page[offset]", "2");
 
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings);
+                queryParams, elideSettings);
         // offset is direct correlation to start field in query
         assertEquals(2, pageData.getOffset());
         assertEquals(10, pageData.getLimit());
@@ -78,7 +77,7 @@ public class PaginationImplTest {
     public void shouldUseDefaultsWhenMissingCurrentPageAndPageSize() {
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings);
+                queryParams, elideSettings);
         assertEquals(PaginationImpl.DEFAULT_OFFSET, pageData.getOffset());
         assertEquals(PaginationImpl.DEFAULT_PAGE_LIMIT, pageData.getLimit());
     }
@@ -142,7 +141,7 @@ public class PaginationImplTest {
         queryParams.add("page[size]", "25000");
         assertThrows(InvalidValueException.class,
                 () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                        Optional.of(queryParams), elideSettings));
+                        queryParams, elideSettings));
     }
 
     @Test
@@ -152,7 +151,7 @@ public class PaginationImplTest {
         queryParams.add("page[offset]", "100");
         assertThrows(InvalidValueException.class,
                 () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                        Optional.of(queryParams), elideSettings));
+                        queryParams, elideSettings));
     }
 
     @Test
@@ -160,7 +159,7 @@ public class PaginationImplTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         queryParams.add("page[number]", "2");
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImpl.class),
-                Optional.of(queryParams), elideSettings);
+                queryParams, elideSettings);
         assertEquals(PaginationImpl.DEFAULT_PAGE_LIMIT, pageData.getLimit());
         assertEquals(PaginationImpl.DEFAULT_PAGE_LIMIT, pageData.getOffset());
     }
@@ -171,7 +170,7 @@ public class PaginationImplTest {
         queryParams.add("page[size]", "2.5");
         assertThrows(InvalidValueException.class,
                 () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                        Optional.of(queryParams), elideSettings));
+                        queryParams, elideSettings));
     }
 
     @Test
@@ -180,7 +179,7 @@ public class PaginationImplTest {
         queryParams.add("page[random]", "1");
         assertThrows(InvalidValueException.class,
         () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings));
+                queryParams, elideSettings));
     }
 
     @Test
@@ -188,7 +187,7 @@ public class PaginationImplTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         queryParams.add("page[totals]", null);
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings);
+                queryParams, elideSettings);
         assertTrue(pageData.returnPageTotals());
     }
 
@@ -196,7 +195,7 @@ public class PaginationImplTest {
     public void shouldNotSetGenerateTotals() {
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings);
+                queryParams, elideSettings);
         assertFalse(pageData.returnPageTotals());
     }
 
@@ -206,12 +205,12 @@ public class PaginationImplTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
 
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), elideSettings);
+                queryParams, elideSettings);
         assertEquals(0, pageData.getOffset());
         assertEquals(PaginationImpl.DEFAULT_PAGE_LIMIT, pageData.getLimit());
 
         pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
-                Optional.of(queryParams), new ElideSettingsBuilder(null)
+                queryParams, new ElideSettingsBuilder(null)
                     .withDefaultPageSize(10)
                     .withDefaultMaxPageSize(10)
                     .build());
@@ -226,7 +225,7 @@ public class PaginationImplTest {
 
         MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationOverrideTest.class),
-                Optional.of(queryParams),
+                queryParams,
                 new ElideSettingsBuilder(null)
                     .withDefaultPageSize(1)
                     .withDefaultMaxPageSize(1)

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -110,7 +109,7 @@ public class IncludedProcessorTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children"));
         testScope.setQueryParams(queryParams);
-        includedProcessor.execute(jsonApiDocument, parentRecord1, Optional.of(queryParams));
+        includedProcessor.execute(jsonApiDocument, parentRecord1, queryParams);
 
         List<Resource> expectedIncluded = Collections.singletonList(childRecord1.toResource());
         List<Resource> actualIncluded = jsonApiDocument.getIncluded();
@@ -130,7 +129,7 @@ public class IncludedProcessorTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children"));
         testScope.setQueryParams(queryParams);
-        includedProcessor.execute(jsonApiDocument, parents, Optional.of(queryParams));
+        includedProcessor.execute(jsonApiDocument, parents, queryParams);
 
         List<Resource> expectedIncluded = Arrays.asList(childRecord1.toResource(), childRecord2.toResource());
         List<Resource> actualIncluded = jsonApiDocument.getIncluded();
@@ -147,7 +146,7 @@ public class IncludedProcessorTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children.friends"));
         testScope.setQueryParams(queryParams);
-        includedProcessor.execute(jsonApiDocument, parentRecord1, Optional.of(queryParams));
+        includedProcessor.execute(jsonApiDocument, parentRecord1, queryParams);
 
         List<Resource> expectedIncluded =
                 Arrays.asList(childRecord1.toResource(), childRecord2.toResource());
@@ -164,7 +163,7 @@ public class IncludedProcessorTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put(INCLUDE, Arrays.asList("children", "spouses"));
         testScope.setQueryParams(queryParams);
-        includedProcessor.execute(jsonApiDocument, parentRecord1, Optional.of(queryParams));
+        includedProcessor.execute(jsonApiDocument, parentRecord1, queryParams);
 
         List<Resource> expectedIncluded =
                 Arrays.asList(childRecord1.toResource(), parentRecord2.toResource());
@@ -181,7 +180,7 @@ public class IncludedProcessorTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children.friends"));
         testScope.setQueryParams(queryParams);
-        includedProcessor.execute(jsonApiDocument, parentRecord3, Optional.of(queryParams));
+        includedProcessor.execute(jsonApiDocument, parentRecord3, queryParams);
 
         Set<Resource> expectedIncluded =
                 Sets.newHashSet(
@@ -203,7 +202,7 @@ public class IncludedProcessorTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("relation1"));
         testScope.setQueryParams(queryParams);
-        includedProcessor.execute(jsonApiDocument, funWithPermissionsRecord, Optional.of(queryParams));
+        includedProcessor.execute(jsonApiDocument, funWithPermissionsRecord, queryParams);
 
         assertNull(jsonApiDocument.getIncluded(),
                 "Included Processor included forbidden relationship");
@@ -212,7 +211,7 @@ public class IncludedProcessorTest {
     @Test
     public void testNoQueryParams() throws Exception {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
-        includedProcessor.execute(jsonApiDocument, parentRecord1, Optional.empty());
+        includedProcessor.execute(jsonApiDocument, parentRecord1, null);
 
         assertNull(jsonApiDocument.getIncluded(),
                 "Included Processor adds no resources when not given query params");
@@ -226,7 +225,7 @@ public class IncludedProcessorTest {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("unused", Collections.emptyList());
         testScope.setQueryParams(queryParams);
-        includedProcessor.execute(jsonApiDocument, parentRecord1, Optional.of(queryParams));
+        includedProcessor.execute(jsonApiDocument, parentRecord1, queryParams);
 
         assertNull(jsonApiDocument.getIncluded(),
                 "Included Processor adds no resources when not given query params");

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/QueryLogger.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/QueryLogger.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.datastores.aggregation.query.Query;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -29,7 +28,7 @@ public interface QueryLogger {
      * @param path The apiQuery endpoint path for the incoming query
      */
     void acceptQuery(UUID queryId, User user, Map<String, String> headers, String apiVer,
-                     Optional<MultivaluedMap<String, String>> queryParams, String path);
+                     MultivaluedMap<String, String> queryParams, String path);
 
     /**
      * Processes and logs all the queries from QueryDetail.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/Slf4jQueryLogger.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/Slf4jQueryLogger.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -48,14 +47,14 @@ public class Slf4jQueryLogger implements QueryLogger {
 
     @Override
     public void acceptQuery(UUID queryId, User user, Map<String, String> headers, String apiVer,
-                            Optional<MultivaluedMap<String, String>> queryParams, String path) {
+                            MultivaluedMap<String, String> queryParams, String path) {
         ObjectNode rootNode = mapper.createObjectNode();
 
         rootNode.put(ID, queryId.toString());
         rootNode.put("user", (user != null && user.getName() != null) ? user.getName() : "Unknown");
-        if (queryParams.isPresent()) {
+        if (!queryParams.isEmpty()) {
             ObjectNode queryParamNode = rootNode.putObject("queryParams");
-            queryParams.get().forEach((key, values) -> {
+            queryParams.forEach((key, values) -> {
                 ArrayNode listNode = queryParamNode.putArray(key);
                 values.stream().forEach(listNode::add);
             });

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/Slf4jQueryLoggerTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/core/Slf4jQueryLoggerTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
+import javax.ws.rs.core.MultivaluedHashMap;
 
 public class Slf4jQueryLoggerTest {
 
@@ -36,7 +36,7 @@ public class Slf4jQueryLoggerTest {
                 new User(null),
                 headers,
                 "1.0",
-                Optional.empty(),
+                new MultivaluedHashMap<>(),
                 "/sales");
     }
 


### PR DESCRIPTION
Resolves https://github.com/yahoo/elide/discussions/1985

## Description
This changes exposes the already existing queryParams to the security.RequestScope interface.

## Motivation and Context
LifeCycleHooks only expose the security.RequestScope. This change makes the queryParams visible there as well.

## How Has This Been Tested?
It's implicitly tested as we just extend an already tested interface.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
