### PR TITLE
Fixing release build javadoc creation

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/annotations/Subscription.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/annotations/Subscription.java
@@ -28,7 +28,7 @@ public @interface Subscription {
 
     /**
      * Notify subscribers whenever a model is manipulated by the given operations.
-     * @return
+     * @return operation topics to post on.
      */
     Operation[] operations() default { CREATE, UPDATE, DELETE };
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/RequestHandler.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/RequestHandler.java
@@ -91,7 +91,7 @@ public class RequestHandler implements Closeable {
 
     /**
      * Close this session.  Synchronized to protect transaction.
-     * @throws IOException
+     * @throws IOException If there is a problem closing the underlying transaction.
      */
     public synchronized void close() throws IOException {
         if (! isOpen.compareAndExchange(true, false)) {
@@ -109,7 +109,6 @@ public class RequestHandler implements Closeable {
     /**
      * Handles an incoming GraphQL query.
      * @param subscribeRequest The GraphQL query.
-     * @return true if the request is still active (ie. - a subscription).
      */
     public void handleRequest(Subscribe subscribeRequest) {
         ExecutionResult executionResult = null;

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/SessionHandler.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/SessionHandler.java
@@ -108,7 +108,7 @@ public class SessionHandler {
 
     /**
      * Close this session.
-     * @throws IOException
+     * @throws IOException If closing the session causes an error.
      */
     public synchronized void close(CloseReason reason) throws IOException {
 
@@ -282,10 +282,9 @@ public class SessionHandler {
     }
 
     /**
-     * Send a text message on the native session.  Synchronized to protect session & isOpen
+     * Send a text message on the native session.  Synchronized to protect session and isOpen
      * (which has dubious thread safety - even when async).
      * @param message The message to send.
-     * @throws IOException
      */
     public synchronized void sendMessage(String message) {
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/ConnectionAck.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/ConnectionAck.java
@@ -7,7 +7,7 @@
 package com.yahoo.elide.graphql.subscriptions.websocket.protocol;
 
 /**
- * Acknowledge an incoming connection (server -> client).
+ * Acknowledge an incoming connection (server to client).
  */
 public class ConnectionAck extends AbstractProtocolMessage {
     public ConnectionAck() {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/ConnectionInit.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/ConnectionInit.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Start an incoming connection (client -> server).
+ * Start an incoming connection (client to server).
  */
 @Value
 @EqualsAndHashCode(callSuper = true)

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/Error.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/Error.java
@@ -17,7 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 /**
- * Error occurred during setup of the subscription (server -> client).
+ * Error occurred during setup of the subscription (server to client).
  */
 @Value
 @EqualsAndHashCode(callSuper = true)

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/Next.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/Next.java
@@ -19,7 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 
 /**
- * Next subscription message (server -> client).
+ * Next subscription message (server to client).
  */
 @Value
 @EqualsAndHashCode(callSuper = true)

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/Subscribe.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/protocol/Subscribe.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Create a subscription (client -> server).
+ * Create a subscription (client to server).
  */
 @Value
 @EqualsAndHashCode(callSuper = true)

--- a/pom.xml
+++ b/pom.xml
@@ -530,6 +530,7 @@
                     <doclint>all,-missing</doclint>
                     <source>${source.jdk.version}</source>
                     <sourcepath>${delombok.output}</sourcepath>
+                    <sourcepath>${project.basedir}/src/main/java</sourcepath>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
We can't release Elide 6 because the nexus plugin requires every artifact to have javadoc.   This was broken when we moved from Elide 5 because of a delombok step in maven.

Other changes include small edits in GraphQL subscriptions that break javadoc.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
