### PR TITLE
Use GraphQLBigDecimal for BigDecimal Conversions in GraphQLConversionUtils

### DIFF
--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -62,6 +62,11 @@
             <version>17.3</version>
         </dependency>
         <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java-extended-scalars</artifactId>
+            <version>17.0</version>
+        </dependency>
+        <dependency>
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
             <version>1.1</version>

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.coerce.CoerceUtil;
 import com.yahoo.elide.core.utils.coerce.converters.ElideTypeConverter;
 import graphql.Scalars;
+import graphql.scalars.java.JavaPrimitives;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLEnumType;
@@ -104,7 +105,7 @@ public class GraphQLConversionUtils {
         } else if (clazz.equals(ClassType.of(String.class)) || clazz.equals(ClassType.of(Object.class))) {
             return Scalars.GraphQLString;
         } else if (clazz.equals(ClassType.of(BigDecimal.class))) {
-            return Scalars.GraphQLFloat;
+            return JavaPrimitives.GraphQLBigDecimal;
         }
         return otherClassToScalarType(clazz);
     }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -25,6 +25,7 @@ import example.Book;
 import example.Publisher;
 import org.junit.jupiter.api.Test;
 import graphql.Scalars;
+import graphql.scalars.java.JavaPrimitives;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLEnumValueDefinition;
@@ -204,7 +205,7 @@ public class ModelBuilderTest {
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_GENRE).getType());
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_LANGUAGE).getType());
         assertEquals(Scalars.GraphQLInt, bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getType());
-        assertEquals(Scalars.GraphQLFloat, bookType.getFieldDefinition(FIELD_WEIGHT_LBS).getType());
+        assertEquals(JavaPrimitives.GraphQLBigDecimal, bookType.getFieldDefinition(FIELD_WEIGHT_LBS).getType());
 
         GraphQLObjectType addressType = (GraphQLObjectType) authorType.getFieldDefinition("homeAddress").getType();
         assertEquals(Scalars.GraphQLString, addressType.getFieldDefinition("street1").getType());

--- a/elide-graphql/src/test/resources/graphql/requests/update/updateComplexAttributeMap.graphql
+++ b/elide-graphql/src/test/resources/graphql/requests/update/updateComplexAttributeMap.graphql
@@ -3,8 +3,8 @@ mutation {
   data: {
          id: "1",
          priceRevisions: [
-            { key: "2016-01-02T00:00Z", value: { units: 126, currency: { currencyCode: "USD" }}},
-            { key: "2016-01-01T00:00Z", value: { units: 125}}
+            { key: "2016-01-02T00:00Z", value: { units: 490056468, currency: { currencyCode: "USD" }}},
+            { key: "2016-01-01T00:00Z", value: { units: 125.7}}
          ]
       }) {
     edges {

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/complexAttribute.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/complexAttribute.json
@@ -6,7 +6,7 @@
           "id": "1",
           "title": "Libro Uno",
           "price": {
-            "units" : 123.0,
+            "units" : 123,
             "currency" : {
               "currencyCode" : "USD"
             }

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/complexAttributeList.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/complexAttributeList.json
@@ -14,13 +14,13 @@
           "title": "Libro Dos",
           "priceHistory": [
             {
-              "units" : 200.0,
+              "units" : 200,
               "currency" : {
                 "currencyCode" : "USD"
               }
             },
             {
-              "units" : 210.0,
+              "units" : 210,
               "currency": {
                 "currencyCode" : "USD"
               }

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/complexAttributeMap.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/complexAttributeMap.json
@@ -16,7 +16,7 @@
             {
               "key" : "2020-05-22T22:48Z",
               "value" : {
-                "units" : 210.0,
+                "units" : 210,
                 "currency" : {
                   "currencyCode" : "USD"
                 }
@@ -25,7 +25,7 @@
             {
               "key" : "2020-05-22T22:46Z",
               "value" : {
-                "units" : 200.0,
+                "units" : 200,
                 "currency" : {
                   "currencyCode" : "USD"
                 }

--- a/elide-graphql/src/test/resources/graphql/responses/update/updateComplexAttributeList.json
+++ b/elide-graphql/src/test/resources/graphql/responses/update/updateComplexAttributeList.json
@@ -6,11 +6,11 @@
           "id": "1",
           "priceHistory": [
             {
-              "units": 125.0,
+              "units": 125,
               "currency": null
             },
             {
-              "units": 126.0,
+              "units": 126,
               "currency": {
                 "currencyCode" : "USD"
               }

--- a/elide-graphql/src/test/resources/graphql/responses/update/updateComplexAttributeMap.json
+++ b/elide-graphql/src/test/resources/graphql/responses/update/updateComplexAttributeMap.json
@@ -8,7 +8,7 @@
             {
               "key": "2016-01-02T00:00Z",
               "value": {
-                "units": 126.0,
+                "units": 490056468,
                 "currency": {
                   "currencyCode": "USD"
                 }
@@ -17,7 +17,7 @@
             {
               "key": "2016-01-01T00:00Z",
               "value": {
-                "units": 125.0,
+                "units": 125.7,
 
                 "currency": null
               }

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
-        <spring.boot.version>2.6.1</spring.boot.version>
+        <spring.boot.version>2.6.2</spring.boot.version>
         <groovy.version>3.0.9</groovy.version>
     </properties>
 

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -45,7 +45,6 @@
 
     <properties>
         <!-- Versions -->
-        <logback.version>1.2.3</logback.version>
         <metrics.version>4.2.5</metrics.version>
 
         <!-- Settings -->
@@ -149,7 +148,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <!-- dependency versions -->
         <version.antlr4>4.9.3</version.antlr4>
-        <version.logback>1.2.7</version.logback>
+        <version.logback>1.2.10</version.logback>
         <version.jetty>9.4.44.v20210927</version.jetty>
         <version.restassured>4.4.0</version.restassured>
         <version.jackson>2.12.5</version.jackson>


### PR DESCRIPTION
## Description
Uses JavaPrimitives.GraphQLBigDecimal for Converting BigDecimal Values to Graphql Input.

## Motivation and Context
BigDecimal Values were converted to Float resulting in precision loss and returning values with Exponents.

## How Has This Been Tested?
Existing test cases passed with updates.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
