### PR TITLE
Fixed mismatching graphQL versions in pom

### DIFF
--- a/elide-test/pom.xml
+++ b/elide-test/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>6.0</version>
+            <version>16.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Fixes bug where elide-tests is pulling in old graphql-java.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
