### PR TITLE
Propogate client query arguments to join tables

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStore.java
@@ -17,7 +17,7 @@ import com.yahoo.elide.datastores.aggregation.annotation.Join;
 import com.yahoo.elide.datastores.aggregation.cache.Cache;
 import com.yahoo.elide.datastores.aggregation.core.QueryLogger;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
-import com.yahoo.elide.datastores.aggregation.metadata.models.Argument;
+import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
@@ -81,7 +81,7 @@ public class AggregationDataStore implements DataStore {
 
             /* Add argument to each Column */
             for (Column col : table.getColumns()) {
-                for (Argument arg : col.getArguments()) {
+                for (ArgumentDefinition arg : col.getArgumentDefinitions()) {
                     dictionary.addArgumentToAttribute(
                             dictionary.getEntityClass(table.getName(), table.getVersion()),
                             col.getName(),
@@ -90,7 +90,7 @@ public class AggregationDataStore implements DataStore {
             }
 
             /* Add argument to each Table */
-            for (Argument arg : table.getArguments()) {
+            for (ArgumentDefinition arg : table.getArgumentDefinitions()) {
                 dictionary.addArgumentToEntity(
                         dictionary.getEntityClass(table.getName(), table.getVersion()),
                         new ArgumentType(arg.getName(), ValueType.getType(arg.getType()), arg.getDefaultValue()));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/DefaultQueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/DefaultQueryValidator.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.request.Sorting;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
+import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Query;
@@ -187,7 +188,7 @@ public class DefaultQueryValidator implements QueryValidator {
     public void validateQueryArguments(Query query) {
         SQLTable table = (SQLTable) query.getSource();
 
-        table.getArguments().forEach(tableArgument -> {
+        table.getArgumentDefinitions().forEach(tableArgument -> {
             Argument clientArgument = query.getArguments().get(tableArgument.getName());
 
             validateArgument(Optional.ofNullable(clientArgument), tableArgument,
@@ -203,7 +204,7 @@ public class DefaultQueryValidator implements QueryValidator {
         SQLTable table = (SQLTable) query.getSource();
         Column column = table.getColumn(Column.class, projection.getName());
 
-        column.getArguments().forEach(columnArgument -> {
+        column.getArgumentDefinitions().forEach(columnArgument -> {
             Argument clientArgument = projection.getArguments().get(columnArgument.getName());
 
             validateArgument(Optional.ofNullable(clientArgument), columnArgument,
@@ -213,7 +214,7 @@ public class DefaultQueryValidator implements QueryValidator {
 
     protected void validateArgument(
             Optional<Argument> clientArgument,
-            com.yahoo.elide.datastores.aggregation.metadata.models.Argument argumentDefinition,
+            ArgumentDefinition argumentDefinition,
             String context
     ) {
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -178,7 +178,7 @@ public abstract class QueryEngine {
                 ));
 
                 //Populate column argument sources.
-                column.getArguments().forEach(argument -> {
+                column.getArgumentDefinitions().forEach(argument -> {
                     argument.setTableSource(TableSource.fromDefinition(
                             argument.getTableSourceDefinition(),
                             table.getVersion(),

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
@@ -211,17 +211,26 @@ public class ColumnContext extends HashMap<String, Object> {
         throw new HandlebarsException(new Throwable("Couldn't find: " + invokedColumnName));
     }
 
-    public static Map<String, Argument> mergedArgumentMap(Map<String, Argument> referencedColumnArgs,
-                                                          Map<String, Argument> callingColumnArgs,
+    /**
+     * Checks if referenced {@link ColumnProjection} or {@link Queryable} arguments are available in either calling
+     * object's arguments or in fixed arguments. If yes, use that value. Fixed arguments gets preference over calling
+     * object's arguments.
+     * @param referencedObjectArgs referenced {@link ColumnProjection} or {@link Queryable} arguments.
+     * @param callingObjectArgs calling {@link ColumnProjection} or {@link Queryable} arguments.
+     * @param fixedArgs Fixed arguments.
+     * @return Available arguments for referenced {@link ColumnProjection} or {@link Queryable}.
+     */
+    public static Map<String, Argument> mergedArgumentMap(Map<String, Argument> referencedObjectArgs,
+                                                          Map<String, Argument> callingObjectArgs,
                                                           Map<String, Argument> fixedArgs) {
 
         Map<String, Argument> columnArgMap = new HashMap<>();
 
-        referencedColumnArgs.forEach((argName, arg) -> {
+        referencedObjectArgs.forEach((argName, arg) -> {
             if (fixedArgs.containsKey(argName)) {
                 columnArgMap.put(argName, fixedArgs.get(argName));
-            } else if (callingColumnArgs.containsKey(argName)) {
-                columnArgMap.put(argName, callingColumnArgs.get(argName));
+            } else if (callingObjectArgs.containsKey(argName)) {
+                columnArgMap.put(argName, callingObjectArgs.get(argName));
             } else {
                 columnArgMap.put(argName, arg);
             }
@@ -230,8 +239,15 @@ public class ColumnContext extends HashMap<String, Object> {
         return columnArgMap;
     }
 
-    public static Map<String, Argument> mergedArgumentMap(Map<String, Argument> referencedColumnArgs,
-                    Map<String, Argument> callingColumnArgs) {
-        return mergedArgumentMap(referencedColumnArgs, callingColumnArgs, emptyMap());
+    /**
+     * Checks if referenced {@link ColumnProjection} or {@link Queryable} arguments are available in calling
+     * object's arguments. If yes, use that value.
+     * @param referencedObjectArgs referenced {@link ColumnProjection} or {@link Queryable} arguments.
+     * @param callingObjectArgs calling {@link ColumnProjection} or {@link Queryable} arguments.
+     * @return Available arguments for referenced {@link ColumnProjection} or {@link Queryable}.
+     */
+    public static Map<String, Argument> mergedArgumentMap(Map<String, Argument> referencedObjectArgs,
+                    Map<String, Argument> callingObjectArgs) {
+        return mergedArgumentMap(referencedObjectArgs, callingObjectArgs, emptyMap());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
+
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Formatter;
 import com.github.jknack.handlebars.Handlebars;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
@@ -18,7 +18,6 @@ import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
-
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Formatter;
 import com.github.jknack.handlebars.Handlebars;
@@ -52,6 +51,7 @@ public class ColumnContext extends HashMap<String, Object> {
     protected final Queryable queryable;
     protected final String alias;
     protected final ColumnProjection column;
+    protected final Map<String, Argument> tableArguments;
 
     private final Handlebars handlebars = new Handlebars()
             .with(EscapingStrategy.NOOP)
@@ -74,7 +74,7 @@ public class ColumnContext extends HashMap<String, Object> {
 
         if (keyStr.equals(TBL_PREFIX)) {
             return TableSubContext.tableSubContextBuilder()
-                            .queryable(this.queryable)
+                            .tableArguments(this.tableArguments)
                             .build();
         }
 
@@ -84,6 +84,7 @@ public class ColumnContext extends HashMap<String, Object> {
                             .alias(this.getAlias())
                             .metaDataStore(this.getMetaDataStore())
                             .column(this.getColumn())
+                            .tableArguments(this.getTableArguments())
                             .build();
         }
 
@@ -123,6 +124,7 @@ public class ColumnContext extends HashMap<String, Object> {
                         .queryable(this.getQueryable())
                         .metaDataStore(this.getMetaDataStore())
                         .column(this.getColumn())
+                        .tableArguments(this.getTableArguments())
                         .build();
 
         // This will resolve everything within join expression except Physical References, Use this resolved value
@@ -132,12 +134,12 @@ public class ColumnContext extends HashMap<String, Object> {
 
         Queryable joinQueryable = metaDataStore.getTable(sqlJoin.getJoinTableType());
         ColumnContext joinCtx = ColumnContext.builder()
-                        .queryable(joinQueryable.withArguments(
-                                        mergedArgumentMap(joinQueryable.getAvailableArguments(),
-                                                          this.queryable.getAvailableArguments())))
+                        .queryable(joinQueryable)
                         .alias(joinAlias)
                         .metaDataStore(this.metaDataStore)
                         .column(this.column)
+                        .tableArguments(mergedArgumentMap(joinQueryable.getAvailableArguments(),
+                                                          this.getTableArguments()))
                         .build();
 
         return joinCtx;
@@ -149,6 +151,7 @@ public class ColumnContext extends HashMap<String, Object> {
                         .alias(context.getAlias())
                         .metaDataStore(context.getMetaDataStore())
                         .column(newColumn)
+                        .tableArguments(context.getTableArguments())
                         .build();
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
@@ -138,7 +138,7 @@ public class ColumnContext extends HashMap<String, Object> {
                         .alias(joinAlias)
                         .metaDataStore(this.metaDataStore)
                         .column(this.column)
-                        .tableArguments(mergedArgumentMap(joinQueryable.getAvailableArguments(),
+                        .tableArguments(mergedArgumentMap(joinQueryable.getArguments(),
                                                           this.getTableArguments()))
                         .build();
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
@@ -51,7 +51,6 @@ public class ColumnContext extends HashMap<String, Object> {
     protected final Queryable queryable;
     protected final String alias;
     protected final ColumnProjection column;
-    protected final Map<String, Argument> tableArguments;
 
     private final Handlebars handlebars = new Handlebars()
             .with(EscapingStrategy.NOOP)
@@ -74,7 +73,7 @@ public class ColumnContext extends HashMap<String, Object> {
 
         if (keyStr.equals(TBL_PREFIX)) {
             return TableSubContext.tableSubContextBuilder()
-                            .tableArguments(this.tableArguments)
+                            .queryable(this.queryable)
                             .build();
         }
 
@@ -84,7 +83,6 @@ public class ColumnContext extends HashMap<String, Object> {
                             .alias(this.getAlias())
                             .metaDataStore(this.getMetaDataStore())
                             .column(this.getColumn())
-                            .tableArguments(this.getTableArguments())
                             .build();
         }
 
@@ -124,7 +122,6 @@ public class ColumnContext extends HashMap<String, Object> {
                         .queryable(this.getQueryable())
                         .metaDataStore(this.getMetaDataStore())
                         .column(this.getColumn())
-                        .tableArguments(this.getTableArguments())
                         .build();
 
         // This will resolve everything within join expression except Physical References, Use this resolved value
@@ -134,12 +131,12 @@ public class ColumnContext extends HashMap<String, Object> {
 
         Queryable joinQueryable = metaDataStore.getTable(sqlJoin.getJoinTableType());
         ColumnContext joinCtx = ColumnContext.builder()
-                        .queryable(joinQueryable)
+                        .queryable(joinQueryable.withArguments(
+                                        mergedArgumentMap(joinQueryable.getAvailableArguments(),
+                                                          this.queryable.getAvailableArguments())))
                         .alias(joinAlias)
                         .metaDataStore(this.metaDataStore)
                         .column(this.column)
-                        .tableArguments(mergedArgumentMap(joinQueryable.getAvailableArguments(),
-                                                          this.getTableArguments()))
                         .build();
 
         return joinCtx;
@@ -151,7 +148,6 @@ public class ColumnContext extends HashMap<String, Object> {
                         .alias(context.getAlias())
                         .metaDataStore(context.getMetaDataStore())
                         .column(newColumn)
-                        .tableArguments(context.getTableArguments())
                         .build();
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
@@ -98,6 +98,9 @@ public class ColumnContext extends HashMap<String, Object> {
             return value;
         }
 
+        // In case of colA references colB and user query has both colA and colB,
+        // we should use default arguments for colB while resolving colA instead of user provided argument for colB.
+        // so taking colB's details from current queryable's source.
         ColumnProjection column = this.getQueryable().getSource().getColumnProjection(keyStr);
         if (column != null) {
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContext.java
@@ -98,14 +98,12 @@ public class ColumnContext extends HashMap<String, Object> {
             return value;
         }
 
-        ColumnProjection column = this.getQueryable().getColumnProjection(keyStr);
+        ColumnProjection column = this.getQueryable().getSource().getColumnProjection(keyStr);
         if (column != null) {
 
             ColumnProjection newColumn = column.withArguments(
-                            getColumnArgMap(this.getQueryable(),
-                                            column.getName(),
-                                            this.getColumn().getArguments(),
-                                            emptyMap()));
+                            mergedArgumentMap(column.getArguments(),
+                                              this.getColumn().getArguments()));
 
             return getNewContext(this, newColumn).resolve(newColumn.getExpression());
         }
@@ -196,28 +194,18 @@ public class ColumnContext extends HashMap<String, Object> {
             return resolvePhysicalReference(invokedCtx, invokedColumnName);
         }
 
-        ColumnProjection column = invokedCtx.getQueryable().getColumnProjection(invokedColumnName);
+        ColumnProjection column = invokedCtx.getQueryable().getSource().getColumnProjection(invokedColumnName);
         if (column != null) {
 
             ColumnProjection newColumn = column.withArguments(
-                            getColumnArgMap(invokedCtx.getQueryable(),
-                                            column.getName(),
-                                            invokedCtx.getColumn().getArguments(),
-                                            pinnedArgs));
+                            mergedArgumentMap(column.getArguments(),
+                                              invokedCtx.getColumn().getArguments(),
+                                              pinnedArgs));
 
             return getNewContext(invokedCtx, newColumn).resolve(newColumn.getExpression());
         }
 
         throw new HandlebarsException(new Throwable("Couldn't find: " + invokedColumnName));
-    }
-
-    public static Map<String, Argument> getColumnArgMap(Queryable queryable,
-                                                        String columnName,
-                                                        Map<String, Argument> callingColumnArgs,
-                                                        Map<String, Argument> fixedArgs) {
-        return mergedArgumentMap(queryable.getSource().getColumnProjection(columnName).getArguments(),
-                                 callingColumnArgs,
-                                 fixedArgs);
     }
 
     public static Map<String, Argument> mergedArgumentMap(Map<String, Argument> referencedColumnArgs,

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnSubContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnSubContext.java
@@ -7,6 +7,7 @@
 package com.yahoo.elide.datastores.aggregation.metadata;
 
 
+import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 
@@ -15,6 +16,8 @@ import com.github.jknack.handlebars.HandlebarsException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.util.Map;
 
 /**
  * Context for resolving args, expr etc under $$column. eg: {{$$column.args.arg1}}, {{$$column.expr}}.
@@ -25,8 +28,8 @@ public class ColumnSubContext extends ColumnContext {
 
     @Builder(builderMethodName = "columnSubContextBuilder")
     public ColumnSubContext(MetaDataStore metaDataStore, Queryable queryable, String alias,
-                    ColumnProjection column) {
-        super(metaDataStore, queryable, alias, column);
+                    ColumnProjection column, Map<String, Argument> tableArguments) {
+        super(metaDataStore, queryable, alias, column, tableArguments);
     }
 
     @Override
@@ -42,6 +45,7 @@ public class ColumnSubContext extends ColumnContext {
                             .alias(this.getAlias())
                             .metaDataStore(this.getMetaDataStore())
                             .column(this.getColumn())
+                            .tableArguments(this.getTableArguments())
                             .build()
                             .resolve(this.getColumn().getExpression());
         }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnSubContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnSubContext.java
@@ -7,7 +7,6 @@
 package com.yahoo.elide.datastores.aggregation.metadata;
 
 
-import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 
@@ -16,8 +15,6 @@ import com.github.jknack.handlebars.HandlebarsException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.Map;
 
 /**
  * Context for resolving args, expr etc under $$column. eg: {{$$column.args.arg1}}, {{$$column.expr}}.
@@ -28,8 +25,8 @@ public class ColumnSubContext extends ColumnContext {
 
     @Builder(builderMethodName = "columnSubContextBuilder")
     public ColumnSubContext(MetaDataStore metaDataStore, Queryable queryable, String alias,
-                    ColumnProjection column, Map<String, Argument> tableArguments) {
-        super(metaDataStore, queryable, alias, column, tableArguments);
+                    ColumnProjection column) {
+        super(metaDataStore, queryable, alias, column);
     }
 
     @Override
@@ -45,7 +42,6 @@ public class ColumnSubContext extends ColumnContext {
                             .alias(this.getAlias())
                             .metaDataStore(this.getMetaDataStore())
                             .column(this.getColumn())
-                            .tableArguments(this.getTableArguments())
                             .build()
                             .resolve(this.getColumn().getExpression());
         }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -26,7 +26,7 @@ import com.yahoo.elide.datastores.aggregation.annotation.Join;
 import com.yahoo.elide.datastores.aggregation.annotation.MetricFormula;
 import com.yahoo.elide.datastores.aggregation.dynamic.NamespacePackage;
 import com.yahoo.elide.datastores.aggregation.dynamic.TableType;
-import com.yahoo.elide.datastores.aggregation.metadata.models.Argument;
+import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Namespace;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
@@ -243,7 +243,7 @@ public class MetaDataStore implements DataStore {
         addMetaData(table, version);
         table.getColumns().forEach(this::addColumn);
 
-        table.getArguments().forEach(arg -> addArgument(arg, version));
+        table.getArgumentDefinitions().forEach(arg -> addArgument(arg, version));
     }
 
     /**
@@ -360,7 +360,7 @@ public class MetaDataStore implements DataStore {
             }
         }
 
-        column.getArguments().forEach(arg -> addArgument(arg, version));
+        column.getArgumentDefinitions().forEach(arg -> addArgument(arg, version));
     }
 
     /**
@@ -368,7 +368,7 @@ public class MetaDataStore implements DataStore {
      *
      * @param argument argument metadata
      */
-    private void addArgument(Argument argument, String version) {
+    private void addArgument(ArgumentDefinition argument, String version) {
         addMetaData(argument, version);
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
@@ -9,7 +9,6 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.PERIOD;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
@@ -17,8 +16,6 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.Map;
 
 /**
  * Context for resolving all handlebars in provided expression except physical references. Keeps physical references as
@@ -33,8 +30,8 @@ public class PhysicalRefColumnContext extends ColumnContext {
 
     @Builder(builderMethodName = "physicalRefContextBuilder")
     public PhysicalRefColumnContext(MetaDataStore metaDataStore, Queryable queryable, String alias,
-                    ColumnProjection column, Map<String, Argument> tableArguments) {
-        super(metaDataStore, queryable, alias, column, tableArguments);
+                    ColumnProjection column) {
+        super(metaDataStore, queryable, alias, column);
     }
 
     @Override
@@ -44,7 +41,6 @@ public class PhysicalRefColumnContext extends ColumnContext {
                         .alias(context.getAlias())
                         .metaDataStore(context.getMetaDataStore())
                         .column(newColumn)
-                        .tableArguments(context.getTableArguments())
                         .build();
     }
 
@@ -56,11 +52,12 @@ public class PhysicalRefColumnContext extends ColumnContext {
 
         PhysicalRefColumnContext joinCtx = PhysicalRefColumnContext.physicalRefContextBuilder()
                         .queryable(joinQueryable)
+                        .queryable(joinQueryable.withArguments(
+                                        mergedArgumentMap(joinQueryable.getAvailableArguments(),
+                                                          this.queryable.getAvailableArguments())))
                         .alias(joinPath)
                         .metaDataStore(this.metaDataStore)
                         .column(this.column)
-                        .tableArguments(mergedArgumentMap(joinQueryable.getAvailableArguments(),
-                                                          this.getTableArguments()))
                         .build();
 
         return joinCtx;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
@@ -51,7 +51,6 @@ public class PhysicalRefColumnContext extends ColumnContext {
         String joinPath = isBlank(this.alias) ? key : this.alias + PERIOD + key;
 
         PhysicalRefColumnContext joinCtx = PhysicalRefColumnContext.physicalRefContextBuilder()
-                        .queryable(joinQueryable)
                         .queryable(joinQueryable.withArguments(
                                         mergedArgumentMap(joinQueryable.getAvailableArguments(),
                                                           this.queryable.getAvailableArguments())))

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
@@ -59,7 +59,7 @@ public class PhysicalRefColumnContext extends ColumnContext {
                         .alias(joinPath)
                         .metaDataStore(this.metaDataStore)
                         .column(this.column)
-                        .tableArguments(mergedArgumentMap(joinQueryable.getAvailableArguments(),
+                        .tableArguments(mergedArgumentMap(joinQueryable.getArguments(),
                                                           this.getTableArguments()))
                         .build();
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
@@ -9,6 +9,7 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.PERIOD;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
@@ -16,6 +17,8 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.util.Map;
 
 /**
  * Context for resolving all handlebars in provided expression except physical references. Keeps physical references as
@@ -30,8 +33,8 @@ public class PhysicalRefColumnContext extends ColumnContext {
 
     @Builder(builderMethodName = "physicalRefContextBuilder")
     public PhysicalRefColumnContext(MetaDataStore metaDataStore, Queryable queryable, String alias,
-                    ColumnProjection column) {
-        super(metaDataStore, queryable, alias, column);
+                    ColumnProjection column, Map<String, Argument> tableArguments) {
+        super(metaDataStore, queryable, alias, column, tableArguments);
     }
 
     @Override
@@ -41,6 +44,7 @@ public class PhysicalRefColumnContext extends ColumnContext {
                         .alias(context.getAlias())
                         .metaDataStore(context.getMetaDataStore())
                         .column(newColumn)
+                        .tableArguments(context.getTableArguments())
                         .build();
     }
 
@@ -51,12 +55,12 @@ public class PhysicalRefColumnContext extends ColumnContext {
         String joinPath = isBlank(this.alias) ? key : this.alias + PERIOD + key;
 
         PhysicalRefColumnContext joinCtx = PhysicalRefColumnContext.physicalRefContextBuilder()
-                        .queryable(joinQueryable.withArguments(
-                                        mergedArgumentMap(joinQueryable.getAvailableArguments(),
-                                                          this.queryable.getAvailableArguments())))
+                        .queryable(joinQueryable)
                         .alias(joinPath)
                         .metaDataStore(this.metaDataStore)
                         .column(this.column)
+                        .tableArguments(mergedArgumentMap(joinQueryable.getAvailableArguments(),
+                                                          this.getTableArguments()))
                         .build();
 
         return joinCtx;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/PhysicalRefColumnContext.java
@@ -9,6 +9,7 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.PERIOD;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
@@ -16,6 +17,8 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.util.Map;
 
 /**
  * Context for resolving all handlebars in provided expression except physical references. Keeps physical references as
@@ -30,8 +33,8 @@ public class PhysicalRefColumnContext extends ColumnContext {
 
     @Builder(builderMethodName = "physicalRefContextBuilder")
     public PhysicalRefColumnContext(MetaDataStore metaDataStore, Queryable queryable, String alias,
-                    ColumnProjection column) {
-        super(metaDataStore, queryable, alias, column);
+                    ColumnProjection column, Map<String, Argument> tableArguments) {
+        super(metaDataStore, queryable, alias, column, tableArguments);
     }
 
     @Override
@@ -41,6 +44,7 @@ public class PhysicalRefColumnContext extends ColumnContext {
                         .alias(context.getAlias())
                         .metaDataStore(context.getMetaDataStore())
                         .column(newColumn)
+                        .tableArguments(context.getTableArguments())
                         .build();
     }
 
@@ -55,6 +59,8 @@ public class PhysicalRefColumnContext extends ColumnContext {
                         .alias(joinPath)
                         .metaDataStore(this.metaDataStore)
                         .column(this.column)
+                        .tableArguments(mergedArgumentMap(joinQueryable.getAvailableArguments(),
+                                                          this.getTableArguments()))
                         .build();
 
         return joinCtx;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableContext.java
@@ -8,8 +8,7 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 
 import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.TBL_PREFIX;
 
-import com.yahoo.elide.datastores.aggregation.query.Queryable;
-
+import com.yahoo.elide.core.request.Argument;
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Formatter;
 import com.github.jknack.handlebars.Handlebars;
@@ -22,6 +21,7 @@ import lombok.ToString;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Context for resolving table arguments in provided expression.
@@ -31,7 +31,7 @@ import java.util.HashMap;
 @Builder
 public class TableContext extends HashMap<String, Object> {
 
-    protected final Queryable queryable;
+    protected final Map<String, Argument> tableArguments;
 
     private final Handlebars handlebars = new Handlebars()
                     .with(EscapingStrategy.NOOP)
@@ -46,7 +46,7 @@ public class TableContext extends HashMap<String, Object> {
 
         if (key.equals(TBL_PREFIX)) {
             return TableSubContext.tableSubContextBuilder()
-                            .queryable(this.queryable)
+                            .tableArguments(this.tableArguments)
                             .build();
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableContext.java
@@ -9,6 +9,7 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.TBL_PREFIX;
 
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
+
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Formatter;
 import com.github.jknack.handlebars.Handlebars;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableContext.java
@@ -8,7 +8,7 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 
 import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.TBL_PREFIX;
 
-import com.yahoo.elide.core.request.Argument;
+import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Formatter;
 import com.github.jknack.handlebars.Handlebars;
@@ -21,7 +21,6 @@ import lombok.ToString;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Context for resolving table arguments in provided expression.
@@ -31,7 +30,7 @@ import java.util.Map;
 @Builder
 public class TableContext extends HashMap<String, Object> {
 
-    protected final Map<String, Argument> tableArguments;
+    protected final Queryable queryable;
 
     private final Handlebars handlebars = new Handlebars()
                     .with(EscapingStrategy.NOOP)
@@ -46,7 +45,7 @@ public class TableContext extends HashMap<String, Object> {
 
         if (key.equals(TBL_PREFIX)) {
             return TableSubContext.tableSubContextBuilder()
-                            .tableArguments(this.tableArguments)
+                            .queryable(this.queryable)
                             .build();
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
@@ -9,6 +9,7 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.ARGS_KEY;
 
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
+
 import com.github.jknack.handlebars.HandlebarsException;
 
 import lombok.Builder;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
@@ -9,9 +9,6 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.ARGS_KEY;
 
 import com.yahoo.elide.core.request.Argument;
-import com.yahoo.elide.datastores.aggregation.query.Query;
-import com.yahoo.elide.datastores.aggregation.query.Queryable;
-import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 
 import com.github.jknack.handlebars.HandlebarsException;
 
@@ -20,9 +17,6 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Context for resolving args under $$table. eg: {{$$table.args.arg1}}.
@@ -32,36 +26,17 @@ import java.util.stream.Collectors;
 public class TableSubContext extends TableContext {
 
     @Builder(builderMethodName = "tableSubContextBuilder")
-    public TableSubContext(Queryable queryable) {
-        super(queryable);
+    public TableSubContext(Map<String, Argument> tableArguments) {
+        super(tableArguments);
     }
 
     @Override
     public Object get(Object key) {
 
         if (key.equals(ARGS_KEY)) {
-
-            if (queryable instanceof SQLTable) {
-                SQLTable table = (SQLTable) queryable;
-                return getDefaultArgumentsMap(table.getArguments());
-            }
-
-            Query query = (Query) queryable;
-            return query.getArguments();
+            return this.getTableArguments();
         }
 
         throw new HandlebarsException(new Throwable("Couldn't find: " + key));
-    }
-
-    public static Map<String, Argument> getDefaultArgumentsMap(
-                    Set<com.yahoo.elide.datastores.aggregation.metadata.models.Argument> availableArgs) {
-
-         return availableArgs.stream()
-                        .filter(arg -> arg.getDefaultValue() != null)
-                        .map(arg -> Argument.builder()
-                                        .name(arg.getName())
-                                        .value(arg.getDefaultValue())
-                                        .build())
-                        .collect(Collectors.toMap(Argument::getName, Function.identity()));
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
@@ -8,15 +8,12 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 
 import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.ARGS_KEY;
 
-import com.yahoo.elide.core.request.Argument;
-
+import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.github.jknack.handlebars.HandlebarsException;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.Map;
 
 /**
  * Context for resolving args under $$table. eg: {{$$table.args.arg1}}.
@@ -26,15 +23,15 @@ import java.util.Map;
 public class TableSubContext extends TableContext {
 
     @Builder(builderMethodName = "tableSubContextBuilder")
-    public TableSubContext(Map<String, Argument> tableArguments) {
-        super(tableArguments);
+    public TableSubContext(Queryable queryable) {
+        super(queryable);
     }
 
     @Override
     public Object get(Object key) {
 
         if (key.equals(ARGS_KEY)) {
-            return this.getTableArguments();
+            return this.queryable.getAvailableArguments();
         }
 
         throw new HandlebarsException(new Throwable("Couldn't find: " + key));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/TableSubContext.java
@@ -8,13 +8,15 @@ package com.yahoo.elide.datastores.aggregation.metadata;
 
 import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.ARGS_KEY;
 
-import com.yahoo.elide.datastores.aggregation.query.Queryable;
+import com.yahoo.elide.core.request.Argument;
 
 import com.github.jknack.handlebars.HandlebarsException;
 
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.util.Map;
 
 /**
  * Context for resolving args under $$table. eg: {{$$table.args.arg1}}.
@@ -24,15 +26,15 @@ import lombok.ToString;
 public class TableSubContext extends TableContext {
 
     @Builder(builderMethodName = "tableSubContextBuilder")
-    public TableSubContext(Queryable queryable) {
-        super(queryable);
+    public TableSubContext(Map<String, Argument> tableArguments) {
+        super(tableArguments);
     }
 
     @Override
     public Object get(Object key) {
 
         if (key.equals(ARGS_KEY)) {
-            return this.queryable.getAvailableArguments();
+            return this.getTableArguments();
         }
 
         throw new HandlebarsException(new Throwable("Couldn't find: " + key));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/ArgumentDefinition.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/ArgumentDefinition.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.datastores.aggregation.metadata.models;
 
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.datastores.aggregation.annotation.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueSourceType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import lombok.AllArgsConstructor;
@@ -27,7 +26,7 @@ import javax.persistence.OneToOne;
 @Data
 @ToString
 @AllArgsConstructor
-public class Argument {
+public class ArgumentDefinition {
     @Id
     private String id;
 
@@ -53,7 +52,8 @@ public class Argument {
         return (defaultValue == null || defaultValue.toString().equals(""));
     }
 
-    public Argument(String idPrefix, ArgumentDefinition argument) {
+    public ArgumentDefinition(String idPrefix,
+                              com.yahoo.elide.datastores.aggregation.annotation.ArgumentDefinition argument) {
         this.id = idPrefix + "." + argument.name();
         this.name = argument.name();
         this.description = argument.description();

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -21,6 +21,8 @@ import com.yahoo.elide.datastores.aggregation.metadata.enums.ColumnType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueSourceType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -80,7 +82,12 @@ public abstract class Column implements Versioned {
 
     @OneToMany
     @ToString.Exclude
-    private final Set<ArgumentDefinition> argumentDefinitions;
+    @Getter(value = AccessLevel.NONE)
+    private final Set<ArgumentDefinition> arguments;
+
+    public Set<ArgumentDefinition> getArgumentDefinitions() {
+        return this.arguments;
+    }
 
     @ToString.Exclude
     private final Set<String> tags;
@@ -120,7 +127,7 @@ public abstract class Column implements Versioned {
             MetricFormula metricFormula = dictionary.getAttributeOrRelationAnnotation(tableClass, MetricFormula.class,
                     fieldName);
             this.expression = metricFormula.value();
-            this.argumentDefinitions = Arrays.stream(metricFormula.arguments())
+            this.arguments = Arrays.stream(metricFormula.arguments())
                     .map(argument -> new ArgumentDefinition(getId(), argument))
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         } else if (dictionary.attributeOrRelationAnnotationExists(tableClass, fieldName, DimensionFormula.class)) {
@@ -128,13 +135,13 @@ public abstract class Column implements Versioned {
             DimensionFormula dimensionFormula = dictionary.getAttributeOrRelationAnnotation(tableClass,
                     DimensionFormula.class, fieldName);
             this.expression = dimensionFormula.value();
-            this.argumentDefinitions = Arrays.stream(dimensionFormula.arguments())
+            this.arguments = Arrays.stream(dimensionFormula.arguments())
                     .map(argument -> new ArgumentDefinition(getId(), argument))
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         } else {
             columnType = FIELD;
             expression = "{{$" + dictionary.getAnnotatedColumnName(tableClass, fieldName) + "}}";
-            this.argumentDefinitions = new LinkedHashSet<>();
+            this.arguments = new LinkedHashSet<>();
         }
 
         this.valueType = getValueType(tableClass, fieldName, dictionary);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -80,7 +80,7 @@ public abstract class Column implements Versioned {
 
     @OneToMany
     @ToString.Exclude
-    private final Set<Argument> arguments;
+    private final Set<ArgumentDefinition> argumentDefinitions;
 
     @ToString.Exclude
     private final Set<String> tags;
@@ -120,21 +120,21 @@ public abstract class Column implements Versioned {
             MetricFormula metricFormula = dictionary.getAttributeOrRelationAnnotation(tableClass, MetricFormula.class,
                     fieldName);
             this.expression = metricFormula.value();
-            this.arguments = Arrays.stream(metricFormula.arguments())
-                    .map(argument -> new Argument(getId(), argument))
+            this.argumentDefinitions = Arrays.stream(metricFormula.arguments())
+                    .map(argument -> new ArgumentDefinition(getId(), argument))
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         } else if (dictionary.attributeOrRelationAnnotationExists(tableClass, fieldName, DimensionFormula.class)) {
             columnType = FORMULA;
             DimensionFormula dimensionFormula = dictionary.getAttributeOrRelationAnnotation(tableClass,
                     DimensionFormula.class, fieldName);
             this.expression = dimensionFormula.value();
-            this.arguments = Arrays.stream(dimensionFormula.arguments())
-                    .map(argument -> new Argument(getId(), argument))
+            this.argumentDefinitions = Arrays.stream(dimensionFormula.arguments())
+                    .map(argument -> new ArgumentDefinition(getId(), argument))
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         } else {
             columnType = FIELD;
             expression = "{{$" + dictionary.getAnnotatedColumnName(tableClass, fieldName) + "}}";
-            this.arguments = new LinkedHashSet<>();
+            this.argumentDefinitions = new LinkedHashSet<>();
         }
 
         this.valueType = getValueType(tableClass, fieldName, dictionary);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -24,6 +24,8 @@ import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
 import org.apache.commons.lang3.StringUtils;
+
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -103,7 +105,12 @@ public abstract class Table implements Versioned {
 
     @OneToMany
     @ToString.Exclude
-    private final Set<ArgumentDefinition> argumentDefinitions;
+    @Getter(value = AccessLevel.NONE)
+    private final Set<ArgumentDefinition> arguments;
+
+    public Set<ArgumentDefinition> getArgumentDefinitions() {
+        return this.arguments;
+    }
 
     public Table(Namespace namespace, Type<?> cls, EntityDictionary dictionary) {
         if (!dictionary.getBoundClasses().contains(cls)) {
@@ -151,9 +158,9 @@ public abstract class Table implements Versioned {
             this.hints = new LinkedHashSet<>(Arrays.asList(meta.hints()));
             this.cardinality = meta.size();
             if (meta.arguments().length == 0) {
-                this.argumentDefinitions = new HashSet<>();
+                this.arguments = new HashSet<>();
             } else {
-                this.argumentDefinitions = Arrays.stream(meta.arguments())
+                this.arguments = Arrays.stream(meta.arguments())
                         .map(argument -> new ArgumentDefinition(getId(), argument))
                         .collect(Collectors.toCollection(LinkedHashSet::new));
             }
@@ -165,7 +172,7 @@ public abstract class Table implements Versioned {
             this.tags = new HashSet<>();
             this.hints = new LinkedHashSet<>();
             this.cardinality = CardinalitySize.UNKNOWN;
-            this.argumentDefinitions = new HashSet<>();
+            this.arguments = new HashSet<>();
         }
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -24,6 +24,8 @@ import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
 import org.apache.commons.lang3.StringUtils;
+
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -46,6 +48,7 @@ import javax.persistence.OneToMany;
 @Getter
 @EqualsAndHashCode
 @ToString
+@AllArgsConstructor
 public abstract class Table implements Versioned {
 
     @Id

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -24,8 +24,6 @@ import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
 import org.apache.commons.lang3.StringUtils;
-
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -48,7 +46,6 @@ import javax.persistence.OneToMany;
 @Getter
 @EqualsAndHashCode
 @ToString
-@AllArgsConstructor
 public abstract class Table implements Versioned {
 
     @Id

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -103,7 +103,7 @@ public abstract class Table implements Versioned {
 
     @OneToMany
     @ToString.Exclude
-    private final Set<Argument> arguments;
+    private final Set<ArgumentDefinition> argumentDefinitions;
 
     public Table(Namespace namespace, Type<?> cls, EntityDictionary dictionary) {
         if (!dictionary.getBoundClasses().contains(cls)) {
@@ -151,10 +151,10 @@ public abstract class Table implements Versioned {
             this.hints = new LinkedHashSet<>(Arrays.asList(meta.hints()));
             this.cardinality = meta.size();
             if (meta.arguments().length == 0) {
-                this.arguments = new HashSet<>();
+                this.argumentDefinitions = new HashSet<>();
             } else {
-                this.arguments = Arrays.stream(meta.arguments())
-                        .map(argument -> new Argument(getId(), argument))
+                this.argumentDefinitions = Arrays.stream(meta.arguments())
+                        .map(argument -> new ArgumentDefinition(getId(), argument))
                         .collect(Collectors.toCollection(LinkedHashSet::new));
             }
         } else {
@@ -165,7 +165,7 @@ public abstract class Table implements Versioned {
             this.tags = new HashSet<>();
             this.hints = new LinkedHashSet<>();
             this.cardinality = CardinalitySize.UNKNOWN;
-            this.arguments = new HashSet<>();
+            this.argumentDefinitions = new HashSet<>();
         }
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -95,4 +95,21 @@ public class Query implements Queryable {
     public Map<String, Argument> getAvailableArguments() {
         return getArguments();
     }
+
+    @Override
+    public Queryable withArguments(Map<String, Argument> arguments) {
+        return Query.builder()
+                        .source(source)
+                        .metricProjections(metricProjections)
+                        .dimensionProjections(dimensionProjections)
+                        .timeDimensionProjections(timeDimensionProjections)
+                        .whereFilter(whereFilter)
+                        .havingFilter(havingFilter)
+                        .sorting(sorting)
+                        .pagination(pagination)
+                        .arguments(arguments)
+                        .bypassingCache(bypassingCache)
+                        .scope(scope)
+                        .build();
+    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -90,9 +90,4 @@ public class Query implements Queryable {
             return this;
         }
     }
-
-    @Override
-    public Map<String, Argument> getAvailableArguments() {
-        return getArguments();
-    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -90,4 +90,9 @@ public class Query implements Queryable {
             return this;
         }
     }
+
+    @Override
+    public Map<String, Argument> getAvailableArguments() {
+        return getArguments();
+    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -95,21 +95,4 @@ public class Query implements Queryable {
     public Map<String, Argument> getAvailableArguments() {
         return getArguments();
     }
-
-    @Override
-    public Queryable withArguments(Map<String, Argument> arguments) {
-        return Query.builder()
-                        .source(source)
-                        .metricProjections(metricProjections)
-                        .dimensionProjections(dimensionProjections)
-                        .timeDimensionProjections(timeDimensionProjections)
-                        .whereFilter(whereFilter)
-                        .havingFilter(havingFilter)
-                        .sorting(sorting)
-                        .pagination(pagination)
-                        .arguments(arguments)
-                        .bypassingCache(bypassingCache)
-                        .scope(scope)
-                        .build();
-    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
@@ -340,13 +340,4 @@ public interface Queryable {
     default Map<String, Argument> getAvailableArguments() {
         return Collections.emptyMap();
     }
-
-    /**
-     * Clones the queryable with provided arguments.
-     * @param arguments A map of String and {@link Argument}
-     * @return The cloned queryable.
-     */
-    default Queryable withArguments(Map<String, Argument> arguments) {
-        return this;
-    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
@@ -340,4 +340,8 @@ public interface Queryable {
     default Map<String, Argument> getAvailableArguments() {
         return Collections.emptyMap();
     }
+
+    default Queryable withArguments(Map<String, Argument> arguments) {
+        return this;
+    }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
@@ -337,7 +337,7 @@ public interface Queryable {
      * Gets the available arguments for this queryable.
      * @return available arguments for this queryable as map of String and {@link Argument}.
      */
-    default Map<String, Argument> getAvailableArguments() {
+    default Map<String, Argument> getArguments() {
         return Collections.emptyMap();
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Streams;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -330,5 +331,13 @@ public interface Queryable {
         }));
 
         return filterProjections;
+    }
+
+    /**
+     * Gets the available arguments for this queryable.
+     * @return available arguments for this queryable as map of String and {@link Argument}.
+     */
+    default Map<String, Argument> getAvailableArguments() {
+        return Collections.emptyMap();
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
@@ -341,6 +341,11 @@ public interface Queryable {
         return Collections.emptyMap();
     }
 
+    /**
+     * Clones the queryable with provided arguments.
+     * @param arguments A map of String and {@link Argument}
+     * @return The cloned queryable.
+     */
     default Queryable withArguments(Map<String, Argument> arguments) {
         return this;
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ExpressionParser.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ExpressionParser.java
@@ -7,7 +7,7 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.expression;
 
 import static com.yahoo.elide.core.request.Argument.getArgumentMapFromString;
-import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.getColumnArgMap;
+import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.mergedArgumentMap;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.PERIOD;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import com.yahoo.elide.core.Path;
@@ -126,9 +126,9 @@ public class ExpressionParser {
                 Preconditions.checkNotNull(referencedColumn);
 
                 ColumnProjection newColumn = referencedColumn.withArguments(
-                                getColumnArgMap(referencedColumn.getArguments(),
-                                                callingColumnArgs,
-                                                fixedArguments));
+                                mergedArgumentMap(referencedColumn.getArguments(),
+                                                  callingColumnArgs,
+                                                  fixedArguments));
 
                 List<Reference> references = buildReferenceForColumn(source, newColumn);
 
@@ -177,9 +177,9 @@ public class ExpressionParser {
         } else {
             ColumnProjection referencedColumn = joinSource.getColumnProjection(fieldName);
             ColumnProjection newColumn = referencedColumn.withArguments(
-                            getColumnArgMap(referencedColumn.getArguments(),
-                                            callingColumnArgs,
-                                            fixedArguments));
+                            mergedArgumentMap(referencedColumn.getArguments(),
+                                              callingColumnArgs,
+                                              fixedArguments));
 
             reference = LogicalReference
                             .builder()

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/JoinExpressionExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/JoinExpressionExtractor.java
@@ -21,6 +21,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.ColumnContext;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.TableContext;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 
@@ -69,7 +70,6 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
                         .alias(this.context.getAlias())
                         .metaDataStore(this.context.getMetaDataStore())
                         .column(newColumn)
-                        .tableArguments(this.context.getTableArguments())
                         .build();
 
         JoinExpressionExtractor visitor = new JoinExpressionExtractor(newCtx);
@@ -110,14 +110,14 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
                 }
             } else {
                 joinType = JoinType.LEFT;
-                SQLTable table = metaDataStore.getTable(joinClass);
+                SQLTable joinTable = metaDataStore.getTable(joinClass);
                 joinCtx = ColumnContext.builder()
-                                .queryable(table)
+                                .queryable(joinTable.withArguments(
+                                                mergedArgumentMap(joinTable.getAvailableArguments(),
+                                                                  currentCtx.getQueryable().getAvailableArguments())))
                                 .alias(appendAlias(currentCtx.getAlias(), joinFieldName))
                                 .metaDataStore(currentCtx.getMetaDataStore())
                                 .column(currentCtx.getColumn())
-                                .tableArguments(mergedArgumentMap(table.getAvailableArguments(),
-                                                                  currentCtx.getTableArguments()))
                                 .build();
 
                 onClause = ON + String.format("%s.%s = %s.%s",
@@ -129,7 +129,7 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
 
             String joinAlias = applyQuotes(joinCtx.getAlias(), currentCtx.getQueryable().getDialect());
             String joinKeyword = currentCtx.getQueryable().getDialect().getJoinKeyword(joinType);
-            String joinSource = constructTableOrSubselect(joinCtx, joinClass);
+            String joinSource = constructTableOrSubselect(joinCtx.getQueryable(), joinClass);
 
             String fullExpression = String.format("%s %s AS %s %s", joinKeyword, joinSource, joinAlias, onClause);
             joinExpressions.add(fullExpression);
@@ -150,19 +150,19 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
 
     /**
      * Get the SELECT SQL or tableName for given entity.
-     * @param columnCtx {@link ColumnContext}.
+     * @param queryable Queryable.
      * @param cls Entity class.
      * @return resolved tableName or sql in Subselect/FromSubquery.
      */
-    private String constructTableOrSubselect(ColumnContext columnCtx, Type<?> cls) {
+    private String constructTableOrSubselect(Queryable queryable, Type<?> cls) {
 
         if (hasSql(cls)) {
             // Resolve any table arguments with in FromSubquery or Subselect
-            TableContext context = TableContext.builder().tableArguments(columnCtx.getTableArguments()).build();
+            TableContext context = TableContext.builder().queryable(queryable).build();
             String selectSql = context.resolve(resolveTableOrSubselect(dictionary, cls));
             return OPEN_BRACKET + selectSql + CLOSE_BRACKET;
         }
 
-        return applyQuotes(resolveTableOrSubselect(dictionary, cls), columnCtx.getQueryable().getDialect());
+        return applyQuotes(resolveTableOrSubselect(dictionary, cls), queryable.getDialect());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/JoinExpressionExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/JoinExpressionExtractor.java
@@ -116,7 +116,7 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
                                 .alias(appendAlias(currentCtx.getAlias(), joinFieldName))
                                 .metaDataStore(currentCtx.getMetaDataStore())
                                 .column(currentCtx.getColumn())
-                                .tableArguments(mergedArgumentMap(table.getAvailableArguments(),
+                                .tableArguments(mergedArgumentMap(table.getArguments(),
                                                                   currentCtx.getTableArguments()))
                                 .build();
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/JoinExpressionExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/JoinExpressionExtractor.java
@@ -7,6 +7,7 @@
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.expression;
 
 import static com.yahoo.elide.core.utils.TypeHelper.appendAlias;
+import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.mergedArgumentMap;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.applyQuotes;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.hasSql;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.resolveTableOrSubselect;
@@ -20,8 +21,8 @@ import com.yahoo.elide.datastores.aggregation.metadata.ColumnContext;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.TableContext;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
-import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -68,6 +69,7 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
                         .alias(this.context.getAlias())
                         .metaDataStore(this.context.getMetaDataStore())
                         .column(newColumn)
+                        .tableArguments(this.context.getTableArguments())
                         .build();
 
         JoinExpressionExtractor visitor = new JoinExpressionExtractor(newCtx);
@@ -108,11 +110,14 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
                 }
             } else {
                 joinType = JoinType.LEFT;
+                SQLTable table = metaDataStore.getTable(joinClass);
                 joinCtx = ColumnContext.builder()
-                                .queryable(metaDataStore.getTable(joinClass))
+                                .queryable(table)
                                 .alias(appendAlias(currentCtx.getAlias(), joinFieldName))
                                 .metaDataStore(currentCtx.getMetaDataStore())
                                 .column(currentCtx.getColumn())
+                                .tableArguments(mergedArgumentMap(table.getAvailableArguments(),
+                                                                  currentCtx.getTableArguments()))
                                 .build();
 
                 onClause = ON + String.format("%s.%s = %s.%s",
@@ -124,7 +129,7 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
 
             String joinAlias = applyQuotes(joinCtx.getAlias(), currentCtx.getQueryable().getDialect());
             String joinKeyword = currentCtx.getQueryable().getDialect().getJoinKeyword(joinType);
-            String joinSource = constructTableOrSubselect(joinCtx.getQueryable(), joinClass);
+            String joinSource = constructTableOrSubselect(joinCtx, joinClass);
 
             String fullExpression = String.format("%s %s AS %s %s", joinKeyword, joinSource, joinAlias, onClause);
             joinExpressions.add(fullExpression);
@@ -145,19 +150,19 @@ public class JoinExpressionExtractor implements ReferenceVisitor<Set<String>> {
 
     /**
      * Get the SELECT SQL or tableName for given entity.
-     * @param queryable Queryable.
+     * @param columnCtx {@link ColumnContext}.
      * @param cls Entity class.
      * @return resolved tableName or sql in Subselect/FromSubquery.
      */
-    private String constructTableOrSubselect(Queryable queryable, Type<?> cls) {
+    private String constructTableOrSubselect(ColumnContext columnCtx, Type<?> cls) {
 
         if (hasSql(cls)) {
             // Resolve any table arguments with in FromSubquery or Subselect
-            TableContext context = TableContext.builder().queryable(queryable).build();
+            TableContext context = TableContext.builder().tableArguments(columnCtx.getTableArguments()).build();
             String selectSql = context.resolve(resolveTableOrSubselect(dictionary, cls));
             return OPEN_BRACKET + selectSql + CLOSE_BRACKET;
         }
 
-        return applyQuotes(resolveTableOrSubselect(dictionary, cls), queryable.getDialect());
+        return applyQuotes(resolveTableOrSubselect(dictionary, cls), columnCtx.getQueryable().getDialect());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.datastores.aggregation.annotation.Join;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
@@ -113,7 +114,8 @@ public class SQLTable extends Table implements Queryable {
     @Override
     public List<MetricProjection> getMetricProjections() {
         return super.getMetrics().stream()
-                .map(metric -> getMetricProjection(metric, metric.getName(), prepareArgMap(metric.getArguments())))
+                .map(metric -> getMetricProjection(metric, metric.getName(),
+                                prepareArgMap(metric.getArgumentDefinitions())))
                 .collect(Collectors.toList());
     }
 
@@ -148,7 +150,7 @@ public class SQLTable extends Table implements Queryable {
         return super.getDimensions()
                 .stream()
                 .map(dimension -> getDimensionProjection(dimension, dimension.getName(),
-                                prepareArgMap(dimension.getArguments())))
+                                prepareArgMap(dimension.getArgumentDefinitions())))
                 .collect(Collectors.toList());
     }
 
@@ -186,7 +188,7 @@ public class SQLTable extends Table implements Queryable {
         return super.getTimeDimensions()
                 .stream()
                 .map(dimension -> getTimeDimensionProjection(dimension, dimension.getName(),
-                                prepareArgMap(dimension.getArguments())))
+                                prepareArgMap(dimension.getArgumentDefinitions())))
                 .collect(Collectors.toList());
     }
 
@@ -206,7 +208,7 @@ public class SQLTable extends Table implements Queryable {
             return null;
         }
 
-        return getColumnProjection(column, prepareArgMap(column.getArguments()));
+        return getColumnProjection(column, prepareArgMap(column.getArgumentDefinitions()));
     }
 
     @Override
@@ -275,8 +277,8 @@ public class SQLTable extends Table implements Queryable {
     }
 
     @Override
-    public Map<String, Argument> getAvailableArguments() {
-        return prepareArgMap(getArguments());
+    public Map<String, Argument> getArguments() {
+        return prepareArgMap(getArgumentDefinitions());
     }
 
     /**
@@ -284,8 +286,7 @@ public class SQLTable extends Table implements Queryable {
      * @param arguments Set of available {@link Column} arguments.
      * @return A map of String and {@link Argument}
      */
-    private static Map<String, Argument> prepareArgMap(
-                    Set<com.yahoo.elide.datastores.aggregation.metadata.models.Argument> arguments) {
+    private static Map<String, Argument> prepareArgMap(Set<ArgumentDefinition> arguments) {
         return arguments.stream()
                         .map(arg -> Argument.builder()
                                         .name(arg.getName())

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -274,6 +274,11 @@ public class SQLTable extends Table implements Queryable {
         return this;
     }
 
+    @Override
+    public Map<String, Argument> getAvailableArguments() {
+        return prepareArgMap(getArguments());
+    }
+
     /**
      * Create a map of String and {@link Argument} using {@link Column}'s arguments.
      * @param arguments Set of available {@link Column} arguments.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -26,7 +26,6 @@ import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLTimeDimensionProjection;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -48,8 +47,6 @@ public class SQLTable extends Table implements Queryable {
 
     private Map<String, SQLJoin> joins;
 
-    private Map<String, Argument> availableArguments;
-
     public SQLTable(Namespace namespace,
                     Type<?> cls,
                     EntityDictionary dictionary,
@@ -57,7 +54,6 @@ public class SQLTable extends Table implements Queryable {
         super(namespace, cls, dictionary);
         this.connectionDetails = connectionDetails;
         this.joins = new HashMap<>();
-        this.availableArguments = prepareArgMap(this.getArguments());
 
         EntityBinding binding = dictionary.getEntityBinding(cls);
         binding.fieldsToValues.forEach((name, field) -> {
@@ -76,17 +72,6 @@ public class SQLTable extends Table implements Queryable {
 
     public SQLTable(Namespace namespace, Type<?> cls, EntityDictionary dictionary) {
         this(namespace, cls, dictionary, null);
-    }
-
-    public SQLTable(SQLTable table, Map<String, Argument> availableArguments) {
-        super(table.getId(), table.getName(), table.getFriendlyName(), table.getCategory(), table.getVersion(),
-                        table.getDescription(), table.getCardinality(), table.getRequiredFilter(), table.isFact(),
-                        table.getNamespace(), table.getColumns(), table.getMetrics(), table.getDimensions(),
-                        table.getTimeDimensions(), table.getTags(), table.getHints(), table.getColumnMap(),
-                        table.getAlias(), table.getArguments());
-        this.connectionDetails = table.getConnectionDetails();
-        this.joins = table.getJoins();
-        this.availableArguments = availableArguments;
     }
 
     @Override
@@ -289,6 +274,11 @@ public class SQLTable extends Table implements Queryable {
         return this;
     }
 
+    @Override
+    public Map<String, Argument> getAvailableArguments() {
+        return prepareArgMap(getArguments());
+    }
+
     /**
      * Create a map of String and {@link Argument} using {@link Column}'s arguments.
      * @param arguments Set of available {@link Column} arguments.
@@ -302,10 +292,5 @@ public class SQLTable extends Table implements Queryable {
                                         .value(arg.getDefaultValue())
                                         .build())
                         .collect(Collectors.toMap(Argument::getName, Function.identity()));
-    }
-
-    @Override
-    public Queryable withArguments(Map<String, Argument> arguments) {
-        return new SQLTable(this, arguments);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
@@ -131,7 +131,7 @@ public class QueryTranslator implements QueryVisitor<NativeQuery.NativeQueryBuil
         Type<?> tableCls = dictionary.getEntityClass(table.getName(), table.getVersion());
         String tableAlias = applyQuotes(table.getAlias());
 
-        TableContext context = TableContext.builder().queryable(clientQuery).build();
+        TableContext context = TableContext.builder().tableArguments(clientQuery.getArguments()).build();
 
         String tableStatement = tableCls.isAnnotationPresent(FromSubquery.class)
                 ? "(" + context.resolve(tableCls.getAnnotation(FromSubquery.class).sql()) + ")"
@@ -300,6 +300,7 @@ public class QueryTranslator implements QueryVisitor<NativeQuery.NativeQueryBuil
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(column)
+                        .tableArguments(query.getArguments())
                         .build();
 
         JoinExpressionExtractor visitor = new JoinExpressionExtractor(context);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryTranslator.java
@@ -131,7 +131,7 @@ public class QueryTranslator implements QueryVisitor<NativeQuery.NativeQueryBuil
         Type<?> tableCls = dictionary.getEntityClass(table.getName(), table.getVersion());
         String tableAlias = applyQuotes(table.getAlias());
 
-        TableContext context = TableContext.builder().tableArguments(clientQuery.getArguments()).build();
+        TableContext context = TableContext.builder().queryable(clientQuery).build();
 
         String tableStatement = tableCls.isAnnotationPresent(FromSubquery.class)
                 ? "(" + context.resolve(tableCls.getAnnotation(FromSubquery.class).sql()) + ")"
@@ -300,7 +300,6 @@ public class QueryTranslator implements QueryVisitor<NativeQuery.NativeQueryBuil
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(column)
-                        .tableArguments(query.getArguments())
                         .build();
 
         JoinExpressionExtractor visitor = new JoinExpressionExtractor(context);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -46,6 +46,7 @@ public interface SQLColumnProjection extends ColumnProjection {
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(this)
+                        .tableArguments(query.getAvailableArguments())
                         .build();
 
         return context.resolve(getExpression());
@@ -64,6 +65,7 @@ public interface SQLColumnProjection extends ColumnProjection {
                         .queryable(query)
                         .metaDataStore(metaDataStore)
                         .column(this)
+                        .tableArguments(query.getAvailableArguments())
                         .build();
 
         return context.resolve(getExpression());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -46,7 +46,7 @@ public interface SQLColumnProjection extends ColumnProjection {
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(this)
-                        .tableArguments(query.getAvailableArguments())
+                        .tableArguments(query.getArguments())
                         .build();
 
         return context.resolve(getExpression());
@@ -65,7 +65,7 @@ public interface SQLColumnProjection extends ColumnProjection {
                         .queryable(query)
                         .metaDataStore(metaDataStore)
                         .column(this)
-                        .tableArguments(query.getAvailableArguments())
+                        .tableArguments(query.getArguments())
                         .build();
 
         return context.resolve(getExpression());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -46,7 +46,6 @@ public interface SQLColumnProjection extends ColumnProjection {
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(this)
-                        .tableArguments(query.getAvailableArguments())
                         .build();
 
         return context.resolve(getExpression());
@@ -65,7 +64,6 @@ public interface SQLColumnProjection extends ColumnProjection {
                         .queryable(query)
                         .metaDataStore(metaDataStore)
                         .column(this)
-                        .tableArguments(query.getAvailableArguments())
                         .build();
 
         return context.resolve(getExpression());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -84,7 +84,7 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection, TimeDime
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(this)
-                        .tableArguments(query.getAvailableArguments())
+                        .tableArguments(query.getArguments())
                         .build();
 
         return context.resolve(grain.getExpression());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -84,6 +84,7 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection, TimeDime
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(this)
+                        .tableArguments(query.getAvailableArguments())
                         .build();
 
         return context.resolve(grain.getExpression());

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -84,7 +84,6 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection, TimeDime
                         .alias(query.getSource().getAlias())
                         .metaDataStore(metaDataStore)
                         .column(this)
-                        .tableArguments(query.getAvailableArguments())
                         .build();
 
         return context.resolve(grain.getExpression());

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -200,10 +200,10 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
         // Verify Table Arguments
         given()
                 .accept("application/vnd.api+json")
-                .get("/table/SalesNamespace_orderDetails?include=argumentDefinitions")
+                .get("/table/SalesNamespace_orderDetails?include=arguments")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.relationships.argumentDefinitions.data.id",
+                .body("data.relationships.arguments.data.id",
                         containsInAnyOrder("SalesNamespace_orderDetails.denominator"));
     }
 
@@ -324,7 +324,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.attributes.category",  equalTo("Score Category"))
                 .body("data.attributes.description",  equalTo("very low score"))
                 .body("data.attributes.tags",  containsInAnyOrder("PRIVATE"))
-                .body("data.attributes.argumentDefinitions", nullValue()) // No Arguments were set.
+                .body("data.attributes.arguments", nullValue()) // No Arguments were set.
                 .body("data.relationships.table.data.id", equalTo("playerStats"));
 
         given()
@@ -336,18 +336,18 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.attributes.valueType",  equalTo("DECIMAL"))
                 .body("data.attributes.columnType",  equalTo("FORMULA"))
                 .body("data.attributes.expression",  equalTo("({{timeSpent}} / (CASE WHEN SUM({{$game_rounds}}) = 0 THEN 1 ELSE {{sessions}} END))"))
-                .body("data.attributes.argumentDefinitions", nullValue()) // No Arguments were set.
+                .body("data.attributes.arguments", nullValue()) // No Arguments were set.
                 .body("data.relationships.table.data.id", equalTo("videoGame"));
 
         // Verify Metric Arguments
         given()
                 .accept("application/vnd.api+json")
-                .get("/table/SalesNamespace_orderDetails/metrics/SalesNamespace_orderDetails.orderTotal?include=argumentDefinitions")
+                .get("/table/SalesNamespace_orderDetails/metrics/SalesNamespace_orderDetails.orderTotal?include=arguments")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("orderTotal"))
                 .body("data.attributes.friendlyName", equalTo("orderTotal"))
-                .body("data.relationships.argumentDefinitions.data.id", containsInAnyOrder("SalesNamespace_orderDetails.orderTotal.precision"));
+                .body("data.relationships.arguments.data.id", containsInAnyOrder("SalesNamespace_orderDetails.orderTotal.precision"));
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -200,10 +200,10 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
         // Verify Table Arguments
         given()
                 .accept("application/vnd.api+json")
-                .get("/table/SalesNamespace_orderDetails?include=arguments")
+                .get("/table/SalesNamespace_orderDetails?include=argumentDefinitions")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("data.relationships.arguments.data.id",
+                .body("data.relationships.argumentDefinitions.data.id",
                         containsInAnyOrder("SalesNamespace_orderDetails.denominator"));
     }
 
@@ -324,7 +324,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.attributes.category",  equalTo("Score Category"))
                 .body("data.attributes.description",  equalTo("very low score"))
                 .body("data.attributes.tags",  containsInAnyOrder("PRIVATE"))
-                .body("data.attributes.arguments", nullValue()) // No Arguments were set.
+                .body("data.attributes.argumentDefinitions", nullValue()) // No Arguments were set.
                 .body("data.relationships.table.data.id", equalTo("playerStats"));
 
         given()
@@ -336,18 +336,18 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.attributes.valueType",  equalTo("DECIMAL"))
                 .body("data.attributes.columnType",  equalTo("FORMULA"))
                 .body("data.attributes.expression",  equalTo("({{timeSpent}} / (CASE WHEN SUM({{$game_rounds}}) = 0 THEN 1 ELSE {{sessions}} END))"))
-                .body("data.attributes.arguments", nullValue()) // No Arguments were set.
+                .body("data.attributes.argumentDefinitions", nullValue()) // No Arguments were set.
                 .body("data.relationships.table.data.id", equalTo("videoGame"));
 
         // Verify Metric Arguments
         given()
                 .accept("application/vnd.api+json")
-                .get("/table/SalesNamespace_orderDetails/metrics/SalesNamespace_orderDetails.orderTotal?include=arguments")
+                .get("/table/SalesNamespace_orderDetails/metrics/SalesNamespace_orderDetails.orderTotal?include=argumentDefinitions")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("orderTotal"))
                 .body("data.attributes.friendlyName", equalTo("orderTotal"))
-                .body("data.relationships.arguments.data.id", containsInAnyOrder("SalesNamespace_orderDetails.orderTotal.precision"));
+                .body("data.relationships.argumentDefinitions.data.id", containsInAnyOrder("SalesNamespace_orderDetails.orderTotal.precision"));
     }
 
     @Test


### PR DESCRIPTION
One of the PR that Resolves https://github.com/yahoo/elide/discussions/1829

## Description
Propagate client query arguments to join tables
Refactor: Getting column projection from queryable's source itself, this column projection will have default/available arguments for the column.  So no need to go-to source for default/available arguments again.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
