### PR TITLE
Add simple configuration to enable verbose errors.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/HttpStatusException.java
@@ -76,8 +76,16 @@ public abstract class HttpStatusException extends RuntimeException {
     }
 
     public String getVerboseMessage() {
-        return verboseMessageSupplier.map(Supplier::get)
+        String result = verboseMessageSupplier.map(Supplier::get)
                 .orElseGet(this::getMessage);
+
+        if (result.equals(this.getMessage())) {
+            return result;
+        } else {
+
+            //return both the message and the verbose message.
+            return this.getMessage() + "\n" + result;
+        }
     }
 
     public int getStatus() {

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
@@ -168,6 +168,10 @@ public class CollectionTerminalState extends BaseState {
         JsonApiDocument doc = requestScope.getJsonApiDocument();
         JsonApiMapper mapper = requestScope.getMapper();
 
+        if (doc.getData() == null) {
+            throw new InvalidEntityBodyException("Invalid JSON-API document: " + doc);
+        }
+
         Data<Resource> data = doc.getData();
         Collection<Resource> resources = data.get();
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/exceptions/HttpStatusExceptionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/exceptions/HttpStatusExceptionTest.java
@@ -32,7 +32,7 @@ public class HttpStatusExceptionTest {
 
     @Test
     public void testGetEncodedVerboseResponseWithSupplier() {
-        String expected = "{\"errors\":[{\"detail\":\"a more verbose &lt;script&gt; encoding test\"}]}";
+        String expected = "{\"errors\":[{\"detail\":\"test&lt;script&gt;encoding\\na more verbose &lt;script&gt; encoding test\"}]}";
         Supplier<String> supplier = () -> "a more verbose <script> encoding test";
         HttpStatusException exception = new HttpStatusException(500, "test<script>encoding",
                 new RuntimeException("runtime exception"), supplier) { };
@@ -42,7 +42,7 @@ public class HttpStatusExceptionTest {
 
     @Test
     public void testGetVerboseResponseWithSupplier() {
-        String expected = "{\"errors\":[{\"detail\":\"a more verbose &lt;script&gt; encoding test\"}]}";
+        String expected = "{\"errors\":[{\"detail\":\"test&lt;script&gt;encoding\\na more verbose &lt;script&gt; encoding test\"}]}";
         Supplier<String> supplier = () -> "a more verbose <script> encoding test";
         HttpStatusException exception = new HttpStatusException(500, "test<script>encoding",
                 new RuntimeException("runtime exception"), supplier) { };

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -146,6 +146,10 @@ public class ElideAutoConfiguration {
                 .withJsonApiPath(settings.getJsonApi().getPath())
                 .withGraphQLApiPath(settings.getGraphql().getPath());
 
+        if (settings.isVerboseErrors()) {
+            builder.withVerboseErrors();
+        }
+
         if (settings.getAsync() != null
                 && settings.getAsync().getExport() != null
                 && settings.getAsync().getExport().isEnabled()) {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -65,4 +65,9 @@ public class ElideConfigProperties {
      * in any callback URLs returned by the service.  If not set, Elide uses the API request to derive the base URL.
      */
     private String baseUrl = "";
+
+    /**
+     * Turns on/off verbose error responses.
+     */
+    private boolean verboseErrors = false;
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableVerboseErrorsTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableVerboseErrorsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.tests;
+
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attr;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.datum;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.core.IsEqual.equalTo;
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import com.yahoo.elide.spring.controllers.JsonApiController;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Tests turning off verbose errors.
+ */
+@TestPropertySource(
+        properties = {
+                "elide.verboseErrors=false",
+        }
+)
+public class DisableVerboseErrorsTest extends IntegrationTest {
+
+    @Test
+    public void verboseErrorsEnabledTest() {
+        given()
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("group"),
+                                        id("foo"),
+                                        attributes(
+                                                attr("deprecated", "Invalid!")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .post("/json/group")
+                .then()
+                .body("errors.detail[0]", equalTo("Invalid value: Invalid!"))
+                .log().all()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/EnableVerboseErrorsTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/EnableVerboseErrorsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.tests;
+
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attr;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.datum;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.core.IsEqual.equalTo;
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import com.yahoo.elide.spring.controllers.JsonApiController;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Tests turning on verbose errors.
+ */
+@TestPropertySource(
+        properties = {
+                "elide.verboseErrors=true",
+        }
+)
+public class EnableVerboseErrorsTest extends IntegrationTest {
+
+    @Test
+    public void verboseErrorsEnabledTest() {
+        given()
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("group"),
+                                        id("foo"),
+                                        attributes(
+                                                attr("deprecated", "Invalid!")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .post("/json/group")
+                .then()
+                .body("errors.detail[0]", equalTo("Invalid value: Invalid!\nCan&#39;t convert value &#39;Invalid!&#39; to type class java.lang.Boolean"))
+                .log().all()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+}

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -126,6 +126,10 @@ public interface ElideStandaloneSettings {
                 .withGraphQLApiPath(getGraphQLApiPathSpec().replaceAll("/\\*", ""))
                 .withAuditLogger(getAuditLogger());
 
+        if (verboseErrors()) {
+            builder.withVerboseErrors();
+        }
+
         if (getAsyncProperties().enableExport()) {
             builder.withExportApiPath(getAsyncProperties().getExportApiPathSpec().replaceAll("/\\*", ""));
         }
@@ -207,6 +211,14 @@ public interface ElideStandaloneSettings {
      */
     default boolean enableGraphQL() {
         return true;
+    }
+
+    /**
+     * Enable/disable verbose error responses.
+     * @return Default: False
+     */
+    default boolean verboseErrors() {
+        return false;
     }
 
     /**

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -291,4 +291,27 @@ public class ElideStandaloneTest {
                 .body("data.attributes.name", equalTo("default"))
                 .body("data.attributes.friendlyName", equalTo("default"));
     }
+
+    @Test
+    public void testVerboseErrors() {
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("post"),
+                                        id("1"),
+                                        attributes(
+                                                attr("content", "This is my first post. woot."),
+                                                attr("date", "Invalid")
+                                        )
+                                )
+                        )
+                )
+                .post("/api/v1/post")
+                .then()
+                .body("errors.detail[0]", equalTo("Invalid value: Invalid\nDate strings must be formatted as yyyy-MM-dd&#39;T&#39;HH:mm&#39;Z&#39;"))
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneTestSettings.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTestSettings.java
@@ -39,6 +39,7 @@ public class ElideStandaloneTestSettings implements ElideStandaloneSettings {
                 .withJSONApiLinks(new DefaultJSONApiLinks(jsonApiBaseUrl))
                 .withBaseUrl("https://elide.io")
                 .withAuditLogger(getAuditLogger())
+                .withVerboseErrors()
                 .withJsonApiPath(getJsonApiPathSpec().replaceAll("/\\*", ""))
                 .withGraphQLApiPath(getGraphQLApiPathSpec().replaceAll("/\\*", ""))
                 .withExportApiPath(getAsyncProperties().getExportApiPathSpec().replaceAll("/\\*", ""));


### PR DESCRIPTION
## Description

- Adds configuration setting to toggle verbose error responses for spring boot and standalone.
- Verbose messages will include both the terse and verbose message in the response.
- Fixes an NPE found in JSON-API collection terminal state when posting invalid entity body.

## Motivation and Context
- Make it simple for customers to turn on verbose errors if the default error response is not sufficient.

## How Has This Been Tested?
- New spring and standalone tests.  Adjusted unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
