### PR TITLE
Verify table arguments.

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/QueryEngine.java
@@ -195,7 +195,16 @@ public abstract class QueryEngine {
                 });
             });
         });
+
+        // Verify populated tables in metadata store.
+        verifyMetaData(metaDataStore);
     }
+
+    /**
+     * Verifies all tables in metadata store after they are constructed by {@link #populateMetaData(MetaDataStore)}.
+     * @param metaDataStore metadata store to verify.
+     */
+    protected abstract void verifyMetaData(MetaDataStore metaDataStore);
 
     /**
      * Contains state necessary for query execution.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/ArgumentDefinition.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/ArgumentDefinition.java
@@ -9,6 +9,8 @@ import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueSourceType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
+import com.yahoo.elide.modelconfig.model.Named;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.ToString;
@@ -26,7 +28,7 @@ import javax.persistence.OneToOne;
 @Data
 @ToString
 @AllArgsConstructor
-public class ArgumentDefinition {
+public class ArgumentDefinition implements Named {
     @Id
     private String id;
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -21,6 +21,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.enums.ColumnType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueSourceType;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+import com.yahoo.elide.modelconfig.model.Named;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -43,7 +44,7 @@ import javax.persistence.OneToOne;
 @Getter
 @EqualsAndHashCode
 @ToString
-public abstract class Column implements Versioned {
+public abstract class Column implements Versioned, Named {
 
     @Id
     private final String id;
@@ -195,5 +196,16 @@ public abstract class Column implements Versioned {
     @Override
     public String getVersion() {
         return table.getVersion();
+    }
+
+    public boolean hasArgumentDefinition(String argName) {
+        return hasName(this.arguments, argName);
+    }
+
+    public ArgumentDefinition getArgumentDefinition(String argName) {
+        return this.arguments.stream()
+                        .filter(arg -> arg.getName().equals(argName))
+                        .findFirst()
+                        .orElse(null);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -24,6 +24,8 @@ import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
+import com.yahoo.elide.modelconfig.model.Named;
+
 import org.apache.commons.lang3.StringUtils;
 
 import lombok.AccessLevel;
@@ -49,7 +51,7 @@ import javax.persistence.OneToMany;
 @Getter
 @EqualsAndHashCode
 @ToString
-public abstract class Table implements Versioned {
+public abstract class Table implements Versioned, Named {
 
     @Id
     private final String id;
@@ -333,6 +335,17 @@ public abstract class Table implements Versioned {
             }
         }
         return null;
+    }
+
+    public boolean hasArgumentDefinition(String argName) {
+        return hasName(this.arguments, argName);
+    }
+
+    public ArgumentDefinition getArgumentDefinition(String argName) {
+        return this.arguments.stream()
+                        .filter(arg -> arg.getName().equals(argName))
+                        .findFirst()
+                        .orElse(null);
     }
 
     public abstract Queryable toQueryable();

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -45,6 +45,7 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLColumnPr
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLTimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.timegrains.Time;
+import com.yahoo.elide.datastores.aggregation.validator.TableArgumentValidator;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import lombok.Getter;
@@ -172,6 +173,15 @@ public class SQLQueryEngine extends QueryEngine {
                                                       String alias,
                                                       Map<String, Argument> arguments) {
         return metric.getMetricProjectionMaker().make(metric, alias, arguments);
+    }
+
+    @Override
+    protected void verifyMetaData(MetaDataStore metaDataStore) {
+        metaDataStore.getTables().forEach(table -> {
+            SQLTable sqlTable = (SQLTable) table;
+            TableArgumentValidator tableArgValidator = new TableArgumentValidator(metaDataStore, sqlTable);
+            tableArgValidator.validate();
+        });
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ExpressionParser.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ExpressionParser.java
@@ -136,7 +136,8 @@ public class ExpressionParser {
                 results.add(buildJoin(source, referenceName, callingColumnArgs, fixedArguments));
             } else {
                 ColumnProjection referencedColumn = source.getColumnProjection(referenceName);
-                Preconditions.checkNotNull(referencedColumn);
+                Preconditions.checkNotNull(referencedColumn, String.format("Couldn't find column: '%s' for table: '%s'",
+                                referenceName, source.getName()));
 
                 ColumnProjection newColumn = referencedColumn.withArguments(
                                 mergedArgumentMap(referencedColumn.getArguments(),

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLReferenceTable.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
-import com.yahoo.elide.datastores.aggregation.metadata.FormulaValidator;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.query.Queryable;
@@ -97,15 +96,9 @@ public class SQLReferenceTable {
             referenceTree.put(key, new HashMap<>());
         }
 
-        FormulaValidator validator = new FormulaValidator(metaDataStore);
-
         queryable.getColumnProjections().forEach(column -> {
-            // validate that there is no reference loop
-            validator.parse(queryable, column);
-
             String fieldName = column.getName();
             referenceTree.get(key).put(fieldName, parser.parse(queryable, column));
-
         });
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.TableA
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Set;
 
@@ -99,7 +100,7 @@ public class TableArgumentValidator {
                                         + "Argument type mismatch. Join table: '%s' has Argument: '%s' with type '%s'.",
                                         joinTable.getName(), joinArgName, joinArgDef.getType()));
                     }
-                } else if (joinArgDef.getDefaultValue() == null) {
+                } else if (StringUtils.isBlank(joinArgDef.getDefaultValue().toString())) {
                     throw new IllegalStateException(String.format(errorMsgPrefix
                                     + "Argument '%s' with type '%s' is not defined but is required by join table: %s.",
                                     joinArgName, joinArgDef.getType(), joinTable.getName()));
@@ -126,12 +127,12 @@ public class TableArgumentValidator {
 
     public static void verifyDefaultvalue(ArgumentDefinition argument, String errorMsgPrefix) {
 
-        if (argument.getDefaultValue() == null) {
-            return;
-        }
-
         String defaultValue = argument.getDefaultValue().toString();
         Set<String> values = argument.getValues();
+
+        if (StringUtils.isBlank(defaultValue)) {
+            return;
+        }
 
         if (CollectionUtils.isEmpty(values)) {
             if (!argument.getType().matches(defaultValue)) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.validator;
 
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.hasSql;
 import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.resolveTableOrSubselect;
-import static com.yahoo.elide.modelconfig.validator.DynamicConfigValidator.validateNameUniqueness;
 
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
@@ -40,9 +39,6 @@ public class TableArgumentValidator {
     }
 
     public void validate() {
-
-        validateNameUniqueness(table.getArgumentDefinitions(),
-                        errorMsgPrefix + "Multiple Table Arguments found with the same name: ");
 
         table.getArgumentDefinitions().forEach(arg -> {
             verifyValues(arg, errorMsgPrefix);
@@ -97,7 +93,8 @@ public class TableArgumentValidator {
                 if (table.hasArgumentDefinition(joinArgName)) {
                     if (joinArgDef.getType() != table.getArgumentDefinition(joinArgName).getType()) {
                         throw new IllegalStateException(String.format(errorMsgPrefix
-                                        + "Argument type mismatch. Join table: '%s' has Argument: '%s' with type '%s'.",
+                                        + "Argument type mismatch. Join table: '%s' has same Argument: '%s'"
+                                        + " with type '%s'.",
                                         joinTable.getName(), joinArgName, joinArgDef.getType()));
                     }
                 } else if (StringUtils.isBlank(joinArgDef.getDefaultValue().toString())) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.validator;
+
+import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.hasSql;
+import static com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLReferenceTable.resolveTableOrSubselect;
+import static com.yahoo.elide.modelconfig.validator.DynamicConfigValidator.validateNameUniqueness;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
+import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.ExpressionParser;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.TableArgReference;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.Set;
+
+public class TableArgumentValidator {
+
+    private final MetaDataStore metaDataStore;
+    private final SQLTable table;
+    private final String errorMsgPrefix;
+    private final ExpressionParser parser;
+    private final EntityDictionary dictionary;
+
+    public TableArgumentValidator(MetaDataStore metaDataStore, SQLTable table) {
+        this.metaDataStore = metaDataStore;
+        this.table = table;
+        this.errorMsgPrefix = String.format("Failed to verify table arguments for table: %s. ", table.getName());
+        this.parser = new ExpressionParser(metaDataStore);
+        this.dictionary = metaDataStore.getMetadataDictionary();
+    }
+
+    public void validate() {
+
+        validateNameUniqueness(table.getArgumentDefinitions(),
+                        errorMsgPrefix + "Multiple Table Arguments found with the same name: ");
+
+        verifyTableArgsInTableSql();
+        verifyTableArgsInColumnDefinition();
+        verifyTableArgsInJoinExpressions();
+        verifyRequiredTableArgsForJoinTables();
+
+        table.getArgumentDefinitions().forEach(arg -> {
+            verifyValues(arg, errorMsgPrefix);
+            verifyDefaultvalue(arg, errorMsgPrefix);
+        });
+    }
+
+    private void verifyTableArgsInTableSql() {
+        Type<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
+
+        if (hasSql(tableClass)) {
+            String selectSql = resolveTableOrSubselect(dictionary, tableClass);
+            verifyTableArgsExists(selectSql, "in table's sql.");
+        }
+    }
+
+    private void verifyTableArgsInColumnDefinition() {
+        table.getColumnProjections().forEach(column -> verifyTableArgsExists(column.getExpression(),
+                        String.format("in definition of column: '%s'.", column.getName())));
+    }
+
+    private void verifyTableArgsInJoinExpressions() {
+        table.getJoins().forEach((joinName, join) -> verifyTableArgsExists(join.getJoinExpression(),
+                        String.format("in definition of join: '%s'.", joinName)));
+    }
+
+    private void verifyTableArgsExists(String expression, String errorMsg) {
+        parser.parse(table, expression).stream()
+                        .filter(ref -> ref instanceof TableArgReference)
+                        .map(TableArgReference.class::cast)
+                        .map(TableArgReference::getArgName)
+                        .forEach(argName -> {
+                            if (!table.hasArgumentDefinition(argName)) {
+                                throw new IllegalStateException(String.format(errorMsgPrefix
+                                                + "Argument '%s' is not defined but found '{{$$table.args.%s}}' "
+                                                + errorMsg, argName, argName));
+                            }
+                        });
+    }
+
+    private void verifyRequiredTableArgsForJoinTables() {
+        table.getJoins().forEach((joinName, sqlJoin) -> {
+            SQLTable joinTable = metaDataStore.getTable(sqlJoin.getJoinTableType());
+            joinTable.getArgumentDefinitions().forEach(argDef -> {
+                String argName = argDef.getName();
+                ValueType argType = argDef.getType();
+                if (!(table.hasArgumentDefinition(argName)
+                                && argType == table.getArgumentDefinition(argName).getType())) {
+                    throw new IllegalStateException(String.format(
+                                    errorMsgPrefix + "Argument '%s' with type '%s' is not defined but is required by"
+                                                    + " join table: %s.",
+                                    argName, argType, joinTable.getName()));
+                }
+            });
+        });
+    }
+
+    public static void verifyValues(ArgumentDefinition argument, String errorMsgPrefix) {
+        Set<String> values = argument.getValues();
+
+        if (CollectionUtils.isEmpty(values)) {
+            return;
+        }
+
+        values.forEach(value -> {
+            if (!argument.getType().matches(value)) {
+                throw new IllegalStateException(String.format(errorMsgPrefix
+                                + "Value: '%s' for Argument '%s' with Type '%s' is invalid.",
+                                value, argument.getName(), argument.getType()));
+            }
+        });
+    }
+
+    public static void verifyDefaultvalue(ArgumentDefinition argument, String errorMsgPrefix) {
+
+        if (argument.getDefaultValue() == null) {
+            return;
+        }
+
+        String defaultValue = argument.getDefaultValue().toString();
+        Set<String> values = argument.getValues();
+
+        if (CollectionUtils.isEmpty(values)) {
+            if (!argument.getType().matches(defaultValue)) {
+                throw new IllegalStateException(String.format(errorMsgPrefix
+                                + "Default Value: '%s' for Argument '%s' with Type '%s' is invalid.",
+                                defaultValue, argument.getName(), argument.getType()));
+            }
+        } else {
+            if (!values.contains(defaultValue)) {
+                throw new IllegalStateException(String.format(errorMsgPrefix
+                                + "Default Value: '%s' for Argument '%s' with Type '%s' must match one of these"
+                                + " values: %s.",
+                                defaultValue, argument.getName(), argument.getType(), values));
+            }
+        }
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContextTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContextTest.java
@@ -238,7 +238,7 @@ public class ColumnContextTest {
 @Data
 @FromTable(name = "revenue_fact")
 @TableMeta(arguments = {
-                @ArgumentDefinition(name = "testPercentage", type = ValueType.TEXT, defaultValue = "0.1"),
+                @ArgumentDefinition(name = "testPercentage", type = ValueType.DECIMAL, defaultValue = "0.1"),
                 @ArgumentDefinition(name = "format", type = ValueType.TEXT)})
 @Include(name = "revenueFact")
 class RevenueFact {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidatorTest.java
@@ -1,0 +1,247 @@
+package com.yahoo.elide.datastores.aggregation.validator;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.datastores.aggregation.DefaultQueryValidator;
+import com.yahoo.elide.datastores.aggregation.QueryValidator;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.query.Optimizer;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialectFactory;
+import com.yahoo.elide.modelconfig.model.Argument;
+import com.yahoo.elide.modelconfig.model.Dimension;
+import com.yahoo.elide.modelconfig.model.Join;
+import com.yahoo.elide.modelconfig.model.NamespaceConfig;
+import com.yahoo.elide.modelconfig.model.Table;
+import com.yahoo.elide.modelconfig.model.Type;
+import com.zaxxer.hikari.HikariDataSource;
+
+import org.apache.commons.compress.utils.Sets;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class TableArgumentValidatorTest {
+
+    private final ConnectionDetails connection;
+    private final Map<String, ConnectionDetails> connectionDetailsMap = new HashMap<>();
+    private final Set<Optimizer> optimizers = new HashSet<>();
+    private final QueryValidator queryValidator = new DefaultQueryValidator(new EntityDictionary(new HashMap<>()));
+
+    private Table.TableBuilder mainTableBuilder;
+    private final Collection<NamespaceConfig> namespaceConfigs;
+    
+    public TableArgumentValidatorTest() {
+        this.connection = new ConnectionDetails(new HikariDataSource(), SQLDialectFactory.getDefaultDialect());
+        this.connectionDetailsMap.put("mycon", this.connection);
+        this.connectionDetailsMap.put("SalesDBConnection", this.connection);
+
+        this.namespaceConfigs = Collections.singleton(NamespaceConfig.builder().name("namespace").build());
+
+        this.mainTableBuilder = Table.builder()
+                        .name("MainTable")
+                        .namespace("namespace")
+                        .argument(Argument.builder()
+                                        .name("mainArg1")
+                                        .type(Type.INTEGER)
+                                        .values(Collections.emptySet())
+                                        .defaultValue("")
+                                        .build())
+                        ;
+    }
+
+    @Test
+    public void testArgumentValues() {
+
+        Table mainTable = mainTableBuilder
+                        .argument(Argument.builder()
+                                        .name("testArg")
+                                        .type(Type.INTEGER)
+                                        .values(Sets.newHashSet("1", "2.5"))
+                                        .defaultValue("")
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Value: '2.5' for Argument 'testArg' with Type 'INTEGER' is invalid.",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testDefaultValueIsInValues() {
+
+        Table mainTable = mainTableBuilder
+                        .argument(Argument.builder()
+                                        .name("testArg")
+                                        .type(Type.INTEGER)
+                                        .values(Sets.newHashSet("1", "2"))
+                                        .defaultValue("5")
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Default Value: '5' for Argument 'testArg' with Type 'INTEGER' must match one of these values: [1, 2].",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testDefaultValueMatchesType() {
+
+        Table mainTable = mainTableBuilder
+                        .argument(Argument.builder()
+                                        .name("testArg")
+                                        .type(Type.INTEGER)
+                                        .values(Collections.emptySet())
+                                        .defaultValue("2.5")
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Default Value: '2.5' for Argument 'testArg' with Type 'INTEGER' is invalid.",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testUndefinedTableArgsInTableSql() {
+
+        Table mainTable = mainTableBuilder
+                        .sql("SELECT something {{$$table.args.mainArg1}} blah {{$$table.args.mainArg2}} FROM")
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$table.args.mainArg2}}' in table's sql.",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testUndefinedTableArgsInColumnDefinition() {
+        Table mainTable = mainTableBuilder
+                        .dimension(Dimension.builder()
+                                        .name("dim1")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("start {{$$table.args.mainArg1}} blah {{$$table.args.mainArg2}} end")
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$table.args.mainArg2}}' in definition of column: 'dim1'.",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testUndefinedTableArgsInJoinExpressions() {
+        Table mainTable = mainTableBuilder
+                        .join(Join.builder()
+                                        .name("join")
+                                        .namespace("namespace")
+                                        .to("JoinTable")
+                                        .definition("start {{$$table.args.mainArg1}} blah {{$$table.args.mainArg2}} end")
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        tables.add(Table.builder()
+                        .name("JoinTable")
+                        .namespace("namespace")
+                        .build());
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$table.args.mainArg2}}' in definition of join: 'join'.",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testMissingRequiredTableArgsForJoinTable() {
+        Table mainTable = mainTableBuilder
+                        .join(Join.builder()
+                                        .name("join")
+                                        .namespace("namespace")
+                                        .to("JoinTable")
+                                        .definition("start {{$$table.args.mainArg1}} end")
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        tables.add(Table.builder()
+                        .name("JoinTable")
+                        .namespace("namespace")
+                        .argument(Argument.builder()
+                                        .name("joinArg1")
+                                        .type(Type.INTEGER)
+                                        .values(Collections.emptySet())
+                                        .defaultValue("")
+                                        .build())
+                        .build());
+
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Argument 'joinArg1' with type 'INTEGER' is not defined but is required by join table: namespace_JoinTable.",
+                        e.getMessage());
+    }
+    
+    @Test
+    public void testTableArgsTypeMismatchForJoinTable() {
+        Table mainTable = mainTableBuilder
+                        .join(Join.builder()
+                                        .name("join")
+                                        .namespace("namespace")
+                                        .to("JoinTable")
+                                        .definition("start {{$$table.args.mainArg1}} end")
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        tables.add(Table.builder()
+                        .name("JoinTable")
+                        .namespace("namespace")
+                        .argument(Argument.builder()
+                                        .name("mainArg1")
+                                        .type(Type.TEXT)
+                                        .values(Collections.emptySet())
+                                        .defaultValue("")
+                                        .build())
+                        .build());
+
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify table arguments for table: namespace_MainTable. Argument type mismatch. Join table: 'namespace_JoinTable' has same Argument: 'mainArg1' with type 'TEXT'.",
+                        e.getMessage());
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidatorTest.java
@@ -1,4 +1,13 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
 package com.yahoo.elide.datastores.aggregation.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.datastores.aggregation.DefaultQueryValidator;
@@ -26,10 +35,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-
 public class TableArgumentValidatorTest {
 
     private final ConnectionDetails connection;
@@ -39,7 +44,7 @@ public class TableArgumentValidatorTest {
 
     private Table.TableBuilder mainTableBuilder;
     private final Collection<NamespaceConfig> namespaceConfigs;
-    
+
     public TableArgumentValidatorTest() {
         this.connection = new ConnectionDetails(new HikariDataSource(), SQLDialectFactory.getDefaultDialect());
         this.connectionDetailsMap.put("mycon", this.connection);
@@ -213,7 +218,7 @@ public class TableArgumentValidatorTest {
         assertEquals("Failed to verify table arguments for table: namespace_MainTable. Argument 'joinArg1' with type 'INTEGER' is not defined but is required by join table: namespace_JoinTable.",
                         e.getMessage());
     }
-    
+
     @Test
     public void testTableArgsTypeMismatchForJoinTable() {
         Table mainTable = mainTableBuilder

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
@@ -741,7 +741,7 @@ public class DynamicConfigValidator implements DynamicConfiguration {
     /**
      * Validates table (or db connection) name is unique across all the dynamic table (or db connection) configs.
      */
-    private static void validateNameUniqueness(Collection<? extends Named> configs, String errorMsg) {
+    public static void validateNameUniqueness(Collection<? extends Named> configs, String errorMsg) {
 
         Set<String> names = new HashSet<>();
         configs.forEach(obj -> {


### PR DESCRIPTION
For any table:
All the table arguments used (in the column definition, Join expressions, or table's SQL) must be defined in the argument list for this table (with or without default value).
All the table arguments required for join tables must be defined in the argument list for this table (with or without default value).





## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
