### PR TITLE
Enable lifecycle, check, and other entity scans by default for Spring.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -101,6 +101,17 @@ public class Elide {
      * @param scanner Scans classes for Elide annotations.
      */
     public Elide(ElideSettings elideSettings, ClassScanner scanner) {
+        this(elideSettings, scanner, true);
+    }
+
+    /**
+     * Instantiates a new Elide instance.
+     *
+     * @param elideSettings Elide settings object.
+     * @param scanner Scans classes for Elide annotations.
+     * @param doScans Perform scans now.
+     */
+    public Elide(ElideSettings elideSettings, ClassScanner scanner, boolean doScans) {
         this.elideSettings = elideSettings;
         this.scanner = scanner;
         this.auditLogger = elideSettings.getAuditLogger();
@@ -108,6 +119,10 @@ public class Elide {
         this.mapper = elideSettings.getMapper();
         this.errorMapper = elideSettings.getErrorMapper();
         this.transactionRegistry = new TransactionRegistry();
+
+        if (doScans) {
+            doScans();
+        }
     }
 
     /**

--- a/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
@@ -132,7 +132,8 @@ public class ErrorMapperTest {
     }
 
     private Elide getElide(DataStore dataStore, EntityDictionary dictionary, ErrorMapper errorMapper) {
-        return new Elide(getElideSettings(dataStore, dictionary, errorMapper));
+        ElideSettings settings = getElideSettings(dataStore, dictionary, errorMapper);
+        return new Elide(settings, settings.getDictionary().getScanner(), false);
     }
 
     private ElideSettings getElideSettings(DataStore dataStore, EntityDictionary dictionary, ErrorMapper errorMapper) {

--- a/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
@@ -1349,7 +1349,8 @@ public class LifeCycleTest {
     }
 
     private Elide getElide(DataStore dataStore, EntityDictionary dictionary, AuditLogger auditLogger) {
-        return new Elide(getElideSettings(dataStore, dictionary, auditLogger));
+        ElideSettings settings = getElideSettings(dataStore, dictionary, auditLogger);
+        return new Elide(settings, settings.getDictionary().getScanner(), false);
     }
 
     private ElideSettings getElideSettings(DataStore dataStore, EntityDictionary dictionary, AuditLogger auditLogger) {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -188,7 +188,6 @@ public class ElideAutoConfiguration {
         }
 
         Elide elide = new Elide(builder.build());
-        elide.doScans();
         return elide;
     }
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -124,7 +124,7 @@ public class ElideResourceConfig extends ResourceConfig {
 
             ElideSettings elideSettings = settings.getElideSettings(dictionary, dataStore,
                     settings.getObjectMapper());
-            Elide elide = new Elide(elideSettings);
+            Elide elide = new Elide(elideSettings, elideSettings.getDictionary().getScanner(), false);
 
             // Bind elide instance for injection into endpoint
             bind(elide).to(Elide.class).named("elide");


### PR DESCRIPTION
This PR improves developer ergonomics whenever the Elide bean is overridden.   Elide.doScan currently must be explicitly called.  With this change, doScan happens automatically for spring boot (but must still be called separately for Elide standalone which relies on Jersey's phased dependency injection).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
