### PR TITLE
bump dependency-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.1.5</version>
+                <version>6.1.6</version>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipSystemScope>true</skipSystemScope>


### PR DESCRIPTION
## Description
Bump dependency-check.  Required for latest CVE files.

## Motivation and Context
Fixes build failure.
>Caused by: java.lang.NullPointerException
    at org.owasp.dependencycheck.data.nvd.ecosystem.CveEcosystemMapper.hasMultipleVendorProductConfigurations (CveEcosystemMapper.java:93)
    at org.owasp.dependencycheck.data.nvd.ecosystem.CveEcosystemMapper.getEcosystem (CveEcosystemMapper.java:67)

## How Has This Been Tested?
Build

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.