### PR TITLE
Fixes #2263.  JSON-API json processing errors will now return a 400 i…

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -39,6 +39,7 @@ import com.yahoo.elide.jsonapi.parser.GetVisitor;
 import com.yahoo.elide.jsonapi.parser.JsonApiParser;
 import com.yahoo.elide.jsonapi.parser.PatchVisitor;
 import com.yahoo.elide.jsonapi.parser.PostVisitor;
+import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -504,7 +505,12 @@ public class Elide {
             }
 
             return response;
+        } catch (JacksonException e) {
+            String message = (e.getLocation() != null && e.getLocation().getSourceRef() != null)
+                    ? e.getMessage() //This will leak Java class info if the location isn't known.
+                    : e.getOriginalMessage();
 
+            return buildErrorResponse(new BadRequestException(message), isVerbose);
         } catch (IOException e) {
             log.error("IO Exception uncaught by Elide", e);
             return buildErrorResponse(new TransactionException(e), isVerbose);

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Resource.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/Resource.java
@@ -33,6 +33,9 @@ import java.util.Objects;
  */
 @ToString
 public class Resource {
+
+    //Doesn't work currently - https://github.com/FasterXML/jackson-databind/issues/230
+    @JsonProperty(required = true)
     private String type;
     private String id;
     private Map<String, Object> attributes;

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/DataDeserializer.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/DataDeserializer.java
@@ -5,11 +5,9 @@
  */
 package com.yahoo.elide.jsonapi.serialization;
 
-import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.Resource;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/DataDeserializer.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/serialization/DataDeserializer.java
@@ -5,11 +5,14 @@
  */
 package com.yahoo.elide.jsonapi.serialization;
 
+import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.jsonapi.models.Data;
 import com.yahoo.elide.jsonapi.models.Resource;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,11 +35,19 @@ public class DataDeserializer extends JsonDeserializer<Data<Resource>> {
             List<Resource> resources = new ArrayList<>();
             for (JsonNode n : node) {
                 Resource r = MAPPER.convertValue(n, Resource.class);
+                validateResource(jsonParser, r);
                 resources.add(r);
             }
             return new Data<>(resources);
         }
         Resource resource = MAPPER.convertValue(node, Resource.class);
+        validateResource(jsonParser, resource);
         return new Data<>(resource);
+    }
+
+    private void validateResource(JsonParser jsonParser, Resource resource) throws IOException {
+        if (resource.getType() == null || resource.getType().isEmpty()) {
+            throw JsonMappingException.from(jsonParser, "Resource 'type' field is missing or empty.");
+        }
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.jsonapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
@@ -23,6 +24,7 @@ import com.yahoo.elide.jsonapi.models.Relationship;
 import com.yahoo.elide.jsonapi.models.Resource;
 import com.yahoo.elide.jsonapi.models.ResourceIdentifier;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import example.Child;
@@ -323,6 +325,20 @@ public class JsonApiTest {
 
         assertEquals(expected, doc);
         checkEquality(jsonApiDocument);
+    }
+
+    @Test
+    public void testMissingTypeInResource() throws IOException {
+        String doc = "{ \"data\": { \"id\": \"22\", \"attributes\": { \"title\": \"works fine\" } } }";
+
+        assertThrows(JsonMappingException.class, () -> mapper.readJsonApiDocument(doc));
+    }
+
+    @Test
+    public void testMissingTypeInResourceList() throws IOException {
+        String doc = "{ \"data\": [{ \"id\": \"22\", \"attributes\": { \"title\": \"works fine\" } } ]}";
+
+        assertThrows(JsonMappingException.class, () -> mapper.readJsonApiDocument(doc));
     }
 
     @Test

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/EncodedErrorObjectsIT.java
@@ -115,7 +115,7 @@ public class EncodedErrorObjectsIT extends IntegrationTest {
             .accept(JSONAPI_CONTENT_TYPE)
             .body(request).post("/invoice")
             .then()
-            .statusCode(HttpStatus.SC_LOCKED)
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body(equalTo(expected));
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/errorEncodingTests/VerboseEncodedErrorResponsesIT.java
@@ -126,7 +126,7 @@ public class VerboseEncodedErrorResponsesIT extends IntegrationTest {
             .accept(JSONAPI_CONTENT_TYPE)
             .body(request).post("/invoice")
             .then()
-            .statusCode(HttpStatus.SC_LOCKED)
+            .statusCode(HttpStatus.SC_BAD_REQUEST)
             .body(equalTo(expected));
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -968,7 +968,6 @@ public class ResourceIT extends IntegrationTest {
                 .body("{ \"data\": { \"id\": \"1\", \"attributes\": { \"firstName\": \"foo\" }}}")
                 .patch("/parent/1")
                 .then()
-                .log().all()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body("errors[0].detail", equalTo(Encode.forHtml(detail)));
     }
@@ -983,7 +982,6 @@ public class ResourceIT extends IntegrationTest {
                 .body("{ ]")
                 .patch("/parent/1")
                 .then()
-                .log().all()
                 .statusCode(HttpStatus.SC_BAD_REQUEST)
                 .body("errors[0].detail", equalTo(Encode.forHtml(detail)));
     }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -959,6 +959,36 @@ public class ResourceIT extends IntegrationTest {
     }
 
     @Test
+    public void testMissingTypeInJsonBody() {
+        String detail = "Resource 'type' field is missing or empty.";
+
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body("{ \"data\": { \"id\": \"1\", \"attributes\": { \"firstName\": \"foo\" }}}")
+                .patch("/parent/1")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("errors[0].detail", equalTo(Encode.forHtml(detail)));
+    }
+
+    @Test
+    public void testInvalidJson() {
+        String detail = "Unexpected close marker ']': expected '}' (for Object starting at [Source: (String)\"{ ]\"; line: 1, column: 1])\n at [Source: (String)\"{ ]\"; line: 1, column: 4]";
+
+        given()
+                .contentType(JSONAPI_CONTENT_TYPE)
+                .accept(JSONAPI_CONTENT_TYPE)
+                .body("{ ]")
+                .patch("/parent/1")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("errors[0].detail", equalTo(Encode.forHtml(detail)));
+    }
+
+    @Test
     public void testGetSortCollection() throws Exception {
 
         String expected = data(PARENT1, PARENT2, PARENT3, PARENT4).toJSON();


### PR DESCRIPTION
…nstead of a 423.

Resolves #2263

## Description
resource.type is now required on all JSON-API payloads.

JSON parsing errors used to return a 423 error.  Now they return a 400 error instead.

## Motivation and Context
Better error handling.

## How Has This Been Tested?
New unit and IT tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
