### PR TITLE
get permission executor from datastore for each model that it manages.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -474,7 +474,7 @@ public class Elide {
             requestScope.runQueuedPostCommitTriggers();
 
             if (log.isTraceEnabled()) {
-                requestScope.getPermissionExecutor().printCheckStats();
+                requestScope.getPermissionExecutor().logCheckStats();
             }
 
             return response;

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -185,7 +185,7 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
 
         Function<RequestScope, PermissionExecutor> permissionExecutorGenerator = elideSettings.getPermissionExecutor();
         this.permissionExecutor = new MultiplexPermissionExecutor(
-                dictionary.getBoundPermissionExecutor(this),
+                dictionary.getPermissionExecutors(this),
                 (permissionExecutorGenerator == null)
                         ? new ActivePermissionExecutor(this)
                         : permissionExecutorGenerator.apply(this),

--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
-import javax.ws.rs.HEAD;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -1055,7 +1055,7 @@ public class EntityDictionary {
      * @param scope - request scope to generate permission executor.
      * @return Map of bound model type to its permission executor object.
      */
-    public Map<Type<?>, PermissionExecutor> getBoundPermissionExecutor(RequestScope scope) {
+    public Map<Type<?>, PermissionExecutor> getPermissionExecutors(RequestScope scope) {
         return entityPermissionExecutor.entrySet().stream()
                 .collect(Collectors.toMap(
                         e -> e.getKey(),

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
@@ -123,7 +123,7 @@ public interface PermissionExecutor {
      * Logs useful information about the check evaluation.
      *
      */
-    default void printCheckStats() {
+    default void logCheckStats() {
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/PermissionExecutor.java
@@ -120,12 +120,10 @@ public interface PermissionExecutor {
     void executeCommitChecks();
 
     /**
-     * Return useful information about the check evaluation.
+     * Logs useful information about the check evaluation.
      *
-     * @return a description describing check execution
      */
-    default String printCheckStats() {
-        return null;
+    default void printCheckStats() {
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
@@ -465,7 +465,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
      *
      */
     @Override
-    public void printCheckStats() {
+    public void logCheckStats() {
         if (log.isTraceEnabled()) {
             StringBuilder sb = new StringBuilder("Permission Check Statistics:\n");
             checkStats.entrySet().stream()

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
@@ -461,12 +461,11 @@ public class ActivePermissionExecutor implements PermissionExecutor {
     }
 
     /**
-     * Print the permission check statistics.
+     * Logs the permission check statistics.
      *
-     * @return the permission check statistics
      */
     @Override
-    public String printCheckStats() {
+    public void printCheckStats() {
         if (log.isTraceEnabled()) {
             StringBuilder sb = new StringBuilder("Permission Check Statistics:\n");
             checkStats.entrySet().stream()
@@ -474,9 +473,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                     .forEachOrdered(e -> sb.append(e.getKey() + ": " + e.getValue() + "\n"));
             String stats = sb.toString();
             log.trace(stats);
-            return stats;
         }
-        return null;
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/MultiplexPermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/MultiplexPermissionExecutor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.security.executors;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.exceptions.ForbiddenAccessException;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.predicates.FilterPredicate;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.PermissionExecutor;
+import com.yahoo.elide.core.security.permissions.ExpressionResult;
+import com.yahoo.elide.core.type.Type;
+
+import lombok.AllArgsConstructor;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.Optional;
+
+@AllArgsConstructor
+public class MultiplexPermissionExecutor implements PermissionExecutor {
+
+    private Map<Type<?>, PermissionExecutor> permissionExecutorMap;
+    private PermissionExecutor defaultPermissionExecutor;
+    private EntityDictionary dictionary;
+
+    public PermissionExecutor getPermissionExecutor(Type<?> cls) {
+        return permissionExecutorMap.getOrDefault(dictionary.lookupBoundClass(cls), defaultPermissionExecutor);
+    }
+
+    @Override
+    public <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
+                                                                   PersistentResource resource) {
+        return getPermissionExecutor(resource.getResourceType())
+                .checkPermission(annotationClass, resource);
+    }
+
+    @Override
+    public <A extends Annotation> ExpressionResult checkPermission(Class<A> annotationClass,
+                                                                   PersistentResource resource,
+                                                                   ChangeSpec changeSpec) {
+        return getPermissionExecutor(resource.getResourceType())
+                .checkPermission(annotationClass, resource, changeSpec);
+    }
+
+    @Override
+    public <A extends Annotation> ExpressionResult checkSpecificFieldPermissions(PersistentResource<?> resource,
+                                                                                 ChangeSpec changeSpec,
+                                                                                 Class<A> annotationClass,
+                                                                                 String field) {
+        return getPermissionExecutor(resource.getResourceType())
+                .checkSpecificFieldPermissions(resource, changeSpec, annotationClass, field);
+    }
+
+    @Override
+    public <A extends Annotation> ExpressionResult checkSpecificFieldPermissionsDeferred(PersistentResource<?> resource,
+                                                                                         ChangeSpec changeSpec,
+                                                                                         Class<A> annotationClass,
+                                                                                         String field) {
+        return getPermissionExecutor(resource.getResourceType())
+                .checkSpecificFieldPermissionsDeferred(resource, changeSpec, annotationClass, field);
+    }
+
+    @Override
+    public <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass,
+                                                                        Class<A> annotationClass) {
+        return getPermissionExecutor(resourceClass)
+                .checkUserPermissions(resourceClass, annotationClass);
+    }
+
+    @Override
+    public <A extends Annotation> ExpressionResult checkUserPermissions(Type<?> resourceClass,
+                                                                        Class<A> annotationClass,
+                                                                        String field) {
+        return getPermissionExecutor(resourceClass)
+                .checkUserPermissions(resourceClass, annotationClass, field);
+    }
+
+    @Override
+    public Optional<FilterExpression> getReadPermissionFilter(Type<?> resourceClass) {
+        return getPermissionExecutor(resourceClass).getReadPermissionFilter(resourceClass);
+    }
+
+    @Override
+    public void executeCommitChecks() {
+        defaultPermissionExecutor.executeCommitChecks();
+        permissionExecutorMap.values().forEach(executor -> executor.executeCommitChecks());
+    }
+
+    @Override
+    public void printCheckStats() {
+        defaultPermissionExecutor.printCheckStats();
+        permissionExecutorMap.values().forEach(executor -> executor.printCheckStats());
+    }
+
+    @Override
+    public boolean isVerbose() {
+        return defaultPermissionExecutor.isVerbose();
+    }
+
+    @Override
+    public ExpressionResult evaluateFilterJoinUserChecks(PersistentResource<?> resource,
+                                                         FilterPredicate filterPredicate) {
+        return getPermissionExecutor(resource.getResourceType())
+                .evaluateFilterJoinUserChecks(resource, filterPredicate);
+    }
+
+    @Override
+    public ExpressionResult handleFilterJoinReject(FilterPredicate filterPredicate,
+                                                   Path.PathElement pathElement,
+                                                   ForbiddenAccessException reason) {
+        return getPermissionExecutor(pathElement.getType())
+                .handleFilterJoinReject(filterPredicate, pathElement, reason);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/MultiplexPermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/MultiplexPermissionExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, Yahoo Inc.
+ * Copyright 2021, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
@@ -23,6 +23,11 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * MultiplexPermissionExecutor manages Model to permssion executor mapping.
+ * All method call to multiple permission executor will be delegated
+ *  to the underlying permission executor based on resource type.
+ */
 @AllArgsConstructor
 public class MultiplexPermissionExecutor implements PermissionExecutor {
 
@@ -94,9 +99,9 @@ public class MultiplexPermissionExecutor implements PermissionExecutor {
     }
 
     @Override
-    public void printCheckStats() {
-        defaultPermissionExecutor.printCheckStats();
-        permissionExecutorMap.values().forEach(executor -> executor.printCheckStats());
+    public void logCheckStats() {
+        defaultPermissionExecutor.logCheckStats();
+        permissionExecutorMap.values().forEach(executor -> executor.logCheckStats());
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.dictionary.ArgumentType;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.security.executors.ActivePermissionExecutor;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.ClassScanner;
@@ -57,12 +58,16 @@ public class AggregationDataStore implements DataStore {
     public void populateEntityDictionary(EntityDictionary dictionary) {
 
         if (dynamicCompiledClasses != null && dynamicCompiledClasses.size() != 0) {
-            dynamicCompiledClasses.forEach(dynamicLoadedClass -> dictionary.bindEntity(dynamicLoadedClass,
-                    Collections.singleton(Join.class)));
+            dynamicCompiledClasses.forEach(dynamicLoadedClass -> {
+                dictionary.bindEntity(dynamicLoadedClass, Collections.singleton(Join.class));
+                dictionary.bindPermissionExecutor(dynamicLoadedClass, ActivePermissionExecutor::new);
+            });
         }
 
-        ClassScanner.getAnnotatedClasses(AGGREGATION_STORE_CLASSES).forEach(
-                cls -> dictionary.bindEntity(cls, Collections.singleton(Join.class))
+        ClassScanner.getAnnotatedClasses(AGGREGATION_STORE_CLASSES).forEach(cls -> {
+                    dictionary.bindEntity(cls, Collections.singleton(Join.class));
+                    dictionary.bindPermissionExecutor(cls, ActivePermissionExecutor::new);
+                }
         );
 
         for (Table table : queryEngine.getMetaDataStore().getMetaData(ClassType.of(Table.class))) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -286,7 +286,7 @@ public class QueryRunner {
             requestScope.runQueuedPostCommitTriggers();
 
             if (log.isTraceEnabled()) {
-                requestScope.getPermissionExecutor().printCheckStats();
+                requestScope.getPermissionExecutor().logCheckStats();
             }
 
             return ElideResponse.builder().responseCode(HttpStatus.SC_OK).body(mapper.writeValueAsString(result))


### PR DESCRIPTION
## Description
Each model a datastore manages can now have its own permission executor generator. new Multiplex permission executor delegates the call to the model's permission executor. 

## Motivation and Context
Support multiple permission executors

## How Has This Been Tested?
IT


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
