### PR TITLE
Templated filter table arguments

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
@@ -25,9 +25,11 @@ import java.util.regex.Pattern;
  * 1. Directly matches a template filter.
  * 2. Contains through conjunction (logical AND) a filter expression that matches a template filter.
  * This is used to enforce table filter constraints.
+ *
+ * Any matching template variables are extracted from the filter expression.
  */
 public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> {
-    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{(\\w*)\\}\\}");
+    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{(\\w+)\\}\\}");
 
     private FilterExpression expressionToMatch;
     private Map<String, Argument> arguments;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
@@ -12,9 +12,12 @@ import com.yahoo.elide.core.filter.expression.NotFilterExpression;
 import com.yahoo.elide.core.filter.expression.OrFilterExpression;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
 import com.yahoo.elide.core.filter.visitors.FilterExpressionNormalizationVisitor;
+import com.yahoo.elide.core.request.Argument;
 import com.google.common.base.Preconditions;
-import lombok.AllArgsConstructor;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -23,11 +26,16 @@ import java.util.regex.Pattern;
  * 2. Contains through conjunction (logical AND) a filter expression that matches a template filter.
  * This is used to enforce table filter constraints.
  */
-@AllArgsConstructor
 public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> {
-    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{\\w*\\}\\}");
+    private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{(\\w*)\\}\\}");
 
     private FilterExpression expressionToMatch;
+    private Map<String, Argument> arguments;
+
+    public MatchesTemplateVisitor(FilterExpression expressionToMatch) {
+        this.expressionToMatch = expressionToMatch;
+        this.arguments = new HashMap<>();
+    }
 
     @Override
     public Boolean visitPredicate(FilterPredicate filterPredicate) {
@@ -51,7 +59,7 @@ public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> 
         return matches(expressionToMatch, expression);
     }
 
-    private static boolean matches(FilterExpression a, FilterExpression b) {
+    private boolean matches(FilterExpression a, FilterExpression b) {
         if (! a.getClass().equals(b.getClass())) {
             return false;
         }
@@ -78,21 +86,44 @@ public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> 
         FilterPredicate predicateB = (FilterPredicate) b;
 
         boolean valueMatches = predicateA.getValues().equals(predicateB.getValues());
-        boolean usingTemplate = predicateA.getValues().stream()
-                .anyMatch(value -> TEMPLATE_PATTERN.matcher(value.toString()).matches());
+        boolean operatorMatches = predicateA.getOperator().equals(predicateB.getOperator());
+        boolean pathMatches = predicateA.getPath().equals(predicateB.getPath());
 
-        return predicateA.getPath().equals(predicateB.getPath())
-                && predicateA.getOperator().equals(predicateB.getOperator())
-                && (usingTemplate || valueMatches);
+        boolean usingTemplate = false;
+
+        if (predicateA.getValues().size() == 1) {
+            String value = predicateA.getValues().get(0).toString();
+            Matcher matcher = TEMPLATE_PATTERN.matcher(value);
+
+            usingTemplate = matcher.matches();
+
+            if (usingTemplate && pathMatches & operatorMatches) {
+                String argumentName = matcher.group(1);
+
+                arguments.put(argumentName, Argument.builder()
+                        .name(argumentName)
+                        .value(predicateB.getValues().size() == 1
+                                ? predicateB.getValues().get(0)
+                                : predicateB.getValues())
+                        .build());
+            }
+        }
+
+        return (operatorMatches && pathMatches && (valueMatches || usingTemplate));
     }
 
     /**
      * Determines if a client filter matches or contains a subexpression that matches a template filter.
      * @param templateFilter A templated filter expression
      * @param clientFilter The client provided filter expression.
+     * @param arguments If the client filter matches, extract any table arguments.
      * @return True if the client filter matches.  False otherwise.
      */
-    public static boolean isValid(FilterExpression templateFilter, FilterExpression clientFilter) {
+    public static boolean isValid(
+            FilterExpression templateFilter,
+            FilterExpression clientFilter,
+            Map<String, Argument> arguments
+    ) {
         Preconditions.checkNotNull(templateFilter);
 
         if (clientFilter == null) {
@@ -104,6 +135,13 @@ public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> 
         FilterExpression normalizedTemplateFilter = templateFilter.accept(new FilterExpressionNormalizationVisitor());
         FilterExpression normalizedClientFilter = clientFilter.accept(new FilterExpressionNormalizationVisitor());
 
-        return normalizedClientFilter.accept(new MatchesTemplateVisitor(normalizedTemplateFilter));
+        MatchesTemplateVisitor templateVisitor = new MatchesTemplateVisitor(normalizedTemplateFilter);
+        boolean matches = normalizedClientFilter.accept(templateVisitor);
+
+        if (matches) {
+            arguments.putAll(templateVisitor.arguments);
+        }
+
+        return matches;
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Query.java
@@ -89,5 +89,26 @@ public class Query implements Queryable {
 
             return this;
         }
+
+        /**
+         * Initializes the builder from another query (copy).
+         * @param query What to copy.
+         * @return A new query builder.
+         */
+        public QueryBuilder query(Query query) {
+            this.source(query.getSource());
+            this.metricProjections(query.getMetricProjections());
+            this.dimensionProjections(query.getDimensionProjections());
+            this.timeDimensionProjections(query.getTimeDimensionProjections());
+            this.arguments(query.getArguments());
+            this.sorting(query.getSorting());
+            this.pagination(query.getPagination());
+            this.whereFilter(query.getWhereFilter());
+            this.havingFilter(query.getHavingFilter());
+            this.bypassingCache(query.isBypassingCache());
+            this.scope(query.getScope());
+
+            return this;
+        }
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -57,6 +57,8 @@ public class SQLTable extends Table implements Queryable {
 
     private Map<String, SQLJoin> joins;
 
+    private Map<String, Argument> arguments;
+
     public SQLTable(Namespace namespace,
                     Type<?> cls,
                     EntityDictionary dictionary,
@@ -64,6 +66,7 @@ public class SQLTable extends Table implements Queryable {
         super(namespace, cls, dictionary);
         this.connectionDetails = connectionDetails;
         this.joins = new HashMap<>();
+        this.arguments = prepareArgMap(getArgumentDefinitions());
 
         EntityBinding binding = dictionary.getEntityBinding(cls);
         binding.fieldsToValues.forEach((name, field) -> {
@@ -303,7 +306,7 @@ public class SQLTable extends Table implements Queryable {
 
     @Override
     public Map<String, Argument> getArguments() {
-        return prepareArgMap(getArgumentDefinitions());
+        return arguments;
     }
 
     /**

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
@@ -85,12 +85,16 @@ public class TableArgumentValidator {
                         .map(TableArgReference.class::cast)
                         .map(TableArgReference::getArgName)
                         .forEach(argName -> {
-                            if (!table.hasArgumentDefinition(argName)) {
+                            if (!table.hasArgumentDefinition(argName) && !hasTemplateFilterArgument(argName)) {
                                 throw new IllegalStateException(String.format(errorMsgPrefix
                                                 + "Argument '%s' is not defined but found '{{$$table.args.%s}}' "
                                                 + errorMsgSuffix, argName, argName));
                             }
                         });
+    }
+
+    private boolean hasTemplateFilterArgument(String argName) {
+        return table.getRequiredFilter() != null && table.getRequiredFilter().contains("{{" + argName + "}}");
     }
 
     private void verifyRequiredTableArgsForJoinTables() {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -168,15 +168,9 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("recordedDate[grain:day]=={{day}}",
                 playerStatsType, false, true);
 
-        Argument expected = Argument.builder()
-                .name("day")
-                .value("2020-01-01")
-                .build();
-
         Map<String, Argument> extractedArgs = new HashMap<>();
         assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
         assertEquals(1, extractedArgs.size());
-        assertEquals(extractedArgs.get("day"), expected);
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.aggregation.timegrains.Time;
 import example.Player;
 import example.PlayerStats;
 import org.junit.jupiter.api.BeforeEach;
@@ -158,6 +159,25 @@ public class MatchesTemplateVisitorTest {
         Map<String, Argument> extractedArgs = new HashMap<>();
         assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
         assertEquals(0, extractedArgs.size());
+    }
+
+    @Test
+    public void parameterizedFilterMatches() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("recordedDate[grain:day]=='2020-01-01'",
+                playerStatsType, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("recordedDate[grain:day]=={{day}}",
+                playerStatsType, false, true);
+
+        Argument expected = Argument.builder()
+                .name("day")
+                .value("2020-01-01")
+                .build();
+
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(1, extractedArgs.size());
+        assertEquals(extractedArgs.get("day"), expected);
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -6,17 +6,22 @@
 
 package com.yahoo.elide.datastores.aggregation.filter.visitor;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import example.Player;
 import example.PlayerStats;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class MatchesTemplateVisitorTest {
     private RSQLFilterDialect dialect;
@@ -35,10 +40,19 @@ public class MatchesTemplateVisitorTest {
         FilterExpression clientExpression = dialect.parseFilterExpression("highScore==123",
                 playerStatsType, true);
 
-        FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{}}",
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{foo}}",
                 playerStatsType, false, true);
 
-        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        Argument expected = Argument.builder()
+                .name("foo")
+                .value(123L)
+                .build();
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+
+        assertEquals(1, extractedArgs.size());
+        assertEquals(extractedArgs.get("foo"), expected);
     }
 
     @Test
@@ -49,7 +63,9 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore==123",
                 playerStatsType, false, true);
 
-        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(0, extractedArgs.size());
     }
 
     @Test
@@ -60,7 +76,16 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        Argument expected = Argument.builder()
+                .name("variable")
+                .value(123L)
+                .build();
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+
+        assertEquals(1, extractedArgs.size());
+        assertEquals(extractedArgs.get("variable"), expected);
     }
 
     @Test
@@ -71,7 +96,16 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("lowScore>100;highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        Argument expected = Argument.builder()
+                .name("variable")
+                .value(123L)
+                .build();
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+
+        assertEquals(1, extractedArgs.size());
+        assertEquals(extractedArgs.get("variable"), expected);
     }
 
     @Test
@@ -82,7 +116,9 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(0, extractedArgs.size());
     }
 
     @Test
@@ -93,7 +129,9 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(0, extractedArgs.size());
     }
 
     @Test
@@ -104,7 +142,16 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("lowScore>100,highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        Argument expected = Argument.builder()
+                .name("variable")
+                .value(123L)
+                .build();
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+
+        assertEquals(1, extractedArgs.size());
+        assertEquals(extractedArgs.get("variable"), expected);
     }
 
     @Test
@@ -115,7 +162,9 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(0, extractedArgs.size());
     }
 
     @Test
@@ -126,7 +175,9 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(0, extractedArgs.size());
     }
 
     @Test
@@ -137,7 +188,9 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore==456",
                 playerStatsType, false, true);
 
-        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(0, extractedArgs.size());
     }
 
     @Test
@@ -149,6 +202,15 @@ public class MatchesTemplateVisitorTest {
         FilterExpression templateExpression = dialect.parseFilterExpression("highScore=={{variable}}",
                 playerStatsType, false, true);
 
-        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression));
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        Argument expected = Argument.builder()
+                .name("variable")
+                .value(123L)
+                .build();
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+
+        assertEquals(1, extractedArgs.size());
+        assertEquals(extractedArgs.get("variable"), expected);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -109,6 +109,32 @@ public class MatchesTemplateVisitorTest {
     }
 
     @Test
+    public void mulipleConjunctionOrderTest() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("lowScore>100;(highScore>=100;highScore<999)",
+                playerStatsType, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("highScore>={{low}};highScore<{{high}}",
+                playerStatsType, false, true);
+
+        Argument expected1 = Argument.builder()
+                .name("low")
+                .value(100L)
+                .build();
+
+        Argument expected2 = Argument.builder()
+                .name("high")
+                .value(999L)
+                .build();
+
+        Map<String, Argument> extractedArgs = new HashMap<>();
+
+        assertTrue(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(2, extractedArgs.size());
+        assertEquals(extractedArgs.get("low"), expected1);
+        assertEquals(extractedArgs.get("high"), expected2);
+    }
+
+    @Test
     public void conjunctionDoesNotContainTest() throws Exception {
         FilterExpression clientExpression = dialect.parseFilterExpression("lowScore>100;player.name==Bob*",
                 playerStatsType, true);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -15,7 +15,6 @@ import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
-import com.yahoo.elide.datastores.aggregation.timegrains.Time;
 import example.Player;
 import example.PlayerStats;
 import org.junit.jupiter.api.BeforeEach;

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitorTest.java
@@ -148,6 +148,19 @@ public class MatchesTemplateVisitorTest {
     }
 
     @Test
+    public void parameterizedFilterDoesNotMatch() throws Exception {
+        FilterExpression clientExpression = dialect.parseFilterExpression("recordedDate[grain:day]=='2020-01-01'",
+                playerStatsType, true);
+
+        FilterExpression templateExpression = dialect.parseFilterExpression("recordedDate=={{day}}",
+                playerStatsType, false, true);
+
+        Map<String, Argument> extractedArgs = new HashMap<>();
+        assertFalse(MatchesTemplateVisitor.isValid(templateExpression, clientExpression, extractedArgs));
+        assertEquals(0, extractedArgs.size());
+    }
+
+    @Test
     public void disjunctionContainsTest() throws Exception {
         FilterExpression clientExpression = dialect.parseFilterExpression("lowScore>100,highScore==123",
                 playerStatsType, true);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -965,6 +965,9 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                 selection(
                         field(
                                 "SalesNamespace_orderDetails",
+                                arguments(
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31'\"")
+                                ),
                                 selections(
                                         field("id"),
                                         field("orderTotal")
@@ -1006,7 +1009,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
     @Test
     public void testDynamicAggregationModel() {
         String getPath = "/SalesNamespace_orderDetails?sort=customerRegion,orderTime&page[totals]&"
-                        + "fields[SalesNamespace_orderDetails]=orderTotal,customerRegion,orderTime&filter=orderTime>=2020-08";
+                        + "fields[SalesNamespace_orderDetails]=orderTotal,customerRegion,orderTime&filter=deliveryTime>=2020-01-01;deliveryTime<2020-12-31;orderTime>=2020-08";
         given()
             .when()
             .get(getPath)
@@ -1039,10 +1042,10 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
 
     @Test
     public void missingClientFilterTest() {
-        String expectedError = "Querying SalesNamespace_deliveryDetails requires a mandatory filter:"
-                + " month&gt;={{start}};month&lt;{{end}}";
+        String expectedError = "Querying SalesNamespace_orderDetails requires a mandatory filter:"
+                + " deliveryTime&gt;={{start}};deliveryTime&lt;{{end}}";
         when()
-        .get("/SalesNamespace_deliveryDetails/")
+        .get("/SalesNamespace_orderDetails/")
         .then()
         .body("errors.detail", hasItems(expectedError))
         .statusCode(HttpStatus.SC_BAD_REQUEST);
@@ -1050,10 +1053,10 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
 
     @Test
     public void incompleteClientFilterTest() {
-        String expectedError = "Querying SalesNamespace_deliveryDetails requires a mandatory filter:"
-                + " month&gt;={{start}};month&lt;{{end}}";
+        String expectedError = "Querying SalesNamespace_orderDetails requires a mandatory filter:"
+                + " deliveryTime&gt;={{start}};deliveryTime&lt;{{end}}";
         when()
-        .get("/SalesNamespace_deliveryDetails?filter=month>=2020-08")
+        .get("/SalesNamespace_orderDetails?filter=deliveryTime>=2020-08")
         .then()
         .body("errors.detail", hasItems(expectedError))
         .statusCode(HttpStatus.SC_BAD_REQUEST);
@@ -1075,7 +1078,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"customerRegion\""),
-                                        argument("filter", "\"orderTime=='2020-08'\"")
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31';orderTime=='2020-08'\"")
                                 ),
                                 selections(
                                         field("orderTotal"),
@@ -1138,7 +1141,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"courierName,deliveryDate,orderTotal\""),
-                                        argument("filter", "\"deliveryDate>='2020-09-01',orderTotal>50\"")
+                                        argument("filter", "\"(deliveryTime>='2020-08-01';deliveryTime<'2020-12-31');(deliveryDate>='2020-09-01',orderTotal>50)\"")
                                 ),
                                 selections(
                                         field("courierName"),
@@ -1254,7 +1257,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"customerRegion\""),
-                                        argument("filter", "\"bySecond=='2020-09-08T16:30:11'\"")
+                                        argument("filter", "\"bySecond=='2020-09-08T16:30:11';(deliveryTime>='2020-01-01';deliveryTime<'2020-12-31')\"")
                                 ),
                                 selections(
                                         field("orderTotal"),
@@ -1349,7 +1352,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"orderTime\""),
-                                        argument("filter", "\"orderTime=='2020-08-01',orderTotal>50\"") //No Grain Arg passed, so works based on Alias's argument in Selection.
+                                        argument("filter", "\"(orderTime=='2020-08-01',orderTotal>50);(deliveryTime>='2020-01-01';deliveryTime<'2020-12-31')\"") //No Grain Arg passed, so works based on Alias's argument in Selection.
                                 ),
                                 selections(
                                         field("orderTotal"),
@@ -1397,7 +1400,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"customerRegion\""),
-                                        argument("filter", "\"orderTime=='2020-08'\"")
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31';orderTime=='2020-08'\"")
                                 ),
                                 selections(
                                         field("orderTotal"),
@@ -1442,7 +1445,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"customerRegion\""),
-                                        argument("filter", "\"orderTime=='2020-08'\"")
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31';orderTime=='2020-08'\"")
                                 ),
                                 selections(
                                         field("customerRegion"),
@@ -1485,7 +1488,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"customerRegion\""),
-                                        argument("filter", "\"orderTime=='2020-08'\"")
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31';orderTime=='2020-08'\"")
                                 ),
                                 selections(
                                         field("customerRegion"),
@@ -1561,7 +1564,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"customerRegion\""),
-                                        argument("filter", "\"orderTime[grain:day]=='2020-09-08'\"")
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31';orderTime[grain:day]=='2020-09-08'\"")
                                 ),
                                 selections(
                                         field("customerRegion"),

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidatorTest.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.datastores.aggregation.validator;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
@@ -216,6 +217,32 @@ public class TableArgumentValidatorTest {
 
         assertEquals("Failed to verify table arguments for table: namespace_MainTable. Argument 'joinArg1' with type 'INTEGER' is not defined but is required by join table: namespace_JoinTable.",
                         e.getMessage());
+    }
+
+    @Test
+    public void testRequiredTableArgsForJoinTableInFilterTemplate() {
+        Table mainTable = Table.builder()
+                .name("MainTable")
+                .namespace("namespace")
+                .filterTemplate("foo>{{filterArg1}}")
+                .join(Join.builder()
+                        .name("join")
+                        .namespace("namespace")
+                        .to("JoinTable")
+                        .definition("start {{$$table.args.filterArg1}} end")
+                        .build())
+                .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        tables.add(Table.builder()
+                .name("JoinTable")
+                .namespace("namespace")
+                .build());
+
+        assertDoesNotThrow(() -> {
+            new MetaDataStore(DefaultClassScanner.getInstance(), tables, this.namespaceConfigs, true);
+        });
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
@@ -8,6 +8,7 @@
       cardinality: large
       readAccess: guest user
       namespace: SalesNamespace
+      filterTemplate : deliveryTime>={{start}};deliveryTime<{{end}}
       arguments:
       [
         { // An argument that can be used to divide orderTotal to convert orders in Millions, Thousands, etc.
@@ -34,7 +35,8 @@
           // References Logical Columns, multiple join condition
           definition: '''
           {{ orderId}} = {{delivery.orderId}} AND
-          {{ delivery.$delivered_on }} > '1970-01-01'
+          {{ delivery.$delivered_on }} >= '{{ $$table.args.start }}' AND
+          {{ delivery.$delivered_on }} < '{{ $$table.args.end }}'
           '''
         }
       ]
@@ -227,7 +229,6 @@
       cardinality: large
       readAccess: guest user
       namespace: SalesNamespace
-      filterTemplate : month>={{start}};month<{{end}}
       dimensions:
       [
         {

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -423,6 +423,33 @@ public class DynamicConfigValidatorTest {
     }
 
     @Test
+    public void testDuplicateArgumentNameInFilter() throws Exception {
+        DynamicConfigValidator testClass = new DynamicConfigValidator(DefaultClassScanner.getInstance(),
+                "src/test/resources/validator/valid");
+        testClass.readConfigs();
+        Table playerStatsTable = testClass.getElideTableConfig().getTable("PlayerNamespace_PlayerStats");
+
+        // PlayerStats table already has a filter argument 'code' with type 'TEXT'.
+        playerStatsTable.getArguments().add(Argument.builder().name("code").type(Type.TEXT).build());
+        Exception e = assertThrows(IllegalStateException.class, () -> testClass.validateConfigs());
+        assertEquals("Multiple Arguments found with the same name: code", e.getMessage());
+    }
+
+    @Test
+    public void testDuplicateArgumentNameInComplexFilter() throws Exception {
+        DynamicConfigValidator testClass = new DynamicConfigValidator(DefaultClassScanner.getInstance(),
+                "src/test/resources/validator/valid");
+        testClass.readConfigs();
+        Table playerStatsTable = testClass.getElideTableConfig().getTable("PlayerNamespace_PlayerStats");
+
+        // PlayerStats table already has a filter argument 'code' with type 'TEXT'.
+        playerStatsTable.getArguments().add(Argument.builder().name("code").type(Type.TEXT).build());
+        playerStatsTable.setFilterTemplate("foo=={{bar}};blah=={{code}}");
+        Exception e = assertThrows(IllegalStateException.class, () -> testClass.validateConfigs());
+        assertEquals("Multiple Arguments found with the same name: code", e.getMessage());
+    }
+
+    @Test
     public void testFormatClassPath() {
         assertEquals("anydir", DynamicConfigValidator.formatClassPath("src/test/resources/anydir"));
         assertEquals("anydir/configs", DynamicConfigValidator.formatClassPath("src/test/resources/anydir/configs"));


### PR DESCRIPTION
Resolves #1956

## Description
This change promotes filterTemplate variables defined in aggregation store data models into table arguments that can be used in table, join, and column expressions.

For example, a table may have defined a filter template (a table required filter) such as:

```
      filterTemplate : deliveryTime>={{start}};deliveryTime<{{end}}
```

The variables 'start' and 'end' can then be referenced in a join as follows:

```
       {
          name: delivery
          to: deliveryDetails
          namespace: SalesNamespace
          kind: toOne
          // References Logical Columns, multiple join condition
          definition: '''
          {{ orderId}} = {{delivery.orderId}} AND
          {{ delivery.$delivered_on }} >= '{{ $$table.args.start }}' AND
          {{ delivery.$delivered_on }} < '{{ $$table.args.end }}'
          '''
        }
```

## Motivation and Context
Allow more powerful generated SQL that leverage required filter template arguments.

## How Has This Been Tested?
New unit tests and adjusted IT tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
