### PR TITLE
Makes Elide JSONPath version proof

### DIFF
--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
 
         <!--Jackson CSV generator does not support Object values for properties (nested Objects)-->
         <dependency>
@@ -70,20 +74,10 @@
             <version>1.0.3</version>
             <exclusions>
                 <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
-                </exclusion>
-                <exclusion>
                 	<groupId>com.fasterxml.jackson.core</groupId>
                 	<artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <version>${jsonpath.version}</version>
         </dependency>
 
         <!-- Test -->

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncQueryOperation.java
@@ -90,7 +90,7 @@ public abstract class AsyncQueryOperation implements Callable<AsyncAPIResult> {
      * @param path The json path expression that represents an array.
      * @return The size of the array.
      */
-    protected static Integer safeJsonPathLength(String json, String path) {
+    public static Integer safeJsonPathLength(String json, String path) {
         Object result = JsonPath.read(json, path);
 
         if (Integer.class.isAssignableFrom(result.getClass())) {

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/AsyncQueryOperation.java
@@ -13,11 +13,13 @@ import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.service.AsyncExecutorService;
 import com.yahoo.elide.core.RequestScope;
 
+import com.jayway.jsonpath.JsonPath;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URISyntaxException;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 /**
@@ -80,4 +82,28 @@ public abstract class AsyncQueryOperation implements Callable<AsyncAPIResult> {
      * @throws URISyntaxException URISyntaxException Exception.
      */
     public abstract ElideResponse execute(AsyncAPI queryObj, RequestScope scope)  throws URISyntaxException;
+
+    /**
+     * Safe method of extracting 'foo.bar.length()' expressions from com.jayway.jsonpath.  This protects
+     * against breaking API changes between 2.4 and beyond.
+     * @param json The json body to extract from.
+     * @param path The json path expression that represents an array.
+     * @return The size of the array.
+     */
+    protected static Integer safeJsonPathLength(String json, String path) {
+        Object result = JsonPath.read(json, path);
+
+        if (Integer.class.isAssignableFrom(result.getClass())) {
+            return (Integer) result;
+        }
+
+        if (List.class.isAssignableFrom(result.getClass())) {
+            result = ((List) result).get(0);
+            if (Integer.class.isAssignableFrom(result.getClass())) {
+                return (Integer) result;
+            }
+        }
+
+        throw new IllegalStateException("Incompatible version of JSONPath");
+    }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
@@ -14,8 +14,6 @@ import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.graphql.QueryRunner;
 
-import com.jayway.jsonpath.JsonPath;
-
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URISyntaxException;
@@ -51,7 +49,7 @@ public class GraphQLAsyncQueryOperation extends AsyncQueryOperation {
     public Integer calculateRecordCount(AsyncQuery queryObj, ElideResponse response) {
         Integer count = 0;
         if (response.getResponseCode() == 200) {
-            count = JsonPath.read(response.getBody(), "$..edges.length()");
+            count = safeJsonPathLength(response.getBody(), "$..edges.length()");
         }
         return count;
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JSONAPIAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JSONAPIAsyncQueryOperation.java
@@ -13,8 +13,6 @@ import com.yahoo.elide.async.service.AsyncExecutorService;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.security.User;
 
-import com.jayway.jsonpath.JsonPath;
-
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -83,7 +81,7 @@ public class JSONAPIAsyncQueryOperation extends AsyncQueryOperation {
     public Integer calculateRecordCount(AsyncQuery queryObj, ElideResponse response) {
         Integer count = null;
         if (response.getResponseCode() == 200) {
-            count = JsonPath.read(response.getBody(), "$.data.length()");
+            count = safeJsonPathLength(response.getBody(), "$.data.length()");
         }
         return count;
     }

--- a/elide-async/src/test/java/com/yahoo/elide/async/operation/SafeJsonPathTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/operation/SafeJsonPathTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests out different JSONPath parsing results.
+ */
+public class SafeJsonPathTest {
+
+    @Test
+    public void testIntegerResult() {
+        Integer count = AsyncQueryOperation.safeJsonPathLength("{ \"data\": [1,2,3] }", "data.length()");
+
+        assertEquals(3, count);
+    }
+
+    @Test
+    public void testArrayResult() {
+        Integer count = AsyncQueryOperation.safeJsonPathLength("{ \"data\": [10] }", "data");
+
+        assertEquals(10, count);
+    }
+
+    @Test
+    public void testInvalidREsult() {
+        assertThrows(IllegalStateException.class, () ->
+                AsyncQueryOperation.safeJsonPathLength("{ \"data\": \"foo\" }", "data"));
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/pom.xml
+++ b/elide-datastore/elide-datastore-aggregation/pom.xml
@@ -97,10 +97,6 @@
                     <artifactId>log4j</artifactId>
                 </exclusion>
                 <!-- Excluded for conflict with elide-async's version -->
-                <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <!-- Avoid CVE-2020-13956 -->
@@ -115,12 +111,6 @@
             <artifactId>httpcore</artifactId>
             <version>4.4.14</version>
             <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <version>${jsonpath.version}</version>
         </dependency>
 
         <!-- Hibernate Entity Manager -->

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,12 @@
                 <version>${version.jetty}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>${jsonpath.version}</version>
+            </dependency>
+
             <!-- Test dependencies -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
com.jayway.jsonpath has breaking API changes between 2.4 and 2.6.  

Expressions like 'foo.bar.length()' return an array containing an integer in 2.4 and just an integer in 2.6.

This change makes Elide JSONPath proof for customers who might pull in the wrong version of JSONPath in their pom by mistake.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
