### PR TITLE
Allow multivalue params and fix header sanitization

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
@@ -73,7 +73,8 @@ public class JsonApiEndpoint {
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders = HeaderUtils.removeAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders =
+                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         return build(elide.post(getBaseUrlEndpoint(uriInfo), path, jsonapiDocument,
                 queryParams, requestHeaders, user, apiVersion, UUID.randomUUID()));
@@ -97,7 +98,8 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders = HeaderUtils.removeAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders =
+                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
         return build(elide.get(getBaseUrlEndpoint(uriInfo), path, queryParams,
@@ -129,7 +131,8 @@ public class JsonApiEndpoint {
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders = HeaderUtils.removeAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders =
+                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         return build(elide.patch(getBaseUrlEndpoint(uriInfo), contentType, accept, path,
                                  jsonapiDocument, queryParams, requestHeaders, user, apiVersion, UUID.randomUUID()));
@@ -155,8 +158,10 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-        String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders = HeaderUtils.removeAuthHeaders(headers.getRequestHeaders());
+        String apiVersion =
+                HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders =
+                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         return build(elide.delete(getBaseUrlEndpoint(uriInfo), path, jsonApiDocument, queryParams, requestHeaders,
                                   user, apiVersion, UUID.randomUUID()));

--- a/elide-core/src/main/java/com/yahoo/elide/utils/HeaderUtils.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/HeaderUtils.java
@@ -8,11 +8,10 @@ package com.yahoo.elide.utils;
 
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-
-import javax.ws.rs.core.HttpHeaders;
+import java.util.stream.Collectors;
 
 
 /**
@@ -38,13 +37,16 @@ public class HeaderUtils {
      * @param headers HttpHeaders
      * @return requestHeaders
      */
-     public static Map<String, List<String>> removeAuthHeaders(Map<String, List<String>> headers) {
-         Map<String, List<String>> requestHeaders = new HashMap<>(headers);
-         if (requestHeaders.get(HttpHeaders.AUTHORIZATION) != null) {
-             requestHeaders.remove(HttpHeaders.AUTHORIZATION);
+     public static Map<String, List<String>> lowercaseAndRemoveAuthHeaders(Map<String, List<String>> headers) {
+         // HTTP headers should be treated lowercase, but maybe not all libraries consider this
+         Map<String, List<String>> requestHeaders = headers.entrySet().stream()
+                 .collect(Collectors.toMap(entry -> entry.getKey().toLowerCase(Locale.ENGLISH), Map.Entry::getValue));
+
+         if (requestHeaders.get("authorization") != null) {
+             requestHeaders.remove("authorization");
          }
-         if (requestHeaders.get("Proxy-Authorization") != null) {
-             requestHeaders.remove("Proxy-Authorization");
+         if (requestHeaders.get("proxy-authorization") != null) {
+             requestHeaders.remove("proxy-authorization");
          }
          return requestHeaders;
      }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -75,7 +75,8 @@ public class GraphQLEndpoint {
             @Context SecurityContext securityContext,
             String graphQLDocument) {
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders = HeaderUtils.removeAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders =
+                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         QueryRunner runner = runners.getOrDefault(apiVersion, null);
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -78,7 +78,8 @@ public class GraphqlController {
                                                  @RequestBody String graphQLDocument, Authentication principal) {
         final User user = new AuthenticationUser(principal);
         final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
-        final Map<String, List<String>> requestHeadersCleaned = HeaderUtils.removeAuthHeaders(requestHeaders);
+        final Map<String, List<String>> requestHeadersCleaned =
+                HeaderUtils.lowercaseAndRemoveAuthHeaders(requestHeaders);
         final QueryRunner runner = runners.get(apiVersion);
         final String baseUrl = getBaseUrlEndpoint();
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -30,19 +30,35 @@ import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.yahoo.elide.Elide;
 import com.yahoo.elide.core.exceptions.HttpStatus;
 import com.yahoo.elide.spring.controllers.JsonApiController;
 import com.yahoo.elide.test.graphql.GraphQLDSL;
+
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 
 /**
  * Example functional test.
@@ -52,7 +68,7 @@ import javax.ws.rs.core.MediaType;
         executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
         scripts = "classpath:db/test_init.sql",
         statements = "INSERT INTO ArtifactGroup (name, commonName, description, deprecated) VALUES\n"
-            + "\t\t('com.example.repository','Example Repository','The code for this project', false);"
+                + "\t\t('com.example.repository','Example Repository','The code for this project', false);"
 )
 @Import(IntegrationTestSetup.class)
 @TestPropertySource(
@@ -63,7 +79,11 @@ import javax.ws.rs.core.MediaType;
 )
 @ActiveProfiles("default")
 public class ControllerTest extends IntegrationTest {
+    public static final String SORT_PARAM = "sort";
     private String baseUrl;
+
+    @SpyBean
+    private Elide elide;
 
     @BeforeAll
     @Override
@@ -135,21 +155,21 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiPatchTest() {
         given()
-            .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
-            .body(
-                datum(
-                    resource(
-                        type("group"),
-                        id("com.example.repository"),
-                        attributes(
-                            attr("commonName", "Changed It.")
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("group"),
+                                        id("com.example.repository"),
+                                        attributes(
+                                                attr("commonName", "Changed It.")
+                                        )
+                                )
                         )
-                    )
                 )
-            )
-            .when()
+                .when()
                 .patch("/json/group/com.example.repository")
-            .then()
+                .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
 
@@ -172,17 +192,17 @@ public class ControllerTest extends IntegrationTest {
                                         relationships(
                                                 relation(
                                                         "products",
-                                                            links(
-                                                                    attr("self", baseUrl + "group/com.example.repository/relationships/products"),
-                                                                    attr("related", baseUrl + "group/com.example.repository/products")
-                                                            )
+                                                        links(
+                                                                attr("self", baseUrl + "group/com.example.repository/relationships/products"),
+                                                                attr("related", baseUrl + "group/com.example.repository/products")
+                                                        )
 
                                                 )
                                         )
                                 )
                         ).toJSON())
                 )
-                        .statusCode(HttpStatus.SC_OK);
+                .statusCode(HttpStatus.SC_OK);
     }
 
     @Test
@@ -219,7 +239,7 @@ public class ControllerTest extends IntegrationTest {
                                                 type("group"),
                                                 id("com.example.repository.foo"),
                                                 attributes(
-                                                    attr("commonName", "Foo")
+                                                        attr("commonName", "Foo")
                                                 )
                                         )
                                 )
@@ -278,9 +298,9 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiDeleteTest() {
         when()
-            .delete("/json/group/com.example.repository")
-        .then()
-            .statusCode(HttpStatus.SC_NO_CONTENT);
+                .delete("/json/group/com.example.repository")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
     }
 
     @Test
@@ -290,11 +310,11 @@ public class ControllerTest extends IntegrationTest {
     })
     public void jsonApiDeleteRelationshipTest() {
         given()
-            .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
-            .body(datum(
-                linkage(type("product"), id("foo"))
-            ))
-        .when()
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(datum(
+                        linkage(type("product"), id("foo"))
+                ))
+                .when()
                 .delete("/json/group/com.example.repository")
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
@@ -306,38 +326,38 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void graphqlTest() {
         given()
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .body("{ \"query\" : \"" + GraphQLDSL.document(
-                query(
-                    selection(
-                        field("group",
-                            selections(
-                                field("name"),
-                                field("commonName"),
-                                field("description")
-                            )
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        query(
+                                selection(
+                                        field("group",
+                                                selections(
+                                                        field("name"),
+                                                        field("commonName"),
+                                                        field("description")
+                                                )
+                                        )
+                                )
                         )
-                    )
+                        ).toQuery() + "\" }"
                 )
-            ).toQuery() + "\" }"
-        )
-        .when()
-            .post("/graphql")
-            .then()
-            .body(equalTo(GraphQLDSL.document(
-                selection(
-                    field(
-                        "group",
-                        selections(
-                            field("name", "com.example.repository"),
-                            field("commonName", "Example Repository"),
-                            field("description", "The code for this project")
+                .when()
+                .post("/graphql")
+                .then()
+                .body(equalTo(GraphQLDSL.document(
+                        selection(
+                                field(
+                                        "group",
+                                        selections(
+                                                field("name", "com.example.repository"),
+                                                field("commonName", "Example Repository"),
+                                                field("description", "The code for this project")
+                                        )
+                                )
                         )
-                    )
-                )
-            ).toResponse()))
-            .statusCode(HttpStatus.SC_OK);
+                ).toResponse()))
+                .statusCode(HttpStatus.SC_OK);
     }
 
     @Test
@@ -422,7 +442,7 @@ public class ControllerTest extends IntegrationTest {
     public void versionedSwaggerDocumentTest() {
         given()
                 .header("ApiVersion", "1.0")
-        .when()
+                .when()
                 .get("/doc")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
@@ -478,5 +498,167 @@ public class ControllerTest extends IntegrationTest {
                 .then()
                 .body("error", equalTo("Not Found"))
                 .statusCode(HttpStatus.SC_NOT_FOUND);
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersGetTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.ACCEPT_LANGUAGE, "en-US")
+                .queryParam(SORT_PARAM, "name", "description")
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("group"),
+                                        id("com.example.repository2"),
+                                        attributes(
+                                                attr("commonName", "New group.")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .post("/json/group")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide).post(any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersPostTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .when()
+                .get("/json/group")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide).get(any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersPatchTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("group"),
+                                        id("com.example.repository"),
+                                        attributes(
+                                                attr("commonName", "Changed It.")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .patch("/json/group/com.example.repository")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide).patch(any(), any(), any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersDeleteTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .when()
+                .delete("/json/group/com.example.repository")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide).delete(
+                any(),
+                any(),
+                any(),
+                requestParamsCaptor.capture(),
+                requestHeadersCleanedCaptor.capture(),
+                any(),
+                any(),
+                any()
+        );
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersDeleteRelationshipTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(datum(
+                        linkage(type("product"), id("foo"))
+                ))
+                .when()
+                .delete("/json/group/com.example.repository")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide).delete(
+                any(),
+                any(),
+                any(),
+                requestParamsCaptor.capture(),
+                requestHeadersCleanedCaptor.capture(),
+                any(),
+                any(),
+                any()
+        );
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertFalse(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
     }
 }


### PR DESCRIPTION
Resolves #2166

## Description
1. The JsonApiController now uses a MultiValueMap to accept multiple values. Since Elide requires MultivaluedHashMap which is not supported by Spring I also added a convert method.
2. Header cleaning now takes into account that headers are to be treated as lowercase. Since we don't have a guarantee that all webservers out there will properly convert headers, I force them into a lowercased map.

## Motivation and Context
1) was a bug I encountered when writing a custom hook. The hooks give multivalue maps but in my integration tests it didn't work.
2) I encountered it when writing integration tests for 1)

## How Has This Been Tested?
There are new integration tests for each JsonApiController method verifying the passthrough of the headers and the correct removal of the auth headers.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
