### PR TITLE
No longer using attribute aliases to generate CSV export headers.  In…

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/export/formatter/CSVExportFormatter.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/export/formatter/CSVExportFormatter.java
@@ -8,6 +8,8 @@ package com.yahoo.elide.async.export.formatter;
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.async.models.TableExport;
 import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.request.Argument;
+import com.yahoo.elide.core.request.Attribute;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.opendevl.JFlat;
@@ -84,20 +86,8 @@ public class CSVExportFormatter implements TableExportFormatter {
         }
 
         return projection.getAttributes().stream()
-        .map(attr -> {
-            StringBuilder column = new StringBuilder();
-            String alias = attr.getAlias();
-            column.append(StringUtils.isNotEmpty(alias) ? alias : attr.getName());
-            return column;
-        })
-        .map(quotable -> {
-            // Quotes at the beginning
-            quotable.insert(0, DOUBLE_QUOTES);
-            // Quotes at the end
-            quotable.append(DOUBLE_QUOTES);
-            return quotable;
-        })
-        .collect(Collectors.joining(COMMA));
+                .map(this::toHeader)
+                .collect(Collectors.joining(COMMA));
     }
 
     @Override
@@ -112,5 +102,27 @@ public class CSVExportFormatter implements TableExportFormatter {
     @Override
     public String postFormat(EntityProjection projection, TableExport query) {
         return null;
+    }
+    
+    private String toHeader(Attribute attribute) {
+        if (attribute.getArguments() == null || attribute.getArguments().size() == 0) {
+            return quote(attribute.getName());
+        }
+
+        StringBuilder header = new StringBuilder();
+        header.append(attribute.getName());
+        header.append("(");
+
+        header.append(attribute.getArguments().stream()
+                .map((arg) -> arg.getName() + "=" + arg.getValue())
+                .collect(Collectors.joining(" ")));
+
+        header.append(")");
+
+        return quote(header.toString());
+    }
+
+    private String quote(String toQuote) {
+        return "\"" + toQuote + "\"";
     }
 }

--- a/elide-async/src/test/java/com/yahoo/elide/async/export/formatter/CSVExportFormatterTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/export/formatter/CSVExportFormatterTest.java
@@ -20,6 +20,7 @@ import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.datastore.inmemory.HashMapDataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.request.Argument;
 import com.yahoo.elide.core.request.Attribute;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.security.checks.Check;
@@ -165,6 +166,60 @@ public class CSVExportFormatterTest {
 
         String output = formatter.preFormat(projection, queryObj);
         assertEquals("\"query\",\"queryType\"", output);
+    }
+
+    @Test
+    public void testHeaderWithNonmatchingAlias() {
+        CSVExportFormatter formatter = new CSVExportFormatter(elide, false);
+
+        TableExport queryObj = new TableExport();
+        String query = "{ tableExport { edges { node { query queryType } } } }";
+        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+        queryObj.setResultType(ResultType.CSV);
+
+        // Prepare EntityProjection
+        Set<Attribute> attributes = new LinkedHashSet<>();
+        attributes.add(Attribute.builder().type(TableExport.class).name("query").alias("foo").build());
+        attributes.add(Attribute.builder().type(TableExport.class).name("queryType").build());
+        EntityProjection projection = EntityProjection.builder().type(TableExport.class).attributes(attributes).build();
+
+        String output = formatter.preFormat(projection, queryObj);
+        assertEquals("\"query\",\"queryType\"", output);
+    }
+
+    @Test
+    public void testHeaderWithArguments() {
+        CSVExportFormatter formatter = new CSVExportFormatter(elide, false);
+
+        TableExport queryObj = new TableExport();
+        String query = "{ tableExport { edges { node { query queryType } } } }";
+        String id = "edc4a871-dff2-4054-804e-d80075cf827d";
+        queryObj.setId(id);
+        queryObj.setQuery(query);
+        queryObj.setQueryType(QueryType.GRAPHQL_V1_0);
+        queryObj.setResultType(ResultType.CSV);
+
+        // Prepare EntityProjection
+        Set<Attribute> attributes = new LinkedHashSet<>();
+        attributes.add(Attribute.builder()
+                .type(TableExport.class)
+                .name("query")
+                .argument(Argument.builder().name("foo").value("bar").build())
+                .alias("query").build());
+
+        attributes.add(Attribute.builder()
+                .type(TableExport.class)
+                .argument(Argument.builder().name("foo").value("bar").build())
+                .argument(Argument.builder().name("baz").value("boo").build())
+                .name("queryType")
+                .build());
+        EntityProjection projection = EntityProjection.builder().type(TableExport.class).attributes(attributes).build();
+
+        String output = formatter.preFormat(projection, queryObj);
+        assertEquals("\"query(foo=bar)\",\"queryType(foo=bar baz=boo)\"", output);
     }
 
     @Test


### PR DESCRIPTION
…stead, using attribute name with arguments.

## Description
When yavin issues analytic queries to Elide, it adds non-descriptive aliases (col0, col1, col2).  When exporting reports to CSV, these aliases are used as column headers - not terribly useful.

Instead, we should leverage the column names and disambiguate parameterized by columns by also displaying their arguments.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
