### PR TITLE
Fixed bug where multiplex manager was not copying complex attributes …

### DIFF
--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
@@ -65,7 +65,7 @@ public final class MultiplexManager implements DataStore {
             );
 
             dataStore.populateEntityDictionary(subordinateDictionary);
-            for (EntityBinding binding : subordinateDictionary.getBindings()) {
+            for (EntityBinding binding : subordinateDictionary.getBindings(false)) {
                 // route class to this database manager
                 this.dataStoreMap.put(binding.entityClass, dataStore);
 

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexManagerTest.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/datastores/multiplex/MultiplexManagerTest.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.exceptions.TransactionException;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.datastores.inmemory.InMemoryDataStore;
+import com.yahoo.elide.example.beans.ComplexAttribute;
 import com.yahoo.elide.example.beans.FirstBean;
 import com.yahoo.elide.example.other.OtherBean;
 import com.google.common.collect.Lists;
@@ -54,13 +55,14 @@ public class MultiplexManagerTest {
         EntityDictionary entityDictionary = multiplexManager.getDictionary();
         assertNotNull(entityDictionary.getJsonAliasFor(ClassType.of(FirstBean.class)));
         assertNotNull(entityDictionary.getJsonAliasFor(ClassType.of(OtherBean.class)));
+        assertNotNull(entityDictionary.getJsonAliasFor(ClassType.of(ComplexAttribute.class)));
     }
 
     @Test
     public void testValidCommit() throws IOException {
         final FirstBean object = new FirstBean();
-        object.id = null;
-        object.name = "Test";
+        object.setId(null);
+        object.setName("Test");
         try (DataStoreTransaction t = multiplexManager.beginTransaction()) {
             assertFalse(t.loadObjects(EntityProjection.builder()
                     .type(FirstBean.class)
@@ -80,7 +82,7 @@ public class MultiplexManagerTest {
             assertNotNull(beans);
             assertTrue(beans.iterator().hasNext());
             FirstBean bean = (FirstBean) IterableUtils.first(beans);
-            assertTrue(bean.id != null && "Test".equals(bean.name));
+            assertTrue(bean.getId() != null && "Test".equals(bean.getName()));
         }
     }
 
@@ -101,7 +103,7 @@ public class MultiplexManagerTest {
                     .build(), null).iterator().hasNext());
 
             FirstBean firstBean = FirstBean.class.newInstance();
-            firstBean.name = "name";
+            firstBean.setName("name");
             t.createObject(firstBean, null);
             //t.save(firstBean);
             assertFalse(t.loadObjects(EntityProjection.builder()
@@ -115,7 +117,7 @@ public class MultiplexManagerTest {
             FirstBean firstBean = (FirstBean) t.loadObjects(EntityProjection.builder()
                     .type(FirstBean.class)
                     .build(), null).iterator().next();
-            firstBean.name = "update";
+            firstBean.setName("update");
             t.save(firstBean, null);
             OtherBean otherBean = OtherBean.class.newInstance();
             t.createObject(otherBean, null);
@@ -133,7 +135,7 @@ public class MultiplexManagerTest {
             assertNotNull(beans);
             ArrayList<Object> list = Lists.newArrayList(beans.iterator());
             assertEquals(list.size(), 1);
-            assertEquals(((FirstBean) list.get(0)).name, "name");
+            assertEquals(((FirstBean) list.get(0)).getName(), "name");
         }
     }
 

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/ComplexAttribute.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/ComplexAttribute.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.example.beans;
+
+import lombok.Data;
+
+@Data
+public class ComplexAttribute {
+    private String a;
+    private String b;
+}

--- a/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/FirstBean.java
+++ b/elide-datastore/elide-datastore-multiplex/src/test/java/com/yahoo/elide/example/beans/FirstBean.java
@@ -7,6 +7,8 @@ package com.yahoo.elide.example.beans;
 
 import com.yahoo.elide.annotation.Include;
 
+import lombok.Data;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -16,18 +18,11 @@ import javax.persistence.Id;
  */
 @Entity
 @Include(rootLevel = false)
+@Data
 public class FirstBean {
-    public String id;
-
-    public String name;
-
     @Id
     @GeneratedValue
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
+    private String id;
+    private String name;
+    private ComplexAttribute complex;
 }


### PR DESCRIPTION
## Description
The multiplex manager was not correctly copying entity bindings from subordinate dictionaries containing complex attributes.

## Motivation and Context
Issue found during #2277 

## How Has This Been Tested?
New unit test.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
