### PR TITLE
Values validation on Column Predicates for Regex Should not fail

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/DefaultQueryValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/DefaultQueryValidatorTest.java
@@ -207,6 +207,26 @@ public class DefaultQueryValidatorTest extends SQLUnitTest {
     }
 
     @Test
+    public void testValidRegexColumnValueInFilter() throws ParseException {
+        FilterExpression originalFilter = filterParser.parseFilterExpression("countryIsoCode=in=('*H'),lowScore<45",
+                playerStatsType, false);
+        SplitFilterExpressionVisitor visitor = new SplitFilterExpressionVisitor(playerStatsTable);
+        FilterConstraints constraints = originalFilter.accept(visitor);
+        FilterExpression whereFilter = constraints.getWhereExpression();
+        FilterExpression havingFilter = constraints.getHavingExpression();
+
+        Query query = Query.builder()
+                .source(playerStatsTable)
+                .metricProjection(playerStatsTable.getMetricProjection("lowScore"))
+                .dimensionProjection(playerStatsTable.getDimensionProjection("countryIsoCode"))
+                .whereFilter(whereFilter)
+                .havingFilter(havingFilter)
+                .build();
+
+        validateQueryDoesNotThrow(query);
+    }
+
+    @Test
     public void testHavingFilterOnDimensionTable() throws ParseException {
         FilterExpression originalFilter = filterParser.parseFilterExpression("country.isoCode==USA,lowScore<45",
                 playerStatsType, false);


### PR DESCRIPTION
Values validation on predicates that had operators like contains should not be enforced.

## Description
Currently a predicate like `col1=in=('*H*')` will fail if the `@ColumnMeta(values = {"HK", "HA"})` is provided and force the user to provide predicate like `col1=in=(HK, HA)`. This change will allow regex based search to work.

## Motivation and Context
See Description above.

## How Has This Been Tested?
Existing and New test cases pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
