### PR TITLE
Use include to set model description

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -2000,6 +2000,20 @@ public class EntityDictionary {
         return entityPrefix + entity.name();
     }
 
+    /**
+     * Looks up the model description for a given class.
+     * @param modelClass The model class to lookup.
+     * @return the description for the model class.
+     */
+    public static String getEntityDescription(Type<?> modelClass) {
+        Include include = (Include) getFirstAnnotation(modelClass, Arrays.asList(Include.class));
+        if (include == null || include.description().isEmpty()) {
+            return null;
+        }
+
+        return include.description();
+    }
+
     public static <T> Type<T> getType(T object) {
         return object instanceof Dynamic
                 ? ((Dynamic) object).getType()

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -46,6 +46,7 @@ import example.FunWithPermissions;
 import example.Job;
 import example.Left;
 import example.Parent;
+import example.Publisher;
 import example.Right;
 import example.StringId;
 import example.User;
@@ -96,6 +97,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         bindEntity(FunWithPermissions.class);
         bindEntity(Parent.class);
         bindEntity(Child.class);
+        bindEntity(Publisher.class);
         bindEntity(User.class);
         bindEntity(Left.class);
         bindEntity(Right.class);
@@ -977,7 +979,8 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertTrue(isRelation(ClassType.of(Book.class), "editor"));
         assertTrue(isAttribute(ClassType.of(Book.class), "title"));
         assertEquals(
-                Arrays.asList(ClassType.of(Book.class), ClassType.of(Author.class), ClassType.of(Editor.class)),
+                Arrays.asList(ClassType.of(Book.class), ClassType.of(Author.class),
+                        ClassType.of(Editor.class), ClassType.of(Publisher.class)),
                 walkEntityGraph(ImmutableSet.of(ClassType.of(Book.class)), x -> x));
 
         assertTrue(hasBinding(ClassType.of(Book.class)));
@@ -1040,7 +1043,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertTrue(models.contains(ClassType.of(BookV2.class)));
 
         models = getBoundClassesByVersion(NO_VERSION);
-        assertEquals(18, models.size());
+        assertEquals(19, models.size());
     }
 
     @Test
@@ -1086,5 +1089,11 @@ public class EntityDictionaryTest extends EntityDictionary {
     public void testEntityPrefix() {
         assertEquals("example_includedPackageLevel",
                 getJsonAliasFor(ClassType.of(IncludedPackageLevel.class)));
+    }
+
+    @Test
+    public void testEntityDescription() {
+        assertEquals("A book publisher", EntityDictionary.getEntityDescription(ClassType.of(Publisher.class)));
+        assertNull(EntityDictionary.getEntityDescription(ClassType.of(Book.class)));
     }
 }

--- a/elide-core/src/test/java/example/Publisher.java
+++ b/elide-core/src/test/java/example/Publisher.java
@@ -28,7 +28,7 @@ import javax.persistence.OneToMany;
  * Model for publisher.
  */
 @Entity
-@Include(rootLevel = false)
+@Include(rootLevel = false, description = "A book publisher")
 public class Publisher {
 
     private long id;

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -169,6 +169,7 @@ public class ModelBuilder {
             String entityName = entityDictionary.getJsonAliasFor(clazz);
             root.field(newFieldDefinition()
                     .name(entityName)
+                    .description(EntityDictionary.getEntityDescription(clazz))
                     .dataFetcher(dataFetcher)
                     .argument(relationshipOpArg)
                     .argument(idArgument)
@@ -244,7 +245,8 @@ public class ModelBuilder {
         log.debug("Building query object for {}", entityClass.getName());
 
         GraphQLObjectType.Builder builder = newObject()
-                .name(nameUtils.toNodeName(entityClass));
+                .name(nameUtils.toNodeName(entityClass))
+                .description(EntityDictionary.getEntityDescription(entityClass));
 
         String id = entityDictionary.getIdFieldName(entityClass);
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.request.Sorting;
 import com.yahoo.elide.core.type.ClassType;
 
+import example.Address;
 import example.Author;
 import example.Book;
 import example.Publisher;
@@ -91,6 +92,7 @@ public class ModelBuilderTest {
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Publisher.class);
+        dictionary.bindEntity(Address.class);
     }
 
     @Test
@@ -155,6 +157,21 @@ public class ModelBuilderTest {
 
         GraphQLObjectType bookType = getConnectedType((GraphQLObjectType) schema.getType(TYPE_BOOK_CONNECTION), null);
         GraphQLObjectType authorType = getConnectedType((GraphQLObjectType) schema.getType(TYPE_AUTHOR_CONNECTION), null);
+        GraphQLObjectType publisherConnectionType = (GraphQLObjectType) bookType.getFieldDefinition(FIELD_PUBLISHER)
+                .getType();
+        GraphQLList publisherEdgesType = (GraphQLList) publisherConnectionType.getFieldDefinition(EDGES)
+                .getType();
+
+        GraphQLObjectType publisherType = (GraphQLObjectType) ((GraphQLObjectType) publisherEdgesType.getWrappedType())
+                .getFieldDefinition(NODE)
+                .getType();
+
+        //Test root type description fields.
+        assertEquals("A GraphQL Book", bookType.getDescription());
+        assertNull(authorType.getDescription());
+
+        //Test non-root type description fields.
+        assertEquals("A book publisher", publisherType.getDescription());
 
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_TITLE).getType());
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_GENRE).getType());
@@ -165,7 +182,6 @@ public class ModelBuilderTest {
         GraphQLObjectType addressType = (GraphQLObjectType) authorType.getFieldDefinition("homeAddress").getType();
         assertEquals(Scalars.GraphQLString, addressType.getFieldDefinition("street1").getType());
         assertEquals(Scalars.GraphQLString, addressType.getFieldDefinition("street2").getType());
-
 
         GraphQLObjectType authorsType = (GraphQLObjectType) bookType.getFieldDefinition(FIELD_AUTHORS).getType();
         GraphQLObjectType authorsNodeType = getConnectedType(authorsType, null);

--- a/elide-graphql/src/test/java/example/Book.java
+++ b/elide-graphql/src/test/java/example/Book.java
@@ -36,7 +36,7 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "book")
-@Include
+@Include(description = "A GraphQL Book")
 @Audit(action = Audit.Action.CREATE,
         operation = 10,
         logStatement = "{0}",

--- a/elide-graphql/src/test/java/example/Publisher.java
+++ b/elide-graphql/src/test/java/example/Publisher.java
@@ -19,7 +19,7 @@ import javax.persistence.OneToMany;
  * Model for publisher.
  */
 @Entity
-@Include(rootLevel = false)
+@Include(rootLevel = false, description = "A book publisher")
 public class Publisher {
     private long id;
     private String name;

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/JsonApiModelResolver.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/JsonApiModelResolver.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.swagger;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
@@ -153,7 +154,14 @@ public class JsonApiModelResolver extends ModelResolver {
     private String getModelDescription(Type<?> clazz) {
         ApiModel model = getApiModel(clazz);
         if (model == null) {
-            return null;
+
+            String description = EntityDictionary.getEntityDescription(clazz);
+
+            if (description == null || description.isEmpty()) {
+                return null;
+            }
+
+            return description;
         }
         return model.description();
     }

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/JsonApiModelResolver.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/JsonApiModelResolver.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.swagger;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
-import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.core.dictionary.EntityDictionary;

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/JsonApiModelResolver.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/JsonApiModelResolver.java
@@ -156,7 +156,7 @@ public class JsonApiModelResolver extends ModelResolver {
 
             String description = EntityDictionary.getEntityDescription(clazz);
 
-            if (description == null || description.isEmpty()) {
+            if (StringUtils.isEmpty(description)) {
                 return null;
             }
 

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/JsonApiModelResolverTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/JsonApiModelResolverTest.java
@@ -81,6 +81,9 @@ public class JsonApiModelResolverTest {
         assertEquals("A book", model.getDescription());
 
         model = getModel(KEY_AUTHOR);
+        assertEquals("The Author", model.getDescription());
+
+        model = getModel(KEY_PUBLISHER);
         assertNull(model.getDescription());
     }
 

--- a/elide-swagger/src/test/java/example/models/Author.java
+++ b/elide-swagger/src/test/java/example/models/Author.java
@@ -14,7 +14,7 @@ import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 
 @Entity
-@Include(rootLevel = false)
+@Include(rootLevel = false, description = "The Author")
 public class Author {
 
     public AuthorType membershipType;


### PR DESCRIPTION
## Adds description information to GraphQL model schemas and Swagger documents extracted from the `@Include` annotation.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
