### PR TITLE
use query with filter to populate query parameters in pagination

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -269,7 +269,7 @@ public class SQLQueryEngine extends QueryEngine {
         return resultBuilder.build();
     }
 
-    private long getPageTotal(Query expandedQuery, NativeQuery sql, Query query, SqlTransaction sqlTransaction) {
+    private long getPageTotal(Query expandedQuery, NativeQuery sql, Query clientQuery, SqlTransaction sqlTransaction) {
         ConnectionDetails details = expandedQuery.getConnectionDetails();
         DataSource dataSource = details.getDataSource();
         SQLDialect dialect = details.getDialect();
@@ -284,7 +284,7 @@ public class SQLQueryEngine extends QueryEngine {
         NamedParamPreparedStatement stmt = sqlTransaction.initializeStatement(paginationSQL.toString(), dataSource);
 
         // Supply the query parameters to the query
-        supplyFilterQueryParameters(query, stmt, dialect);
+        supplyFilterQueryParameters(clientQuery, stmt, dialect);
 
         // Run the Pagination query and log the time spent.
         Long result = CoerceUtil.coerce(runQuery(stmt, paginationSQL.toString(), SINGLE_RESULT_MAPPER), Long.class);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -253,7 +253,7 @@ public class SQLQueryEngine extends QueryEngine {
 
         Pagination pagination = query.getPagination();
         if (returnPageTotals(pagination)) {
-            resultBuilder.pageTotals(getPageTotal(expandedQuery, sql, sqlTransaction));
+            resultBuilder.pageTotals(getPageTotal(expandedQuery, sql, query, sqlTransaction));
         }
 
         log.debug("SQL Query: " + queryString);
@@ -269,7 +269,7 @@ public class SQLQueryEngine extends QueryEngine {
         return resultBuilder.build();
     }
 
-    private long getPageTotal(Query query, NativeQuery sql, SqlTransaction sqlTransaction) {
+    private long getPageTotal(Query query, NativeQuery sql, Query origQuery, SqlTransaction sqlTransaction) {
         ConnectionDetails details = query.getConnectionDetails();
         DataSource dataSource = details.getDataSource();
         SQLDialect dialect = details.getDialect();
@@ -284,7 +284,7 @@ public class SQLQueryEngine extends QueryEngine {
         NamedParamPreparedStatement stmt = sqlTransaction.initializeStatement(paginationSQL.toString(), dataSource);
 
         // Supply the query parameters to the query
-        supplyFilterQueryParameters(query, stmt, dialect);
+        supplyFilterQueryParameters(origQuery, stmt, dialect);
 
         // Run the Pagination query and log the time spent.
         Long result = CoerceUtil.coerce(runQuery(stmt, paginationSQL.toString(), SINGLE_RESULT_MAPPER), Long.class);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SQLQueryEngine.java
@@ -269,11 +269,11 @@ public class SQLQueryEngine extends QueryEngine {
         return resultBuilder.build();
     }
 
-    private long getPageTotal(Query query, NativeQuery sql, Query origQuery, SqlTransaction sqlTransaction) {
-        ConnectionDetails details = query.getConnectionDetails();
+    private long getPageTotal(Query expandedQuery, NativeQuery sql, Query query, SqlTransaction sqlTransaction) {
+        ConnectionDetails details = expandedQuery.getConnectionDetails();
         DataSource dataSource = details.getDataSource();
         SQLDialect dialect = details.getDialect();
-        NativeQuery paginationSQL = toPageTotalSQL(query, sql, dialect);
+        NativeQuery paginationSQL = toPageTotalSQL(expandedQuery, sql, dialect);
 
         if (paginationSQL == null) {
             // The query returns the aggregated metric without any dimension.
@@ -284,7 +284,7 @@ public class SQLQueryEngine extends QueryEngine {
         NamedParamPreparedStatement stmt = sqlTransaction.initializeStatement(paginationSQL.toString(), dataSource);
 
         // Supply the query parameters to the query
-        supplyFilterQueryParameters(origQuery, stmt, dialect);
+        supplyFilterQueryParameters(query, stmt, dialect);
 
         // Run the Pagination query and log the time spent.
         Long result = CoerceUtil.coerce(runQuery(stmt, paginationSQL.toString(), SINGLE_RESULT_MAPPER), Long.class);


### PR DESCRIPTION
Resolves #2465

## Description
This uses the original query with filters to populate pagination query filter parameters. 

## How Has This Been Tested?
Unit test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
