### PR TITLE
Added new flag to enable subscription publishing in a separate servic…

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/SubscriptionEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/SubscriptionEntityProjectionMaker.java
@@ -23,7 +23,7 @@ public class SubscriptionEntityProjectionMaker extends GraphQLEntityProjectionMa
 
     @Override
     protected boolean supportsOperationType(OperationDefinition.Operation operation) {
-        if (operation != OperationDefinition.Operation.MUTATION) {
+        if (operation == OperationDefinition.Operation.SUBSCRIPTION) {
             return true;
         }
         return false;

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcher.java
@@ -7,12 +7,14 @@
 package com.yahoo.elide.graphql.subscriptions;
 
 import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.exceptions.InvalidEntityBodyException;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.graphql.Environment;
 import com.yahoo.elide.graphql.NonEntityDictionary;
 import com.yahoo.elide.graphql.QueryLogger;
 import com.yahoo.elide.graphql.RelationshipOp;
 import com.yahoo.elide.graphql.subscriptions.containers.SubscriptionNodeContainer;
+import graphql.language.OperationDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.reactivex.BackpressureStrategy;
@@ -50,8 +52,14 @@ public class SubscriptionDataFetcher implements DataFetcher<Object>, QueryLogger
 
     @Override
     public Object get(DataFetchingEnvironment environment) throws Exception {
+        OperationDefinition.Operation op = environment.getOperationDefinition().getOperation();
+        if (op != OperationDefinition.Operation.SUBSCRIPTION) {
+            throw new InvalidEntityBodyException(String.format("%s not supported for subscription models.", op));
+        }
+
         /* build environment object, extracts required fields */
         Environment context = new Environment(environment, nonEntityDictionary);
+
 
         /* safe enable debugging */
         if (log.isDebugEnabled()) {

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -39,6 +39,22 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     }
 
     @Test
+    public void testSubscriptionThrowsError() throws Exception {
+        String query = "subscription {\n"
+                + "  book(ids: [\"1\"]) {\n"
+                + "    edges {\n"
+                + "      node {\n"
+                + "        id\n"
+                + "        title\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+
+        assertQueryFailsWith(query, "Schema is not configured for subscriptions.");
+    }
+
+    @Test
     public void testRootSingle() throws Exception {
         runComparisonTest("rootSingle");
     }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcherTest.java
@@ -143,6 +143,26 @@ public class SubscriptionDataFetcherTest extends GraphQLTest {
     }
 
     @Test
+    void testRootNonSchemaQuery() {
+        Book book1 = new Book();
+        book1.setTitle("Book 1");
+        book1.setId(1);
+
+        Book book2 = new Book();
+        book2.setTitle("Book 2");
+        book2.setId(2);
+
+        when(dataStoreTransaction.loadObjects(any(), any())).thenReturn(List.of(book1, book2));
+
+        List<String> responses = List.of("{\"book\":null}");
+        List<String> errors = List.of("QUERY not supported for subscription models");
+
+        String graphQLRequest = "query {book(topic: ADDED) {id title}}";
+
+        assertSubscriptionEquals(graphQLRequest, responses, errors);
+    }
+
+    @Test
     void testRootSubscriptionWithFilter() {
         Book book1 = new Book();
         book1.setTitle("Book 1");

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
@@ -29,12 +29,12 @@ import javax.websocket.server.ServerEndpointConfig;
  */
 @Configuration
 @EnableConfigurationProperties(ElideConfigProperties.class)
-@ConditionalOnExpression("${elide.subscription.enabled:false}")
 public class ElideSubscriptionConfiguration {
     public static final String SUBSCRIPTION_MODELS = "subscriptionModels";
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnExpression("${elide.subscription.enabled:false} or ${elide.subscription.publishingEnabled:false}")
     SubscriptionScanner subscriptionScanner(Elide elide, ConnectionFactory connectionFactory) {
         SubscriptionScanner scanner = SubscriptionScanner.builder()
 
@@ -58,6 +58,7 @@ public class ElideSubscriptionConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnExpression("${elide.subscription.enabled:false}")
     ServerEndpointConfig serverEndpointConfig(
             ElideConfigProperties config,
             SubscriptionWebSocket.UserFactory userFactory,
@@ -86,6 +87,7 @@ public class ElideSubscriptionConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnExpression("${elide.subscription.enabled:false}")
     ServerEndpointExporter serverEndpointExporter() {
         ServerEndpointExporter exporter = new ServerEndpointExporter();
         return exporter;
@@ -93,6 +95,7 @@ public class ElideSubscriptionConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnExpression("${elide.subscription.enabled:false}")
     SubscriptionWebSocket.UserFactory getUserFactory() {
         return DEFAULT_USER_FACTORY;
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/SubscriptionProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/SubscriptionProperties.java
@@ -14,6 +14,11 @@ import lombok.Data;
 public class SubscriptionProperties extends ControllerProperties {
 
     /**
+     * Whether Elide should publish subscription notifications to JMS on lifecycle events.
+     */
+    protected boolean publishingEnabled = isEnabled();
+
+    /**
      * Websocket sends a PING immediate after receiving a SUBSCRIBE.  Only useful for testing.
      * @see com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketTestClient
      */

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -133,7 +133,7 @@ public class ElideResourceConfig extends ResourceConfig {
             bind(elideSettings.getDataStore()).to(DataStore.class).named("elideDataStore");
 
             //Bind subscription hooks.
-            if (settings.getSubscriptionProperties().enabled()) {
+            if (settings.getSubscriptionProperties().publishingEnabled()) {
                 settings.getSubscriptionProperties().subscriptionScanner(elide,
                         settings.getSubscriptionProperties().getConnectionFactory());
             }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
@@ -30,6 +30,15 @@ public interface ElideStandaloneSubscriptionSettings {
     }
 
     /**
+     * Enable support for subscriptions.
+     *
+     * @return Default: False
+     */
+    default boolean publishingEnabled() {
+        return enabled();
+    }
+
+    /**
      * Websocket root path for the subscription endpoint.
      *
      * @return Default: /subscription


### PR DESCRIPTION
…e.  Disallow queries in subscription endpoint.

## Description
We need a flag to allow a separate, non-subscription service to publish subscription events to a JMS broker even when the subscription endpoint is disabled.

Also, fixes an NPE when the client sends a query to the subscription endpoint.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
