### PR TITLE
Aggregation Store: Fix hjson metric projection maker config

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -488,7 +488,11 @@ public class TableType implements Type<DynamicModelInstance> {
 
             @Override
             public String value() {
-                return trimColumnReferences(measure.getDefinition());
+                if (measure.getDefinition() != null) {
+                    return trimColumnReferences(measure.getDefinition());
+                } else {
+                    return "";
+                }
             }
 
             @Override
@@ -813,6 +817,7 @@ public class TableType implements Type<DynamicModelInstance> {
      */
     private static String trimColumnReferences(String str) {
         String expr = replaceNewlineWithSpace(str);
+
         Matcher matcher = REFERENCE_PARENTHESES.matcher(expr);
         while (matcher.find()) {
             String reference = matcher.group(1);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ExpressionParser.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/expression/ExpressionParser.java
@@ -222,7 +222,7 @@ public class ExpressionParser {
         if (! isEmpty(expression)) {
             Matcher matcher = REFERENCE_PARENTHESES.matcher(expression);
             while (matcher.find()) {
-                references.add(matcher.group(1));
+                references.add(matcher.group(1).trim());
             }
         }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/example/metrics/SalesViewOrderMax.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/example/metrics/SalesViewOrderMax.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package example.metrics;
+
+import com.yahoo.elide.core.request.Argument;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Metric;
+import com.yahoo.elide.datastores.aggregation.query.MetricProjection;
+import com.yahoo.elide.datastores.aggregation.query.MetricProjectionMaker;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLMetricProjection;
+
+import java.util.Map;
+
+/**
+ * For testing HJSON metric projection maker configuration.
+ */
+public class SalesViewOrderMax implements MetricProjectionMaker {
+    @Override
+    public MetricProjection make(Metric metric, String alias, Map<String, Argument> arguments) {
+        return SQLMetricProjection.builder()
+                .alias(alias)
+                .arguments(arguments)
+                .name(metric.getName())
+                .expression("MAX({{ $order_total }})")
+                .valueType(metric.getValueType())
+                .columnType(metric.getColumnType())
+                .build();
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
@@ -56,6 +56,21 @@
               default: 0.00
             }
           ]
+        },
+        {
+          name: orderMax
+          type: DECIMAL
+          // TODO : Use Arguments
+          maker: example.metrics.SalesViewOrderMax
+          readAccess: admin.user
+          arguments:
+          [
+            { // An argument that can be used to divide orderTotal to convert orders in Millions, Thousands, etc.
+              name: precision
+              type: DECIMAL
+              default: 0.00
+            }
+          ]
         }
       ]
       dimensions:

--- a/elide-model-config/src/main/resources/elideTableSchema.json
+++ b/elide-model-config/src/main/resources/elideTableSchema.json
@@ -188,7 +188,7 @@
                     "title": "Metric Projection Maker",
                     "description": "Registers a custom function to create a projection for this metric",
                     "type": "string",
-                    "format": "javaClassNameWithExt"
+                    "format": "javaClassName"
                 },
                 "type": {
                     "title": "Measure field type",
@@ -214,10 +214,21 @@
                     }
                 }
             },
-            "required": [
-                "name",
-                "type",
-                "definition"
+            "oneOf": [
+                {
+                    "required": [
+                        "name",
+                        "type",
+                        "definition"
+                    ]
+                },
+                {
+                    "required": [
+                        "name",
+                        "type",
+                        "maker"
+                    ]
+                }
             ],
             "additionalProperties": false
         },

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/DynamicConfigSchemaValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/DynamicConfigSchemaValidatorTest.java
@@ -136,7 +136,9 @@ public class DynamicConfigSchemaValidatorTest {
                         + "[ERROR]\n"
                         + "Instance[/tables/0/filterTemplate] failed to validate against schema[/properties/tables/items/properties/filterTemplate]. Input value[countryIsoCode={{code}};startTime=={{start}}] is not a valid RSQL filter expression. Please visit page https://elide.io/pages/guide/v5/11-graphql.html#operators for samples.\n"
                         + "[ERROR]\n"
-                        + "Instance[/tables/0/measures/0/maker] failed to validate against schema[/definitions/measure/properties/maker]. Input value[com.yahoo.elide.datastores.aggregation.query@DefaultMetricProjectionMaker.class] is not a valid Java class name with .class extension.\n"
+                        + "Instance[/tables/0/measures/0] failed to validate against schema[/definitions/measure]. instance failed to match exactly one schema (matched 2 out of 2)\n"
+                        + "[ERROR]\n"
+                        + "Instance[/tables/0/measures/0/maker] failed to validate against schema[/definitions/measure/properties/maker]. Input value[com.yahoo.elide.datastores.aggregation.query@DefaultMetricProjectionMaker.class] is not a valid Java class name.\n"
                         + "[ERROR]\n"
                         + "Instance[/tables/0/name] failed to validate against schema[/properties/tables/items/properties/name]. Name [Country@10] is not allowed. Name must start with an alphabetic character and can include alaphabets, numbers and '_' only.";
 

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -393,7 +393,7 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals("Multiple DB configs found with the same name: OracleConnection\n", error);
+        assertTrue(error.contains("Multiple DB configs found with the same name: OracleConnection"));
     }
 
     @Test

--- a/elide-model-config/src/test/resources/validator/valid/models/tables/player_stats_extends.hjson
+++ b/elide-model-config/src/test/resources/validator/valid/models/tables/player_stats_extends.hjson
@@ -13,7 +13,6 @@
             type : Text
             description : very awesome score
             definition: 'MAX({{score}})'
-            maker: 'com.yahoo.elide.datastores.aggregation.query.DefaultMetricProjectionMaker.class'
             tags: ['PUBLIC']
           },
           {


### PR DESCRIPTION
## Description
It was not possible to configure a 'maker' for metric/measure using HJSON.

## Motivation and Context
Class configuration worked fine but HJSON configuration was broken.

## How Has This Been Tested?
Modified existing HJSON to include a new measure with a custom maker.  
Modified existing UTs.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
