### PR TITLE
add validation for security checks in agg model table, namespace and fields

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -196,6 +196,23 @@ public class EntityDictionary {
      * or {@code @ReadPermission(expression="Prefab.Common.UpdateOnCreate")})
      * @param checks a map that links the identifiers used in the permission expression strings
      *               to their implementing classes
+     * @param roleChecks a map that links the user check identifiers used in the permission expression strings
+     *      *               to their User Check object
+     * @param injector a function typically associated with a dependency injection framework that will
+     *                 initialize Elide models.
+     */
+    public EntityDictionary(Map<String, Class<? extends Check>> checks,
+                            Map<String, UserCheck> roleChecks, Injector injector) {
+        this(checks, roleChecks, injector, CoerceUtil::lookup, Collections.emptySet());
+    }
+
+    /**
+     * Instantiate a new EntityDictionary with the provided set of checks and an injection function.
+     * In addition all of the checks * in {@link com.yahoo.elide.core.security.checks.prefab} are mapped
+     * to {@code Prefab.CONTAINER.CHECK} * (e.g. {@code @ReadPermission(expression="Prefab.Role.All")}
+     * or {@code @ReadPermission(expression="Prefab.Common.UpdateOnCreate")})
+     * @param checks a map that links the identifiers used in the permission expression strings
+     *               to their implementing classes
      * @param injector a function typically associated with a dependency injection framework that will
      *                 initialize Elide models.
      * @param entitiesToExclude Set of Models to exclude from Binding.
@@ -215,9 +232,17 @@ public class EntityDictionary {
             Injector injector,
             Function<Class, Serde> serdeLookup,
             Set<Type<?>> entitiesToExclude) {
+        this(checks, null, injector, serdeLookup, entitiesToExclude);
+    }
+
+    public EntityDictionary(Map<String, Class<? extends Check>> checks,
+                            Map<String, UserCheck> roleChecks,
+                            Injector injector,
+                            Function<Class, Serde> serdeLookup,
+                            Set<Type<?>> entitiesToExclude) {
         this.serdeLookup = serdeLookup;
         this.checkNames = Maps.synchronizedBiMap(HashBiMap.create(checks));
-        this.roleChecks = new HashMap<>();
+        this.roleChecks = roleChecks == null ? new HashMap<>() : roleChecks;
         this.apiVersions = new HashSet<>();
         initializeChecks();
         this.injector = injector;
@@ -266,6 +291,14 @@ public class EntityDictionary {
      */
     public UserCheck getRoleCheck(String role) {
         return roleChecks.get(role);
+    }
+
+    /**
+     * Returns the map of role to their user role check object.
+     * @return
+     */
+    public Map<String, UserCheck> getRoleChecks() {
+        return roleChecks;
     }
 
     /**

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -228,7 +228,9 @@ public class EntityDictionaryTest extends EntityDictionary {
         EntityDictionary testDictionary = new EntityDictionary(
                 new HashMap<>(),
                 null,
-                unused -> new ISO8601DateSerde());
+                null,
+                unused -> new ISO8601DateSerde(),
+                Collections.emptySet());
 
         testDictionary.bindEntity(EntityWithDateId.class);
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/dimensions/RegionDetails.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/dimensions/RegionDetails.java
@@ -25,7 +25,7 @@ import javax.persistence.Id;
 @ToString
 @Data
 @FromTable(name = "region_details", dbConnectionName = "SalesDBConnection")
-@ReadPermission(expression = "Principal is guest user")
+@ReadPermission(expression = "guest user")
 @TableMeta(description = "RegionDetails", category = "", tags = {}, filterTemplate = "", size = CardinalitySize.SMALL)
 @Include(name = "regionDetails")
 public class RegionDetails {
@@ -42,7 +42,7 @@ public class RegionDetails {
         this.id = id;
     }
 
-    @ReadPermission(expression = "Principal is guest user")
+    @ReadPermission(expression = "guest user")
     @ColumnMeta(description = "region", category = "", values = {}, tags = {})
     @DimensionFormula("{{$region}}")
     public String getRegion() {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -40,6 +40,11 @@ import javax.sql.DataSource;
 
 public class MetaDataStoreIntegrationTest extends IntegrationTest {
 
+    public MetaDataStoreIntegrationTest() {
+        super();
+        userRoles.addAll(VALIDATOR.getElideSecurityConfig().getRoles());
+    }
+
     @Override
     protected DataStoreTestHarness createHarness() {
 

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
@@ -56,6 +56,7 @@ public final class MultiplexManager implements DataStore {
         for (DataStore dataStore : dataStores) {
             EntityDictionary subordinateDictionary = new EntityDictionary(
                 dictionary.getCheckMappings(),
+                dictionary.getRoleChecks(),
                 dictionary.getInjector()
             );
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/IntegrationTest.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/IntegrationTest.java
@@ -37,6 +37,8 @@ import io.restassured.RestAssured;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Integration test initializer.  Tests are intended to run sequentially (so they don't stomp on each other's data).
@@ -47,6 +49,7 @@ public abstract class IntegrationTest {
 
     /* Shared between the test setup code (to insert test data) as well as the Jetty server (to serve test data) */
     protected static DataStoreTestHarness dataStoreHarness;
+    protected static Set<String> userRoles = new HashSet<>();
 
     protected final ObjectMapper mapper = new ObjectMapper();
     protected DataStore dataStore = null;
@@ -104,6 +107,10 @@ public abstract class IntegrationTest {
      */
     public static DataStore getDataStore() {
         return dataStoreHarness.getDataStore();
+    }
+
+    public static Set<String> getAdditionalUserRoles() {
+        return userRoles;
     }
 
     @AfterEach

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/StandardTestBinder.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/StandardTestBinder.java
@@ -13,6 +13,8 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.MultipleFilterDialect;
+import com.yahoo.elide.core.security.checks.prefab.Role;
+
 import example.TestCheckMappings;
 import example.models.triggers.services.BillingService;
 import org.glassfish.hk2.api.Factory;
@@ -52,6 +54,11 @@ public class StandardTestBinder extends AbstractBinder {
                 MultipleFilterDialect multipleFilterStrategy = new MultipleFilterDialect(
                         Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy),
                         Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy)
+                );
+
+                dictionary.scanForSecurityChecks();
+                IntegrationTest.getAdditionalUserRoles().forEach(role ->
+                        dictionary.addRoleCheck(role, new Role.RoleMemberCheck(role))
                 );
 
                 return new Elide(new ElideSettingsBuilder(IntegrationTest.getDataStore())


### PR DESCRIPTION
Resolves #2048

## Description
Have validations for all security checks in aggregation datastore. 

- Fields can only be decorated with User checks.
- Tables can only be decorated with any combination (AND, OR, NOT) of User Checks and Filter Expression Checks.

## Motivation and Context
Restricting all checks that could run in memory after the records are returned from the aggregation datastore.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
