### PR TITLE
Fixing bug where Hibernate is not detecting updates to complex attrib…

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -2177,11 +2177,22 @@ public class EntityDictionary {
 
         Class<?> clazz = type.getUnderlyingClass().get();
 
+        boolean hasNoArgConstructor =
+                Arrays.stream(clazz.getConstructors()).anyMatch(constructor -> constructor.getParameterCount() == 0);
+
+        //We don't bind primitives.
         if (ClassUtils.isPrimitiveOrWrapper(clazz)
                 || clazz.equals(String.class)
                 || clazz.isEnum()
+
+                //We don't bind collections.
                 || Collection.class.isAssignableFrom(clazz)
                 || Map.class.isAssignableFrom(clazz)
+
+                //We can't bind an attribute type if Elide can't create it...
+                || ! hasNoArgConstructor
+
+                //If there is a Serde, we assume the type is opaque to Elide....
                 || serdeLookup.apply(clazz) != null) {
             return false;
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -2130,37 +2130,6 @@ public class EntityDictionary {
         return canBind(attributeType);
     }
 
-    public Object deepCopy(Object object, RequestScope scope) {
-        if (object == null) {
-            return null;
-        }
-
-        Type<?> type = getType(object);
-        EntityBinding binding = getEntityBinding(type);
-
-        Preconditions.checkState(! binding.equals(EMPTY_BINDING), "Model not found.");
-        Preconditions.checkState(binding.apiRelationships.isEmpty(), "Deep copy of relationships not supported");
-
-        Object copy;
-        try {
-            copy = type.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new IllegalStateException("Cannot perform deep copy of " + type.getName(), e);
-        }
-
-        binding.apiAttributes.forEach(attribute -> {
-            Object newValue;
-            if (! isComplexAttribute(type, attribute)) {
-                newValue = getValue(object, attribute, scope);
-            } else {
-                newValue = deepCopy(getValue(object, attribute, scope), scope);
-            }
-            setValue(copy, attribute, newValue);
-        });
-
-        return copy;
-    }
-
     private void bindHookMethod(
             EntityBinding binding,
             Method method,

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -12,12 +12,14 @@ import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.core.audit.AuditLogger;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.TestDictionary;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.TestUser;
@@ -75,6 +77,8 @@ public class PersistenceResourceTestSetup extends PersistentResource {
 
     protected final ElideSettings elideSettings;
 
+    protected static LifeCycleHook bookUpdatePrice = mock(LifeCycleHook.class);
+
     protected static EntityDictionary initDictionary() {
         EntityDictionary dictionary = TestDictionary.getTestDictionary();
 
@@ -107,6 +111,11 @@ public class PersistenceResourceTestSetup extends PersistentResource {
         dictionary.bindEntity(StrictNoTransfer.class);
         dictionary.bindEntity(Untransferable.class);
         dictionary.bindEntity(Company.class);
+
+        dictionary.bindTrigger(Book.class, "price",
+                LifeCycleHookBinding.Operation.UPDATE,
+                LifeCycleHookBinding.TransactionPhase.PRESECURITY, bookUpdatePrice);
+
         return dictionary;
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -72,6 +72,7 @@ import example.NoReadEntity;
 import example.NoShareEntity;
 import example.NoUpdateEntity;
 import example.Parent;
+import example.Price;
 import example.Right;
 import example.Shape;
 import example.nontransferable.ContainerWithPackageShare;
@@ -90,10 +91,12 @@ import org.mockito.ArgumentCaptor;
 import io.reactivex.Observable;
 import nocreate.NoCreateEntity;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Currency;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -1796,6 +1799,76 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         parentResource.updateAttribute("address", address);
 
         assertEquals(address, company.getAddress(), "The attribute was updated successfully");
+
+        goodScope.saveOrCreateObjects();
+        verify(tx, times(1)).save(company, goodScope);
+    }
+
+    @Test
+    public void testUpdateComplexAttributeClone1() {
+        Book book = new Book();
+
+        Price originalPrice = new Price();
+        originalPrice.setUnits(new BigDecimal(1.0));
+        originalPrice.setCurrency(Currency.getInstance("USD"));
+        book.setPrice(originalPrice);
+
+        Map<String, Object> newPrice = new HashMap<>();
+        newPrice.put("units", new BigDecimal(2.0));
+        newPrice.put("currency", Currency.getInstance("CNY"));
+
+        RequestScope goodScope = buildRequestScope(tx, goodUser);
+        PersistentResource<Book> bookResource = new PersistentResource<>(book, "1", goodScope);
+        bookResource.updateAttribute("price", newPrice);
+
+        //check that original value was unmodified.
+        assertEquals(Currency.getInstance("USD"), originalPrice.getCurrency());
+        assertEquals(new BigDecimal(1.0), originalPrice.getUnits());
+
+        //check that new value matches expected.
+        assertEquals(Currency.getInstance("CNY"), book.getPrice().getCurrency());
+        assertEquals(new BigDecimal(2.0), book.getPrice().getUnits());
+
+        goodScope.saveOrCreateObjects();
+        verify(tx, times(1)).save(book, goodScope);
+    }
+
+    @Test
+    public void testUpdateComplexAttributeClone2() {
+        Company company = newCompany("abc");
+        Address originalAddress = new Address();
+        originalAddress.setStreet1("street1");
+        originalAddress.setStreet2("street2");
+
+        GeoLocation originalGeo = new GeoLocation();
+        originalGeo.setLatitude("1");
+        originalGeo.setLongitude("2");
+        originalAddress.setGeo(originalGeo);
+
+        Map<String, Object> newAddress = new HashMap<>();
+        newAddress.put("street1", "Elm");
+        newAddress.put("street2", "Maple");
+        Map<String, Object> newGeo = new HashMap<>();
+        newGeo.put("latitude", "X");
+        newGeo.put("longitude", "Y");
+        newAddress.put("geo", newGeo);
+
+        RequestScope goodScope = buildRequestScope(tx, goodUser);
+        PersistentResource<Company> parentResource = new PersistentResource<>(company, "1", goodScope);
+
+        parentResource.updateAttribute("address", newAddress);
+
+        //check that original value was unmodified.
+        assertEquals("street1", originalAddress.getStreet1());
+        assertEquals("street2", originalAddress.getStreet2());
+        assertEquals("1", originalAddress.getGeo().getLatitude());
+        assertEquals("2", originalAddress.getGeo().getLongitude());
+
+        //check the new value matches the expected.
+        assertEquals("Elm", company.getAddress().getStreet1());
+        assertEquals("Maple", company.getAddress().getStreet2());
+        assertEquals("X", company.getAddress().getGeo().getLatitude());
+        assertEquals("Y", company.getAddress().getGeo().getLongitude());
 
         goodScope.saveOrCreateObjects();
         verify(tx, times(1)).save(company, goodScope);

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
@@ -41,6 +41,7 @@ import example.Address;
 import example.Author;
 import example.Book;
 import example.Editor;
+import example.Price;
 import example.Publisher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,7 +114,8 @@ public class InMemoryStoreTransactionTest {
                 System.currentTimeMillis(),
                 Sets.newHashSet(author1),
                 publisher1,
-                Arrays.asList("Prize1"));
+                Arrays.asList("Prize1"),
+                new Price());
 
         book2 = new Book(2,
                 "Book 2",
@@ -122,7 +124,8 @@ public class InMemoryStoreTransactionTest {
                 System.currentTimeMillis(),
                 Sets.newHashSet(author1),
                 publisher1,
-                Arrays.asList("Prize1", "Prize2"));
+                Arrays.asList("Prize1", "Prize2"),
+                new Price());
 
         book3 = new Book(3,
                 "Book 3",
@@ -131,7 +134,8 @@ public class InMemoryStoreTransactionTest {
                 System.currentTimeMillis(),
                 Sets.newHashSet(author1),
                 publisher2,
-                Arrays.asList());
+                Arrays.asList(),
+                new Price());
 
         books.add(book1);
         books.add(book2);

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -51,6 +51,7 @@ import example.GeoLocation;
 import example.Job;
 import example.Left;
 import example.Parent;
+import example.Price;
 import example.Publisher;
 import example.Right;
 import example.StringId;
@@ -1107,6 +1108,10 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertTrue(isComplexAttribute(ClassType.of(Author.class), "homeAddress"));
         //Test nested complex attribute
         assertTrue(isComplexAttribute(ClassType.of(Address.class), "geo"));
+        //Test another complex attribute.
+        assertTrue(isComplexAttribute(ClassType.of(Book.class), "price"));
+        //Test Java Type with no default constructor.
+        assertFalse(isComplexAttribute(ClassType.of(Price.class), "currency"));
         //Test String
         assertFalse(isComplexAttribute(ClassType.of(Book.class), "title"));
         //Test primitive

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
@@ -28,6 +28,7 @@ import example.Address;
 import example.Author;
 import example.Book;
 import example.Editor;
+import example.Price;
 import example.Publisher;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,7 @@ public class EntityProjectionMakerTest {
                 .attribute(Attribute.builder().name("language").type(String.class).build())
                 .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                 .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                .attribute(Attribute.builder().name("price").type(Price.class).build())
                 .relationship("authors", EntityProjection.builder()
                         .type(Author.class)
                         .build())
@@ -129,6 +131,7 @@ public class EntityProjectionMakerTest {
                 .attribute(Attribute.builder().name("language").type(String.class).build())
                 .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                 .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                .attribute(Attribute.builder().name("price").type(Price.class).build())
                 .relationship("authors", EntityProjection.builder()
                         .type(Author.class)
                         .build())
@@ -288,6 +291,7 @@ public class EntityProjectionMakerTest {
                 .attribute(Attribute.builder().name("language").type(String.class).build())
                 .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                 .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                .attribute(Attribute.builder().name("price").type(Price.class).build())
                 .relationship("authors", EntityProjection.builder()
                         .type(Author.class)
                         .attribute(Attribute.builder().name("name").type(String.class).build())
@@ -332,6 +336,7 @@ public class EntityProjectionMakerTest {
                 .attribute(Attribute.builder().name("language").type(String.class).build())
                 .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                 .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                .attribute(Attribute.builder().name("price").type(Price.class).build())
                 .relationship("authors", EntityProjection.builder()
                         .type(Author.class)
                         .attribute(Attribute.builder().name("name").type(String.class).build())
@@ -384,6 +389,7 @@ public class EntityProjectionMakerTest {
                         .attribute(Attribute.builder().name("language").type(String.class).build())
                         .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                         .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                        .attribute(Attribute.builder().name("price").type(Price.class).build())
                         .relationship("editor", EntityProjection.builder()
                                 .type(Editor.class)
                                 .attribute(Attribute.builder().name("firstName").type(String.class).build())
@@ -443,6 +449,7 @@ public class EntityProjectionMakerTest {
                         .attribute(Attribute.builder().name("language").type(String.class).build())
                         .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                         .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                        .attribute(Attribute.builder().name("price").type(Price.class).build())
                         .relationship("publisher", EntityProjection.builder()
                                 .type(Publisher.class)
                                 .attribute(Attribute.builder().name("name").type(String.class).build())
@@ -500,6 +507,7 @@ public class EntityProjectionMakerTest {
                                         .attribute(Attribute.builder().name("language").type(String.class).build())
                                         .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                                         .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                                        .attribute(Attribute.builder().name("price").type(Price.class).build())
                                         .relationship("authors", EntityProjection.builder()
                                                 .type(Author.class)
                                                 .build())
@@ -547,6 +555,7 @@ public class EntityProjectionMakerTest {
                                         .attribute(Attribute.builder().name("language").type(String.class).build())
                                         .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                                         .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                                        .attribute(Attribute.builder().name("price").type(Price.class).build())
                                         .relationship("authors", EntityProjection.builder()
                                                 .type(Author.class)
                                                 .build())
@@ -633,6 +642,7 @@ public class EntityProjectionMakerTest {
                 .attribute(Attribute.builder().name("awards").type(Collection.class).build())
                 .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                 .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                .attribute(Attribute.builder().name("price").type(Price.class).build())
                 .filterExpression(expression)
                 .relationship("publisher", EntityProjection.builder()
                         .type(Publisher.class)
@@ -755,6 +765,7 @@ public class EntityProjectionMakerTest {
                 .attribute(Attribute.builder().name("language").type(String.class).build())
                 .attribute(Attribute.builder().name("publishDate").type(long.class).build())
                 .attribute(Attribute.builder().name("authorTypes").type(Collection.class).build())
+                .attribute(Attribute.builder().name("price").type(Price.class).build())
                 .filterExpression(expression)
                 .relationship("authors", EntityProjection.builder()
                         .type(Author.class)

--- a/elide-core/src/test/java/example/Book.java
+++ b/elide-core/src/test/java/example/Book.java
@@ -58,6 +58,7 @@ public class Book {
     private Collection<Author> authors = new ArrayList<>();
     private Publisher publisher = null;
     private Collection<String> awards = new ArrayList<>();
+    private Price price;
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     public long getId() {
@@ -132,6 +133,14 @@ public class Book {
 
     public void setPublisher(Publisher publisher) {
         this.publisher = publisher;
+    }
+
+    public Price getPrice() {
+        return price;
+    }
+
+    public void setPrice(Price price) {
+        this.price = price;
     }
 
     @Transient

--- a/elide-core/src/test/java/example/Price.java
+++ b/elide-core/src/test/java/example/Price.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package example;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.Currency;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Price {
+    private BigDecimal units;
+    private Currency currency;
+}


### PR DESCRIPTION
…utes serialized using Hibernate TypeDef.

## Description
There are two bugs when updating complex attributes:

1. Life cycle hooks are not getting invoked:
2. If the complex attribute is leveraging the Hibernate annotation`@TypeDef` to map the type to a database field like a VARCHAR, hibernate will not notice the change (because the parent object's reference has not changed).  

## How Has This Been Tested?
New Unit Tests

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
