### PR TITLE
AggregationStore: Templated filter column arguments

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransaction.java
@@ -195,7 +195,7 @@ public class AggregationDataStoreTransaction implements DataStoreTransaction {
             FilterExpression requiredFilter = column.getRequiredFilter(dictionary);
 
             if (requiredFilter != null) {
-                Map<String, Argument> templateFilterArguments = validateRequiredFilter(requiredFilter, query, table);
+                Map<String, Argument> templateFilterArguments = validateRequiredFilter(requiredFilter, query, column);
 
                 if (!templateFilterArguments.isEmpty()) {
                     Map<String, Argument> columnArguments = Stream.concat(

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/annotation/ColumnMeta.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/annotation/ColumnMeta.java
@@ -26,6 +26,12 @@ public @interface ColumnMeta {
     String [] values() default {};
 
     /**
+     * Whether or not querying this column requires a client provided filter.
+     * @return The required filter template.
+     */
+    String filterTemplate() default "";
+
+    /**
      * Indicates the cardinality for the column.
      * @return size
      */

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -470,6 +470,11 @@ public class TableType implements Type<DynamicModelInstance> {
             }
 
             @Override
+            public String filterTemplate() {
+                return measure.getFilterTemplate();
+            }
+
+            @Override
             public CardinalitySize size() {
                 return CardinalitySize.UNKNOWN;
             }
@@ -603,6 +608,11 @@ public class TableType implements Type<DynamicModelInstance> {
             @Override
             public String[] values() {
                 return dimension.getValues().toArray(new String[0]);
+            }
+
+            @Override
+            public String filterTemplate() {
+                return dimension.getFilterTemplate();
             }
 
             @Override
@@ -778,6 +788,11 @@ public class TableType implements Type<DynamicModelInstance> {
             @Override
             public String[] values() {
                 return new String[0];
+            }
+
+            @Override
+            public String filterTemplate() {
+                return "";
             }
 
             @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Column.java
@@ -43,7 +43,7 @@ import javax.persistence.OneToOne;
 @Getter
 @EqualsAndHashCode
 @ToString
-public abstract class Column implements Versioned, Named {
+public abstract class Column implements Versioned, Named, RequiresFilter {
 
     @Id
     private final String id;
@@ -72,6 +72,8 @@ public abstract class Column implements Versioned, Named {
     private final ValueSourceType valueSourceType;
 
     private final Set<String> values;
+
+    private String requiredFilter;
 
     @OneToOne
     @Setter
@@ -111,6 +113,7 @@ public abstract class Column implements Versioned, Named {
             this.tableSourceDefinition = meta.tableSource();
             this.valueSourceType = ValueSourceType.getValueSourceType(this.values, this.tableSourceDefinition);
             this.cardinality = meta.size();
+            this.requiredFilter = meta.filterTemplate();
         } else {
             this.friendlyName = name;
             this.description = null;
@@ -120,6 +123,7 @@ public abstract class Column implements Versioned, Named {
             this.tableSourceDefinition = null;
             this.valueSourceType = ValueSourceType.NONE;
             this.cardinality = CardinalitySize.UNKNOWN;
+            this.requiredFilter = null;
         }
 
         if (dictionary.attributeOrRelationAnnotationExists(tableClass, fieldName, MetricFormula.class)) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/RequiresFilter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/RequiresFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.aggregation.metadata.models;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.ParseException;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.modelconfig.model.Named;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Metadata models that require a client filter.
+ */
+public interface RequiresFilter extends Named {
+    Table getTable();
+
+    String getRequiredFilter();
+
+    default FilterExpression getRequiredFilter(EntityDictionary dictionary) {
+        Type<?> cls = dictionary.getEntityClass(getTable().getName(), getTable().getVersion());
+        RSQLFilterDialect filterDialect = new RSQLFilterDialect(dictionary);
+
+        if (StringUtils.isNotEmpty(getRequiredFilter())) {
+            try {
+                return filterDialect.parseFilterExpression(getRequiredFilter(), cls, false, true);
+            } catch (ParseException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        return null;
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -49,7 +49,7 @@ import javax.persistence.OneToMany;
 @Getter
 @EqualsAndHashCode
 @ToString
-public abstract class Table implements Versioned, Named {
+public abstract class Table implements Versioned, Named, RequiresFilter {
 
     @Id
     private final String id;
@@ -321,18 +321,9 @@ public abstract class Table implements Versioned, Named {
         return getMetric(fieldName) != null;
     }
 
-    public FilterExpression getRequiredFilter(EntityDictionary dictionary) {
-        Type<?> cls = dictionary.getEntityClass(name, version);
-        RSQLFilterDialect filterDialect = new RSQLFilterDialect(dictionary);
-
-        if (StringUtils.isNotEmpty(requiredFilter)) {
-            try {
-                return filterDialect.parseFilterExpression(requiredFilter, cls, false, true);
-            } catch (ParseException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-        return null;
+    @Override
+    public Table getTable() {
+        return this;
     }
 
     public boolean hasArgumentDefinition(String argName) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/models/Table.java
@@ -10,9 +10,6 @@ import static com.yahoo.elide.datastores.aggregation.metadata.models.Column.getV
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
-import com.yahoo.elide.core.filter.dialect.ParseException;
-import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
-import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.TypeHelper;
 import com.yahoo.elide.datastores.aggregation.AggregationDataStore;
@@ -25,7 +22,6 @@ import com.yahoo.elide.datastores.aggregation.query.Queryable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
 import com.yahoo.elide.modelconfig.model.Named;
-import org.apache.commons.lang3.StringUtils;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidator.java
@@ -76,7 +76,7 @@ public class ColumnArgumentValidator {
                         .flatMap(Set::stream)
                         .map(ColumnArgReference::getArgName)
                         .forEach(argName -> {
-                            if (!column.hasArgumentDefinition(argName)) {
+                            if (!column.hasArgumentDefinition(argName) && !hasTemplateFilterArgument(argName)) {
                                 throw new IllegalStateException(String.format(errorMsgPrefix
                                                 + "Argument '%s' is not defined but found '{{$$column.args.%s}}'.",
                                                 argName, argName));
@@ -140,5 +140,9 @@ public class ColumnArgumentValidator {
                             errorMsgPrefix + "Pinned ");
             }
         });
+    }
+
+    private boolean hasTemplateFilterArgument(String argName) {
+        return column.getRequiredFilter() != null && column.getRequiredFilter().contains("{{" + argName + "}}");
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransactionTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/AggregationDataStoreTransactionTest.java
@@ -6,9 +6,13 @@
 
 package com.yahoo.elide.datastores.aggregation;
 
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 import static com.yahoo.elide.core.request.Pagination.DEFAULT_PAGE_LIMIT;
 import static com.yahoo.elide.core.request.Pagination.MAX_PAGE_LIMIT;
+import static com.yahoo.elide.datastores.aggregation.dynamic.NamespacePackage.DEFAULT_NAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -17,19 +21,35 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.exceptions.BadRequestException;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.pagination.PaginationImpl;
+import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.Pagination;
+import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.core.utils.DefaultClassScanner;
+import com.yahoo.elide.core.utils.coerce.CoerceUtil;
+import com.yahoo.elide.core.utils.coerce.converters.ISO8601DateSerde;
 import com.yahoo.elide.datastores.aggregation.cache.Cache;
 import com.yahoo.elide.datastores.aggregation.cache.QueryKeyExtractor;
 import com.yahoo.elide.datastores.aggregation.core.QueryLogger;
 import com.yahoo.elide.datastores.aggregation.core.QueryResponse;
 import com.yahoo.elide.datastores.aggregation.framework.SQLUnitTest;
+import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Namespace;
+import com.yahoo.elide.datastores.aggregation.metadata.models.Table;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.QueryResult;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.NativeQuery;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.SQLMetricProjection;
 import example.PlayerStats;
+import example.PlayerStatsWithRequiredFilter;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +60,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
 
 @ExtendWith(MockitoExtension.class)
 class AggregationDataStoreTransactionTest extends SQLUnitTest {
@@ -56,15 +79,19 @@ class AggregationDataStoreTransactionTest extends SQLUnitTest {
 
     // inject our own query instead of using buildQuery impl
     private class MyAggregationDataStoreTransaction extends AggregationDataStoreTransaction {
-
         public MyAggregationDataStoreTransaction(QueryEngine queryEngine, Cache cache, QueryLogger queryLogger) {
             super(queryEngine, cache, queryLogger);
         }
 
         @Override
-        protected Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
+        Query buildQuery(EntityProjection entityProjection, RequestScope scope) {
             return query;
         }
+    }
+
+    public AggregationDataStoreTransactionTest() {
+        metaDataStore = new MetaDataStore(DefaultClassScanner.getInstance(), false);
+        CoerceUtil.register(Date.class, new ISO8601DateSerde());
     }
 
     @BeforeAll
@@ -75,6 +102,94 @@ class AggregationDataStoreTransactionTest extends SQLUnitTest {
     @BeforeEach
     public void setUp() {
         when(queryEngine.beginTransaction()).thenReturn(qeTransaction);
+    }
+
+    @Test
+    public void testMissingRequiredTableFilter() {
+        EntityDictionary dictionary = EntityDictionary.builder()
+                .build();
+        dictionary.bindEntity(PlayerStatsWithRequiredFilter.class);
+
+        Table table = new SQLTable(new Namespace(DEFAULT_NAMESPACE),
+                ClassType.of(PlayerStatsWithRequiredFilter.class), dictionary);
+
+        AggregationDataStoreTransaction tx = new AggregationDataStoreTransaction(queryEngine, cache, queryLogger);
+        assertThrows(BadRequestException.class, () -> tx.addTableFilterArguments(table, query, dictionary));
+    }
+
+    @Test
+    public void testRequiredTableFilterArguments() throws Exception {
+        Type<PlayerStatsWithRequiredFilter> tableType = ClassType.of(PlayerStatsWithRequiredFilter.class);
+
+        EntityDictionary dictionary = EntityDictionary.builder()
+                .build();
+        dictionary.bindEntity(PlayerStatsWithRequiredFilter.class);
+
+        SQLTable table = new SQLTable(new Namespace(DEFAULT_NAMESPACE), tableType, dictionary);
+
+        RSQLFilterDialect filterDialect = new RSQLFilterDialect(dictionary);
+        FilterExpression where = filterDialect.parse(tableType, new HashSet<>(),
+                "recordedDate>=2019-07-12T00:00Z;recordedDate<2030-07-12T00:00Z", NO_VERSION);
+
+        Query query = Query.builder()
+                .source(table)
+                .whereFilter(where).build();
+
+        AggregationDataStoreTransaction tx = new AggregationDataStoreTransaction(queryEngine, cache, queryLogger);
+
+        Query modifiedQuery = tx.addTableFilterArguments(table, query, dictionary);
+        Map<String, Argument> tableArguments = modifiedQuery.getArguments();
+        assertTrue(tableArguments.containsKey("start"));
+        assertTrue(tableArguments.containsKey("end"));
+        assertEquals(2, tableArguments.size());
+    }
+
+    @Test
+    public void testMissingRequiredColumnFilter() throws Exception {
+        Type<PlayerStatsWithRequiredFilter> tableType = ClassType.of(PlayerStatsWithRequiredFilter.class);
+
+        EntityDictionary dictionary = EntityDictionary.builder()
+                .build();
+        dictionary.bindEntity(PlayerStatsWithRequiredFilter.class);
+
+        SQLTable table = new SQLTable(new Namespace(DEFAULT_NAMESPACE), tableType, dictionary);
+
+        Query query = Query.builder()
+                .column(SQLMetricProjection.builder().name("highScore").build())
+                .source(table)
+                .build();
+
+        AggregationDataStoreTransaction tx = new AggregationDataStoreTransaction(queryEngine, cache, queryLogger);
+
+        assertThrows(BadRequestException.class, () -> tx.addColumnFilterArguments(table, query, dictionary));
+    }
+
+    @Test
+    public void testRequiredColumnFilterArguments() throws Exception {
+        Type<PlayerStatsWithRequiredFilter> tableType = ClassType.of(PlayerStatsWithRequiredFilter.class);
+
+        EntityDictionary dictionary = EntityDictionary.builder()
+                .build();
+        dictionary.bindEntity(PlayerStatsWithRequiredFilter.class);
+
+        SQLTable table = new SQLTable(new Namespace(DEFAULT_NAMESPACE), tableType, dictionary);
+
+        RSQLFilterDialect filterDialect = new RSQLFilterDialect(dictionary);
+        FilterExpression where = filterDialect.parse(tableType, new HashSet<>(),
+                "recordedDate>2019-07-12T00:00Z", NO_VERSION);
+
+        Query query = Query.builder()
+                .column(SQLMetricProjection.builder().name("highScore").alias("highScore").build())
+                .whereFilter(where)
+                .source(table)
+                .build();
+
+        AggregationDataStoreTransaction tx = new AggregationDataStoreTransaction(queryEngine, cache, queryLogger);
+
+        Query modifiedQuery = tx.addColumnFilterArguments(table, query, dictionary);
+        Map<String, Argument> columnArguments = modifiedQuery.getColumnProjection("highScore").getArguments();
+        assertTrue(columnArguments.containsKey("recordedDate"));
+        assertEquals(1, columnArguments.size());
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -1141,7 +1141,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("sort", "\"courierName,deliveryDate,orderTotal\""),
-                                        argument("filter", "\"(deliveryTime>='2020-08-01';deliveryTime<'2020-12-31');(deliveryDate>='2020-09-01',orderTotal>50)\"")
+                                        argument("filter", "\"deliveryYear=='2020';(deliveryTime>='2020-08-01';deliveryTime<'2020-12-31');(deliveryDate>='2020-09-01',orderTotal>50)\"")
                                 ),
                                 selections(
                                         field("courierName"),
@@ -1754,6 +1754,33 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
         runQueryWithExpectedError(graphQLRequest, expected);
     }
 
+    /**
+     * Test missing required column filter on deliveryYear.
+     * @throws Exception exception
+     */
+    @Test
+    public void missingRequiredColumnFilter() throws Exception {
+        String graphQLRequest = document(
+                selection(
+
+                        field(
+                                "SalesNamespace_orderDetails",
+                                arguments(
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31'\"")
+                                ),
+                                selections(
+                                        field("orderTotal"),
+                                        field("deliveryYear")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String errorMessage = "Exception while fetching data (/SalesNamespace_orderDetails) : "
+                + "Querying deliveryYear requires a mandatory filter: deliveryYear=={{deliveryYear}}";
+
+        runQueryWithExpectedError(graphQLRequest, errorMessage);
+    }
 
     //Security
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
@@ -156,6 +156,46 @@ class ColumnArgumentValidatorTest {
     }
 
     @Test
+    public void testMissingRequiredColumnArgs() {
+        Table mainTable = mainTableBuilder
+               .dimension(Dimension.builder()
+                        .name("dim1")
+                        .type(Type.BOOLEAN)
+                        .values(Collections.emptySet())
+                        .tags(Collections.emptySet())
+                        .definition("start {{$$column.args.mainArg1}} end")
+                        .build())
+                .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(DefaultClassScanner.getInstance(), tables, this.namespaceConfigs, true);
+        Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+
+        assertEquals("Failed to verify column arguments for column: dim1 in table: namespace_MainTable. Argument 'mainArg1' is not defined but found '{{$$column.args.mainArg1}}'.",
+                e.getMessage());
+    }
+
+    @Test
+    public void testRequiredColumnArgsInFilterTemplate() {
+        Table mainTable = mainTableBuilder
+                .dimension(Dimension.builder()
+                        .name("dim1")
+                        .type(Type.BOOLEAN)
+                        .values(Collections.emptySet())
+                        .tags(Collections.emptySet())
+                        .definition("start {{$$column.args.mainArg1}} end")
+                        .filterTemplate("dim1=={{mainArg1}}")
+                        .build())
+                .build();
+
+        Set<Table> tables = new HashSet<>();
+        tables.add(mainTable);
+        MetaDataStore metaDataStore = new MetaDataStore(DefaultClassScanner.getInstance(), tables, this.namespaceConfigs, true);
+        assertDoesNotThrow(() -> new SQLQueryEngine(metaDataStore, connection, connectionDetailsMap, optimizers, queryValidator));
+    }
+
+    @Test
     public void testMissingRequiredColumnArgsForDepenedentColumnCase1() {
         Table mainTable = mainTableBuilder
                         .dimension(Dimension.builder()

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/example/PlayerStatsWithRequiredFilter.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/example/PlayerStatsWithRequiredFilter.java
@@ -127,7 +127,7 @@ public class PlayerStatsWithRequiredFilter {
     }
 
     @MetricFormula("MAX(highScore)")
-    @ColumnMeta(description = "very awesome score", category = "Score Category")
+    @ColumnMeta(description = "very awesome score", category = "Score Category", filterTemplate = "recordedDate>{{recordedDate}}")
     public long getHighScore() {
         return highScore;
     }

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/SalesView.hjson
@@ -189,6 +189,7 @@
             type: YEAR
             sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy'), 'yyyy')
           }]
+          filterTemplate: 'deliveryYear=={{deliveryYear}}'
         }
         {
           name: deliveryDefault

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
@@ -105,7 +105,6 @@ public abstract class GraphQLIntegrationTest extends IntegrationTest {
                 .header("ApiVersion", apiVersion)
                 .post("/graphQL")
                 .then()
-                .log().all()
                 .statusCode(HttpStatus.SC_OK);
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
@@ -105,6 +105,7 @@ public abstract class GraphQLIntegrationTest extends IntegrationTest {
                 .header("ApiVersion", apiVersion)
                 .post("/graphQL")
                 .then()
+                .log().all()
                 .statusCode(HttpStatus.SC_OK);
     }
 

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ValidateDimPropertiesValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/jsonformats/ValidateDimPropertiesValidator.java
@@ -28,7 +28,7 @@ public class ValidateDimPropertiesValidator extends AbstractKeywordValidator {
 
     public static final Set<String> COMMON_DIM_PROPERTIES = ImmutableSet.of("name", "friendlyName",
                     "description", "category", "hidden", "readAccess", "definition", "cardinality", "tags", "type",
-                    "arguments");
+                    "arguments", "filterTemplate");
     private static final Set<String> ADDITIONAL_DIM_PROPERTIES = ImmutableSet.of("values", "tableSource");
 
     public static final String KEYWORD = "validateDimensionProperties";

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Dimension.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Dimension.java
@@ -40,7 +40,8 @@ import java.util.Set;
     "tags",
     "arguments",
     "values",
-    "tableSource"
+    "tableSource",
+    "filterTemplate"
 })
 @Data
 @EqualsAndHashCode()
@@ -94,6 +95,9 @@ public class Dimension implements Named {
 
     @JsonProperty("tableSource")
     private TableSource tableSource;
+
+    @JsonProperty("filterTemplate")
+    private String filterTemplate;
 
     /**
      * Returns description of the dimension.

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Measure.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Measure.java
@@ -37,6 +37,7 @@ import java.util.Set;
     "type",
     "tags",
     "arguments",
+    "filterTemplate"
 })
 @Data
 @EqualsAndHashCode()
@@ -79,6 +80,9 @@ public class Measure implements Named {
     @JsonProperty("arguments")
     @Singular
     private List<Argument> arguments = new ArrayList<>();
+
+    @JsonProperty("filterTemplate")
+    private String filterTemplate;
 
     /**
      * Returns description of the measure.

--- a/elide-model-config/src/main/resources/elideTableSchema.json
+++ b/elide-model-config/src/main/resources/elideTableSchema.json
@@ -212,6 +212,12 @@
                     "items": {
                         "$ref": "#/definitions/argument"
                     }
+                },
+                "filterTemplate": {
+                    "title": "Required RSQL Filter Template",
+                    "description": "Client queries must include a filter conforming to this RSQL template.",
+                    "type": "string",
+                    "format": "elideRSQLFilter"
                 }
             },
             "oneOf": [
@@ -297,6 +303,12 @@
                     "items": {
                         "$ref": "#/definitions/argument"
                     }
+                },
+                "filterTemplate": {
+                    "title": "Required RSQL Filter Template",
+                    "description": "Client queries must include a filter conforming to this RSQL template.",
+                    "type": "string",
+                    "format": "elideRSQLFilter"
                 }
             }
         },

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/parser/handlebars/HandlebarsHydratorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/parser/handlebars/HandlebarsHydratorTest.java
@@ -120,6 +120,7 @@ public class HandlebarsHydratorTest {
             + "           friendlyName : Created On\n"
             + "           type : TIME\n"
             + "           definition : '{{create_on}}'\n"
+            + "           filterTemplate : 'createdOn=={{createdOn}}'\n"
             + "           grains:\n"
             + "            [{\n"
             + "             type : DaY\n"

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -423,7 +423,17 @@ public class DynamicConfigValidatorTest {
     }
 
     @Test
-    public void testDuplicateArgumentNameInFilter() throws Exception {
+    public void testDuplicateArgumentNameInColumnFilter() throws Exception {
+        DynamicConfigValidator testClass = new DynamicConfigValidator(DefaultClassScanner.getInstance(),
+                "src/test/resources/validator/duplicate_column_args");
+        testClass.readConfigs();
+
+        Exception e = assertThrows(IllegalStateException.class, () -> testClass.validateConfigs());
+        assertEquals("Multiple Arguments found with the same name: foo", e.getMessage());
+    }
+
+    @Test
+    public void testDuplicateArgumentNameInTableFilter() throws Exception {
         DynamicConfigValidator testClass = new DynamicConfigValidator(DefaultClassScanner.getInstance(),
                 "src/test/resources/validator/valid");
         testClass.readConfigs();
@@ -436,7 +446,7 @@ public class DynamicConfigValidatorTest {
     }
 
     @Test
-    public void testDuplicateArgumentNameInComplexFilter() throws Exception {
+    public void testDuplicateArgumentNameInComplexTableFilter() throws Exception {
         DynamicConfigValidator testClass = new DynamicConfigValidator(DefaultClassScanner.getInstance(),
                 "src/test/resources/validator/valid");
         testClass.readConfigs();

--- a/elide-model-config/src/test/resources/validator/duplicate_column_args/models/tables/table.hjson
+++ b/elide-model-config/src/test/resources/validator/duplicate_column_args/models/tables/table.hjson
@@ -1,0 +1,27 @@
+{
+    tables: [{
+        name: Player
+        table: player
+        schema: playerdb
+        description:
+        '''
+        A long description
+        '''
+        cardinality : large
+        measures : [
+        {
+            name : highScore
+            type : "INTEGER"
+            definition: 'MAX({{score}})'
+            //'foo' here conflicts with the argument 'foo' below.
+            filterTemplate: highScore>{{foo}}
+            arguments: [
+                {
+                    name: foo
+                    type: TEXT
+                }
+            ]
+        }]
+        dimensions: []
+    }]
+}

--- a/elide-model-config/src/test/resources/validator/valid/models/tables/player_stats.hjson
+++ b/elide-model-config/src/test/resources/validator/valid/models/tables/player_stats.hjson
@@ -95,6 +95,7 @@
            friendlyName : Created On
            type : TIME
            definition : '{{create_on}}'
+           filterTemplate : 'createdOn=={{createdOn}}'
            grains:
             [{
              type : DaY


### PR DESCRIPTION
## Resolves #2291 

## Description
Feature support for templated filters (required filters) for columns:

Column definitions can now have a filterTemplate:

```
        {
          name: deliveryYear
          type: TIME
          // Logical Column Reference in same table, which references another Logical Column in referred table, which references another Logical column in referred table, which references another Logical column in referred table, which references Physical column in referred table
          definition: '{{deliveryMonth}}'
          readAccess: guest user
          grains:
          [{
            type: YEAR
            sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy'), 'yyyy')
          }]
          filterTemplate: 'deliveryYear=={{deliveryYear}}'
        }
```

or in Java:

```java
    @MetricFormula("MAX(highScore)")
    @ColumnMeta(description = "very awesome score", category = "Score Category", filterTemplate = "recordedDate>{{recordedDate}}")
    public long getHighScore() {
        return highScore;
    }
```

Whenever a client requests the given field, they must also supply a filter that matches the template (matching can be exact match or conjoined with another filter expression).

If the filter template includes variables ({{variableName}}), then the variable will be added to the column's arguments.  These arguments can be accessed in HJSON as `$$column.args.variableName`

## Motivation and Context
This allows join and column definitions parameterized by the client provided filter.  Unlike a required table filter, the column filter is only required if the client requests the given column.

## How Has This Been Tested?
- HJSON parsing UT
- new HJSON validation UT 
- new Aggregation store IT tests
- new Aggregation store transaction UT tests
- existing tests pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
