### PR TITLE
Add ability to map unknown exceptions to custom exceptions

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -575,7 +575,7 @@ public class Elide {
         throw new RuntimeException(error);
     }
 
-    protected CustomErrorException mapError(RuntimeException error) {
+    public CustomErrorException mapError(RuntimeException error) {
         if (errorMapper != null) {
             log.trace("Attempting to map unknown exception of type {}", error.getClass());
             CustomErrorException customizedError = errorMapper.map(error);

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -9,6 +9,7 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.audit.AuditLogger;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.exceptions.ErrorMapper;
 import com.yahoo.elide.core.filter.dialect.graphql.FilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.JoinFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.SubqueryFilterDialect;
@@ -32,6 +33,7 @@ public class ElideSettings {
     @Getter private final DataStore dataStore;
     @Getter private final EntityDictionary dictionary;
     @Getter private final JsonApiMapper mapper;
+    @Getter private final ErrorMapper errorMapper;
     @Getter private final Function<RequestScope, PermissionExecutor> permissionExecutor;
     @Getter private final List<JoinFilterDialect> joinFilterDialects;
     @Getter private final List<SubqueryFilterDialect> subqueryFilterDialects;

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -10,6 +10,7 @@ import com.yahoo.elide.core.audit.AuditLogger;
 import com.yahoo.elide.core.audit.Slf4jLogger;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.exceptions.ErrorMapper;
 import com.yahoo.elide.core.exceptions.HttpStatus;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.dialect.graphql.FilterDialect;
@@ -48,6 +49,7 @@ public class ElideSettingsBuilder {
     private final DataStore dataStore;
     private AuditLogger auditLogger;
     private JsonApiMapper jsonApiMapper;
+    private ErrorMapper errorMapper;
     private EntityDictionary entityDictionary;
     private Function<RequestScope, PermissionExecutor> permissionExecutorFunction = ActivePermissionExecutor::new;
     private List<JoinFilterDialect> joinFilterDialects;
@@ -110,6 +112,7 @@ public class ElideSettingsBuilder {
                 dataStore,
                 entityDictionary,
                 jsonApiMapper,
+                errorMapper,
                 permissionExecutorFunction,
                 joinFilterDialects,
                 subqueryFilterDialects,
@@ -139,6 +142,12 @@ public class ElideSettingsBuilder {
 
     public ElideSettingsBuilder withJsonApiMapper(JsonApiMapper jsonApiMapper) {
         this.jsonApiMapper = jsonApiMapper;
+        return this;
+    }
+
+
+    public ElideSettingsBuilder withErrorMapper(ErrorMapper errorMapper) {
+        this.errorMapper = errorMapper;
         return this;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ErrorMapper.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ErrorMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.exceptions;
+
+import javax.annotation.Nullable;
+
+/**
+ * The ErrorMapper allows mapping any RuntimeException of your choice into more meaningful
+ * CustomErrorExceptions to improved your error response to the client.
+ */
+@FunctionalInterface
+public interface ErrorMapper {
+    /**
+     * @param origin any Exception not caught by default
+     * @return a mapped CustomErrorException or null if you do not want to map this error
+     */
+    @Nullable CustomErrorException map(Exception origin);
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.exceptions;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideResponse;
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.ElideSettingsBuilder;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.datastore.DataStore;
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.dictionary.TestDictionary;
+import com.yahoo.elide.core.lifecycle.FieldTestModel;
+import com.yahoo.elide.core.lifecycle.LegacyTestModel;
+import com.yahoo.elide.core.lifecycle.PropertyTestModel;
+import com.yahoo.elide.core.security.TestUser;
+import com.yahoo.elide.core.security.User;
+import com.yahoo.elide.core.type.ClassType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/**
+ * Tests the error mapping logic.
+ */
+public class ErrorMapperTest {
+
+    private final String baseUrl = "http://localhost:8080/api/v1";
+    private static final ErrorMapper MOCK_ERROR_MAPPER = mock(ErrorMapper.class);
+    private static final Exception EXPECTED_EXCEPTION = new IllegalStateException("EXPECTED_EXCEPTION");
+    private static final CustomErrorException MAPPED_EXCEPTION = new CustomErrorException(
+            422,
+            "MAPPED_EXCEPTION",
+            ErrorObjects.builder()
+                    .addError()
+                    .withCode("SOME_ERROR")
+                    .build()
+    );
+    private EntityDictionary dictionary;
+
+    ErrorMapperTest() throws Exception {
+        dictionary = TestDictionary.getTestDictionary();
+        dictionary.bindEntity(FieldTestModel.class);
+        dictionary.bindEntity(PropertyTestModel.class);
+        dictionary.bindEntity(LegacyTestModel.class);
+    }
+
+    @AfterEach
+    private void afterEach() {
+        reset(MOCK_ERROR_MAPPER);
+    }
+
+    @Test
+    public void testElideCreateNoErrorMapper() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel mockModel = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, null);
+
+        String body = "{\"data\": {\"type\":\"testModel\",\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(ClassType.of(FieldTestModel.class))).thenReturn(mockModel);
+        doThrow(EXPECTED_EXCEPTION).when(tx).preCommit(any());
+
+        RuntimeException result = assertThrows(RuntimeException.class, () -> elide.post(baseUrl, "/testModel", body, null, NO_VERSION));
+        assertEquals(EXPECTED_EXCEPTION, result.getCause());
+
+        verify(tx).close();
+    }
+
+    @Test
+    public void testElideCreateWithErrorMapperUnmapped() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel mockModel = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, MOCK_ERROR_MAPPER);
+
+        String body = "{\"data\": {\"type\":\"testModel\",\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(ClassType.of(FieldTestModel.class))).thenReturn(mockModel);
+        doThrow(EXPECTED_EXCEPTION).when(tx).preCommit(any());
+
+        RuntimeException result = assertThrows(RuntimeException.class, () -> elide.post(baseUrl, "/testModel", body, null, NO_VERSION));
+        assertEquals(EXPECTED_EXCEPTION, result.getCause());
+
+        verify(tx).close();
+    }
+
+    @Test
+    public void testElideCreateWithErrorMapperMapped() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel mockModel = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, MOCK_ERROR_MAPPER);
+
+        String body = "{\"data\": {\"type\":\"testModel\",\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(ClassType.of(FieldTestModel.class))).thenReturn(mockModel);
+        doThrow(EXPECTED_EXCEPTION).when(tx).preCommit(any());
+        when(MOCK_ERROR_MAPPER.map(EXPECTED_EXCEPTION)).thenReturn(MAPPED_EXCEPTION);
+
+        ElideResponse response = elide.post(baseUrl, "/testModel", body, null, NO_VERSION);
+        assertEquals(422, response.getResponseCode());
+        assertEquals(
+                "{\"errors\":[{\"code\":\"SOME_ERROR\"}]}",
+                response.getBody());
+
+        verify(tx).close();
+    }
+
+    private Elide getElide(DataStore dataStore, EntityDictionary dictionary, ErrorMapper errorMapper) {
+        return new Elide(getElideSettings(dataStore, dictionary, errorMapper));
+    }
+
+    private ElideSettings getElideSettings(DataStore dataStore, EntityDictionary dictionary, ErrorMapper errorMapper) {
+        return new ElideSettingsBuilder(dataStore)
+                .withEntityDictionary(dictionary)
+                .withErrorMapper(errorMapper)
+                .withVerboseErrors()
+                .build();
+    }
+
+    private RequestScope buildRequestScope(EntityDictionary dict, DataStoreTransaction tx) {
+        User user = new TestUser("1");
+
+        return new RequestScope(null, null, NO_VERSION, null, tx, user, null, null, UUID.randomUUID(),
+                getElideSettings(null, dict, MOCK_ERROR_MAPPER));
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -14,6 +14,7 @@ import com.yahoo.elide.core.audit.Slf4jLogger;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.Injector;
+import com.yahoo.elide.core.exceptions.ErrorMapper;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.security.checks.prefab.Role;
 import com.yahoo.elide.core.type.ClassType;
@@ -135,10 +136,13 @@ public class ElideAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public Elide initializeElide(EntityDictionary dictionary,
-            DataStore dataStore, ElideConfigProperties settings) {
+                                 DataStore dataStore,
+                                 ElideConfigProperties settings,
+                                 ErrorMapper errorMapper) {
 
         ElideSettingsBuilder builder = new ElideSettingsBuilder(dataStore)
                 .withEntityDictionary(dictionary)
+                .withErrorMapper(errorMapper)
                 .withDefaultMaxPageSize(settings.getMaxPageSize())
                 .withDefaultPageSize(settings.getPageSize())
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
@@ -386,6 +390,12 @@ public class ElideAutoConfiguration {
     @ConditionalOnMissingBean
     public ClassScanner getClassScanner() {
         return new DefaultClassScanner();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ErrorMapper getErrorMapper() {
+        return error -> null;
     }
 
     private boolean isDynamicConfigEnabled(ElideConfigProperties settings) {

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.core.audit.Slf4jLogger;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.Injector;
+import com.yahoo.elide.core.exceptions.ErrorMapper;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.prefab.Role;
@@ -120,6 +121,7 @@ public interface ElideStandaloneSettings {
 
         ElideSettingsBuilder builder = new ElideSettingsBuilder(dataStore)
                 .withEntityDictionary(dictionary)
+                .withErrorMapper(getErrorMapper())
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
                 .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
                 .withBaseUrl(getBaseUrl())
@@ -533,5 +535,14 @@ public interface ElideStandaloneSettings {
      */
     default ClassScanner getClassScanner() {
         return new DefaultClassScanner();
+    }
+
+    /**
+     * Get the error mapper for this Elide instance. By default no errors will be mapped.
+     *
+     * @return error mapper implementation
+     */
+    default ErrorMapper getErrorMapper() {
+        return error -> null;
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -35,7 +35,7 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
 
             @Override
             public ElideStandaloneAnalyticSettings getAnalyticProperties() {
-                ElideStandaloneAnalyticSettings analyticPropeties = new ElideStandaloneAnalyticSettings() {
+                ElideStandaloneAnalyticSettings analyticProperties = new ElideStandaloneAnalyticSettings() {
                     @Override
                     public boolean enableDynamicModelConfig() {
                         return true;
@@ -51,7 +51,7 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
                         return "src/test/resources/configs/";
                     }
                 };
-                return analyticPropeties;
+                return analyticProperties;
             }
         });
         elide.start(false);

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
@@ -27,7 +27,7 @@ public class ElideStandaloneDisableMetaDataStoreTest extends ElideStandaloneTest
 
             @Override
             public ElideStandaloneAnalyticSettings getAnalyticProperties() {
-                ElideStandaloneAnalyticSettings analyticPropeties = new ElideStandaloneAnalyticSettings() {
+                ElideStandaloneAnalyticSettings analyticProperties = new ElideStandaloneAnalyticSettings() {
                     @Override
                     public boolean enableDynamicModelConfig() {
                         return true;
@@ -48,7 +48,7 @@ public class ElideStandaloneDisableMetaDataStoreTest extends ElideStandaloneTest
                         return "src/test/resources/configs/";
                     }
                 };
-                return analyticPropeties;
+                return analyticProperties;
             }
         });
         elide.start(false);

--- a/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
@@ -45,7 +45,7 @@ public class ElideStandaloneExportTest {
 
             @Override
             public ElideStandaloneAsyncSettings getAsyncProperties() {
-                ElideStandaloneAsyncSettings asyncPropeties = new ElideStandaloneAsyncSettings() {
+                ElideStandaloneAsyncSettings asyncProperties = new ElideStandaloneAsyncSettings() {
                     @Override
                     public boolean enabled() {
                         return true;
@@ -76,12 +76,12 @@ public class ElideStandaloneExportTest {
                         return true;
                     }
                 };
-                return asyncPropeties;
+                return asyncProperties;
             }
 
             @Override
             public ElideStandaloneAnalyticSettings getAnalyticProperties() {
-                ElideStandaloneAnalyticSettings analyticPropeties = new ElideStandaloneAnalyticSettings() {
+                ElideStandaloneAnalyticSettings analyticProperties = new ElideStandaloneAnalyticSettings() {
                     @Override
                     public boolean enableDynamicModelConfig() {
                         return true;
@@ -107,7 +107,7 @@ public class ElideStandaloneExportTest {
                         return "src/test/resources/configs/";
                     }
                 };
-                return analyticPropeties;
+                return analyticProperties;
             }
         });
         elide.start(false);

--- a/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
@@ -31,7 +31,7 @@ public class ElideStandaloneMetadataStoreMissingTest {
 
             @Override
             public ElideStandaloneAnalyticSettings getAnalyticProperties() {
-                ElideStandaloneAnalyticSettings analyticPropeties = new ElideStandaloneAnalyticSettings() {
+                ElideStandaloneAnalyticSettings analyticProperties = new ElideStandaloneAnalyticSettings() {
                     @Override
                     public boolean enableDynamicModelConfig() {
                         return true;
@@ -52,7 +52,7 @@ public class ElideStandaloneMetadataStoreMissingTest {
                         return "src/test/resources/configs/";
                     }
                 };
-                return analyticPropeties;
+                return analyticProperties;
             }
 
             @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneTestSettings.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTestSettings.java
@@ -33,6 +33,7 @@ public class ElideStandaloneTestSettings implements ElideStandaloneSettings {
 
         ElideSettingsBuilder builder = new ElideSettingsBuilder(dataStore)
                 .withEntityDictionary(dictionary)
+                .withErrorMapper(getErrorMapper())
                 .withJoinFilterDialect(new RSQLFilterDialect(dictionary))
                 .withSubqueryFilterDialect(new RSQLFilterDialect(dictionary))
                 .withJSONApiLinks(new DefaultJSONApiLinks(jsonApiBaseUrl))

--- a/elide-standalone/src/test/java/example/ElideStandaloneTestSettings.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTestSettings.java
@@ -94,7 +94,7 @@ public class ElideStandaloneTestSettings implements ElideStandaloneSettings {
 
     @Override
     public ElideStandaloneAsyncSettings getAsyncProperties() {
-        ElideStandaloneAsyncSettings asyncPropeties = new ElideStandaloneAsyncSettings() {
+        ElideStandaloneAsyncSettings asyncProperties = new ElideStandaloneAsyncSettings() {
             @Override
             public boolean enabled() {
                 return true;
@@ -125,12 +125,12 @@ public class ElideStandaloneTestSettings implements ElideStandaloneSettings {
                 return false;
             }
         };
-        return asyncPropeties;
+        return asyncProperties;
     }
 
     @Override
     public ElideStandaloneAnalyticSettings getAnalyticProperties() {
-        ElideStandaloneAnalyticSettings analyticPropeties = new ElideStandaloneAnalyticSettings() {
+        ElideStandaloneAnalyticSettings analyticProperties = new ElideStandaloneAnalyticSettings() {
             @Override
             public boolean enableDynamicModelConfig() {
                 return true;
@@ -156,6 +156,6 @@ public class ElideStandaloneTestSettings implements ElideStandaloneSettings {
                 return "src/test/resources/configs/";
             }
         };
-        return analyticPropeties;
+        return analyticProperties;
     }
 }


### PR DESCRIPTION
Resolves #2204

## Description
ElideSettings now take an (optional) ErrorMapper. This is a functional interface that can map any Exception into a different CustomErrorException.

When handling a request now, Elide runs throw the previous error handling up to the point where it is considered an unknown exception. In that case, the unknown exception is passed to the error mapper, which can map it into a CustomErrorException. If the mapping is successful, we build an error response out of it, otherwise we rethrow the untouched exception (just as before).

<!--- Describe your changes in detail -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Motivation and Context
While Elide maps javax.validation.ConstraintValidationException into proper error messages, it fails to do the same for org.hibernate.ConstraintViolationException as the latter ones might only refer to database constraint names, which have no context.
With a custom mapping a developer can capture these exceptions, read them out and turn them into a more meaningful exception (e.g. a tablename_unique_name constraint becomes a UsernameNotUniqueException extending CustomErrorException).

## How Has This Been Tested?
Not yet. This is only RFC so far.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
