### PR TITLE
Improve Server Boot Time: Reducing ClassGraph scans to a single scan

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
@@ -7,11 +7,11 @@ package com.yahoo.elide.core.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import com.yahoo.elide.annotation.ReadPermission;
-import com.yahoo.elide.annotation.UpdatePermission;
+import com.yahoo.elide.annotation.Include;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+import javax.persistence.Entity;
 
 public class ClassScannerTest {
 
@@ -24,25 +24,25 @@ public class ClassScannerTest {
 
     @Test
     public void testGetAnnotatedClasses() {
-        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses("example", ReadPermission.class);
-        assertEquals(6, classes.size(), "Actual: " + classes);
-        classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(ReadPermission.class)));
+        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses("example", Include.class);
+        assertEquals(30, classes.size(), "Actual: " + classes);
+        classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(Include.class)));
     }
 
     @Test
     public void testGetAllAnnotatedClasses() {
-        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(ReadPermission.class);
-        assertEquals(12, classes.size(), "Actual: " + classes);
-        classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(ReadPermission.class)));
+        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(Include.class);
+        assertEquals(41, classes.size(), "Actual: " + classes);
+        classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(Include.class)));
     }
 
     @Test
     public void testGetAnyAnnotatedClasses() {
-        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(ReadPermission.class, UpdatePermission.class);
-        assertEquals(17, classes.size());
+        Set<Class<?>> classes = ClassScanner.getAnnotatedClasses(Include.class, Entity.class);
+        assertEquals(52, classes.size());
         for (Class<?> cls : classes) {
-            assertTrue(cls.isAnnotationPresent(ReadPermission.class)
-                    || cls.isAnnotationPresent(UpdatePermission.class));
+            assertTrue(cls.isAnnotationPresent(Include.class)
+                    || cls.isAnnotationPresent(Entity.class));
         }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -28,10 +28,14 @@ import com.yahoo.elide.datastores.aggregation.dynamic.NamespacePackage;
 import com.yahoo.elide.datastores.aggregation.dynamic.TableType;
 import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Column;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Namespace;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
+import com.yahoo.elide.datastores.aggregation.metadata.models.TableSource;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension;
 import com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Versioned;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
 import org.apache.commons.lang3.tuple.Pair;
@@ -179,7 +183,21 @@ public class MetaDataStore implements DataStore {
      * @param enableMetaDataStore If Enable MetaDataStore
      */
     public MetaDataStore(Set<Type<?>> modelsToBind, boolean enableMetaDataStore) {
-        this.metadataModelClasses = ClassScanner.getAllClasses(META_DATA_PACKAGE.getName());
+
+        //Hardcoded to avoid ClassGraph scan.
+        this.metadataModelClasses = new HashSet<>(Arrays.asList(
+                Column.class,
+                Metric.class,
+                ArgumentDefinition.class,
+                TableSource.class,
+                Dimension.class,
+                TimeDimension.class,
+                TimeDimensionGrain.class,
+                Table.class,
+                Versioned.class,
+                Namespace.class
+        ));
+
         this.enableMetaDataStore = enableMetaDataStore;
 
         modelsToBind.forEach(cls -> {
@@ -223,7 +241,7 @@ public class MetaDataStore implements DataStore {
 
     private final Function<String, HashMapDataStore> getHashMapDataStoreInitializer() {
         return key -> {
-            HashMapDataStore hashMapDataStore = new HashMapDataStore(META_DATA_PACKAGE);
+            HashMapDataStore hashMapDataStore = new HashMapDataStore(metadataModelClasses);
             EntityDictionary dictionary = new EntityDictionary(new HashMap<>());
             metadataModelClasses.forEach(dictionary::bindEntity);
             hashMapDataStore.populateEntityDictionary(dictionary);


### PR DESCRIPTION
## Description
ClassGraph scans are really expensive.  This reduces scans at service startup from 7 to 1.

## How Has This Been Tested?
Existing tests.

Profiling spring-boot example before and after change.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
