### PR TITLE
Revised JSON-API path grammar to accept colon, space, and ampersand in ID fields

### DIFF
--- a/elide-core/src/main/antlr4/com/yahoo/elide/generated/parsers/Core.g4
+++ b/elide-core/src/main/antlr4/com/yahoo/elide/generated/parsers/Core.g4
@@ -30,24 +30,28 @@ relationship: RELATIONSHIPS '/' term;
 
 query: ; // Visitor performs query and outputs result
 
+id: IDSTR | PATHSTR;
 term: PATHSTR;
-id: PATHSTR;
 
 RELATIONSHIPS: 'relationships';
 
-PATHSTR: UNRESERVED+;
+PATHSTR: ALPHA ( ALPHANUM | UNDERSCORE | HYPHEN )+;
+IDSTR: UNRESERVED+;
 
 UNRESERVED
     : ALPHANUM
     | MARK
+    | UNDERSCORE
+    | HYPHEN
     ;
 
 MARK
-    : '-'
-    | '_'
-    | '.'
+    : '.'
     | '!'
     | '~'
+    | ':'
+    | ' '
+    | '&'
     | '='  //For BASE64 IDs
     | '%'  //For URL encoded IDs
     | '*'
@@ -55,6 +59,9 @@ MARK
     | '('
     | ')'
     ;
+
+UNDERSCORE : '_';
+HYPHEN : '-';
 
 ALPHANUM
       : ALPHA

--- a/elide-core/src/test/java/com/yahoo/elide/endpoints/ResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/endpoints/ResourceTest.java
@@ -37,9 +37,39 @@ public class ResourceTest {
     }
 
     @Test
+    public void verifyUnderscoreInPath() {
+        assertNull(new CoreBaseVisitor().visit(parse(
+                "foo_bar/")));
+    }
+
+    @Test
+    public void verifyHyphenInPath() {
+        assertNull(new CoreBaseVisitor().visit(parse(
+                "foo-bar/")));
+    }
+
+    @Test
     public void verifyURLEncodedID() {
         assertNull(new CoreBaseVisitor().visit(parse(
                 "company/abcdef%201234")));
+    }
+
+    @Test
+    public void verifyAmpersandId() {
+        assertNull(new CoreBaseVisitor().visit(parse(
+                "company/abcdef&234")));
+    }
+
+    @Test
+    public void verifySpaceId() {
+        assertNull(new CoreBaseVisitor().visit(parse(
+                "company/abcdef 234")));
+    }
+
+    @Test
+    public void verifyColonId() {
+        assertNull(new CoreBaseVisitor().visit(parse(
+                "company/abcdef:234")));
     }
 
     @Test
@@ -61,6 +91,35 @@ public class ResourceTest {
         assertThrows(
                 ParseCancellationException.class,
                 () -> new CoreBaseVisitor().visit(parse("company/123|apps/2/links/foo")));
+    }
+
+    @Test
+
+    public void invalidNumberStartingPath() {
+        assertThrows(
+                ParseCancellationException.class,
+                () -> new CoreBaseVisitor().visit(parse("3company/")));
+    }
+
+    @Test
+    public void invalidSpaceInPath() {
+        assertThrows(
+                ParseCancellationException.class,
+                () -> new CoreBaseVisitor().visit(parse("comp any/relationships")));
+    }
+
+    @Test
+    public void invalidColonInPath() {
+        assertThrows(
+                ParseCancellationException.class,
+                () -> new CoreBaseVisitor().visit(parse("comp:any/relationships")));
+    }
+
+    @Test
+    public void invalidAmpersandInPath() {
+        assertThrows(
+                ParseCancellationException.class,
+                () -> new CoreBaseVisitor().visit(parse("comp&any/relationships")));
     }
 
     @Test


### PR DESCRIPTION
Resolves # (if appropriate)

Same as #2342 but for elide-4.x

Description
Same as #2342:
Changes JSON-API path parsing grammar to allow colon, ampersand, and space in IDs. For example, the following are now valid:

```
/company/123:456
/company/123 456
/company123&456
```
The grammar was also made more strict for what can be passed as a collection or relationship. These must now strictly be alphanumeric. For example, the following collection path would result in an error.

`/comp&any`

How Has This Been Tested?
New UTs for parsing JSON-API paths.

License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.