### PR TITLE
Make AS before table alias optional, i.e. dialect based

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.datastores.aggregation.queryengines.sql;
 
+import static com.yahoo.elide.datastores.aggregation.metadata.ColumnContext.applyQuotes;
+
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.filter.expression.PredicateExtractionVisitor;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
@@ -505,8 +507,9 @@ public class SQLQueryEngine extends QueryEngine {
 
         return NativeQuery.builder()
                 .projectionClause("COUNT(*)")
-                .fromClause(String.format("(%s) AS %spagination_subquery%s",
-                        innerQuery.toString(), sqlDialect.getBeginQuote(), sqlDialect.getEndQuote()))
+                .fromClause(QueryTranslator.getFromClause("(" + innerQuery + ")",
+                                                          applyQuotes("pagination_subquery", sqlDialect),
+                                                          sqlDialect))
                 .build();
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/AbstractSqlDialect.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/AbstractSqlDialect.java
@@ -249,6 +249,11 @@ public abstract class AbstractSqlDialect implements SQLDialect {
     }
 
     @Override
+    public boolean useASBeforeTableAlias() {
+        return true;
+    }
+
+    @Override
     public String generateOffsetLimitClause(int offset, int limit) {
         return OFFSET + offset + SPACE + LIMIT + limit;
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialect.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialect.java
@@ -30,6 +30,12 @@ public interface SQLDialect {
     boolean useAliasForOrderByClause();
 
     /**
+     * Add "AS" before table/subquery aliases in generated SQL.
+     * @return boolean.
+     */
+    boolean useASBeforeTableAlias();
+
+    /**
      * Generates required offset and limit clause.
      * @param offset position of the first record.
      * @param limit maximum number of record.

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/UseASBeforeTableAliasExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/UseASBeforeTableAliasExplainQueryTest.java
@@ -20,7 +20,7 @@ public class UseASBeforeTableAliasExplainQueryTest extends SQLUnitTest {
     @BeforeAll
     public static void init() {
         SQLUnitTest.init(new AbstractSqlDialect() {
-            
+
             @Override
             public String getDialectType() {
                 return "test";

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/UseASBeforeTableAliasExplainQueryTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/UseASBeforeTableAliasExplainQueryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.queryengines.sql;
+
+import com.yahoo.elide.datastores.aggregation.framework.SQLUnitTest;
+import com.yahoo.elide.datastores.aggregation.query.Query;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.AbstractSqlDialect;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UseASBeforeTableAliasExplainQueryTest extends SQLUnitTest {
+
+    @BeforeAll
+    public static void init() {
+        SQLUnitTest.init(new AbstractSqlDialect() {
+            
+            @Override
+            public String getDialectType() {
+                return "test";
+            }
+
+            @Override
+            public boolean useASBeforeTableAlias() {
+                return false;
+            }
+        });
+    }
+
+    @Test
+    public void testExplainPagination() {
+        String expectedQueryStr1 = "SELECT COUNT(*) FROM "
+                        + "(SELECT `com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`overallRating`, "
+                        + "PARSEDATETIME(FORMATDATETIME(`com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`recordedDate`, 'yyyy-MM-dd'), 'yyyy-MM-dd') "
+                        + "FROM `playerStats` `com_yahoo_elide_datastores_aggregation_example_PlayerStats` "
+                        + "GROUP BY `com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`overallRating`, "
+                        + "PARSEDATETIME(FORMATDATETIME(`com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`recordedDate`, 'yyyy-MM-dd'), 'yyyy-MM-dd') ) `pagination_subquery`";
+
+        String expectedQueryStr2 =
+                "SELECT MIN(`com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`lowScore`) AS "
+                        + "`lowScore`,`com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`overallRating` AS "
+                        + "`overallRating`,PARSEDATETIME(FORMATDATETIME("
+                        + "`com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`recordedDate`, 'yyyy-MM-dd'), "
+                        + "'yyyy-MM-dd') AS `recordedDate` FROM `playerStats` "
+                        + "`com_yahoo_elide_datastores_aggregation_example_PlayerStats`   "
+                        + "GROUP BY `com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`overallRating`, "
+                        + "PARSEDATETIME(FORMATDATETIME("
+                        + "`com_yahoo_elide_datastores_aggregation_example_PlayerStats`.`recordedDate`, 'yyyy-MM-dd'), "
+                        + "'yyyy-MM-dd') OFFSET 0 LIMIT 1";
+        List<String> expectedQueryList = new ArrayList<>();
+        expectedQueryList.add(expectedQueryStr1);
+        expectedQueryList.add(expectedQueryStr2);
+        compareQueryLists(expectedQueryList, engine.explain(TestQuery.PAGINATION_TOTAL.getQuery()));
+    }
+
+    @Test
+    public void testInnerJoin() throws Exception {
+        Query query = TestQuery.INNER_JOIN.getQuery();
+
+        String expectedQueryStr =
+                        "SELECT DISTINCT `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerInnerJoin_XXX`.`name` AS `playerNameInnerJoin` FROM `videoGames` `com_yahoo_elide_datastores_aggregation_example_VideoGame`"
+                                        + " INNER JOIN `players` `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerInnerJoin_XXX` ON `com_yahoo_elide_datastores_aggregation_example_VideoGame`.`player_id`"
+                                        + " = `com_yahoo_elide_datastores_aggregation_example_VideoGame_playerInnerJoin_XXX`.`id`";
+
+        compareQueryLists(expectedQueryStr, engine.explain(query));
+    }
+}


### PR DESCRIPTION
Make AS before table alias optional, i.e. dialect based.
Oracle doesn’t support `AS` in FROM clause and currently, we generate SQL like `table_name AS table_alias` so it doesn't work. Oracle supports `AS` in the SELECT clause so no issues with `column_name AS column_alias`. 


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
