### PR TITLE
Aggregation Store: Relaxing filter template matching to ignore aliases

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/filter/visitor/MatchesTemplateVisitor.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.filter.visitor;
 
+import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.filter.expression.AndFilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
@@ -89,7 +90,7 @@ public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> 
 
         boolean valueMatches = predicateA.getValues().equals(predicateB.getValues());
         boolean operatorMatches = predicateA.getOperator().equals(predicateB.getOperator());
-        boolean pathMatches = predicateA.getPath().equals(predicateB.getPath());
+        boolean pathMatches = pathMatches(predicateA.getPath(), predicateB.getPath());
 
         boolean usingTemplate = false;
 
@@ -112,6 +113,31 @@ public class MatchesTemplateVisitor implements FilterExpressionVisitor<Boolean> 
         }
 
         return (operatorMatches && pathMatches && (valueMatches || usingTemplate));
+    }
+
+    private boolean pathMatches(Path a, Path b) {
+        if (a.getPathElements().size() != b.getPathElements().size()) {
+            return false;
+        }
+
+        for (int idx = 0; idx < a.getPathElements().size(); idx++) {
+            Path.PathElement aElement = a.getPathElements().get(idx);
+            Path.PathElement bElement = b.getPathElements().get(idx);
+
+            if (! aElement.getType().equals(bElement.getType())) {
+                return false;
+            }
+
+            if (! aElement.getFieldName().equals(bElement.getFieldName())) {
+                return false;
+            }
+
+            if (! aElement.getArguments().equals(bElement.getArguments())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Description
The logic which compares a filter template with a client provided filter also compares aliases.  If the client provides an alias, the filter template will never match because the logic is using object equality (and a filter template will never have an alias).

When comparing the RSQL filter path of a template with the client path, aliases should be ignored.

## How Has This Been Tested?
New unit test plus existing unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
