### PR TITLE
Exclude json-path from calcite

### DIFF
--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.6.0</version>
+            <version>${jsonpath.version}</version>
         </dependency>
 
         <!-- Test -->

--- a/elide-datastore/elide-datastore-aggregation/pom.xml
+++ b/elide-datastore/elide-datastore-aggregation/pom.xml
@@ -101,7 +101,18 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <!-- Excluded for conflict with elide-async's version -->
+                <exclusion>
+                    <groupId>com.jayway.jsonpath</groupId>
+                    <artifactId>json-path</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${jsonpath.version}</version>
         </dependency>
 
         <!-- Hibernate Entity Manager -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <version.jersey>2.32</version.jersey>
         <version.junit>5.7.2</version.junit>
         <version.junit.platform>1.7.2</version.junit.platform>
+        <jsonpath.version>2.6.0</jsonpath.version>
         <hibernate3.version>3.6.10.Final</hibernate3.version>
         <hibernate5.version>5.5.2.Final</hibernate5.version>
         <slf4j-api.version>1.7.30</slf4j-api.version>


### PR DESCRIPTION
Calcite uses `json-path` version `2.4.0` which conflicts with elide-async's required json version `2.6.0`.



## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
