### PR TITLE
Fix suggestionColumns to add correct columns

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TableSource.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/TableSource.java
@@ -73,7 +73,7 @@ public class TableSource {
         if (sourceDefinition.suggestionColumns().length > 0) {
             for (int idx = 0; idx < sourceDefinition.suggestionColumns().length; idx++) {
                 String suggestionColumnName = sourceDefinition.suggestionColumns()[idx];
-                Column suggestionColumn = sourceTable.getDimension(sourceDefinition.column());
+                Column suggestionColumn = sourceTable.getDimension(suggestionColumnName);
 
                 Preconditions.checkNotNull(sourceTable, "Unable to locate table suggestion column: "
                         + suggestionColumnName);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/PlayerStats.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/example/PlayerStats.java
@@ -194,7 +194,7 @@ public class PlayerStats extends ParameterizedModel {
     @DimensionFormula("{{country.nickName}}")
     @ColumnMeta(
             description = "SubCountry NickName",
-            tableSource = @TableSource(table = "subCountry", column = "name")
+            tableSource = @TableSource(table = "subCountry", column = "name", suggestionColumns = { "id", "isoCode" })
     )
     public String getCountryNickName() {
         return fetch("countryNickName", countryNickName);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -194,6 +194,17 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
     }
 
     @Test
+    public void tableSourceTest() {
+        given()
+                .accept("application/vnd.api+json")
+                .get("/table/playerStats/dimensions/playerStats.countryNickName/tableSource")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("data.relationships.suggestionColumns.data.id", containsInAnyOrder("subCountry.id", "subCountry.isoCode"))
+                .body("data.relationships.valueSource.data.id", equalTo("subCountry.name"));
+    }
+
+    @Test
     public void tableTest() {
         given()
                .accept("application/vnd.api+json")


### PR DESCRIPTION
Resolves #2163 

## Description
Currently the config for suggestionColumns is ignored and for each suggestionColumn the valueSource column is added again

## Motivation and Context
Fix for suggestionColumns

## How Has This Been Tested?
Added a test to show tableSource is properly populated in metadata

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
