### PR TITLE
Disable PR build from forked repo

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,6 +1,9 @@
 cache:
    pipeline: ["~/.m2"]
 
+annotations:
+   screwdriver.cd/restrictPR: fork
+
 shared:
    annotations:
        screwdriver.cd/cpu: TURBO


### PR DESCRIPTION
## Description
Disable PR builds from forked repos in light of the recent security issue with a PR where some code was executed on the build containers by an unknown entity. https://patch-diff.githubusercontent.com/raw/yahoo/elide/pull/2260.patch

SD has feature to disable this: https://docs.screwdriver.cd/user-guide/configuration/annotations#:~:text=restrictPR

## Motivation and Context
Prevent harmful code from an unknown user being executed in the build containers.

## How Has This Been Tested?
Existing builds pass. Will manually verify after the PR is merged.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
