### PR TITLE
Verify column arguments.

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -46,6 +46,7 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLColumnPr
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLTimeDimensionProjection;
 import com.yahoo.elide.datastores.aggregation.timegrains.Time;
+import com.yahoo.elide.datastores.aggregation.validator.ColumnArgumentValidator;
 import com.yahoo.elide.datastores.aggregation.validator.TableArgumentValidator;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
@@ -182,9 +183,16 @@ public class SQLQueryEngine extends QueryEngine {
     protected void verifyMetaData(MetaDataStore metaDataStore) {
         metaDataStore.getTables().forEach(table -> {
             SQLTable sqlTable = (SQLTable) table;
+
             checkForCycles(sqlTable);
+
             TableArgumentValidator tableArgValidator = new TableArgumentValidator(metaDataStore, sqlTable);
             tableArgValidator.validate();
+
+            sqlTable.getColumns().forEach(column -> {
+                ColumnArgumentValidator colArgValidator = new ColumnArgumentValidator(metaDataStore, sqlTable, column);
+                colArgValidator.validate();
+            });
         });
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ReferenceExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ReferenceExtractor.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.datastores.aggregation.core.JoinPath;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
-import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 
@@ -24,12 +23,18 @@ import java.util.Set;
  */
 public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor<Set<T>> {
 
-    private final Queryable limitedTo;
     private final Class<T> referenceType;
     private final Set<T> references;
     private MetaDataStore metaDataStore;
     private Set<SQLJoin> visitedJoins;
     private ExpressionParser parser;
+    private Mode mode;
+
+    public enum Mode {
+        ALL,
+        SAME_QUERY,
+        SAME_COLUMN,
+    }
 
     /**
      * Constructor.
@@ -37,18 +42,17 @@ public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor
      * @param metaDataStore Metadata store.
      */
     public ReferenceExtractor(Class<T> referenceType, MetaDataStore metaDataStore) {
-        this(referenceType, metaDataStore, null);
+        this(referenceType, metaDataStore, Mode.ALL);
     }
 
     /**
      * Constructor.
      * @param referenceType The reference type to extract.
      * @param metaDataStore Metadata store.
-     * @param limitedTo Only extract references that belong to the source table.  null means extract everything
-     *                  regardless of source table.
+     * @param mode {@link Mode}.
      */
-    public ReferenceExtractor(Class<T> referenceType, MetaDataStore metaDataStore, Queryable limitedTo) {
-        this.limitedTo = limitedTo;
+    public ReferenceExtractor(Class<T> referenceType, MetaDataStore metaDataStore, Mode mode) {
+        this.mode = mode;
         this.referenceType = referenceType;
         this.references = new LinkedHashSet<>();
         this.metaDataStore = metaDataStore;
@@ -58,11 +62,6 @@ public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor
 
     @Override
     public Set<T> visitPhysicalReference(PhysicalReference reference) {
-        //This visitor is limited to references that belong to the given queryable.
-        if (limitedTo != null && ! sameSourceTable(reference.getSource())) {
-            return references;
-        }
-
         if (referenceType.equals(PhysicalReference.class)) {
             references.add((T) reference);
         }
@@ -72,19 +71,18 @@ public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor
 
     @Override
     public Set<T> visitLogicalReference(LogicalReference reference) {
-        //This visitor is limited to references that belong to the given queryable.
-        if (limitedTo != null && ! sameSourceTable(reference.getSource())) {
-            return references;
-        }
-
         if (referenceType.equals(LogicalReference.class)) {
             references.add((T) reference);
         }
 
-        reference.getReferences().stream()
-                .map(ref -> ref.accept(this))
-                .flatMap(Set::stream)
-                .forEach(references::add);
+        if (mode != Mode.SAME_COLUMN) {
+            reference.getReferences().stream()
+                            .map(ref -> ref.accept(this))
+                            .flatMap(Set::stream)
+                            .forEach(references::add);
+
+            return references;
+        }
 
         return references;
     }
@@ -92,18 +90,15 @@ public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor
     @Override
     public Set<T> visitJoinReference(JoinReference reference) {
 
-        //This visitor is limited to references that belong to the given queryable.
-        if (limitedTo != null && ! sameSourceTable(reference.getSource())) {
-            return references;
-        }
-
         if (referenceType.equals(JoinReference.class)) {
             references.add((T) reference);
         }
 
         JoinPath path = reference.getPath();
 
-        for (int idx = 0; idx < path.getPathElements().size() - 1; idx++) {
+        int pathLimit = (mode == Mode.SAME_QUERY) ? 1 : path.getPathElements().size() - 1;
+
+        for (int idx = 0; idx < pathLimit; idx++) {
             Path.PathElement pathElement = path.getPathElements().get(idx);
 
             String fieldName = pathElement.getFieldName();
@@ -119,10 +114,13 @@ public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor
 
             parser.parse(table, join.getJoinExpression()).stream().forEach(
                     ref -> ref.accept(this));
-
         }
 
-        return reference.getReference().accept(this);
+        if (mode != Mode.SAME_QUERY) {
+            return reference.getReference().accept(this);
+        }
+
+        return references;
     }
 
     @Override
@@ -141,9 +139,5 @@ public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor
         }
 
         return references;
-    }
-
-    private boolean sameSourceTable(Queryable referenceSource) {
-        return limitedTo.getRoot().equals(referenceSource.getRoot());
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ReferenceExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ReferenceExtractor.java
@@ -80,8 +80,6 @@ public class ReferenceExtractor<T extends Reference> implements ReferenceVisitor
                             .map(ref -> ref.accept(this))
                             .flatMap(Set::stream)
                             .forEach(references::add);
-
-            return references;
         }
 
         return references;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryPlanTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryPlanTranslator.java
@@ -159,7 +159,7 @@ public class QueryPlanTranslator implements QueryVisitor<Query.QueryBuilder> {
                     .map(reference -> reference.accept(new ReferenceExtractor<LogicalReference>(
                             LogicalReference.class,
                             lookupTable.getMetaDataStore(),
-                            query.getSource())))
+                            ReferenceExtractor.Mode.SAME_QUERY)))
                     .flatMap(Set::stream)
                     .map(LogicalReference::getColumn)
                     .forEach(indirectReferenceColumns::add);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -93,8 +93,8 @@ public interface SQLColumnProjection extends ColumnProjection {
         //Search for any join expression that contains $$column.  If found, we cannot nest
         //because rewriting the SQL in the outer expression will lose the context of the calling $$column.
         return references.stream()
-                .map(reference -> reference.accept(
-                        new ReferenceExtractor<JoinReference>(JoinReference.class, metaDataStore, source)))
+                .map(reference -> reference.accept(new ReferenceExtractor<JoinReference>(
+                                JoinReference.class, metaDataStore, ReferenceExtractor.Mode.SAME_QUERY)))
                 .flatMap(Set::stream)
                 .map(reference -> reference.accept(
                         new ReferenceExtractor<ColumnArgReference>(ColumnArgReference.class, metaDataStore)))
@@ -164,8 +164,8 @@ public interface SQLColumnProjection extends ColumnProjection {
             List<Reference> references,
             MetaDataStore store) {
         return references.stream()
-                .map(ref ->
-                        ref.accept(new ReferenceExtractor<PhysicalReference>(PhysicalReference.class, store, source)))
+                .map(ref -> ref.accept(new ReferenceExtractor<PhysicalReference>(
+                                PhysicalReference.class, store, ReferenceExtractor.Mode.SAME_QUERY)))
                 .flatMap(Set::stream)
                 .map(ref -> SQLPhysicalColumnProjection.builder()
                         .name(ref.getName())

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
@@ -101,7 +101,6 @@ public class ColumnArgumentValidator {
 
         Column refColumn = sqlTable.getColumn(Column.class, columnProj.getName());
 
-
         verifyPinnedArguments(mergedArguments, refColumn, String.format(errorMsgPrefix
                         + "Type mismatch of Fixed value provided for Dependent Column: '%s' in table: '%s'. ",
                         refColumn.getName(), sqlTable.getName()));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
@@ -71,16 +71,10 @@ public class ColumnArgumentValidator {
             verifyDefaultValue(arg, errorMsgPrefix);
         });
 
-        List<Reference> references =
-                        verifyColumnArgsExists(table, column.getExpression(), "in this column's definition.");
+        List<Reference> references = parser.parse(table, column.getExpression());
+        verifyColumnArgsExists(references, "in this column's definition.");
         verifyColumnArgsWithDirectlyDependentColumnsArgs(references, "in this column's definition.");
         verifyColumnArgsInJoinExpressions(references);
-    }
-
-    private List<Reference> verifyColumnArgsExists(SQLTable table, String expression, String errorMsgSuffix) {
-        List<Reference> references = parser.parse(table, expression);
-        verifyColumnArgsExists(references, errorMsgSuffix);
-        return references;
     }
 
     private void verifyColumnArgsExists(List<Reference> references, String errorMsgSuffix) {
@@ -108,9 +102,9 @@ public class ColumnArgumentValidator {
                         .forEach(joinExprKV -> {
                             String joinExpression = joinExprKV.getValue();
                             String errorMsgSuffix = String.format("in join expression: '%s'.", joinExpression);
-                            List<Reference> joinExprReferences = verifyColumnArgsExists(joinExprKV.getKey(),
-                                                                                        joinExpression,
-                                                                                        errorMsgSuffix);
+                            List<Reference> joinExprReferences = parser.parse(joinExprKV.getKey(), joinExpression);
+
+                            verifyColumnArgsExists(joinExprReferences, errorMsgSuffix);
                             verifyColumnArgsWithDirectlyDependentColumnsArgs(joinExprReferences, errorMsgSuffix);
                         });
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
@@ -80,7 +80,7 @@ public class ColumnArgumentValidator {
                         .forEach(argName -> {
                             if (!column.hasArgumentDefinition(argName)) {
                                 throw new IllegalStateException(String.format(errorMsgPrefix
-                                                + "Argument '%s' is not defined but found '{{$$ccolumn.args.%s}}'.",
+                                                + "Argument '%s' is not defined but found '{{$$column.args.%s}}'.",
                                                 argName, argName));
                             }
                         });

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.validator;
+
+import static com.yahoo.elide.datastores.aggregation.validator.TableArgumentValidator.verifyDefaultValue;
+import static com.yahoo.elide.datastores.aggregation.validator.TableArgumentValidator.verifyValue;
+import static com.yahoo.elide.datastores.aggregation.validator.TableArgumentValidator.verifyValues;
+
+import com.yahoo.elide.core.Path.PathElement;
+import com.yahoo.elide.core.request.Argument;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.core.JoinPath;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
+import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.ColumnArgReference;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.ExpressionParser;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.JoinReference;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.LogicalReference;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.Reference;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLJoin;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Verifies all defined arguments for column.
+ * Ensures all arguments required for column are defined.
+ * For any column:
+ * <ul>
+ *   <li>All the column arguments used (Either in column definition Or in Join expressions for join referenced directly
+ *    in column definition) must be defined in the argument list for this column (with or without default value)</li>
+ *   <li>If the column references another logical column (Either in column definition Or in Join expressions for join
+ *    referenced directly in column definition), If any argument in the argument list for this logical column doesn't
+ *     have default value then that argument must be defined for this column also (with or without default value). The
+ *      only exception is if this logical column is referenced using SQL helper by this column, which defines a fixed
+ *       value for this argument, then there is no need to redefine the argument for this column.</li>
+ * </ul>
+ */
+public class ColumnArgumentValidator {
+
+    private final MetaDataStore metaDataStore;
+    private final SQLTable table;
+    private final Column column;
+    private final String errorMsgPrefix;
+    private final ExpressionParser parser;
+
+    public ColumnArgumentValidator(MetaDataStore metaDataStore, SQLTable table, Column column) {
+        this.metaDataStore = metaDataStore;
+        this.table = table;
+        this.column = column;
+        this.errorMsgPrefix = String.format("Failed to verify column arguments for column: %s in table: %s. ",
+                        column.getName(), table.getName());
+        this.parser = new ExpressionParser(metaDataStore);
+    }
+
+    public void validate() {
+
+        column.getArgumentDefinitions().forEach(arg -> {
+            verifyValues(arg, errorMsgPrefix);
+            verifyDefaultValue(arg, errorMsgPrefix);
+        });
+
+        List<Reference> references =
+                        verifyColumnArgsExists(table, column.getExpression(), "in this column's definition.");
+        verifyColumnArgsWithDirectlyDependentColumnsArgs(references, "in this column's definition.");
+        verifyColumnArgsInJoinExpressions(references);
+    }
+
+    private List<Reference> verifyColumnArgsExists(SQLTable table, String expression, String errorMsgSuffix) {
+        List<Reference> references = parser.parse(table, expression);
+        verifyColumnArgsExists(references, errorMsgSuffix);
+        return references;
+    }
+
+    private void verifyColumnArgsExists(List<Reference> references, String errorMsgSuffix) {
+        references.stream()
+                        .filter(ref -> ref instanceof ColumnArgReference)
+                        .map(ColumnArgReference.class::cast)
+                        .map(ColumnArgReference::getArgName)
+                        .forEach(argName -> {
+                            if (!column.hasArgumentDefinition(argName)) {
+                                throw new IllegalStateException(String.format(errorMsgPrefix
+                                                + "Argument '%s' is not defined but found '{{$$ccolumn.args.%s}}' "
+                                                + errorMsgSuffix, argName, argName));
+                            }
+                        });
+    }
+
+    private void verifyColumnArgsInJoinExpressions(List<Reference> references) {
+        references.stream()
+                        .filter(ref -> ref instanceof JoinReference)
+                        .map(JoinReference.class::cast)
+                        .map(JoinReference::getPath)
+                        .map(this::extractJoinExpressionsFromJoinPath)
+                        .map(Map::entrySet)
+                        .flatMap(Set::stream)
+                        .forEach(joinExprKV -> {
+                            String joinExpression = joinExprKV.getValue();
+                            String errorMsgSuffix = String.format("in join expression: '%s'.", joinExpression);
+                            List<Reference> joinExprReferences = verifyColumnArgsExists(joinExprKV.getKey(),
+                                                                                        joinExpression,
+                                                                                        errorMsgSuffix);
+                            verifyColumnArgsWithDirectlyDependentColumnsArgs(joinExprReferences, errorMsgSuffix);
+                        });
+    }
+
+    private Map<SQLTable, String> extractJoinExpressionsFromJoinPath(JoinPath joinPath) {
+
+        List<PathElement> pathElements = joinPath.getPathElements();
+        Map<SQLTable, String> joinExpressions = new HashMap<>();
+        SQLTable currentTable = this.table;
+
+        for (int i = 0; i < pathElements.size() - 1; i++) {
+            PathElement pathElement = pathElements.get(i);
+            Type<?> joinClass = pathElement.getFieldType();
+            SQLTable joinTable = metaDataStore.getTable(joinClass);
+            String joinFieldName = pathElement.getFieldName();
+
+            SQLJoin sqlJoin = currentTable.getJoin(joinFieldName);
+            if (sqlJoin != null) {
+                joinExpressions.put(currentTable, sqlJoin.getJoinExpression());
+            }
+            currentTable = joinTable;
+        }
+
+        return joinExpressions;
+    }
+
+    /**
+     * Verifies dependent column's argument requirements are satisfied by this column.
+     */
+    private void verifyColumnArgsWithDirectlyDependentColumnsArgs(List<Reference> references, String errorMsgSuffix) {
+        references.forEach(reference -> {
+            if (reference instanceof LogicalReference) {
+                verifyLogicalReference((LogicalReference) reference, errorMsgSuffix);
+            } else if (reference instanceof JoinReference) {
+                JoinReference joinRef = (JoinReference) reference;
+                if (joinRef.getReference() instanceof LogicalReference) {
+                    verifyLogicalReference((LogicalReference) joinRef.getReference(), errorMsgSuffix);
+                }
+            }
+        });
+    }
+
+    private void verifyLogicalReference(LogicalReference reference, String errorMsgSuffix) {
+
+        SQLTable sqlTable = (SQLTable) reference.getSource();
+        ColumnProjection columnProj = reference.getColumn();
+
+        // This will have dependent column's defined arguments merged with pinned arguments used to invoke this column.
+        Map<String, Argument> mergedArguments = columnProj.getArguments();
+
+        Column refColumn = sqlTable.getColumn(Column.class, columnProj.getName());
+
+        verifyPinnedArguments(mergedArguments, refColumn, errorMsgSuffix);
+
+        refColumn.getArgumentDefinitions().forEach(argDef -> {
+            String argName = argDef.getName();
+
+            if (column.hasArgumentDefinition(argName)) {
+                if (argDef.getType() != column.getArgumentDefinition(argName).getType()) {
+                    throw new IllegalStateException(String.format(errorMsgPrefix
+                                    + "Argument type mismatch. Dependent Column: '%s' %s has same Argument: '%s'"
+                                    + " with type '%s'.",
+                                    refColumn.getName(), StringUtils.chop(errorMsgSuffix), argName, argDef.getType()));
+                }
+            } else if (StringUtils.isBlank(argDef.getDefaultValue().toString())
+                            && StringUtils.isBlank(mergedArguments.get(argName).getValue().toString())) {
+                throw new IllegalStateException(String.format(errorMsgPrefix
+                                + "Argument '%s' with type '%s' is not defined but is required by"
+                                + " Dependent Column: '%s' %s",
+                                argName, argDef.getType(), refColumn.getName(), errorMsgSuffix));
+            }
+        });
+    }
+
+    /**
+     * Verifies pinned value for any argument matches with {@link ArgumentDefinition}.
+     * @param mergedArguments Dependent {@link Column}'s defined arguments merged with pinned arguments used to
+     *         invoke this column.
+     * @param refColumn Original dependent {@link Column}.
+     * @param errorMsgSuffix Custom error message.
+     */
+    private void verifyPinnedArguments(Map<String, Argument> mergedArguments, Column refColumn, String errorMsgSuffix) {
+        mergedArguments.forEach((argName, arg) -> {
+            Object originalValue = refColumn.getArgumentDefinition(argName).getDefaultValue();
+
+            if (! arg.getValue().equals(originalValue)) {
+                verifyValue(refColumn.getArgumentDefinition(argName),
+                            arg.getValue().toString(),
+                            errorMsgPrefix + "Type mismatch for Pinned value " + errorMsgSuffix + " Pinned ");
+            }
+        });
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
@@ -22,6 +22,17 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Set;
 
+/**
+ * Verifies all defined arguments for table.
+ * Ensures all arguments required for table are defined.
+ * For any table:
+ * <ul>
+ *   <li>All the table arguments used (in the column definition, Join expressions, or table's SQL) must be defined
+ *    in the argument list for this table (with or without default value).</li>
+ *   <li>All the table arguments required for join tables must be defined in the argument list for this table
+ *    (with or without default value).</li>
+ * </ul>
+ */
 public class TableArgumentValidator {
 
     private final MetaDataStore metaDataStore;
@@ -42,7 +53,7 @@ public class TableArgumentValidator {
 
         table.getArgumentDefinitions().forEach(arg -> {
             verifyValues(arg, errorMsgPrefix);
-            verifyDefaultvalue(arg, errorMsgPrefix);
+            verifyDefaultValue(arg, errorMsgPrefix);
         });
 
         verifyTableArgsInTableSql();
@@ -70,7 +81,7 @@ public class TableArgumentValidator {
                         String.format("in definition of join: '%s'.", joinName)));
     }
 
-    private void verifyTableArgsExists(String expression, String errorMsg) {
+    private void verifyTableArgsExists(String expression, String errorMsgSuffix) {
         parser.parse(table, expression).stream()
                         .filter(ref -> ref instanceof TableArgReference)
                         .map(TableArgReference.class::cast)
@@ -79,7 +90,7 @@ public class TableArgumentValidator {
                             if (!table.hasArgumentDefinition(argName)) {
                                 throw new IllegalStateException(String.format(errorMsgPrefix
                                                 + "Argument '%s' is not defined but found '{{$$table.args.%s}}' "
-                                                + errorMsg, argName, argName));
+                                                + errorMsgSuffix, argName, argName));
                             }
                         });
     }
@@ -122,27 +133,30 @@ public class TableArgumentValidator {
         });
     }
 
-    public static void verifyDefaultvalue(ArgumentDefinition argument, String errorMsgPrefix) {
-
+    public static void verifyDefaultValue(ArgumentDefinition argument, String errorMsgPrefix) {
         String defaultValue = argument.getDefaultValue().toString();
+        verifyValue(argument, defaultValue, errorMsgPrefix + "Default ");
+    }
+
+    public static void verifyValue(ArgumentDefinition argument, String value, String errorMsgPrefix) {
+
         Set<String> values = argument.getValues();
 
-        if (StringUtils.isBlank(defaultValue)) {
+        if (StringUtils.isBlank(value)) {
             return;
         }
 
         if (CollectionUtils.isEmpty(values)) {
-            if (!argument.getType().matches(defaultValue)) {
+            if (!argument.getType().matches(value)) {
                 throw new IllegalStateException(String.format(errorMsgPrefix
-                                + "Default Value: '%s' for Argument '%s' with Type '%s' is invalid.",
-                                defaultValue, argument.getName(), argument.getType()));
+                                + "Value: '%s' for Argument '%s' with Type '%s' is invalid.",
+                                value, argument.getName(), argument.getType()));
             }
         } else {
-            if (!values.contains(defaultValue)) {
+            if (!values.contains(value)) {
                 throw new IllegalStateException(String.format(errorMsgPrefix
-                                + "Default Value: '%s' for Argument '%s' with Type '%s' must match one of these"
-                                + " values: %s.",
-                                defaultValue, argument.getName(), argument.getType(), values));
+                                + "Value: '%s' for Argument '%s' with Type '%s' must match one of these values: %s.",
+                                value, argument.getName(), argument.getType(), values));
             }
         }
     }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContextTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/metadata/ColumnContextTest.java
@@ -304,7 +304,7 @@ class CurrencyRate {
     private String id;
 
     @DimensionFormula(value = "TO_CHAR({{$conversion_rate}}, {{$$column.args.format}})",
-                    arguments = {@ArgumentDefinition(name = "format", type = ValueType.INTEGER,
+                    arguments = {@ArgumentDefinition(name = "format", type = ValueType.TEXT,
                                     defaultValue = "9D0")})
     private String conversionRate;
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/HasColumnArgsVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/HasColumnArgsVisitorTest.java
@@ -13,9 +13,11 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.annotation.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.annotation.DimensionFormula;
 import com.yahoo.elide.datastores.aggregation.annotation.Join;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
@@ -43,7 +45,8 @@ public class HasColumnArgsVisitorTest {
         @Join(value = "{{$$column.args.foo}} = '123' AND {{$id}} == {{joinWithColumnArgs.$id}}")
         TableB joinWithColumnArgs;
 
-        @DimensionFormula(value = "{{joinWithColumnArgs.physical}}")
+        @DimensionFormula(value = "{{joinWithColumnArgs.physical}}",
+                          arguments = {@ArgumentDefinition(name = "foo", type = ValueType.TEXT)})
         String joinWithColumnArgsToPhysical;
 
         @DimensionFormula(value = "{{physical}}")
@@ -76,7 +79,8 @@ public class HasColumnArgsVisitorTest {
         @Join(value = "{{$id}} == {{simpleJoin.$id}} AND {{columnArgs}} = '123'")
         TableB joinWithLogicalWithColumnArgs;
 
-        @DimensionFormula(value = "{{simpleJoin.joinWithColumnArgs.physical}}")
+        @DimensionFormula(value = "{{simpleJoin.joinWithColumnArgs.physical}}",
+                          arguments = {@ArgumentDefinition(name = "foo", type = ValueType.TEXT)})
         String nestedJoinWithColumnArgs;
 
         @DimensionFormula(value = "{{simpleJoin.logical}}")
@@ -85,10 +89,12 @@ public class HasColumnArgsVisitorTest {
         @DimensionFormula(value = "{{$physical}}")
         String physical;
 
-        @DimensionFormula(value = "{{$$column.args.foo}}")
+        @DimensionFormula(value = "{{$$column.args.foo}}",
+                          arguments = {@ArgumentDefinition(name = "foo", type = ValueType.TEXT)})
         String columnArgs;
 
-        @DimensionFormula(value = "{{joinWithLogicalWithColumnArgs.physical}}")
+        @DimensionFormula(value = "{{joinWithLogicalWithColumnArgs.physical}}",
+                          arguments = {@ArgumentDefinition(name = "foo", type = ValueType.TEXT)})
         String joinWithLogicalWithColumnArgsToPhysical;
 
         @DimensionFormula(value = "{{joinWithPhysical.physical}}")

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/LogicalReferenceExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/LogicalReferenceExtractorTest.java
@@ -69,7 +69,7 @@ public class LogicalReferenceExtractorTest {
 
         assertTrue(references.size() == 1);
         ReferenceExtractor<LogicalReference> extractor =
-                new ReferenceExtractor(LogicalReference.class, metaDataStore, playerStats);
+                new ReferenceExtractor(LogicalReference.class, metaDataStore, ReferenceExtractor.Mode.SAME_QUERY);
         Set<LogicalReference> logicalReferences = references.get(0).accept(extractor);
 
         assertTrue(logicalReferences.size() == 0);
@@ -84,7 +84,7 @@ public class LogicalReferenceExtractorTest {
         assertTrue(references.size() == 1);
 
         ReferenceExtractor<LogicalReference> extractor =
-                new ReferenceExtractor(LogicalReference.class, metaDataStore, playerStats);
+                new ReferenceExtractor(LogicalReference.class, metaDataStore, ReferenceExtractor.Mode.SAME_QUERY);
 
         Set<LogicalReference> logicalReferences = references.get(0).accept(extractor);
 
@@ -99,7 +99,7 @@ public class LogicalReferenceExtractorTest {
 
         assertTrue(references.size() == 1);
         ReferenceExtractor<LogicalReference> extractor =
-                new ReferenceExtractor(LogicalReference.class, metaDataStore, playerStats);
+                new ReferenceExtractor(LogicalReference.class, metaDataStore, ReferenceExtractor.Mode.SAME_QUERY);
         Set<LogicalReference> logicalReferences = references.get(0).accept(extractor);
 
         assertEquals(1, logicalReferences.size());

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/PhysicalReferenceExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/PhysicalReferenceExtractorTest.java
@@ -70,7 +70,7 @@ public class PhysicalReferenceExtractorTest {
         assertTrue(references.size() == 1);
 
         ReferenceExtractor<PhysicalReference> extractor =
-                new ReferenceExtractor(PhysicalReference.class, metaDataStore, playerStats);
+                new ReferenceExtractor(PhysicalReference.class, metaDataStore, ReferenceExtractor.Mode.SAME_QUERY);
 
         Set<PhysicalReference> physicalReferences = references.get(0).accept(extractor);
 
@@ -92,7 +92,7 @@ public class PhysicalReferenceExtractorTest {
         assertTrue(references.size() == 1);
 
         ReferenceExtractor<PhysicalReference> extractor =
-                new ReferenceExtractor(PhysicalReference.class, metaDataStore, playerStats);
+                new ReferenceExtractor(PhysicalReference.class, metaDataStore, ReferenceExtractor.Mode.SAME_QUERY);
 
         Set<PhysicalReference> physicalReferences = references.get(0).accept(extractor);
 
@@ -114,7 +114,7 @@ public class PhysicalReferenceExtractorTest {
         assertTrue(references.size() == 1);
 
         ReferenceExtractor<PhysicalReference> extractor =
-                new ReferenceExtractor(PhysicalReference.class, metaDataStore, playerStats);
+                new ReferenceExtractor(PhysicalReference.class, metaDataStore, ReferenceExtractor.Mode.SAME_QUERY);
         Set<PhysicalReference> physicalReferences = references.get(0).accept(extractor);
 
         assertEquals(1, physicalReferences.size());

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjectionTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjectionTest.java
@@ -14,9 +14,11 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.annotation.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.annotation.DimensionFormula;
 import com.yahoo.elide.datastores.aggregation.annotation.Join;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.query.ColumnProjection;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
@@ -43,10 +45,12 @@ public class SQLColumnProjectionTest {
         @Join(value = "{{$$column.args.foo}} = '123' AND {{$id}} == {{tableB.$id}}")
         TableB tableB;
 
-        @DimensionFormula(value = "{{tableB.dim1}}")
+        @DimensionFormula(value = "{{tableB.dim1}}",
+                          arguments = {@ArgumentDefinition(name = "foo", type = ValueType.TEXT)})
         String dim1;
 
-        @DimensionFormula(value = "{{$$column.args.foo}}")
+        @DimensionFormula(value = "{{$$column.args.foo}}",
+                          arguments = {@ArgumentDefinition(name = "foo", type = ValueType.TEXT)})
         String dim2;
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.validator;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.datastores.aggregation.DefaultQueryValidator;
+import com.yahoo.elide.datastores.aggregation.QueryValidator;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.query.Optimizer;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialectFactory;
+import com.yahoo.elide.modelconfig.model.Argument;
+import com.yahoo.elide.modelconfig.model.Dimension;
+import com.yahoo.elide.modelconfig.model.NamespaceConfig;
+import com.yahoo.elide.modelconfig.model.Table;
+import com.yahoo.elide.modelconfig.model.Type;
+import com.zaxxer.hikari.HikariDataSource;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+class ColumnArgumentValidatorTest {
+
+    private final ConnectionDetails connection;
+    private final Map<String, ConnectionDetails> connectionDetailsMap = new HashMap<>();
+    private final Set<Optimizer> optimizers = new HashSet<>();
+    private final QueryValidator queryValidator = new DefaultQueryValidator(new EntityDictionary(new HashMap<>()));
+
+    private Table.TableBuilder mainTableBuilder;
+    private final Argument mainArg1;
+    private final Collection<NamespaceConfig> namespaceConfigs;
+
+    public ColumnArgumentValidatorTest() {
+        this.connection = new ConnectionDetails(new HikariDataSource(), SQLDialectFactory.getDefaultDialect());
+        this.connectionDetailsMap.put("mycon", this.connection);
+        this.connectionDetailsMap.put("SalesDBConnection", this.connection);
+
+        this.namespaceConfigs = Collections.singleton(NamespaceConfig.builder().name("namespace").build());
+
+        this.mainTableBuilder = Table.builder()
+                        .name("MainTable")
+                        .namespace("namespace");
+
+        this.mainArg1 = Argument.builder()
+                        .name("mainArg1")
+                        .type(Type.INTEGER)
+                        .values(Collections.emptySet())
+                        .defaultValue("")
+                        .build();
+    }
+
+    @Test
+    public void testUndefinedTableArgsInColumnDefinition() {
+        Table mainTable = mainTableBuilder
+                        .dimension(Dimension.builder()
+                                        .name("dim1")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("start {{$$column.args.mainArg1}} blah {{$$column.args.mainArg2}} end")
+                                        .argument(mainArg1)
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$ccolumn.args.mainArg2}}' in this column's definition.",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testColumnArgsTypeMismatchForDepenedentColumn() {
+        Table mainTable = mainTableBuilder
+                        .dimension(Dimension.builder()
+                                        .name("dim1")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("start {{$$column.args.mainArg1}} blah {{dim2}} end")
+                                        .argument(mainArg1)
+                                        .build())
+                        .dimension(Dimension.builder()
+                                        .name("dim2")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("{{$dim2}} blah {{$$column.args.mainArg1}} end")
+                                        .argument(Argument.builder()
+                                                        .name("mainArg1")
+                                                        .type(Type.TEXT)
+                                                        .values(Collections.emptySet())
+                                                        .defaultValue("")
+                                                        .build())
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument type mismatch. Dependent Column: 'dim2' in this column's definition has same Argument: 'mainArg1' with type 'TEXT'.",
+                        e.getMessage());
+    }
+
+    @Test
+    public void testMissingRequiredColumnArgsForDepenedentColumn() {
+        Table mainTable = mainTableBuilder
+                        .dimension(Dimension.builder()
+                                        .name("dim1")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("start {{$$column.args.mainArg1}} blah {{dim2}} end")
+                                        .argument(mainArg1)
+                                        .build())
+                        .dimension(Dimension.builder()
+                                        .name("dim2")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("{{$dim2}} blah {{$$column.args.dependentArg1}} end")
+                                        .argument(Argument.builder()
+                                                        .name("dependentArg1")
+                                                        .type(Type.INTEGER)
+                                                        .values(Collections.emptySet())
+                                                        .defaultValue("")
+                                                        .build())
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument 'dependentArg1' with type 'INTEGER' is not defined but is required by Dependent Column: 'dim2' in this column's definition.",
+                        e.getMessage());
+
+        // If 'dim2' is invoked using SQL helper, must not complain.
+        mainTable = mainTableBuilder
+                        .dimension(Dimension.builder()
+                                        .name("dim1")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("start {{$$column.args.mainArg1}} blah {{sql column='dim2[dependentArg1:123]'}} end")
+                                        .argument(mainArg1)
+                                        .build())
+                        .dimension(Dimension.builder()
+                                        .name("dim2")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("{{$dim2}} blah {{$$column.args.dependentArg1}} end")
+                                        .argument(Argument.builder()
+                                                        .name("dependentArg1")
+                                                        .type(Type.INTEGER)
+                                                        .values(Collections.emptySet())
+                                                        .defaultValue("")
+                                                        .build())
+                                        .build())
+                        .build();
+
+        tables = new HashSet<>();
+        tables.add(mainTable);
+
+        MetaDataStore metaDataStore1 = new MetaDataStore(tables, this.namespaceConfigs, true);
+        assertDoesNotThrow(() -> new SQLQueryEngine(metaDataStore1, connection, connectionDetailsMap, optimizers, queryValidator));
+    }
+
+    @Test
+    public void testMissingRequiredColumnArgsForDepenedentColumnInvalidPinnedArg() {
+        // 'dim2' is invoked using SQL helper, pinned value is Invalid
+        Table mainTable = mainTableBuilder
+                        .dimension(Dimension.builder()
+                                        .name("dim1")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("start {{$$column.args.mainArg1}} blah {{sql column='dim2[dependentArg1:foo]'}} end")
+                                        .argument(mainArg1)
+                                        .build())
+                        .dimension(Dimension.builder()
+                                        .name("dim2")
+                                        .type(Type.BOOLEAN)
+                                        .values(Collections.emptySet())
+                                        .tags(Collections.emptySet())
+                                        .definition("{{$dim2}} blah {{$$column.args.dependentArg1}} end")
+                                        .argument(Argument.builder()
+                                                        .name("dependentArg1")
+                                                        .type(Type.INTEGER)
+                                                        .values(Collections.emptySet())
+                                                        .defaultValue("")
+                                                        .build())
+                                        .build())
+                        .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+
+        MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Type mismatch for Pinned value in this column's definition. Pinned Value: 'foo' for Argument 'dependentArg1' with Type 'INTEGER' is invalid.",
+                        e.getMessage());
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
@@ -86,7 +86,7 @@ class ColumnArgumentValidatorTest {
         MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
         Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
 
-        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$ccolumn.args.mainArg2}}'.",
+        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$column.args.mainArg2}}'.",
                         e.getMessage());
     }
 
@@ -115,7 +115,7 @@ class ColumnArgumentValidatorTest {
         MetaDataStore metaDataStore = new MetaDataStore(tables, this.namespaceConfigs, true);
         Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
 
-        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$ccolumn.args.mainArg2}}'.",
+        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument 'mainArg2' is not defined but found '{{$$column.args.mainArg2}}'.",
                         e.getMessage());
     }
 


### PR DESCRIPTION
For any column:

- All the column arguments used (Either in column definition Or in Join expressions for join referenced directly in column definition) must be defined in the argument list for this column (with or without default value)
- If the column references another logical column (Either in column definition Or in Join expressions for join referenced directly in column definition), If any argument in the argument list for this logical column doesn’t have default value then that argument must be defined for this column also (with or without default value). The only exception is if this logical column is referenced using SQL helper by this column, which defines a fixed value for this argument, then there is no need to redefine the argument for this column. 



## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
