### PR TITLE
Lifecycle events should trigger once for relationship updates

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -724,12 +724,6 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
 
         checkTransferablePermission(added);
 
-        Collection collection = (Collection) this.getValueUnchecked(fieldName);
-
-        if (collection == null) {
-            this.setValue(fieldName, mine);
-        }
-
         Set<Object> newRelationships = new LinkedHashSet<>();
         Set<Object> deletedRelationships = new LinkedHashSet<>();
 
@@ -745,6 +739,7 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
                     newRelationships.add(toAdd.getObject());
                 });
 
+        Collection collection = (Collection) this.getValueUnchecked(fieldName);
         modifyCollection(collection, fieldName, newRelationships, deletedRelationships, true);
 
         if (!updated.isEmpty()) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -888,7 +888,7 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
                 return;
             }
             modifyCollection((Collection) relation, fieldName, Collections.emptySet(),
-                    Set.of(removeResource.getObject()), false);
+                    Set.of(removeResource.getObject()), true);
         } else {
             if (relation == null || removeResource == null || !relation.equals(removeResource.getObject())) {
                 //Nothing to do

--- a/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/PersistentResource.java
@@ -736,18 +736,16 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
         deleted
                 .stream()
                 .forEach(toDelete -> {
-                    delFromCollection(collection, fieldName, toDelete, false);
-                    deleteInverseRelation(fieldName, toDelete.getObject());
                     deletedRelationships.add(toDelete.getObject());
                 });
 
         added
                 .stream()
                 .forEach(toAdd -> {
-                    addToCollection(collection, fieldName, toAdd);
-                    addInverseRelation(fieldName, toAdd.getObject());
                     newRelationships.add(toAdd.getObject());
                 });
+
+        modifyCollection(collection, fieldName, newRelationships, deletedRelationships, true);
 
         if (!updated.isEmpty()) {
             this.markDirty();
@@ -830,14 +828,6 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
 
         RelationshipType type = getRelationshipType(relationName);
 
-        mine.stream()
-                .forEach(toDelete -> {
-                    if (hasInverseRelation(relationName)) {
-                        deleteInverseRelation(relationName, toDelete.getObject());
-                        toDelete.markDirty();
-                    }
-                });
-
         if (type.isToOne()) {
             PersistentResource oldValue = IterableUtils.first(mine);
             if (oldValue != null && oldValue.getObject() != null) {
@@ -854,12 +844,9 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
                 Set<Object> deletedRelationships = new LinkedHashSet<>();
                 mine.stream()
                         .forEach(toDelete -> {
-                            delFromCollection(collection, relationName, toDelete, false);
-                            if (hasInverseRelation(relationName)) {
-                                toDelete.markDirty();
-                            }
                             deletedRelationships.add(toDelete.getObject());
                         });
+                modifyCollection(collection, relationName, Collections.emptySet(), deletedRelationships, true);
                 this.markDirty();
                 //hook for updateToManyRelation
                 transaction.updateToManyRelation(transaction, obj, relationName,
@@ -900,18 +887,19 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
                 //Nothing to do
                 return;
             }
-            delFromCollection((Collection) relation, fieldName, removeResource, false);
+            modifyCollection((Collection) relation, fieldName, Collections.emptySet(),
+                    Set.of(removeResource.getObject()), false);
         } else {
             if (relation == null || removeResource == null || !relation.equals(removeResource.getObject())) {
                 //Nothing to do
                 return;
             }
             this.nullValue(fieldName, removeResource);
-        }
 
-        if (hasInverseRelation(fieldName)) {
-            deleteInverseRelation(fieldName, removeResource.getObject());
-            removeResource.markDirty();
+            if (hasInverseRelation(fieldName)) {
+                deleteInverseRelation(fieldName, removeResource.getObject());
+                removeResource.markDirty();
+            }
         }
 
         if (!Objects.equals(original, modified)) {
@@ -965,7 +953,8 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
         Object relation = this.getValueUnchecked(fieldName);
 
         if (relation instanceof Collection) {
-            if (addToCollection((Collection) relation, fieldName, newRelation)) {
+            if (modifyCollection((Collection) relation, fieldName,
+                    Set.of(newRelation.getObject()), Collections.emptySet(), true)) {
                 this.markDirty();
             }
             //Hook for updateToManyRelation
@@ -1687,94 +1676,47 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
         return getValue(getObject(), fieldName, requestScope);
     }
 
-    /**
-     * Adds a new element to a collection and tests update permission.
-     *
-     * @param collection     the collection
-     * @param collectionName the collection name
-     * @param toAdd          the to add
-     * @return True if added to collection false otherwise (i.e. element already in collection)
-     */
-    protected boolean addToCollection(Collection collection, String collectionName, PersistentResource toAdd) {
-        final Collection singleton = Collections.singleton(toAdd.getObject());
-        final Collection original = copyCollection(collection);
-        checkFieldAwareDeferPermissions(
-                UpdatePermission.class,
-                collectionName,
-                CollectionUtils.union(CollectionUtils.emptyIfNull(collection), singleton),
-                original);
-        if (collection == null) {
-            collection = Collections.singleton(toAdd.getObject());
-            Object value = getValueUnchecked(collectionName);
-            if (!Objects.equals(value, toAdd.getObject())) {
-                this.setValueChecked(collectionName, collection);
-                return true;
-            }
-        } else {
-            if (!collection.contains(toAdd.getObject())) {
-                collection.add(toAdd.getObject());
-
-                triggerUpdate(collectionName, original, collection);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Deletes an existing element in a collection and tests update and delete permissions.
-     *
-     * @param collection     the collection
-     * @param collectionName the collection name
-     * @param toDelete       the to delete
-     * @param isInverseCheck Whether or not the deletion is already coming from cleaning up an inverse.
-     *                       Without this parameter, we could find ourselves in a loop of checks.
-     *                       TODO: This is a band-aid for a quick fix. This should certainly be refactored.
-     */
-    protected void delFromCollection(
-            Collection collection,
+    protected boolean modifyCollection(
+            Collection toModify,
             String collectionName,
-            PersistentResource toDelete,
-            boolean isInverseCheck) {
-        final Collection original = copyCollection(collection);
+            Collection toAdd,
+            Collection toRemove,
+            boolean updateInverse) {
+
+        Collection copyOfOriginal = copyCollection(toModify);
+
+        Collection modified = CollectionUtils.union(CollectionUtils.emptyIfNull(toModify), toAdd);
+        modified = CollectionUtils.subtract(modified, toRemove);
+
         checkFieldAwareDeferPermissions(
                 UpdatePermission.class,
                 collectionName,
-                CollectionUtils.disjunction(collection, Collections.singleton(toDelete.getObject())),
-                original
-        );
+                modified,
+                copyOfOriginal);
 
-        String inverseField = getInverseRelationField(collectionName);
-        if (!isInverseCheck && !inverseField.isEmpty()) {
-            // Compute the ChangeSpec for the inverse relation and check whether or not we have access
-            // to apply this change to that field.
-            final Object originalValue = toDelete.getValueUnchecked(inverseField);
-            final Collection originalBidirectional;
-
-            if (originalValue instanceof Collection) {
-                originalBidirectional = copyCollection((Collection) originalValue);
-            } else {
-                originalBidirectional = Collections.singleton(originalValue);
+        if (updateInverse) {
+            for (Object adding : toAdd) {
+                addInverseRelation(collectionName, adding);
             }
 
-            final Collection removedBidrectional = CollectionUtils
-                    .disjunction(Collections.singleton(this.getObject()), originalBidirectional);
-
-            toDelete.checkFieldAwareDeferPermissions(
-                    UpdatePermission.class,
-                    inverseField,
-                    removedBidrectional,
-                    originalBidirectional
-            );
+            for (Object removing : toRemove) {
+                deleteInverseRelation(collectionName, removing);
+            }
         }
 
-        if (collection == null) {
-            return;
+        if (toModify == null) {
+            this.setValueChecked(collectionName, modified);
+            return true;
+        } else {
+            if (copyOfOriginal.equals(modified)) {
+                return false;
+            }
+            toModify.addAll(toAdd);
+            toModify.removeAll(toRemove);
+
+            triggerUpdate(collectionName, copyOfOriginal, modified);
+            return true;
         }
-
-        collection.remove(toDelete.getObject());
-
-        triggerUpdate(collectionName, original, collection);
     }
 
     /**
@@ -1814,7 +1756,8 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
             }
 
             if (inverseRelation instanceof Collection) {
-                inverseResource.delFromCollection((Collection) inverseRelation, inverseField, this, true);
+                inverseResource.modifyCollection((Collection) inverseRelation, inverseField,
+                        Collections.emptySet(), Set.of(this.getObject()), false);
             } else if (inverseType.isAssignableFrom(this.getResourceType())) {
                 inverseResource.nullValue(inverseField, this);
             } else {
@@ -1864,7 +1807,8 @@ public class PersistentResource<T> implements com.yahoo.elide.core.security.Pers
 
             if (COLLECTION_TYPE.isAssignableFrom(inverseType)) {
                 if (inverseRelation != null) {
-                    inverseResource.addToCollection((Collection) inverseRelation, inverseName, this);
+                    inverseResource.modifyCollection((Collection) inverseRelation, inverseName,
+                            Set.of(this.getObject()), Collections.emptySet(), false);
                 } else {
                     inverseResource.setValueChecked(inverseName, Collections.singleton(this.getObject()));
                 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/FieldTestModel.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/FieldTestModel.java
@@ -15,6 +15,7 @@ import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.P
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.core.security.ChangeSpec;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -43,6 +44,8 @@ import javax.persistence.OneToMany;
 @LifeCycleHookBinding(hook = FieldTestModel.ClassPreFlushHook.class, operation = UPDATE, phase = PREFLUSH)
 @LifeCycleHookBinding(hook = FieldTestModel.ClassPreCommitHook.class, operation = UPDATE, phase = PRECOMMIT)
 @LifeCycleHookBinding(hook = FieldTestModel.ClassPostCommitHook.class, operation = UPDATE, phase = POSTCOMMIT)
+
+@EqualsAndHashCode
 public class FieldTestModel {
 
     @Id

--- a/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
@@ -38,6 +38,7 @@ import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.audit.AuditLogger;
 import com.yahoo.elide.core.datastore.DataStore;
+import com.yahoo.elide.core.datastore.DataStoreIterable;
 import com.yahoo.elide.core.datastore.DataStoreIterableBuilder;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
@@ -434,6 +435,43 @@ public class LifeCycleTest {
     }
 
     @Test
+    public void testElidePatchRelationshipAddMultiple() {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel parent = mock(FieldTestModel.class);
+        FieldTestModel child1 = mock(FieldTestModel.class);
+        FieldTestModel child2 = mock(FieldTestModel.class);
+        FieldTestModel child3 = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
+
+        String body = "{\"data\": {\"type\":\"testModel\",\"id\":\"1\",\"relationships\": { \"models\": { \"data\": [ { \"type\": \"testModel\", \"id\": \"2\" }, {\"type\": \"testModel\", \"id\": \"3\" } ] } } } }";
+
+        dictionary.setValue(parent, "id", "1");
+        dictionary.setValue(child1, "id", "2");
+        dictionary.setValue(child2, "id", "3");
+        dictionary.setValue(child3, "id", "4");
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.loadObject(isA(EntityProjection.class), eq("1"), isA(RequestScope.class))).thenReturn(parent);
+        when(tx.loadObject(isA(EntityProjection.class), eq("2"), isA(RequestScope.class))).thenReturn(child1);
+        when(tx.loadObject(isA(EntityProjection.class), eq("3"), isA(RequestScope.class))).thenReturn(child2);
+        when(tx.loadObject(isA(EntityProjection.class), eq("4"), isA(RequestScope.class))).thenReturn(child3);
+
+        DataStoreIterable iterable = new DataStoreIterableBuilder(List.of(child3)).build();
+        when(tx.getToManyRelation(any(), any(), isA(Relationship.class), isA(RequestScope.class))).thenReturn(iterable);
+
+        String contentType = JSONAPI_CONTENT_TYPE;
+        ElideResponse response = elide.patch(baseUrl, contentType, contentType, "/testModel/1", body, null, NO_VERSION);
+        assertEquals(HttpStatus.SC_NO_CONTENT, response.getResponseCode());
+
+        verify(parent, times(1)).relationCallback(eq(UPDATE), eq(POSTCOMMIT), notNull());
+
+        verify(parent, times(4)).classCallback(eq(UPDATE), any());
+        verify(parent, never()).classAllFieldsCallback(any(), any());
+        verify(parent, never()).attributeCallback(any(), any(), any());
+    }
+
+    @Test
     public void testLegacyElidePatch() throws Exception {
         DataStore store = mock(DataStore.class);
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
@@ -562,8 +600,6 @@ public class LifeCycleTest {
         verify(tx).commit(isA(RequestScope.class));
         verify(tx).close();
     }
-
-//TODO - these need to be rewritten for Elide 5.
 
     @Test
     public void testElidePatchExtensionCreate() throws Exception {
@@ -1096,9 +1132,8 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).classCallback(any(), any());
         verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRESECURITY));
 
-        //TODO - this should be only called once.  THis is called twice because the mock has a null collection.
-        verify(mockModel, times(2)).relationCallback(any(), any(), any());
-        verify(mockModel, times(2)).relationCallback(eq(UPDATE), eq(PRESECURITY), notNull());
+        verify(mockModel, times(1)).relationCallback(any(), any(), any());
+        verify(mockModel, times(1)).relationCallback(eq(UPDATE), eq(PRESECURITY), notNull());
 
         verify(mockModel, never()).attributeCallback(any(), any(), any());
         verify(mockModel, never()).classAllFieldsCallback(any(), any());
@@ -1116,9 +1151,8 @@ public class LifeCycleTest {
         verify(mockModel, times(1)).classCallback(any(), any());
         verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PREFLUSH));
 
-        //TODO - this should be only called once.  THis is called twice because the mock has a null collection.
-        verify(mockModel, times(2)).relationCallback(any(), any(), any());
-        verify(mockModel, times(2)).relationCallback(eq(UPDATE), eq(PREFLUSH), notNull());
+        verify(mockModel, times(1)).relationCallback(any(), any(), any());
+        verify(mockModel, times(1)).relationCallback(eq(UPDATE), eq(PREFLUSH), notNull());
 
         clearInvocations(mockModel);
         scope.runQueuedPreCommitTriggers();
@@ -1128,9 +1162,8 @@ public class LifeCycleTest {
 
         verify(mockModel, times(1)).classCallback(any(), any());
         verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(PRECOMMIT));
-        //TODO - this should be only called once.
-        verify(mockModel, times(2)).relationCallback(any(), any(), any());
-        verify(mockModel, times(2)).relationCallback(eq(UPDATE), eq(PRECOMMIT), notNull());
+        verify(mockModel, times(1)).relationCallback(any(), any(), any());
+        verify(mockModel, times(1)).relationCallback(eq(UPDATE), eq(PRECOMMIT), notNull());
 
         clearInvocations(mockModel);
         scope.getPermissionExecutor().executeCommitChecks();
@@ -1141,9 +1174,8 @@ public class LifeCycleTest {
 
         verify(mockModel, times(1)).classCallback(any(), any());
         verify(mockModel, times(1)).classCallback(eq(UPDATE), eq(POSTCOMMIT));
-        //TODO - this should be only called once.
-        verify(mockModel, times(2)).relationCallback(any(), any(), any());
-        verify(mockModel, times(2)).relationCallback(eq(UPDATE), eq(POSTCOMMIT), notNull());
+        verify(mockModel, times(1)).relationCallback(any(), any(), any());
+        verify(mockModel, times(1)).relationCallback(eq(UPDATE), eq(POSTCOMMIT), notNull());
     }
 
     @Test
@@ -1153,13 +1185,15 @@ public class LifeCycleTest {
         RequestScope scope = buildRequestScope(dictionary, tx);
         when(tx.createNewObject(ClassType.of(PropertyTestModel.class), scope)).thenReturn(mockModel);
 
-        PropertyTestModel modelToAdd = mock(PropertyTestModel.class);
+        PropertyTestModel modelToAdd1 = mock(PropertyTestModel.class);
+        PropertyTestModel modelToAdd2 = mock(PropertyTestModel.class);
 
         //First we test adding to a newly created object.
         PersistentResource resource = PersistentResource.createObject(ClassType.of(PropertyTestModel.class), scope, Optional.of("1"));
-        PersistentResource resourceToAdd = new PersistentResource(modelToAdd, scope.getUUIDFor(mockModel), scope);
+        PersistentResource resourceToAdd1 = new PersistentResource(modelToAdd1, scope.getUUIDFor(mockModel), scope);
+        PersistentResource resourceToAdd2 = new PersistentResource(modelToAdd2, scope.getUUIDFor(mockModel), scope);
 
-        resource.updateRelation("models", new HashSet<>(Arrays.asList(resourceToAdd)));
+        resource.updateRelation("models", new HashSet<>(Arrays.asList(resourceToAdd1, resourceToAdd2)));
 
         scope.runQueuedPreSecurityTriggers();
         scope.runQueuedPreCommitTriggers();
@@ -1173,7 +1207,7 @@ public class LifeCycleTest {
         resource = new PersistentResource(mockModel, scope.getUUIDFor(mockModel), scope);
         reset(mockModel);
 
-        resource.updateRelation("models", new HashSet<>(Arrays.asList(resourceToAdd)));
+        resource.updateRelation("models", new HashSet<>(Arrays.asList(resourceToAdd1, resourceToAdd2)));
 
         scope.runQueuedPreSecurityTriggers();
         scope.runQueuedPreCommitTriggers();


### PR DESCRIPTION
## Description
When updating a relationship, lifecycle hooks were being invoked multiple times - once for each change to the relationship.  

This PR ensures a hook is called once per field (regardless of how many relationships are being added or removed). 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
