### PR TITLE
GraphQL Subscriptions PR1: Subscription model builder

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -1123,6 +1123,28 @@ public class EntityDictionary {
     }
 
     /**
+     * Returns whether a class (including superclasses) or any of its
+     * fields (attributes/relationships) has a given annotation.
+     * @param recordClass The elide model to check.
+     * @param annotationClass The annotation to search for.
+     * @param <A> The annotation type.
+     * @return True if the model is decorated with the annotation.  False otherwise.
+     */
+    public <A extends Annotation> boolean hasAnnotation(Type<?> recordClass, Class<A> annotationClass) {
+        if (this.getAnnotation(recordClass, annotationClass) != null) {
+            return true;
+        }
+
+        for (String fieldName : getEntityBinding(recordClass).fieldsToValues.keySet()) {
+            if (this.getAttributeOrRelationAnnotation(recordClass, annotationClass, fieldName) != null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Return annotation from class for provided method.
      * @param recordClass the record class
      * @param method the method

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -252,6 +252,13 @@ public class EntityDictionaryTest extends EntityDictionary {
     }
 
     @Test
+    public void testHasAnnotation() {
+        assertTrue(hasAnnotation(ClassType.of(Book.class), Include.class));
+        assertTrue(hasAnnotation(ClassType.of(Book.class), Transient.class));
+        assertFalse(hasAnnotation(ClassType.of(Book.class), Exclude.class));
+    }
+
+    @Test
     public void testBindingTriggerPriorToBindingEntityClass1() {
         @Entity
         @Include(rootLevel = false)

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -48,7 +48,6 @@ public class GraphQLConversionUtils {
     protected static final String ERROR_MESSAGE = "Value should either be integer, String or float";
 
     private final Map<Type<?>, GraphQLScalarType> scalarMap = new HashMap<>();
-    private Set<GraphQLObjectType> objectTypes;
 
     protected NonEntityDictionary nonEntityDictionary;
     protected EntityDictionary entityDictionary;
@@ -61,13 +60,11 @@ public class GraphQLConversionUtils {
 
     public GraphQLConversionUtils(
             EntityDictionary entityDictionary,
-            NonEntityDictionary nonEntityDictionary,
-            Set<GraphQLObjectType> objectTypes
+            NonEntityDictionary nonEntityDictionary
     ) {
         this.entityDictionary = entityDictionary;
         this.nonEntityDictionary = nonEntityDictionary;
         this.nameUtils = new GraphQLNameUtils(entityDictionary);
-        this.objectTypes = objectTypes;
         registerCustomScalars();
     }
 
@@ -177,7 +174,6 @@ public class GraphQLConversionUtils {
 
         GraphQLList outputMap = new GraphQLList(mapType);
 
-        objectTypes.add(mapType);
         mapConversions.put(mapName, outputMap);
 
         return mapConversions.get(mapName);
@@ -395,7 +391,6 @@ public class GraphQLConversionUtils {
         }
 
         GraphQLObjectType object = objectBuilder.build();
-        objectTypes.add(object);
         outputConversions.put(clazz, object);
 
         return object;
@@ -531,5 +526,16 @@ public class GraphQLConversionUtils {
             inputType = classToInputObject(conversionClass);
         }
         return inputType;
+    }
+
+    public Set<GraphQLObjectType> getObjectTypes() {
+        Set<GraphQLObjectType> allObjects = mapConversions.values().stream()
+                .map(GraphQLList::getWrappedType)
+                .filter(type -> type instanceof GraphQLObjectType)
+                .map(GraphQLObjectType.class::cast)
+                .collect(Collectors.toSet());
+
+        allObjects.addAll(outputConversions.values());
+        return allObjects;
     }
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
@@ -80,7 +80,7 @@ public class GraphQLNameUtils {
                 break;
             }
         }
-        return toOutputTypeName(clazz) + suffix;
+        return StringUtils.uncapitalize(toOutputTypeName(clazz) + suffix);
     }
 
     public String toNonElideOutputTypeName(Type<?> clazz) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLNameUtils.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.graphql;
 
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.graphql.subscriptions.Subscription;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -61,6 +62,25 @@ public class GraphQLNameUtils {
 
     public String toConnectionName(Type<?> clazz) {
         return toOutputTypeName(clazz) + CONNECTION_SUFFIX;
+    }
+
+    public String toSubscriptionName(Type<?> clazz, Subscription.Operation operation) {
+        String suffix;
+        switch (operation) {
+            case CREATE: {
+                suffix = "Added";
+                break;
+            }
+            case DELETE: {
+                suffix = "Deleted";
+                break;
+            }
+            default : {
+                suffix = "Updated";
+                break;
+            }
+        }
+        return toOutputTypeName(clazz) + suffix;
     }
 
     public String toNonElideOutputTypeName(Type<?> clazz) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -83,7 +83,7 @@ public class ModelBuilder {
                         NonEntityDictionary nonEntityDictionary,
                         DataFetcher dataFetcher, String apiVersion) {
         objectTypes = new HashSet<>();
-        this.generator = new GraphQLConversionUtils(entityDictionary, nonEntityDictionary, objectTypes);
+        this.generator = new GraphQLConversionUtils(entityDictionary, nonEntityDictionary);
 
         this.entityDictionary = entityDictionary;
         this.nameUtils = new GraphQLNameUtils(entityDictionary);
@@ -199,6 +199,7 @@ public class ModelBuilder {
 
         GraphQLCodeRegistry.Builder codeRegistry = GraphQLCodeRegistry.newCodeRegistry();
 
+        objectTypes.addAll(generator.getObjectTypes());
         for (GraphQLObjectType objectType : objectTypes) {
             String objectName = objectType.getName();
             for (GraphQLFieldDefinition fieldDefinition : objectType.getFieldDefinitions()) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/Subscription.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/Subscription.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.subscriptions;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({TYPE, METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface Subscription {
+    enum Operation {
+        CREATE,
+        UPDATE,
+        DELETE
+    };
+
+    Operation[] operations();
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/Subscription.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/Subscription.java
@@ -5,15 +5,19 @@
  */
 package com.yahoo.elide.graphql.subscriptions;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
+import static com.yahoo.elide.graphql.subscriptions.Subscription.Operation.CREATE;
+import static com.yahoo.elide.graphql.subscriptions.Subscription.Operation.DELETE;
+import static com.yahoo.elide.graphql.subscriptions.Subscription.Operation.UPDATE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-@Target({TYPE, METHOD, FIELD})
+/**
+ * Marks an Elide model as a root level subscription topic.
+ */
+@Target({TYPE})
 @Retention(RUNTIME)
 public @interface Subscription {
     enum Operation {
@@ -22,5 +26,9 @@ public @interface Subscription {
         DELETE
     };
 
-    Operation[] operations();
+    /**
+     * Notify subscribers whenever a model is manipulated by the given operations.
+     * @return
+     */
+    Operation[] operations() default { CREATE, UPDATE, DELETE };
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionField.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionField.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.subscriptions;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Includes a particular model field in a subscription.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface SubscriptionField {
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilder.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.graphql.subscriptions;
 
-import static graphql.introspection.Introspection.__Type;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLObjectType.newObject;
@@ -18,15 +17,16 @@ import com.yahoo.elide.graphql.NonEntityDictionary;
 import com.google.common.collect.Sets;
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLCodeRegistry;
-import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeReference;
-import graphql.schema.PropertyDataFetcher;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
@@ -35,9 +35,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Builds a GraphQL schema for subscriptions.
+ */
 @Slf4j
 public class SubscriptionModelBuilder {
-    private Map<Type<?>, GraphQLType> queryObjectRegistry;
+    private Map<Type<?>, GraphQLObjectType> queryObjectRegistry;
     private final String apiVersion;
     private GraphQLConversionUtils generator;
     private GraphQLNameUtils nameUtils;
@@ -45,6 +48,7 @@ public class SubscriptionModelBuilder {
     private DataFetcher dataFetcher;
     private GraphQLArgument filterArgument;
     private Set<Type<?>> excludedEntities;
+    private Set<GraphQLObjectType> objectTypes;
 
     /**
      * Class constructor, constructs the custom arguments to handle mutations.
@@ -55,7 +59,8 @@ public class SubscriptionModelBuilder {
     public SubscriptionModelBuilder(EntityDictionary entityDictionary,
                         NonEntityDictionary nonEntityDictionary,
                         DataFetcher dataFetcher, String apiVersion) {
-        this.generator = new GraphQLConversionUtils(entityDictionary, nonEntityDictionary);
+        objectTypes = new HashSet<>();
+        this.generator = new GraphQLConversionUtils(entityDictionary, nonEntityDictionary, objectTypes);
         this.entityDictionary = entityDictionary;
         this.nameUtils = new GraphQLNameUtils(entityDictionary);
         this.dataFetcher = dataFetcher;
@@ -88,13 +93,18 @@ public class SubscriptionModelBuilder {
 
         /* Construct root object */
         GraphQLObjectType.Builder root = newObject().name("Subscription");
+
+        String [] subscriptionTypes = { "Added", "Updated", "Deleted"};
+
         for (Type<?> clazz : rootClasses) {
-            String entityName = entityDictionary.getJsonAliasFor(clazz);
-            root.field(newFieldDefinition()
-                    .name(entityName)
-                    .description(EntityDictionary.getEntityDescription(clazz))
-                    .argument(filterArgument)
-                    .type(buildConnectionObject(clazz)));
+            for (String subscriptionType : subscriptionTypes) {
+                String subscriptionName = entityDictionary.getJsonAliasFor(clazz) + subscriptionType;
+                root.field(newFieldDefinition()
+                        .name(subscriptionName)
+                        .description(EntityDictionary.getEntityDescription(clazz))
+                        .argument(filterArgument)
+                        .type(buildQueryObject(clazz)));
+            }
         }
 
         GraphQLObjectType queryRoot = root.build();
@@ -102,26 +112,24 @@ public class SubscriptionModelBuilder {
         /*
          * Walk the object graph (avoiding cycles) and construct the GraphQL output object types.
          */
-        entityDictionary.walkEntityGraph(rootClasses, this::buildConnectionObject);
+        entityDictionary.walkEntityGraph(rootClasses, this::buildQueryObject);
+
+        GraphQLCodeRegistry.Builder codeRegistry = GraphQLCodeRegistry.newCodeRegistry();
+
+        for (GraphQLObjectType objectType : objectTypes) {
+            String objectName = objectType.getName();
+            for (GraphQLFieldDefinition fieldDefinition : objectType.getFieldDefinitions()) {
+                codeRegistry.dataFetcher(
+                        FieldCoordinates.coordinates(objectName, fieldDefinition.getName()),
+                        dataFetcher);
+            }
+        }
 
         /* Construct the schema */
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .subscription(queryRoot)
-
-                //Workaround for bug in GraphQL java (https://github.com/graphql-java/graphql-java/issues/2493).
-                //Check if schema introspection is trying to user our default data fetcher.  If so, don't let it.
-                .codeRegistry(GraphQLCodeRegistry.newCodeRegistry()
-                        .defaultDataFetcher((env) -> {
-                            GraphQLType type = env.getFieldDefinition().getType();
-                            if (type instanceof GraphQLNonNull) {
-                                type = ((GraphQLNonNull) type).getWrappedType();
-                            }
-                            if (type.equals(__Type) && env.getFieldDefinition().getName().equals("type")) {
-                                return PropertyDataFetcher.fetching("type");
-                            }
-                            return dataFetcher;
-                        })
-                        .build())
+                .query(queryRoot)
+                .codeRegistry(codeRegistry.build())
                 .additionalTypes(Sets.newHashSet(queryObjectRegistry.values()))
                 .build();
 
@@ -133,7 +141,7 @@ public class SubscriptionModelBuilder {
      * @param entityClass The class to use to construct the output object.
      * @return The graphQL object
      */
-    private GraphQLType buildQueryObjectStub(Type<?> entityClass) {
+    private GraphQLObjectType buildQueryObject(Type<?> entityClass) {
         if (queryObjectRegistry.containsKey(entityClass)) {
             return queryObjectRegistry.get(entityClass);
         }
@@ -141,7 +149,7 @@ public class SubscriptionModelBuilder {
         log.debug("Building subscription object for {}", entityClass.getName());
 
         GraphQLObjectType.Builder builder = newObject()
-                .name(nameUtils.toNodeName(entityClass))
+                .name(nameUtils.toOutputTypeName(entityClass))
                 .description(EntityDictionary.getEntityDescription(entityClass));
 
         String id = entityDictionary.getIdFieldName(entityClass);
@@ -174,6 +182,29 @@ public class SubscriptionModelBuilder {
                     .arguments(generator.attributeArgumentToQueryObject(entityClass, attribute, dataFetcher))
                     .type((GraphQLOutputType) attributeType)
             );
+        }
+
+        for (String relationship : entityDictionary.getElideBoundRelationships(entityClass)) {
+            log.debug("Resolving relationship {} for {}", relationship, entityClass.getName());
+            Type<?> relationshipClass = entityDictionary.getParameterizedType(entityClass, relationship);
+            if (excludedEntities.contains(relationshipClass)) {
+                continue;
+            }
+
+            RelationshipType type = entityDictionary.getRelationshipType(entityClass, relationship);
+            String relationshipEntityName = nameUtils.toOutputTypeName(relationshipClass);
+
+            if (type.isToOne()) {
+                builder.field(newFieldDefinition()
+                        .name(relationship)
+                        .type(new GraphQLTypeReference(relationshipEntityName))
+                        .build());
+            } else {
+                builder.field(newFieldDefinition()
+                        .name(relationship)
+                        .type(new GraphQLList(new GraphQLTypeReference(relationshipEntityName)))
+                        .build());
+            }
         }
 
         GraphQLObjectType queryObject = builder.build();

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilder.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.subscriptions;
+
+import static graphql.introspection.Introspection.__Type;
+import static graphql.schema.GraphQLArgument.newArgument;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLObjectType.newObject;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.dictionary.RelationshipType;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.graphql.GraphQLConversionUtils;
+import com.yahoo.elide.graphql.GraphQLNameUtils;
+import com.yahoo.elide.graphql.NonEntityDictionary;
+import com.google.common.collect.Sets;
+import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.GraphQLType;
+import graphql.schema.GraphQLTypeReference;
+import graphql.schema.PropertyDataFetcher;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SubscriptionModelBuilder {
+    private Map<Type<?>, GraphQLType> queryObjectRegistry;
+    private final String apiVersion;
+    private GraphQLConversionUtils generator;
+    private GraphQLNameUtils nameUtils;
+    private EntityDictionary entityDictionary;
+    private DataFetcher dataFetcher;
+    private GraphQLArgument filterArgument;
+    private Set<Type<?>> excludedEntities;
+
+    /**
+     * Class constructor, constructs the custom arguments to handle mutations.
+     * @param entityDictionary elide entity dictionary
+     * @param nonEntityDictionary elide non-entity dictionary
+     * @param dataFetcher graphQL data fetcher
+     */
+    public SubscriptionModelBuilder(EntityDictionary entityDictionary,
+                        NonEntityDictionary nonEntityDictionary,
+                        DataFetcher dataFetcher, String apiVersion) {
+        this.generator = new GraphQLConversionUtils(entityDictionary, nonEntityDictionary);
+        this.entityDictionary = entityDictionary;
+        this.nameUtils = new GraphQLNameUtils(entityDictionary);
+        this.dataFetcher = dataFetcher;
+        this.apiVersion = apiVersion;
+        excludedEntities = new HashSet<>();
+        queryObjectRegistry = new HashMap<>();
+
+        filterArgument = newArgument()
+                .name("filter")
+                .type(Scalars.GraphQLString)
+                .build();
+    }
+
+    public void withExcludedEntities(Set<Type<?>> excludedEntities) {
+        this.excludedEntities = excludedEntities;
+    }
+
+    /**
+     * Builds a GraphQL schema.
+     * @return The built schema.
+     */
+    public GraphQLSchema build() {
+        Set<Type<?>> allClasses = entityDictionary.getBoundClassesByVersion(apiVersion);
+
+        if (allClasses.isEmpty()) {
+            throw new IllegalArgumentException("None of the provided classes are exported by Elide");
+        }
+
+        Set<Type<?>> rootClasses =  allClasses.stream().filter(entityDictionary::isRoot).collect(Collectors.toSet());
+
+        /* Construct root object */
+        GraphQLObjectType.Builder root = newObject().name("Subscription");
+        for (Type<?> clazz : rootClasses) {
+            String entityName = entityDictionary.getJsonAliasFor(clazz);
+            root.field(newFieldDefinition()
+                    .name(entityName)
+                    .description(EntityDictionary.getEntityDescription(clazz))
+                    .argument(filterArgument)
+                    .type(buildConnectionObject(clazz)));
+        }
+
+        GraphQLObjectType queryRoot = root.build();
+
+        /*
+         * Walk the object graph (avoiding cycles) and construct the GraphQL output object types.
+         */
+        entityDictionary.walkEntityGraph(rootClasses, this::buildConnectionObject);
+
+        /* Construct the schema */
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+                .subscription(queryRoot)
+
+                //Workaround for bug in GraphQL java (https://github.com/graphql-java/graphql-java/issues/2493).
+                //Check if schema introspection is trying to user our default data fetcher.  If so, don't let it.
+                .codeRegistry(GraphQLCodeRegistry.newCodeRegistry()
+                        .defaultDataFetcher((env) -> {
+                            GraphQLType type = env.getFieldDefinition().getType();
+                            if (type instanceof GraphQLNonNull) {
+                                type = ((GraphQLNonNull) type).getWrappedType();
+                            }
+                            if (type.equals(__Type) && env.getFieldDefinition().getName().equals("type")) {
+                                return PropertyDataFetcher.fetching("type");
+                            }
+                            return dataFetcher;
+                        })
+                        .build())
+                .additionalTypes(Sets.newHashSet(queryObjectRegistry.values()))
+                .build();
+
+        return schema;
+    }
+
+    /**
+     * Builds a graphQL output object from an entity class.
+     * @param entityClass The class to use to construct the output object.
+     * @return The graphQL object
+     */
+    private GraphQLType buildQueryObjectStub(Type<?> entityClass) {
+        if (queryObjectRegistry.containsKey(entityClass)) {
+            return queryObjectRegistry.get(entityClass);
+        }
+
+        log.debug("Building subscription object for {}", entityClass.getName());
+
+        GraphQLObjectType.Builder builder = newObject()
+                .name(nameUtils.toNodeName(entityClass))
+                .description(EntityDictionary.getEntityDescription(entityClass));
+
+        String id = entityDictionary.getIdFieldName(entityClass);
+
+        builder.field(newFieldDefinition()
+                .name(id)
+                .type(Scalars.GraphQLID));
+
+        for (String attribute : entityDictionary.getAttributes(entityClass)) {
+            Type<?> attributeClass = entityDictionary.getType(entityClass, attribute);
+            if (excludedEntities.contains(attributeClass)) {
+                continue;
+            }
+
+            log.debug("Building subscription attribute {} {} with arguments {} for entity {}",
+                    attribute,
+                    attributeClass.getName(),
+                    entityDictionary.getAttributeArguments(attributeClass, attribute).toString(),
+                    entityClass.getName());
+
+            GraphQLType attributeType =
+                    generator.attributeToQueryObject(entityClass, attributeClass, attribute, dataFetcher);
+
+            if (attributeType == null) {
+                continue;
+            }
+
+            builder.field(newFieldDefinition()
+                    .name(attribute)
+                    .arguments(generator.attributeArgumentToQueryObject(entityClass, attribute, dataFetcher))
+                    .type((GraphQLOutputType) attributeType)
+            );
+        }
+
+        GraphQLObjectType queryObject = builder.build();
+        queryObjectRegistry.put(entityClass, queryObject);
+        return queryObject;
+    }
+}

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLConversionUtilsTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLConversionUtilsTest.java
@@ -17,7 +17,6 @@ import graphql.schema.GraphQLScalarType;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.TimeZone;
 
 public class GraphQLConversionUtilsTest {
@@ -26,7 +25,7 @@ public class GraphQLConversionUtilsTest {
     public void testGraphQLConversionUtilsOffsetDateTimeToScalarType() {
         CoerceUtil.register(OffsetDateTime.class, new OffsetDateTimeSerde());
         GraphQLConversionUtils graphQLConversionUtils =
-                new GraphQLConversionUtils(new EntityDictionary(new HashMap<>()), new NonEntityDictionary(), new HashSet<>());
+                new GraphQLConversionUtils(new EntityDictionary(new HashMap<>()), new NonEntityDictionary());
         GraphQLScalarType offsetDateTimeType = graphQLConversionUtils.classToScalarType(ClassType.of(OffsetDateTime.class));
         assertNotNull(offsetDateTimeType);
         String expected = "OffsetDateTime";
@@ -36,7 +35,7 @@ public class GraphQLConversionUtilsTest {
     public void testGraphQLConversionUtilsTimeZoneToScalarType() {
         CoerceUtil.register(TimeZone.class, new TimeZoneSerde());
         GraphQLConversionUtils graphQLConversionUtils =
-                new GraphQLConversionUtils(new EntityDictionary(new HashMap<>()), new NonEntityDictionary(), new HashSet<>());
+                new GraphQLConversionUtils(new EntityDictionary(new HashMap<>()), new NonEntityDictionary());
         GraphQLScalarType timeZoneType = graphQLConversionUtils.classToScalarType(ClassType.of(TimeZone.class));
         assertNotNull(timeZoneType);
         String expectedTimezone = "TimeZone";

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -295,7 +295,7 @@ public class ModelBuilderTest {
         return getConnectedType((GraphQLObjectType) rootType.getFieldDefinition(connectionName).getType(), null);
     }
 
-    private boolean validateEnum(Class<?> expected, GraphQLEnumType actual) {
+    public static boolean validateEnum(Class<?> expected, GraphQLEnumType actual) {
         Enum [] values = (Enum []) expected.getEnumConstants();
         Set<String> enumNames = actual.getValues().stream()
                 .map(GraphQLEnumValueDefinition::getName)

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
@@ -35,15 +35,22 @@ public class SubscriptionModelBuilderTest {
 
     private static final String FILTER = "filter";
 
+    private static final String BOOK_ADDED = "bookAdded";
+    private static final String BOOK_DELETED = "bookDeleted";
+    private static final String BOOK_UPDATED = "bookUpdated";
+    private static final String AUTHOR_ADDED = "authorAdded";
+    private static final String AUTHOR_DELETED = "authorDeleted";
+    private static final String AUTHOR_UPDATED = "authorUpdated";
+
     private static final String SUBSCRIPTION = "Subscription";
     private static final String TYPE_BOOK = "Book";
     private static final String TYPE_AUTHOR = "Author";
-    private static final String FIELD_PUBLISHER = "publisher";
+    private static final String TYPE_PREVIEW = "Preview";
+    private static final String FIELD_ID = "id";
     private static final String FIELD_TITLE = "title";
     private static final String FIELD_GENRE = "genre";
     private static final String FIELD_LANGUAGE = "language";
     private static final String FIELD_PUBLISH_DATE = "publishDate";
-    private static final String FIELD_WEIGHT_LBS = "weightLbs";
     private static final String FIELD_AUTHORS = "authors";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_TYPE = "type";
@@ -69,13 +76,25 @@ public class SubscriptionModelBuilderTest {
 
         GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
         GraphQLObjectType authorType = (GraphQLObjectType) schema.getType(TYPE_AUTHOR);
-        assertEquals(bookType, subscriptionType.getFieldDefinition("bookAdded").getType());
-        assertNull(subscriptionType.getFieldDefinition("bookDeleted"));
-        assertEquals(bookType, subscriptionType.getFieldDefinition("bookUpdated").getType());
 
-        assertEquals(authorType, subscriptionType.getFieldDefinition("authorAdded").getType());
-        assertEquals(authorType, subscriptionType.getFieldDefinition("authorDeleted").getType());
-        assertEquals(authorType, subscriptionType.getFieldDefinition("authorUpdated").getType());
+        assertEquals(bookType, subscriptionType.getFieldDefinition(BOOK_ADDED).getType());
+        assertNotNull(subscriptionType.getFieldDefinition(BOOK_ADDED).getArgument(FILTER));
+
+        assertNull(subscriptionType.getFieldDefinition(BOOK_DELETED));
+
+        assertEquals(bookType, subscriptionType.getFieldDefinition(BOOK_UPDATED).getType());
+        assertNotNull(subscriptionType.getFieldDefinition(BOOK_UPDATED).getArgument(FILTER));
+
+        assertEquals(authorType, subscriptionType.getFieldDefinition(AUTHOR_ADDED).getType());
+        assertNotNull(subscriptionType.getFieldDefinition(AUTHOR_ADDED).getArgument(FILTER));
+        assertEquals(authorType, subscriptionType.getFieldDefinition(AUTHOR_DELETED).getType());
+        assertNotNull(subscriptionType.getFieldDefinition(AUTHOR_DELETED).getArgument(FILTER));
+        assertEquals(authorType, subscriptionType.getFieldDefinition(AUTHOR_UPDATED).getType());
+        assertNotNull(subscriptionType.getFieldDefinition(AUTHOR_UPDATED).getArgument(FILTER));
+
+        assertNull(subscriptionType.getFieldDefinition("publisherAdded"));
+        assertNull(subscriptionType.getFieldDefinition("publisherDeleted"));
+        assertNull(subscriptionType.getFieldDefinition("publisherUpdated"));
     }
 
     @Test
@@ -88,36 +107,50 @@ public class SubscriptionModelBuilderTest {
 
         GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
         GraphQLObjectType authorType = (GraphQLObjectType) schema.getType(TYPE_AUTHOR);
-
-        GraphQLObjectType publisherType = (GraphQLObjectType) bookType.getFieldDefinition(FIELD_PUBLISHER).getType();
+        GraphQLObjectType previewType = (GraphQLObjectType) schema.getType(TYPE_PREVIEW);
+        GraphQLObjectType publisherType = (GraphQLObjectType) schema.getType("publisher");
 
         assertNotNull(bookType);
         assertNotNull(authorType);
+        assertNotNull(previewType);
+        assertNull(publisherType);
         assertNotNull(schema.getType(SUBSCRIPTION));
 
         //Test root type description fields.
         assertEquals("A GraphQL Book", bookType.getDescription());
         assertNull(authorType.getDescription());
 
-        //Test non-root type description fields.
-        assertEquals("A book publisher", publisherType.getDescription());
-
+        //Verify Book Fields
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_TITLE).getType());
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_GENRE).getType());
-        assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_LANGUAGE).getType());
-        assertEquals(Scalars.GraphQLLong, bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getType());
-        assertEquals(Scalars.GraphQLBigDecimal, bookType.getFieldDefinition(FIELD_WEIGHT_LBS).getType());
+        assertEquals(Scalars.GraphQLID, previewType.getFieldDefinition(FIELD_ID).getType());
+        assertEquals(previewType,
+                ((GraphQLList) bookType.getFieldDefinition("previews").getType()).getWrappedType());
+        assertEquals(authorType,
+                ((GraphQLList) bookType.getFieldDefinition(FIELD_AUTHORS).getType()).getWrappedType());
+        assertEquals(5, bookType.getFieldDefinitions().size());
 
+        //Verify fields without SubscriptionField are missing.
+        assertNull(bookType.getFieldDefinition(FIELD_LANGUAGE));
+        assertNull(bookType.getFieldDefinition(FIELD_PUBLISH_DATE));
+        assertNull(bookType.getFieldDefinition("publisher"));
+
+        //Verify Author Fields
+        assertEquals(Scalars.GraphQLID, authorType.getFieldDefinition(FIELD_ID).getType());
         GraphQLObjectType addressType = (GraphQLObjectType) authorType.getFieldDefinition("homeAddress").getType();
         assertEquals(Scalars.GraphQLString, addressType.getFieldDefinition("street1").getType());
         assertEquals(Scalars.GraphQLString, addressType.getFieldDefinition("street2").getType());
-
-        GraphQLObjectType authorsType = (GraphQLObjectType)
-                ((GraphQLList) bookType.getFieldDefinition(FIELD_AUTHORS).getType()).getWrappedType();
-
-        assertEquals(Scalars.GraphQLString, authorsType.getFieldDefinition(FIELD_NAME).getType());
+        assertEquals(Scalars.GraphQLString, authorType.getFieldDefinition(FIELD_NAME).getType());
         assertTrue(validateEnum(Author.AuthorType.class,
-                (GraphQLEnumType) authorsType.getFieldDefinition(FIELD_TYPE).getType()));
+                (GraphQLEnumType) authorType.getFieldDefinition(FIELD_TYPE).getType()));
+        assertEquals(4, authorType.getFieldDefinitions().size());
+
+        //Verify fields without SubscriptionField are missing.
+        assertNull(bookType.getFieldDefinition("books"));
+
+        //Verify Preview Fields
+        assertEquals(Scalars.GraphQLID, previewType.getFieldDefinition(FIELD_ID).getType());
+        assertEquals(1, previewType.getFieldDefinitions().size());
 
     }
 }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.graphql.subscriptions;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+import static com.yahoo.elide.graphql.ModelBuilderTest.validateEnum;
+import static graphql.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.graphql.NonEntityDictionary;
+import example.Address;
+import example.Author;
+import example.Book;
+import example.Publisher;
+import org.junit.jupiter.api.Test;
+import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLEnumType;
+import graphql.schema.GraphQLList;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
+import java.util.Collections;
+
+public class SubscriptionModelBuilderTest {
+    private EntityDictionary dictionary;
+
+    private static final String FILTER = "filter";
+
+    private static final String SUBSCRIPTION = "Subscription";
+    private static final String TYPE_BOOK = "Book";
+    private static final String TYPE_AUTHOR = "Author";
+    private static final String FIELD_PUBLISHER = "publisher";
+    private static final String FIELD_TITLE = "title";
+    private static final String FIELD_GENRE = "genre";
+    private static final String FIELD_LANGUAGE = "language";
+    private static final String FIELD_PUBLISH_DATE = "publishDate";
+    private static final String FIELD_WEIGHT_LBS = "weightLbs";
+    private static final String FIELD_AUTHORS = "authors";
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_TYPE = "type";
+
+    public SubscriptionModelBuilderTest() {
+        dictionary = new EntityDictionary(Collections.emptyMap());
+
+        dictionary.bindEntity(Book.class);
+        dictionary.bindEntity(Author.class);
+        dictionary.bindEntity(Publisher.class);
+        dictionary.bindEntity(Address.class);
+    }
+
+    @Test
+    public void testRootType() {
+        DataFetcher fetcher = mock(DataFetcher.class);
+        SubscriptionModelBuilder builder = new SubscriptionModelBuilder(dictionary,
+                new NonEntityDictionary(), fetcher, NO_VERSION);
+
+        GraphQLSchema schema = builder.build();
+        GraphQLObjectType subscriptionType = (GraphQLObjectType) schema.getType("Subscription");
+
+        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
+        GraphQLObjectType authorType = (GraphQLObjectType) schema.getType(TYPE_AUTHOR);
+        subscriptionType.getFieldDefinition("bookAdded").getType().equals(bookType);
+        subscriptionType.getFieldDefinition("bookDeleted").getType().equals(bookType);
+        subscriptionType.getFieldDefinition("bookUpdated").getType().equals(bookType);
+
+        subscriptionType.getFieldDefinition("authorAdded").getType().equals(authorType);
+        subscriptionType.getFieldDefinition("authorDeleted").getType().equals(authorType);
+        subscriptionType.getFieldDefinition("authorUpdated").getType().equals(authorType);
+    }
+
+    @Test
+    public void testModelTypes() {
+        DataFetcher fetcher = mock(DataFetcher.class);
+        SubscriptionModelBuilder builder = new SubscriptionModelBuilder(dictionary,
+                new NonEntityDictionary(), fetcher, NO_VERSION);
+
+        GraphQLSchema schema = builder.build();
+
+        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
+        GraphQLObjectType authorType = (GraphQLObjectType) schema.getType(TYPE_AUTHOR);
+
+        GraphQLObjectType publisherType = (GraphQLObjectType) bookType.getFieldDefinition(FIELD_PUBLISHER).getType();
+
+        assertNotNull(bookType);
+        assertNotNull(authorType);
+        assertNotNull(schema.getType(SUBSCRIPTION));
+
+        //Test root type description fields.
+        assertEquals("A GraphQL Book", bookType.getDescription());
+        assertNull(authorType.getDescription());
+
+        //Test non-root type description fields.
+        assertEquals("A book publisher", publisherType.getDescription());
+
+        assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_TITLE).getType());
+        assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_GENRE).getType());
+        assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_LANGUAGE).getType());
+        assertEquals(Scalars.GraphQLLong, bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getType());
+        assertEquals(Scalars.GraphQLBigDecimal, bookType.getFieldDefinition(FIELD_WEIGHT_LBS).getType());
+
+        GraphQLObjectType addressType = (GraphQLObjectType) authorType.getFieldDefinition("homeAddress").getType();
+        assertEquals(Scalars.GraphQLString, addressType.getFieldDefinition("street1").getType());
+        assertEquals(Scalars.GraphQLString, addressType.getFieldDefinition("street2").getType());
+
+        GraphQLObjectType authorsType = (GraphQLObjectType)
+                ((GraphQLList) bookType.getFieldDefinition(FIELD_AUTHORS).getType()).getWrappedType();
+
+        assertEquals(Scalars.GraphQLString, authorsType.getFieldDefinition(FIELD_NAME).getType());
+        assertTrue(validateEnum(Author.AuthorType.class,
+                (GraphQLEnumType) authorsType.getFieldDefinition(FIELD_TYPE).getType()));
+
+    }
+}

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.graphql.NonEntityDictionary;
 import example.Address;
 import example.Author;
 import example.Book;
+import example.Preview;
 import example.Publisher;
 import org.junit.jupiter.api.Test;
 import graphql.Scalars;
@@ -54,6 +55,7 @@ public class SubscriptionModelBuilderTest {
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Publisher.class);
         dictionary.bindEntity(Address.class);
+        dictionary.bindEntity(Preview.class);
     }
 
     @Test
@@ -67,13 +69,13 @@ public class SubscriptionModelBuilderTest {
 
         GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
         GraphQLObjectType authorType = (GraphQLObjectType) schema.getType(TYPE_AUTHOR);
-        subscriptionType.getFieldDefinition("bookAdded").getType().equals(bookType);
-        subscriptionType.getFieldDefinition("bookDeleted").getType().equals(bookType);
-        subscriptionType.getFieldDefinition("bookUpdated").getType().equals(bookType);
+        assertEquals(bookType, subscriptionType.getFieldDefinition("bookAdded").getType());
+        assertNull(subscriptionType.getFieldDefinition("bookDeleted"));
+        assertEquals(bookType, subscriptionType.getFieldDefinition("bookUpdated").getType());
 
-        subscriptionType.getFieldDefinition("authorAdded").getType().equals(authorType);
-        subscriptionType.getFieldDefinition("authorDeleted").getType().equals(authorType);
-        subscriptionType.getFieldDefinition("authorUpdated").getType().equals(authorType);
+        assertEquals(authorType, subscriptionType.getFieldDefinition("authorAdded").getType());
+        assertEquals(authorType, subscriptionType.getFieldDefinition("authorDeleted").getType());
+        assertEquals(authorType, subscriptionType.getFieldDefinition("authorUpdated").getType());
     }
 
     @Test

--- a/elide-graphql/src/test/java/example/Author.java
+++ b/elide-graphql/src/test/java/example/Author.java
@@ -8,6 +8,8 @@ package example;
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.graphql.subscriptions.Subscription;
+import com.yahoo.elide.graphql.subscriptions.SubscriptionField;
 import lombok.Builder;
 
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import javax.persistence.Transient;
         operation = 10,
         logStatement = "{0}",
         logExpressions = {"${author.name}"})
+@Subscription
 public class Author {
     public enum AuthorType {
         EXCLUSIVE,
@@ -64,6 +67,7 @@ public class Author {
     private Object obj = "foo";
     private Map<PublicationFormat, Integer> booksPublishedByFormat = new HashMap<>();
 
+    @SubscriptionField
     public String getName() {
         return name;
     }
@@ -79,6 +83,8 @@ public class Author {
     public Object getObj() {
         return obj;
     }
+
+    @SubscriptionField
     public AuthorType getType() {
         return type;
     }
@@ -95,6 +101,7 @@ public class Author {
         this.secondaryType = secondaryType;
     }
 
+    @SubscriptionField
     public Address getHomeAddress() {
         return homeAddress;
     }

--- a/elide-graphql/src/test/java/example/Book.java
+++ b/elide-graphql/src/test/java/example/Book.java
@@ -7,6 +7,8 @@ package example;
 
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.graphql.subscriptions.SubscriptionField;
+import com.yahoo.elide.graphql.subscriptions.Subscription;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Singular;
@@ -41,6 +43,7 @@ import javax.persistence.Table;
         operation = 10,
         logStatement = "{0}",
         logExpressions = {"${book.title}"})
+@Subscription( operations = { Subscription.Operation.CREATE, Subscription.Operation.UPDATE})
 public class Book {
 
     private long id;
@@ -52,6 +55,7 @@ public class Book {
     @Singular private Collection<Author> authors = new ArrayList<>();
     private Publisher publisher = null;
     private Date publicationDate = null;
+
     private Date lastPurchasedDate = null;
     private Author.AuthorType authorTypeAtTimeOfPublication;
     private Set<PublicationFormat> publicationFormats = new HashSet<>();
@@ -70,6 +74,7 @@ public class Book {
         this.id = id;
     }
 
+    @SubscriptionField
     public String getTitle() {
         return title;
     }
@@ -78,6 +83,7 @@ public class Book {
         this.title = title;
     }
 
+    @SubscriptionField
     public String getGenre() {
         return genre;
     }
@@ -135,6 +141,7 @@ public class Book {
         return this.weightLbs;
     }
 
+    @SubscriptionField
     @ManyToMany
     public Collection<Author> getAuthors() {
         return authors;
@@ -144,6 +151,7 @@ public class Book {
         this.authors = authors;
     }
 
+    @SubscriptionField
     @OneToMany(mappedBy = "book")
     public Collection<Preview> getPreviews() {
         return previews;

--- a/elide-graphql/src/test/java/example/Book.java
+++ b/elide-graphql/src/test/java/example/Book.java
@@ -7,8 +7,8 @@ package example;
 
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.graphql.subscriptions.SubscriptionField;
 import com.yahoo.elide.graphql.subscriptions.Subscription;
+import com.yahoo.elide.graphql.subscriptions.SubscriptionField;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Singular;
@@ -43,7 +43,7 @@ import javax.persistence.Table;
         operation = 10,
         logStatement = "{0}",
         logExpressions = {"${book.title}"})
-@Subscription( operations = { Subscription.Operation.CREATE, Subscription.Operation.UPDATE})
+@Subscription(operations = { Subscription.Operation.CREATE, Subscription.Operation.UPDATE})
 public class Book {
 
     private long id;


### PR DESCRIPTION
This first PR adds the Subscription and SubscriptionField annotations and constructs a new GraphQL schema for subscription models (which are subsets of Elide models).


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
