### PR TITLE
GraphQL subscription life cycle hooks

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/CRUDEvent.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/CRUDEvent.java
@@ -11,7 +11,7 @@ import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.DELETE;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.READ;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.UPDATE;
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
-import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.security.PersistentResource;
 import com.yahoo.elide.core.security.ChangeSpec;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/CRUDEvent.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/CRUDEvent.java
@@ -11,8 +11,8 @@ import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.DELETE;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.READ;
 import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.UPDATE;
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
-import com.yahoo.elide.core.security.PersistentResource;
 import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.PersistentResource;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/LifeCycleHook.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/LifeCycleHook.java
@@ -25,9 +25,28 @@ public interface LifeCycleHook<T> {
      * @param requestScope The request scope
      * @param changes Optionally, the changes that were made to the entity
      */
-    public abstract void execute(LifeCycleHookBinding.Operation operation,
-                                 LifeCycleHookBinding.TransactionPhase phase,
-                                 T elideEntity,
-                                 RequestScope requestScope,
-                                 Optional<ChangeSpec> changes);
+    void execute(LifeCycleHookBinding.Operation operation,
+                 LifeCycleHookBinding.TransactionPhase phase,
+                 T elideEntity,
+                 RequestScope requestScope,
+                 Optional<ChangeSpec> changes);
+
+    /**
+     * Base method of life cycle hook invoked by Elide.  Includes access to the underlying
+     * CRUDEvent and the PersistentResource.
+     * @param operation CREATE, READ, UPDATE, or DELETE
+     * @param phase PRESECURITY, PRECOMMIT or POSTCOMMIT
+     * @param event The CRUD Event that triggered this hook.
+     */
+    default void execute(
+            LifeCycleHookBinding.Operation operation,
+            LifeCycleHookBinding.TransactionPhase phase,
+            CRUDEvent event) {
+        this.execute(
+                operation,
+                phase,
+                (T) event.getResource().getObject(),
+                event.getResource().getRequestScope(),
+                event.getChanges());
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/LifecycleHookInvoker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/lifecycle/LifecycleHookInvoker.java
@@ -55,13 +55,7 @@ public class LifecycleHookInvoker implements Observer<CRUDEvent> {
         try {
             //Invoke all the hooks
             hooks.forEach(hook ->
-                    hook.execute(
-                            this.op,
-                            this.phase,
-                            event.getResource().getObject(),
-                            event.getResource().getRequestScope(),
-                            event.getChanges())
-
+                    hook.execute(this.op, this.phase, event)
             );
         } catch (RuntimeException e) {
             exception = Optional.of(e);

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
@@ -6,6 +6,10 @@
 
 package com.yahoo.elide.datastores.jms;
 
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.DELETE;
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.UPDATE;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
 import lombok.Getter;
@@ -15,18 +19,20 @@ import lombok.Getter;
  */
 @Getter
 public enum TopicType {
-    ADDED("Added"),
-    DELETED("Deleted"),
-    UPDATED("Updated");
+    ADDED("Added", CREATE),
+    DELETED("Deleted", DELETE),
+    UPDATED("Updated", UPDATE);
 
-    private String topicSuffix;
+    private final String topicSuffix;
+    private final LifeCycleHookBinding.Operation operation;
 
     /**
      * Constructor.
      * @param topicSuffix The suffix of the topic name.
      */
-    TopicType(String topicSuffix) {
+    TopicType(String topicSuffix, LifeCycleHookBinding.Operation operation) {
         this.topicSuffix = topicSuffix;
+        this.operation = operation;
     }
 
     /**
@@ -37,5 +43,24 @@ public enum TopicType {
      */
     public String toTopicName(Type<?> type, EntityDictionary dictionary) {
         return dictionary.getJsonAliasFor(type) + topicSuffix;
+    }
+
+    /**
+     * Converts a LifeCycleHookBinding to a topic type.
+     * @param op The lifecyle operation
+     * @return The corresponding topic type.
+     */
+    public static TopicType fromOperation(LifeCycleHookBinding.Operation op) {
+        switch (op){
+            case CREATE: {
+                return ADDED;
+            }
+            case DELETE: {
+                return DELETED;
+            }
+            default : {
+                return UPDATED;
+            }
+        }
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/TopicType.java
@@ -51,7 +51,7 @@ public enum TopicType {
      * @return The corresponding topic type.
      */
     public static TopicType fromOperation(LifeCycleHookBinding.Operation op) {
-        switch (op){
+        switch (op) {
             case CREATE: {
                 return ADDED;
             }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHook.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHook.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.jms.hooks;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.ResourceLineage;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.lifecycle.CRUDEvent;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.type.Type;
+import com.yahoo.elide.datastores.jms.TopicType;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.JMSProducer;
+
+/**
+ * Life cycle hook that sends serialized model events to a JMS topic.
+ * @param <T> The model type.
+ */
+@Slf4j
+public class NotifyTopicLifeCycleHook<T> implements LifeCycleHook<T> {
+
+    @Inject
+    private JMSContext context;
+
+    @Inject
+    @Named("subscriptionModels")
+    private Set<Type<?>> modelsWithTopics;
+
+    @Inject
+    private ObjectMapper mapper;
+
+    @Override
+    public void execute(
+            LifeCycleHookBinding.Operation operation,
+            LifeCycleHookBinding.TransactionPhase phase,
+            CRUDEvent event) {
+
+        PersistentResource<T> resource = (PersistentResource<T>) event.getResource();
+
+        //We only have topics for models managed by this store.  If an ancestor model
+        //triggered the hook, we need to locate the managed model through its lineage.
+        Type<?> modelType = findManagedModel(resource);
+
+        //Ignore the lifecycle change if the model is not managed.
+        if (modelType == null) {
+            log.debug("Ignoring life cycle event {} {} {}", operation, phase, event);
+            return;
+        }
+
+        TopicType topicType = TopicType.fromOperation(operation);
+        String topicName = topicType.toTopicName(modelType, resource.getDictionary());
+
+        JMSProducer producer = context.createProducer();
+        Destination destination = context.createTopic(topicName);
+
+        try {
+            producer.send(destination, mapper.writeValueAsString(resource.getObject()));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void execute(
+            LifeCycleHookBinding.Operation operation,
+            LifeCycleHookBinding.TransactionPhase phase,
+            T elideEntity,
+            RequestScope requestScope,
+            Optional<ChangeSpec> changes) {
+        //NOOP
+    }
+
+    private Type<?> findManagedModel(PersistentResource<T> resource) {
+        EntityDictionary dictionary = resource.getDictionary();
+        Type<?> modelType = resource.getResourceType();
+
+        if (modelsWithTopics.contains(modelType)) {
+            return modelType;
+        }
+
+        //If the type is not 'owned' and doesn't have a topic, it isn't managed.
+        if (! dictionary.isTransferable(modelType)) {
+            return null;
+        }
+
+        //Invert the resource lineage to work backwards...
+        List<ResourceLineage.LineagePath> inversePath = new ArrayList<>();
+        inversePath.addAll(resource.getLineage().getResourcePath());
+        Collections.reverse(inversePath);
+
+        for (ResourceLineage.LineagePath pathElement : inversePath) {
+            modelType = pathElement.getResource().getResourceType();
+            if (modelsWithTopics.contains(modelType)) {
+                return modelType;
+            } else if (! dictionary.isTransferable(modelType)) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+}

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHook.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHook.java
@@ -23,9 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
-import java.util.Set;
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.jms.Destination;
 import javax.jms.JMSContext;
 import javax.jms.JMSProducer;
@@ -45,10 +43,6 @@ public class NotifyTopicLifeCycleHook<T> implements LifeCycleHook<T> {
     private JMSContext context;
 
     @Inject
-    @Named("subscriptionModels")
-    private Set<Type<?>> modelsWithTopics;
-
-    @Inject
     private ObjectMapper mapper;
 
     @Override
@@ -59,14 +53,7 @@ public class NotifyTopicLifeCycleHook<T> implements LifeCycleHook<T> {
 
         PersistentResource<T> resource = (PersistentResource<T>) event.getResource();
 
-        //We only have topics for models managed by this store.
-        Type<?> modelType = findManagedModel(resource);
-
-        //Ignore the lifecycle change if the model is not managed.
-        if (modelType == null) {
-            log.debug("Ignoring life cycle event {} {} {}", operation, phase, event);
-            return;
-        }
+        Type<?> modelType = resource.getResourceType();
 
         TopicType topicType = TopicType.fromOperation(operation);
         String topicName = topicType.toTopicName(modelType, resource.getDictionary());
@@ -89,15 +76,5 @@ public class NotifyTopicLifeCycleHook<T> implements LifeCycleHook<T> {
             RequestScope requestScope,
             Optional<ChangeSpec> changes) {
         //NOOP
-    }
-
-    private Type<?> findManagedModel(PersistentResource<T> resource) {
-        Type<?> modelType = resource.getResourceType();
-
-        if (modelsWithTopics.contains(modelType)) {
-            return modelType;
-        }
-
-        return null;
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHook.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHook.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.JMSContext;
 import javax.jms.JMSProducer;
@@ -40,7 +41,7 @@ import javax.jms.JMSProducer;
 public class NotifyTopicLifeCycleHook<T> implements LifeCycleHook<T> {
 
     @Inject
-    private JMSContext context;
+    private ConnectionFactory connectionFactory;
 
     @Inject
     private ObjectMapper mapper;
@@ -50,6 +51,8 @@ public class NotifyTopicLifeCycleHook<T> implements LifeCycleHook<T> {
             LifeCycleHookBinding.Operation operation,
             LifeCycleHookBinding.TransactionPhase phase,
             CRUDEvent event) {
+
+        JMSContext context = connectionFactory.createContext();
 
         PersistentResource<T> resource = (PersistentResource<T>) event.getResource();
 

--- a/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHookTest.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHookTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Optional;
+import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.JMSContext;
 import javax.jms.JMSProducer;
@@ -33,6 +34,7 @@ import javax.jms.Topic;
 
 public class NotifyTopicLifeCycleHookTest {
 
+    private ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
     private JMSContext context = mock(JMSContext.class);
     private JMSProducer producer = mock(JMSProducer.class);
     private RequestScope scope = mock(RequestScope.class);
@@ -45,8 +47,9 @@ public class NotifyTopicLifeCycleHookTest {
 
         Topic destination = mock(Topic.class);
         reset(scope);
-        reset(context);
+        reset(connectionFactory);
         reset(producer);
+        when(connectionFactory.createContext()).thenReturn(context);
         when(context.createProducer()).thenReturn(producer);
         when(context.createTopic(any())).thenReturn(destination);
         when(scope.getDictionary()).thenReturn(dictionary);
@@ -56,7 +59,7 @@ public class NotifyTopicLifeCycleHookTest {
     public void testManagedModelNotification() {
 
         NotifyTopicLifeCycleHook<Book> bookHook = new NotifyTopicLifeCycleHook(
-                context,
+                connectionFactory,
                 new ObjectMapper());
 
         Book book = new Book();

--- a/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHookTest.java
+++ b/elide-datastore/elide-datastore-jms/src/test/java/com/yahoo/elide/datastores/jms/hooks/NotifyTopicLifeCycleHookTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
 package com.yahoo.elide.datastores.jms.hooks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -97,34 +103,5 @@ public class NotifyTopicLifeCycleHookTest {
 
         verify(context, never()).createTopic(any());
         verify(producer, never()).send(isA(Destination.class), isA(String.class));
-    }
-
-    @Test
-    public void testLineageModelNotification() {
-
-        NotifyTopicLifeCycleHook<Book> bookHook = new NotifyTopicLifeCycleHook(
-                context,
-                Set.of(ClassType.of(Book.class)),
-                new ObjectMapper());
-
-
-        Book book = new Book();
-        PersistentResource<Book> bookResource = new PersistentResource<>(book, "123", scope);
-
-        Author author = new Author();
-        PersistentResource<Author> authorResource = new PersistentResource<>(author, bookResource, "authors", "1", scope);
-
-        bookHook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.PRECOMMIT,
-                new CRUDEvent(
-                        LifeCycleHookBinding.Operation.CREATE,
-                        authorResource,
-                        "",
-                        Optional.empty()
-                ));
-
-        ArgumentCaptor<String> topicCaptor = ArgumentCaptor.forClass(String.class);
-        verify(context).createTopic(topicCaptor.capture());
-        assertEquals("bookAdded", topicCaptor.getValue());
-        verify(producer, times(1)).send(isA(Destination.class), isA(String.class));
     }
 }

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -28,4 +28,9 @@
         <cve>CVE-2019-14900</cve>
     </suppress>
 
+    <!-- Tomcat - Only related to 'Windows Language Pack Installer" -->
+    <suppress>
+        <cve>CVE-2020-0822</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
Part 3 of GraphQL subscription work.

## Description

Adds an internal life cycle hook that will be registered for Elide models with subscriptions.  The hook will publish a message to a JMS topic whenever a subscription model is created, updated, or deleted.

Other improvements include:
- Provides a mechanism for life cycle hooks to get access to the PersistentResource (and corresponding lineage) if needed.
- Updates suppression.xml to ignore a tomcat CVE

## How Has This Been Tested?
New unit tests.  IT tests will come later when other pieces are in place.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
