### PR TITLE
Disallow ConfigFile path to be changed in ConfigStore

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -7,6 +7,8 @@
 package com.yahoo.elide.core.dictionary;
 
 import static com.yahoo.elide.core.dictionary.EntityBinding.EMPTY_BINDING;
+import static com.yahoo.elide.core.security.checks.prefab.Role.ALL_ROLE;
+import static com.yahoo.elide.core.security.checks.prefab.Role.NONE_ROLE;
 import static com.yahoo.elide.core.type.ClassType.COLLECTION_TYPE;
 import static com.yahoo.elide.core.type.ClassType.MAP_TYPE;
 import com.yahoo.elide.annotation.ApiVersion;
@@ -171,9 +173,9 @@ public class EntityDictionary {
         UserCheck none = new Role.NONE();
 
         addRoleCheck("Prefab.Role.All", all);
-        addRoleCheck("ALL", all);
+        addRoleCheck(ALL_ROLE, all);
         addRoleCheck("Prefab.Role.None", none);
-        addRoleCheck("NONE", none);
+        addRoleCheck(NONE_ROLE, none);
 
         addPrefabCheck("Prefab.Collections.AppendOnly", AppendOnly.class);
         addPrefabCheck("Prefab.Collections.RemoveOnly", RemoveOnly.class);

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/checks/prefab/Role.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/checks/prefab/Role.java
@@ -12,6 +12,8 @@ import com.yahoo.elide.core.security.checks.UserCheck;
  * Simple checks to always grant or deny.
  */
 public class Role {
+    public static final String NONE_ROLE = "NONE";
+    public static final String ALL_ROLE = "ALL";
     /**
      * Check which always grants.
      */

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/models/ConfigFile.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/models/ConfigFile.java
@@ -7,6 +7,7 @@
 package com.yahoo.elide.modelconfig.store.models;
 
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+import static com.yahoo.elide.core.security.checks.prefab.Role.NONE_ROLE;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
@@ -51,7 +52,7 @@ public class ConfigFile {
     @GeneratedValue
     private String id; //Base64 encoded path-version
 
-    @UpdatePermission(expression = "NONE")
+    @UpdatePermission(expression = NONE_ROLE)
     private String path;
 
     private String version;

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/models/ConfigFile.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/models/ConfigFile.java
@@ -51,6 +51,7 @@ public class ConfigFile {
     @GeneratedValue
     private String id; //Base64 encoded path-version
 
+    @UpdatePermission(expression = "NONE")
     private String path;
 
     private String version;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
@@ -447,6 +447,73 @@ public class ConfigStoreTest {
     }
 
     @Test
+    public void testPathUpdatePermissionError() {
+        String hjson = "{            \n"
+                + "  tables: [{     \n"
+                + "      name: Test\n"
+                + "      table: test\n"
+                + "      schema: test\n"
+                + "      measures : [\n"
+                + "         {\n"
+                + "          name : measure\n"
+                + "          type : INTEGER\n"
+                + "          definition: 'MAX({{$measure}})'\n"
+                + "         }\n"
+                + "      ]      \n"
+                + "      dimensions : [\n"
+                + "         {\n"
+                + "           name : dimension\n"
+                + "           type : TEXT\n"
+                + "           definition : '{{$dimension}}'\n"
+                + "         }\n"
+                + "      ]\n"
+                + "  }]\n"
+                + "}";
+
+        given()
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("config"),
+                                        attributes(
+                                                attr("path", "models/tables/table1.hjson"),
+                                                attr("type", "TABLE"),
+                                                attr("content", hjson)
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .post("http://localhost:" + port + "/json/config")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        given()
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("config"),
+                                        id("bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24="),
+                                        attributes(
+                                                attr("path", "models/tables/newName.hjson")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .patch("http://localhost:" + port + "/json/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
+                .then()
+                .statusCode(HttpStatus.SC_FORBIDDEN);
+
+        when()
+                .delete("http://localhost:" + port + "/json/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
     public void testHackAttempt() {
         String hjson = "#!/bin/sh ...";
 


### PR DESCRIPTION
ConfigFile path cannot be changed as the ID is derived from it.  It is immutable.  This PR explicitly disallows changes.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
