### PR TITLE
bump log4j2 API to 2.17.0

### DIFF
--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -93,6 +93,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.17.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.17.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -45,7 +45,6 @@
 
     <properties>
         <!-- Versions -->
-        <logback.version>1.2.3</logback.version>
         <metrics.version>4.2.5</metrics.version>
 
         <!-- Settings -->
@@ -149,7 +148,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
+            <version>${version.logback}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <!-- dependency versions -->
         <version.antlr4>4.9.3</version.antlr4>
-        <version.logback>1.2.7</version.logback>
+        <version.logback>1.2.9</version.logback>
         <version.jetty>9.4.44.v20210927</version.jetty>
         <version.restassured>4.4.0</version.restassured>
         <version.jackson>2.12.5</version.jackson>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -28,9 +28,4 @@
         <cve>CVE-2021-42340</cve>
     </suppress>
 
-    <!-- Log4J Sev 10 - disabled because spring pulls in the api but not the core engine.  Elide doesn't use log4j" -->
-    <suppress until="2022-03-01">
-        <cve>CVE-2021-44228</cve>
-    </suppress>
-
 </suppressions>


### PR DESCRIPTION
## Description
log4j2 API to 2.17.0

## Motivation and Context
CVE-2021-45105, CVE-2021-45046

## How Has This Been Tested?
Build and unit testing

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.