### PR TITLE
Fixed Elide 6 Release Build

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -33,4 +33,8 @@
         <cve>CVE-2020-0822</cve>
     </suppress>
 
+    <!-- Tomcat - Memory leak with websockets" -->
+    <suppress until="2021-12-31">
+        <cve>CVE-2021-42340</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Temporarily ignore CVE error for Tomcat memory leak (CVE-2021-42340).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
