### PR TITLE
use column name to extract cache key in agg datastore

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
@@ -76,7 +76,7 @@ public final class QueryKeyExtractor implements FilterExpressionVisitor<Object> 
 
     // Query Components
     private void visit(Queryable source) {
-        visit(source.getName());
+        visit(source.getAlias());
     }
 
     private void visit(ColumnProjection columnProjection) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
@@ -58,12 +58,12 @@ public final class QueryKeyExtractor implements FilterExpressionVisitor<Object> 
         endGroup();
         beginGroup();
         // `groupByDimensions` is an unordered set - sort
-        query.getDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getAlias))
+        query.getDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getName))
                 .forEachOrdered(this::visit);
         endGroup();
         beginGroup();
         // `timeDimensions` is an unordered set - sort
-        query.getTimeDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getAlias))
+        query.getTimeDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getName))
                 .forEachOrdered(this::visit);
         endGroup();
 
@@ -76,11 +76,11 @@ public final class QueryKeyExtractor implements FilterExpressionVisitor<Object> 
 
     // Query Components
     private void visit(Queryable source) {
-        visit(source.getAlias());
+        visit(source.getName());
     }
 
     private void visit(ColumnProjection columnProjection) {
-        visit(columnProjection.getAlias());
+        visit(columnProjection.getName());
         visit(columnProjection.getArguments());
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractor.java
@@ -58,12 +58,12 @@ public final class QueryKeyExtractor implements FilterExpressionVisitor<Object> 
         endGroup();
         beginGroup();
         // `groupByDimensions` is an unordered set - sort
-        query.getDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getName))
+        query.getDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getSafeAlias))
                 .forEachOrdered(this::visit);
         endGroup();
         beginGroup();
         // `timeDimensions` is an unordered set - sort
-        query.getTimeDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getName))
+        query.getTimeDimensionProjections().stream().sorted(Comparator.comparing(ColumnProjection::getSafeAlias))
                 .forEachOrdered(this::visit);
         endGroup();
 
@@ -80,7 +80,7 @@ public final class QueryKeyExtractor implements FilterExpressionVisitor<Object> 
     }
 
     private void visit(ColumnProjection columnProjection) {
-        visit(columnProjection.getName());
+        visit(columnProjection.getSafeAlias());
         visit(columnProjection.getArguments());
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
@@ -50,7 +50,7 @@ public class QueryKeyExtractorTest {
                 .metricProjection(playerStatsTable.getMetricProjection("highScore"))
                 .build();
         assertEquals(
-                "playerStats;{highScore;{}}{}{};;;;",
+                "com_yahoo_elide_datastores_aggregation_example_PlayerStats;{highScore;{}}{}{};;;;",
                 QueryKeyExtractor.extractKey(query));
     }
 
@@ -71,7 +71,7 @@ public class QueryKeyExtractorTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .pagination(new ImmutablePagination(0, 2, false, true))
                 .build();
-        assertEquals("playerStats;" // table name
+        assertEquals("com_yahoo_elide_datastores_aggregation_example_PlayerStats;" // table name
                         + "{highScore;{}}" // columns
                         + "{overallRating;{}}" // group by
                         + "{recordedDate;{}}" // time dimensions

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
@@ -50,7 +50,7 @@ public class QueryKeyExtractorTest {
                 .metricProjection(playerStatsTable.getMetricProjection("highScore"))
                 .build();
         assertEquals(
-                "com_yahoo_elide_datastores_aggregation_example_PlayerStats;{highScore;{}}{}{};;;;",
+                "playerStats;{highScore;{}}{}{};;;;",
                 QueryKeyExtractor.extractKey(query));
     }
 
@@ -71,7 +71,7 @@ public class QueryKeyExtractorTest {
                 .sorting(new SortingImpl(sortMap, PlayerStats.class, dictionary))
                 .pagination(new ImmutablePagination(0, 2, false, true))
                 .build();
-        assertEquals("com_yahoo_elide_datastores_aggregation_example_PlayerStats;" // table name
+        assertEquals("playerStats;" // table name
                         + "{highScore;{}}" // columns
                         + "{overallRating;{}}" // group by
                         + "{recordedDate;{}}" // time dimensions


### PR DESCRIPTION

## Description
Using an alias as a key could be misleading since users can use the same alias for different columns across different requests.  Use name instead. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
