### PR TITLE
Add ability to retrieve data store properties in life cycle hooks.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/DataStoreTransaction.java
@@ -311,4 +311,14 @@ public interface DataStoreTransaction extends Closeable {
      * @param scope contains request level metadata.
      */
     void cancel(RequestScope scope);
+
+    /**
+     * Returns a data store transaction property.
+     * @param propertyName The property name.
+     * @param <T> The type of the property.
+     * @return The property.
+     */
+    default <T> T getProperty(String propertyName) {
+        return null;
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -457,4 +457,9 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
    public void cancel(RequestScope scope) {
        tx.cancel(scope);
    }
+
+    @Override
+    public <T> T getProperty(String propertyName) {
+        return tx.getProperty(propertyName);
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapper.java
@@ -122,4 +122,9 @@ public abstract class TransactionWrapper implements DataStoreTransaction {
     public void cancel(RequestScope scope) {
         tx.cancel(scope);
     }
+
+    @Override
+    public <T> T getProperty(String propertyName) {
+        return tx.getProperty(propertyName);
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/RequestScope.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.core.security;
 
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+
 import java.util.List;
 import java.util.Map;
 
@@ -17,4 +19,5 @@ public interface RequestScope {
     String getRequestHeaderByName(String headerName);
     String getBaseUrlEndPoint();
     Map<String, List<String>> getQueryParams();
+    DataStoreTransaction getTransaction();
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
@@ -554,6 +554,17 @@ public class InMemoryStoreTransactionTest {
     }
 
     @Test
+    public void testGetProperty() {
+        when(wrappedTransaction.getProperty(any())).thenReturn(1);
+
+        Integer result = inMemoryStoreTransaction.getProperty("foo");
+
+        verify(wrappedTransaction, times(1)).getProperty(eq("foo"));
+
+        assertEquals(1, result);
+    }
+
+    @Test
     public void testInMemoryDataStore() {
         HashMapDataStore wrapped = new HashMapDataStore(Book.class.getPackage());
         InMemoryDataStore store = new InMemoryDataStore(wrapped);

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapperTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/wrapped/TransactionWrapperTest.java
@@ -215,4 +215,17 @@ public class TransactionWrapperTest {
         verify(wrapped, times(1)).loadObject(any(), any(), any());
         assertEquals(1L, actual);
     }
+
+    @Test
+    public void testGetProperty() {
+        DataStoreTransaction wrapped = mock(DataStoreTransaction.class);
+        DataStoreTransaction wrapper = new TestTransactionWrapper(wrapped);
+
+        when(wrapped.getProperty(any())).thenReturn(1L);
+
+        Object actual = wrapper.getProperty("foo");
+
+        verify(wrapped, times(1)).getProperty(any());
+        assertEquals(1L, actual);
+    }
 }

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
@@ -31,6 +31,10 @@ import javax.validation.ConstraintViolationException;
  */
 @Slf4j
 public abstract class AbstractJpaTransaction extends JPQLTransaction implements JpaTransaction {
+
+    public static final String ENTITY_MANAGER_PROPERTY =
+            "com.yahoo.elide.datastores.jpa.transaction.entitymanager";
+
     private static final Predicate<Collection<?>> IS_PERSISTENT_COLLECTION =
             new PersistentCollectionChecker();
 
@@ -157,6 +161,15 @@ public abstract class AbstractJpaTransaction extends JPQLTransaction implements 
     @Override
     public void cancel(RequestScope scope) {
         jpaTransactionCancel.accept(em);
+    }
+
+    @Override
+    public <T> T getProperty(String propertyName) {
+        if (ENTITY_MANAGER_PROPERTY.equals(propertyName)) {
+            return (T) em;
+        }
+
+        return super.getProperty(propertyName);
     }
 
     @Override

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
@@ -32,8 +32,9 @@ import javax.validation.ConstraintViolationException;
 @Slf4j
 public abstract class AbstractJpaTransaction extends JPQLTransaction implements JpaTransaction {
 
-    public static final String ENTITY_MANAGER_PROPERTY =
-            "com.yahoo.elide.datastores.jpa.transaction.entitymanager";
+    //Data store transaction properties must be prefixed with their package name.
+    public static final String ENTITY_MANAGER_PROPERTY = AbstractJpaTransaction.class.getPackage().getName()
+            + ".entityManager";
 
     private static final Predicate<Collection<?>> IS_PERSISTENT_COLLECTION =
             new PersistentCollectionChecker();

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/EntityManagerLifeCycleHookIT.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/EntityManagerLifeCycleHookIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jpa;
+
+import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.datum;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import com.yahoo.elide.initialization.IntegrationTest;
+import example.Book;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class EntityManagerLifeCycleHookIT extends IntegrationTest {
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        try (DataStoreTransaction tx = dataStore.beginTransaction()) {
+            Book book1 = new Book();
+            book1.setTitle("Test Book1");
+            tx.createObject(book1, null);
+
+            Book book2 = new Book();
+            book2.setTitle("Test Book2");
+            tx.createObject(book2, null);
+
+            Book book3 = new Book();
+            book3.setTitle("Test Book3");
+            tx.createObject(book3, null);
+
+            tx.commit(null);
+        }
+    }
+
+    @Test
+    void testBookCatalogCreationHook() {
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("bookCatalog"),
+                                        id("123")
+                                )
+                        )
+                )
+                .post("/bookCatalog")
+                .then()
+                .body("data.relationships.books.data.id", containsInAnyOrder("1", "2", "3"))
+                .statusCode(HttpStatus.SC_CREATED);
+    }
+}

--- a/elide-datastore/elide-datastore-jpa/src/test/java/example/BookCatalog.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/example/BookCatalog.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package example;
+
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PREFLUSH;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+
+import example.hook.BookCatalogOnCreateHook;
+import lombok.Data;
+
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+@Include
+@Entity
+@Data
+@LifeCycleHookBinding(
+        operation = LifeCycleHookBinding.Operation.CREATE,
+        phase = PREFLUSH,
+        hook = BookCatalogOnCreateHook.class
+)
+public class BookCatalog {
+
+    @Id
+    private long id;
+
+    @OneToMany
+    private Set<Book> books;
+}

--- a/elide-datastore/elide-datastore-jpa/src/test/java/example/hook/BookCatalogOnCreateHook.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/example/hook/BookCatalogOnCreateHook.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.hook;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.datastores.jpa.transaction.AbstractJpaTransaction;
+import example.BookCatalog;
+
+import java.util.HashSet;
+import java.util.Optional;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+public class BookCatalogOnCreateHook implements LifeCycleHook<BookCatalog> {
+    @Override
+    public void execute(
+            LifeCycleHookBinding.Operation operation,
+            LifeCycleHookBinding.TransactionPhase phase,
+            BookCatalog catalog,
+            RequestScope requestScope,
+            Optional<ChangeSpec> changes) {
+
+        EntityManager entityManager =
+                requestScope.getTransaction().getProperty(AbstractJpaTransaction.ENTITY_MANAGER_PROPERTY);
+
+        /* Load all the books */
+        Query query = entityManager.createQuery("SELECT book FROM Book book");
+        catalog.setBooks(new HashSet<>(query.getResultList()));
+    }
+}

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexTransaction.java
@@ -250,4 +250,12 @@ public abstract class MultiplexTransaction implements DataStoreTransaction {
     public void cancel(RequestScope scope) {
         transactions.values().forEach(dataStoreTransaction -> dataStoreTransaction.cancel(scope));
     }
+
+    @Override
+    public <T> T getProperty(String propertyName) {
+        return (T) transactions.values().stream().map(tx -> tx.getProperty(propertyName))
+                .filter(property -> property != null)
+                .findFirst()
+                .orElse(null);
+    }
 }


### PR DESCRIPTION
A common use case for life cycle hooks is to use an entity manager to load something from a database and edit the model in the lifecycle hook.

There is no convenient way in Elide to gain access to the current entity manager/session.

This PR provides that by:
1. Adding a method to get access to the current data store transaction via the request scope.
2. Adding a getProperty method in the data store transaction.
3. Implementing the getProperty method in data store transaction implementations.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
