### PR TITLE
Updating screwdriver build for JDK11 and Elide 6

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -21,6 +21,14 @@ jobs:
     steps:
       - build: mvn -B clean verify coveralls:report
 
+  elide-6-build:
+    image: maven:3.8.2-openjdk-11
+    requires: [~pr:elide-6.x, ~commit:elide-6.x]
+    secrets:
+        - COVERALLS_REPO_TOKEN
+    steps:
+      - build: mvn -B clean verify coveralls:report
+
   elide-5-build:
     requires: [~pr:elide-5.x, ~commit:elide-5.x]
     secrets:


### PR DESCRIPTION
## Description
Create a new build for Elide 6 using open JDK 11.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
