### PR TITLE
Fix defaultMaxPageSize setting

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -419,7 +419,7 @@ public class GraphQLEntityProjectionMaker {
                     pagination.getOffset(),
                     value,
                     elideSettings.getDefaultPageSize(),
-                    elideSettings.getDefaultPageSize(),
+                    elideSettings.getDefaultMaxPageSize(),
                     pagination.returnPageTotals(),
                     false);
         } else if (ModelBuilder.ARGUMENT_AFTER.equals(argument.getName())) {
@@ -428,7 +428,7 @@ public class GraphQLEntityProjectionMaker {
                     value,
                     pagination.getLimit(),
                     elideSettings.getDefaultPageSize(),
-                    elideSettings.getDefaultPageSize(),
+                    elideSettings.getDefaultMaxPageSize(),
                     pagination.returnPageTotals(),
                     false);
         }


### PR DESCRIPTION
Fix defaultMaxPageSize setting. I see `defaultPageSize` was passed instead of `defaultMaxPageSize`, so it was throwing error despite correct settings used.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
