### PR TITLE
GraphQL Subscriptions PR2: Jms data store

### DIFF
--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -75,12 +75,14 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-server</artifactId>
             <version>2.17.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-client-all</artifactId>
             <version>2.17.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -88,7 +90,6 @@
             <artifactId>javax.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
 
     </dependencies>
     <build>

--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>elide-datastore-jms</artifactId>
+    <name>Elide Data Store: JMS</name>
+    <parent>
+        <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-datastore-parent-pom</artifactId>
+        <version>5.0.5-SNAPSHOT</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Yahoo Inc.</name>
+            <url>https://github.com/yahoo</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <developerConnection>scm:git:ssh://git@github.com/yahoo/elide.git</developerConnection>
+        <url>https://github.com/yahoo/elide.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <!-- Elide dependencies (include test dependencies) -->
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-core</artifactId>
+        </dependency>
+        <!-- Jackson data-binder -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>5.0.5-SNAPSHOT</version>
+        <version>5.0.7-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -71,6 +71,25 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-server</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client-all</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
     </dependencies>
     <build>
         <plugins>

--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -45,6 +45,13 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>javax.jms</groupId>
+            <artifactId>javax.jms-api</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-parent-pom</artifactId>
-        <version>5.0.7-SNAPSHOT</version>
+        <version>5.0.8-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
@@ -12,8 +12,14 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
 
 import java.util.Set;
+import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
 
 public class JMSDataStore implements DataStore {
     Set<Type<?>> models;
@@ -33,13 +39,24 @@ public class JMSDataStore implements DataStore {
 
     @Override
     public DataStoreTransaction beginTransaction() {
-        JMSContext context = connectionFactory.createContext()
+        JMSContext context = connectionFactory.createContext();
+        try {
+            Connection connection = connectionFactory.createConnection();
+            Session session = connection.createSession();
+            Destination destination = session.createTopic("foo");
+            MessageConsumer consumer = session.createConsumer(destination);
+
+
+
+        } catch (JMSException e) {
+
+        }
         return new JMSDataStoreTransaction(context);
     }
 
     @Override
     public DataStoreTransaction beginReadTransaction() {
-        JMSContext context = connectionFactory.createContext()
+        JMSContext context = connectionFactory.createContext();
         return new JMSDataStoreTransaction(context);
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
@@ -24,10 +24,12 @@ import javax.jms.Session;
 public class JMSDataStore implements DataStore {
     Set<Type<?>> models;
     ConnectionFactory connectionFactory;
+    EntityDictionary dictionary;
 
-    public JMSDataStore(Set<Type<?>> models, ConnectionFactory connectionFactory) {
+    public JMSDataStore(Set<Type<?>> models, ConnectionFactory connectionFactory, EntityDictionary dictionary) {
         this.models = models;
         this.connectionFactory = connectionFactory;
+        this.dictionary = dictionary;
     }
 
     @Override
@@ -40,23 +42,12 @@ public class JMSDataStore implements DataStore {
     @Override
     public DataStoreTransaction beginTransaction() {
         JMSContext context = connectionFactory.createContext();
-        try {
-            Connection connection = connectionFactory.createConnection();
-            Session session = connection.createSession();
-            Destination destination = session.createTopic("foo");
-            MessageConsumer consumer = session.createConsumer(destination);
-
-
-
-        } catch (JMSException e) {
-
-        }
-        return new JMSDataStoreTransaction(context);
+        return new JMSDataStoreTransaction(context, dictionary);
     }
 
     @Override
     public DataStoreTransaction beginReadTransaction() {
         JMSContext context = connectionFactory.createContext();
-        return new JMSDataStoreTransaction(context);
+        return new JMSDataStoreTransaction(context, dictionary);
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
@@ -12,21 +12,27 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
 
 import java.util.Set;
-import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
-import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
-import javax.jms.Session;
 
+/**
+ * Elide datastore that reads models from JMS message topics.
+ */
 public class JMSDataStore implements DataStore {
-    Set<Type<?>> models;
-    ConnectionFactory connectionFactory;
-    EntityDictionary dictionary;
+    private Set<Type<?>> models;
+    private ConnectionFactory connectionFactory;
+    private EntityDictionary dictionary;
 
-    public JMSDataStore(Set<Type<?>> models, ConnectionFactory connectionFactory, EntityDictionary dictionary) {
+    /**
+     * Constructor.
+     * @param models The set of models to manage.
+     * @param connectionFactory The JMS connection factory.
+     * @param dictionary The entity dictionary.
+     */
+    public JMSDataStore(
+            Set<Type<?>> models,
+            ConnectionFactory connectionFactory,
+            EntityDictionary dictionary) {
         this.models = models;
         this.connectionFactory = connectionFactory;
         this.dictionary = dictionary;

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
@@ -12,12 +12,16 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
 
 import java.util.Set;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
 
 public class JMSDataStore implements DataStore {
     Set<Type<?>> models;
+    ConnectionFactory connectionFactory;
 
-    public JMSDataStore(Set<Type<?>> models) {
+    public JMSDataStore(Set<Type<?>> models, ConnectionFactory connectionFactory) {
         this.models = models;
+        this.connectionFactory = connectionFactory;
     }
 
     @Override
@@ -29,11 +33,13 @@ public class JMSDataStore implements DataStore {
 
     @Override
     public DataStoreTransaction beginTransaction() {
-        return new JMSDataStoreTransaction();
+        JMSContext context = connectionFactory.createContext()
+        return new JMSDataStoreTransaction(context);
     }
 
     @Override
     public DataStoreTransaction beginReadTransaction() {
-        return new JMSDataStoreTransaction();
+        JMSContext context = connectionFactory.createContext()
+        return new JMSDataStoreTransaction(context);
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.jms;
+
+import com.yahoo.elide.core.datastore.DataStore;
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.type.Type;
+
+import java.util.Set;
+
+public class JMSDataStore implements DataStore {
+    Set<Type<?>> models;
+
+    public JMSDataStore(Set<Type<?>> models) {
+        this.models = models;
+    }
+
+    @Override
+    public void populateEntityDictionary(EntityDictionary dictionary) {
+        for (Type<?> model : models) {
+            dictionary.bindEntity(model);
+        }
+    }
+
+    @Override
+    public DataStoreTransaction beginTransaction() {
+        return new JMSDataStoreTransaction();
+    }
+
+    @Override
+    public DataStoreTransaction beginReadTransaction() {
+        return new JMSDataStoreTransaction();
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
@@ -49,7 +49,6 @@ public class JMSDataStoreTransaction implements DataStoreTransaction {
 
     @Override
     public <T> Iterable<T> loadObjects(EntityProjection entityProjection, RequestScope scope) {
-        context.createQueue()
         return null;
     }
 

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
@@ -8,18 +8,23 @@ package com.yahoo.elide.datastores.jms;
 
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.request.EntityProjection;
 
+import javax.jms.Destination;
+import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
 
 import java.io.IOException;
 
 public class JMSDataStoreTransaction implements DataStoreTransaction {
     private JMSContext context;
+    private EntityDictionary dictionary;
 
-    public JMSDataStoreTransaction(JMSContext context) {
+    public JMSDataStoreTransaction(JMSContext context, EntityDictionary dictionary) {
         this.context = context;
+        this.dictionary = dictionary;
     }
 
     @Override
@@ -49,16 +54,26 @@ public class JMSDataStoreTransaction implements DataStoreTransaction {
 
     @Override
     public <T> Iterable<T> loadObjects(EntityProjection entityProjection, RequestScope scope) {
-        return null;
+        //TODO - extract topic type (added, updated, deleted) from SubscriptionRequestScope
+        String topicName = dictionary.getJsonAliasFor(entityProjection.getType()) + "Added";
+
+        Destination destination = context.createTopic(topicName);
+
+        JMSConsumer consumer = context.createConsumer(destination);
+
+        context.start();
+
+        return new MessageIterator<>(consumer, 2000, new MessageDeserializer<>(entityProjection.getType()));
     }
 
     @Override
     public void cancel(RequestScope scope) {
-
+        context.stop();
     }
 
     @Override
     public void close() throws IOException {
-
+        context.stop();
+        context.close();
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
@@ -11,9 +11,17 @@ import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.request.EntityProjection;
 
+import javax.jms.JMSContext;
+
 import java.io.IOException;
 
 public class JMSDataStoreTransaction implements DataStoreTransaction {
+    private JMSContext context;
+
+    public JMSDataStoreTransaction(JMSContext context) {
+        this.context = context;
+    }
+
     @Override
     public <T> void save(T entity, RequestScope scope) {
         throw new BadRequestException("Unsupported operation");
@@ -41,6 +49,7 @@ public class JMSDataStoreTransaction implements DataStoreTransaction {
 
     @Override
     public <T> Iterable<T> loadObjects(EntityProjection entityProjection, RequestScope scope) {
+        context.createQueue()
         return null;
     }
 

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.jms;
+
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.exceptions.BadRequestException;
+import com.yahoo.elide.core.request.EntityProjection;
+
+import java.io.IOException;
+
+public class JMSDataStoreTransaction implements DataStoreTransaction {
+    @Override
+    public <T> void save(T entity, RequestScope scope) {
+        throw new BadRequestException("Unsupported operation");
+    }
+
+    @Override
+    public <T> void delete(T entity, RequestScope scope) {
+        throw new BadRequestException("Unsupported operation");
+    }
+
+    @Override
+    public void flush(RequestScope scope) {
+
+    }
+
+    @Override
+    public void commit(RequestScope scope) {
+
+    }
+
+    @Override
+    public <T> void createObject(T entity, RequestScope scope) {
+        throw new BadRequestException("Unsupported operation");
+    }
+
+    @Override
+    public <T> Iterable<T> loadObjects(EntityProjection entityProjection, RequestScope scope) {
+        return null;
+    }
+
+    @Override
+    public void cancel(RequestScope scope) {
+
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
@@ -12,14 +12,12 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.request.EntityProjection;
-
 import com.google.common.base.Preconditions;
 
+import java.io.IOException;
 import javax.jms.Destination;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
-
-import java.io.IOException;
 
 /**
  * Data store transaction for reading Elide models from JMS topics.

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStoreTransaction.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.core.request.EntityProjection;
 import com.google.common.base.Preconditions;
 
 import java.io.IOException;
+import java.util.Optional;
 import javax.jms.Destination;
 import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
@@ -26,6 +27,11 @@ public class JMSDataStoreTransaction implements DataStoreTransaction {
     private JMSContext context;
     private EntityDictionary dictionary;
 
+    /**
+     * Constructor.
+     * @param context JMS Context
+     * @param dictionary Elide Entity Dictionary
+     */
     public JMSDataStoreTransaction(JMSContext context, EntityDictionary dictionary) {
         this.context = context;
         this.dictionary = dictionary;
@@ -84,5 +90,23 @@ public class JMSDataStoreTransaction implements DataStoreTransaction {
     public void close() throws IOException {
         context.stop();
         context.close();
+    }
+
+    @Override
+    public <T> FeatureSupport supportsFiltering(RequestScope scope, Optional<T> parent, EntityProjection projection) {
+        //Delegate to in-memory filtering
+        return FeatureSupport.NONE;
+    }
+
+    @Override
+    public <T> boolean supportsSorting(RequestScope scope, Optional<T> parent, EntityProjection projection) {
+        //Delegate to in-memory sorting
+        return false;
+    }
+
+    @Override
+    public <T> boolean supportsPagination(RequestScope scope, Optional<T> parent, EntityProjection projection) {
+        //Delegate to in-memory pagination
+        return false;
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageDeserializer.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageDeserializer.java
@@ -16,11 +16,19 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.TextMessage;
 
+/**
+ * Converts JMS messages to elide model instances via Jackson.
+ * @param <T> elide model type.
+ */
 public class MessageDeserializer<T> implements Function<Message, T> {
 
     private ObjectMapper mapper;
     Type<?> type;
 
+    /**
+     * Constructor.
+     * @param type The type to deserialize to.
+     */
     public MessageDeserializer(Type<?> type) {
         this.type = type;
         this.mapper = new ObjectMapper();

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageDeserializer.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageDeserializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.jms;
+
+import com.yahoo.elide.core.exceptions.InternalServerErrorException;
+import com.yahoo.elide.core.type.Type;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.function.Function;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+
+public class MessageDeserializer<T> implements Function<Message, T> {
+
+    private ObjectMapper mapper;
+    Type<?> type;
+
+    public MessageDeserializer(Type<?> type) {
+        this.type = type;
+        this.mapper = new ObjectMapper();
+    }
+
+    @Override
+    public T apply(Message message) {
+        try {
+            return (T) mapper.readValue(((TextMessage) message).getText(), type.getUnderlyingClass().get());
+        } catch (JsonProcessingException | JMSException e) {
+            throw new InternalServerErrorException(e);
+        }
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
@@ -69,8 +69,7 @@ public class MessageIterator<T> implements Iterable<T> {
                         return messageConverter.apply(message);
                     }
                     return null;
-                }
-                catch (JMSRuntimeException e)  {
+                } catch (JMSRuntimeException e)  {
                     return null;
                 }
             }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
@@ -56,7 +56,15 @@ public class MessageIterator<T> implements Iterable<T> {
                 }
 
                 try {
-                    Message message = consumer.receive(timeout);
+                    Message message;
+                    if (timeout == 0) {
+                        message = consumer.receiveNoWait();
+                    } else if (timeout > 0) {
+                        message = consumer.receive(timeout);
+                    } else {
+                        message = consumer.receive();
+                    }
+
                     if (message != null) {
                         return messageConverter.apply(message);
                     }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
@@ -35,11 +35,11 @@ public class MessageIterator<T> implements Iterable<T> {
     @Override
     public Iterator<T> iterator() {
         return new Iterator() {
-            Message next;
+            T next;
 
             @Override
             public boolean hasNext() {
-                next = (Message) next();
+                next = next();
                 if (next == null) {
                     return false;
                 }
@@ -49,6 +49,12 @@ public class MessageIterator<T> implements Iterable<T> {
 
             @Override
             public T next() {
+                if (next != null) {
+                    T result = next;
+                    next = null;
+                    return result;
+                }
+
                 try {
                     Message message = consumer.receive(timeout);
                     if (message != null) {

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.jms;
+
+import java.util.Iterator;
+import java.util.function.Function;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSRuntimeException;
+import javax.jms.Message;
+
+/**
+ * Converts a JMS message consumer into an Iterable.
+ * @param <T> The type to convert a Message into.
+ */
+public class MessageIterator<T> implements Iterable<T> {
+
+    private JMSConsumer consumer;
+    private long timeout;
+    private Function<Message, T> messageConverter;
+
+    public MessageIterator(
+            JMSConsumer consumer,
+            long timeout,
+            Function<Message, T> messageConverter
+    ) {
+        this.consumer = consumer;
+        this.timeout = timeout;
+        this.messageConverter = messageConverter;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new Iterator() {
+            Message next;
+
+            @Override
+            public boolean hasNext() {
+                next = (Message) next();
+                if (next == null) {
+                    return false;
+                }
+
+                return true;
+            }
+
+            @Override
+            public T next() {
+                try {
+                    Message message = consumer.receive(timeout);
+                    if (message != null) {
+                        return messageConverter.apply(message);
+                    }
+                    return null;
+                }
+                catch (JMSRuntimeException e)  {
+                    return null;
+                }
+            }
+        };
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/MessageIterator.java
@@ -22,6 +22,12 @@ public class MessageIterator<T> implements Iterable<T> {
     private long timeout;
     private Function<Message, T> messageConverter;
 
+    /**
+     * Constructor.
+     * @param consumer The JMS message consumer to convert to an interator.
+     * @param timeout The timeout to wait on message topics.  0 means no wait.  Less than 0 means wait forever.
+     * @param messageConverter Converts JMS messages into some other thing.
+     */
     public MessageIterator(
             JMSConsumer consumer,
             long timeout,

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/SubscriptionRequestScope.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/SubscriptionRequestScope.java
@@ -10,7 +10,6 @@ import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.security.User;
-
 import lombok.Getter;
 
 import java.util.List;

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/SubscriptionRequestScope.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/SubscriptionRequestScope.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.jms;
+
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.security.User;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.ws.rs.core.MultivaluedHashMap;
+
+/**
+ * Request Scope for GraphQL Subscription requests.
+ */
+public class SubscriptionRequestScope extends RequestScope {
+
+    @Getter
+    private long timeoutInMs;
+
+    /**
+     * Constructor.
+     * @param baseUrlEndpoint base path URL
+     * @param transaction Data store transaction
+     * @param user The user
+     * @param apiVersion The api version
+     * @param elideSettings Elide settings
+     * @param requestId Elide internal request ID
+     * @param requestHeaders HTTP request headers.
+     * @param timeoutInMs request timeout in milliseconds.  0 means immediate.  -1 means no timeout.
+     */
+    public SubscriptionRequestScope(
+            String baseUrlEndpoint,
+            DataStoreTransaction transaction,
+            User user,
+            String apiVersion,
+            ElideSettings elideSettings,
+            UUID requestId,
+            Map<String, List<String>> requestHeaders,
+            long timeoutInMs
+    ) {
+        super(baseUrlEndpoint, "/", apiVersion, null, transaction, user,
+                new MultivaluedHashMap<>(), requestHeaders, requestId, elideSettings);
+
+        this.timeoutInMs = timeoutInMs;
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
@@ -21,10 +21,20 @@ public enum TopicType {
 
     private String topicSuffix;
 
+    /**
+     * Constructor.
+     * @param topicSuffix The suffix of the topic name.
+     */
     TopicType(String topicSuffix) {
         this.topicSuffix = topicSuffix;
     }
 
+    /**
+     * Converts a TopicType to a JMS topic name.
+     * @param type Elide model type.
+     * @param dictionary Elide entity dictionary.
+     * @return a JMS topic name.
+     */
     public String toTopicName(Type<?> type, EntityDictionary dictionary) {
         return dictionary.getJsonAliasFor(type) + topicSuffix;
     }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.jms;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.type.Type;
+import lombok.Getter;
+
+/**
+ * JMS Topic Names.
+ */
+@Getter
+public enum TopicType {
+    ADDED("Added"),
+    DELETED("Deleted"),
+    UPDATED("Updated");
+
+    private String topicSuffix;
+
+    TopicType(String topicSuffix) {
+        this.topicSuffix = topicSuffix;
+    }
+
+    public String toTopicName(Type<?> type, EntityDictionary dictionary) {
+        return dictionary.getJsonAliasFor(type) + topicSuffix;
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/JMSDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/JMSDataStoreTest.java
@@ -1,0 +1,73 @@
+package com.yahoo.elide.datastores.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.request.EntityProjection;
+import com.yahoo.elide.core.type.ClassType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Sets;
+import example.Book;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.JournalType;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.JMSProducer;
+import javax.jms.Topic;
+
+public class JMSDataStoreTest {
+
+    @Test
+    public void myTest() throws Exception {
+        EmbeddedActiveMQ embedded = new EmbeddedActiveMQ();
+        Configuration configuration = new ConfigurationImpl();
+        configuration.addAcceptorConfiguration("default", "vm://0");
+        configuration.setPersistenceEnabled(true);
+        configuration.setSecurityEnabled(false);
+        configuration.setJournalType(JournalType.NIO);
+
+        embedded.setConfiguration(configuration);
+        embedded.start();
+
+        ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("vm://0");
+
+        Book book = new Book();
+        book.setTitle("Enders Game");
+        book.setId(1);
+        ObjectMapper mapper = new ObjectMapper();
+
+        JMSContext context = cf.createContext();
+        context.start();
+        Destination destination = context.createTopic("bookAdded");
+
+        JMSProducer producer = context.createProducer();
+        producer.setTimeToLive(50000);
+        producer.send(destination, mapper.writeValueAsString(book));
+
+        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
+        dictionary.bindEntity(Book.class);
+
+        JMSDataStore store = new JMSDataStore(Sets.newHashSet(ClassType.of(Book.class)), cf, dictionary);
+
+        store.populateEntityDictionary(dictionary);
+
+        DataStoreTransaction tx = store.beginReadTransaction();
+
+        Iterable<Book> books = tx.loadObjects(
+                EntityProjection.builder().type(Book.class).build(),
+                null
+        );
+
+        Book received = books.iterator().next();
+        assertEquals("Enders Game", received.getTitle());
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/JMSDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/JMSDataStoreTest.java
@@ -6,32 +6,49 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.type.ClassType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import example.Book;
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
+import org.apache.activemq.artemis.api.core.client.ClientProducer;
+import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.junit.jupiter.api.Test;
 
+import net.jodah.concurrentunit.Waiter;
+
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import javax.jms.DeliveryMode;
 import javax.jms.Destination;
+import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
 import javax.jms.JMSProducer;
+import javax.jms.Message;
 import javax.jms.Topic;
+import javax.naming.InitialContext;
 
 public class JMSDataStoreTest {
 
     @Test
-    public void myTest() throws Exception {
+    public void testLoadObjects() throws Exception {
         EmbeddedActiveMQ embedded = new EmbeddedActiveMQ();
         Configuration configuration = new ConfigurationImpl();
         configuration.addAcceptorConfiguration("default", "vm://0");
-        configuration.setPersistenceEnabled(true);
+        configuration.setPersistenceEnabled(false);
         configuration.setSecurityEnabled(false);
         configuration.setJournalType(JournalType.NIO);
 
@@ -40,32 +57,28 @@ public class JMSDataStoreTest {
 
         ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("vm://0");
 
+        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
+        dictionary.bindEntity(Book.class);
+
         Book book = new Book();
         book.setTitle("Enders Game");
-        book.setId(1);
-        ObjectMapper mapper = new ObjectMapper();
+
+        JMSDataStore store = new JMSDataStore(Sets.newHashSet(ClassType.of(Book.class)), cf, dictionary);
+        store.populateEntityDictionary(dictionary);
+
+        DataStoreTransaction tx = store.beginReadTransaction();
+        Iterable<Book> books = tx.loadObjects(
+            EntityProjection.builder().type(Book.class).build(),
+            null
+        );
 
         JMSContext context = cf.createContext();
         context.start();
         Destination destination = context.createTopic("bookAdded");
 
         JMSProducer producer = context.createProducer();
-        producer.setTimeToLive(50000);
+        ObjectMapper mapper = new ObjectMapper();
         producer.send(destination, mapper.writeValueAsString(book));
-
-        EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
-        dictionary.bindEntity(Book.class);
-
-        JMSDataStore store = new JMSDataStore(Sets.newHashSet(ClassType.of(Book.class)), cf, dictionary);
-
-        store.populateEntityDictionary(dictionary);
-
-        DataStoreTransaction tx = store.beginReadTransaction();
-
-        Iterable<Book> books = tx.loadObjects(
-                EntityProjection.builder().type(Book.class).build(),
-                null
-        );
 
         Book received = books.iterator().next();
         assertEquals("Enders Game", received.getTitle());

--- a/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/JMSDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/JMSDataStoreTest.java
@@ -1,45 +1,27 @@
 package com.yahoo.elide.datastores.jms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.type.ClassType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import example.Book;
-import org.apache.activemq.artemis.api.core.QueueConfiguration;
-import org.apache.activemq.artemis.api.core.RoutingType;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.api.core.client.ClientConsumer;
-import org.apache.activemq.artemis.api.core.client.ClientMessage;
-import org.apache.activemq.artemis.api.core.client.ClientProducer;
-import org.apache.activemq.artemis.api.core.client.ClientSession;
-import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
-import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.config.CoreAddressConfiguration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.junit.jupiter.api.Test;
 
-import net.jodah.concurrentunit.Waiter;
-
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
-import javax.jms.DeliveryMode;
+import java.util.Iterator;
 import javax.jms.Destination;
-import javax.jms.JMSConsumer;
 import javax.jms.JMSContext;
 import javax.jms.JMSProducer;
-import javax.jms.Message;
-import javax.jms.Topic;
-import javax.naming.InitialContext;
 
 public class JMSDataStoreTest {
 
@@ -60,27 +42,46 @@ public class JMSDataStoreTest {
         EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
         dictionary.bindEntity(Book.class);
 
-        Book book = new Book();
-        book.setTitle("Enders Game");
+        Book book1 = new Book();
+        book1.setTitle("Enders Game");
+        book1.setId(1);
+
+        Book book2 = new Book();
+        book2.setTitle("Grapes of Wrath");
+        book2.setId(2);
 
         JMSDataStore store = new JMSDataStore(Sets.newHashSet(ClassType.of(Book.class)), cf, dictionary);
         store.populateEntityDictionary(dictionary);
 
-        DataStoreTransaction tx = store.beginReadTransaction();
-        Iterable<Book> books = tx.loadObjects(
-            EntityProjection.builder().type(Book.class).build(),
-            null
-        );
+        try (DataStoreTransaction tx = store.beginReadTransaction()) {
 
-        JMSContext context = cf.createContext();
-        context.start();
-        Destination destination = context.createTopic("bookAdded");
+            Iterable<Book> books = tx.loadObjects(
+                    EntityProjection.builder().type(Book.class).build(),
+                    null
+            );
 
-        JMSProducer producer = context.createProducer();
-        ObjectMapper mapper = new ObjectMapper();
-        producer.send(destination, mapper.writeValueAsString(book));
+            JMSContext context = cf.createContext();
+            context.start();
+            Destination destination = context.createTopic("bookAdded");
 
-        Book received = books.iterator().next();
-        assertEquals("Enders Game", received.getTitle());
+            JMSProducer producer = context.createProducer();
+            ObjectMapper mapper = new ObjectMapper();
+            producer.send(destination, mapper.writeValueAsString(book1));
+            producer.send(destination, mapper.writeValueAsString(book2));
+
+            Iterator<Book> booksIterator = books.iterator();
+
+            assertTrue(booksIterator.hasNext());
+            Book received = booksIterator.next();
+            assertEquals("Enders Game", received.getTitle());
+            assertEquals(1, received.getId());
+
+            assertTrue(booksIterator.hasNext());
+            received = booksIterator.next();
+            assertEquals("Grapes of Wrath", received.getTitle());
+            assertEquals(2, received.getId());
+
+            assertFalse(booksIterator.hasNext());
+        }
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/MessageDeserializerTest.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/MessageDeserializerTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.yahoo.elide.core.type.ClassType;
+import example.Book;
+import org.junit.jupiter.api.Test;
+
+import javax.jms.TextMessage;
+
+public class MessageDeserializerTest {
+
+    @Test
+    public void testDeserialization() throws Exception {
+        TextMessage message = mock(TextMessage.class);
+        when(message.getText()).thenReturn("{ \"title\": \"Foo\", \"id\" : 123 }");
+
+        MessageDeserializer<Book> deserializer = new MessageDeserializer(ClassType.of(Book.class));
+
+        Book book = deserializer.apply(message);
+        assertEquals("Foo", book.getTitle());
+        assertEquals(123, book.getId());
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/MessageIteratorTest.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/MessageIteratorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.yahoo.elide.core.type.ClassType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSRuntimeException;
+import javax.jms.TextMessage;
+
+public class MessageIteratorTest {
+
+    @Test
+    public void testIteratorMultipleItems() throws Exception {
+        JMSConsumer consumer = mock(JMSConsumer.class);
+        TextMessage msg1 = mock(TextMessage.class);
+        when(msg1.getText()).thenReturn("1");
+        TextMessage msg2 = mock(TextMessage.class);
+        when(msg2.getText()).thenReturn("2");
+        TextMessage msg3 = mock(TextMessage.class);
+        when(msg3.getText()).thenReturn("3");
+
+        when(consumer.receive(anyLong()))
+                .thenReturn(msg1)
+                .thenReturn(msg2)
+                .thenReturn(msg3)
+                .thenThrow(new JMSRuntimeException("timeout"));
+
+        Iterator<String> iterator = new MessageIterator(
+                consumer,
+                1000,
+                new MessageDeserializer(ClassType.of(String.class))).iterator();
+
+        assertTrue(iterator.hasNext());
+        assertEquals("1", iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals("2", iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals("3", iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testZeroTimeout() throws Exception {
+        JMSConsumer consumer = mock(JMSConsumer.class);
+        TextMessage msg1 = mock(TextMessage.class);
+        when(msg1.getText()).thenReturn("1");
+
+        when(consumer.receiveNoWait())
+                .thenReturn(msg1)
+                .thenReturn(null);
+
+        Iterator<String> iterator = new MessageIterator(
+                consumer,
+                0,
+                new MessageDeserializer(ClassType.of(String.class))).iterator();
+
+        assertTrue(iterator.hasNext());
+        assertEquals("1", iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testNegativeTimeout() throws Exception {
+        JMSConsumer consumer = mock(JMSConsumer.class);
+        TextMessage msg1 = mock(TextMessage.class);
+        when(msg1.getText()).thenReturn("1");
+
+        when(consumer.receive())
+                .thenReturn(msg1)
+                .thenReturn(null);
+
+        Iterator<String> iterator = new MessageIterator(
+                consumer,
+                -1,
+                new MessageDeserializer(ClassType.of(String.class))).iterator();
+
+        assertTrue(iterator.hasNext());
+        assertEquals("1", iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/test/java/example/Author.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/example/Author.java
@@ -9,18 +9,13 @@ package example;
 import com.yahoo.elide.annotation.Include;
 import lombok.Data;
 
-import java.util.Set;
 import javax.persistence.Id;
-import javax.persistence.ManyToMany;
 
 @Include
 @Data
-public class Book {
+public class Author {
     @Id
     private long id;
 
-    private String title;
-
-    @ManyToMany
-    private Set<Author> authors;
+    private String name;
 }

--- a/elide-datastore/elide-datastore-jms/src/test/java/example/Book.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/example/Book.java
@@ -1,0 +1,15 @@
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import lombok.Data;
+
+import javax.persistence.Id;
+
+@Include
+@Data
+public class Book {
+    @Id
+    private long id;
+
+    private String title;
+}

--- a/elide-datastore/pom.xml
+++ b/elide-datastore/pom.xml
@@ -53,6 +53,7 @@
         <module>elide-datastore-multiplex</module>
         <module>elide-datastore-noop</module>
         <module>elide-datastore-search</module>
+        <module>elide-datastore-jms</module>
     </modules>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -620,6 +620,7 @@
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipSystemScope>true</skipSystemScope>
+                    <skipTestScope>true</skipTestScope>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                     <suppressionFile>suppressions.xml</suppressionFile>
                     <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>


### PR DESCRIPTION
Adds a new, read-only JMS data store that deserializes Elide models from JMS topics.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
