### PR TITLE
File Extension Support for Export Attachments

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/FileExtensionType.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/FileExtensionType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.async.models;
+
+/**
+ * ENUM of supported file extension types.
+ */
+public enum FileExtensionType {
+    JSON(".json"),
+    CSV(".csv"),
+    NONE("");
+
+    private final String extension;
+
+    FileExtensionType(String extension) {
+        this.extension = extension;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/ResultType.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/ResultType.java
@@ -9,6 +9,16 @@ package com.yahoo.elide.async.models;
  * ENUM of supported result types.
  */
 public enum ResultType {
-    JSON,
-    CSV
+    JSON(FileExtensionType.JSON),
+    CSV(FileExtensionType.CSV);
+
+    private final FileExtensionType fileExtensionType;
+
+    ResultType(FileExtensionType fileExtensionType) {
+        this.fileExtensionType = fileExtensionType;
+    }
+
+    public FileExtensionType getFileExtensionType() {
+        return fileExtensionType;
+    }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/TableExportOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/TableExportOperation.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.async.export.validator.SingleRootProjectionValidator;
 import com.yahoo.elide.async.export.validator.Validator;
 import com.yahoo.elide.async.models.AsyncAPI;
 import com.yahoo.elide.async.models.AsyncAPIResult;
+import com.yahoo.elide.async.models.FileExtensionType;
 import com.yahoo.elide.async.models.TableExport;
 import com.yahoo.elide.async.models.TableExportResult;
 import com.yahoo.elide.async.service.AsyncExecutorService;
@@ -159,7 +160,10 @@ public abstract class TableExportOperation implements Callable<AsyncAPIResult> {
     public String generateDownloadURL(TableExport exportObj, RequestScope scope) {
         String downloadPath =  scope.getElideSettings().getExportApiPath();
         String baseURL = scope.getBaseUrlEndPoint();
-        return baseURL + downloadPath + "/" + exportObj.getId();
+        String extension = this.engine.isExtensionEnabled()
+                ? exportObj.getResultType().getFileExtensionType().getExtension()
+                : FileExtensionType.NONE.getExtension();
+        return baseURL + downloadPath + "/" + exportObj.getId() + extension;
     }
 
     /**

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/ResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/ResultStorageEngine.java
@@ -26,8 +26,14 @@ public interface ResultStorageEngine {
 
     /**
      * Searches for the async query results by ID and returns the record.
-     * @param asyncQueryID is the query ID of the AsyncQuery
-     * @return returns the result associated with the AsyncQueryID
+     * @param tableExportID is the ID of the TableExport. It may include extension too if enabled.
+     * @return returns the result associated with the tableExportID
      */
-    public Observable<String> getResultsByID(String asyncQueryID);
+    public Observable<String> getResultsByID(String tableExportID);
+
+    /**
+     * Whether the result storage engine has enabled extensions for attachments.
+     * @return returns whether the file extensions are enabled
+     */
+    public boolean isExtensionEnabled();
 }

--- a/elide-async/src/test/java/com/yahoo/elide/async/operation/GraphQLTableExportOperationTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/operation/GraphQLTableExportOperationTest.java
@@ -77,7 +77,7 @@ public class GraphQLTableExportOperationTest {
         user = mock(User.class);
         requestScope = mock(RequestScope.class);
         asyncExecutorService = mock(AsyncExecutorService.class);
-        engine = new FileResultStorageEngine(tempDir.toString());
+        engine = new FileResultStorageEngine(tempDir.toString(), false);
         when(asyncExecutorService.getElide()).thenReturn(elide);
         when(requestScope.getApiVersion()).thenReturn(NO_VERSION);
         when(requestScope.getUser()).thenReturn(user);

--- a/elide-async/src/test/java/com/yahoo/elide/async/operation/JsonAPITableExportOperationTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/operation/JsonAPITableExportOperationTest.java
@@ -78,7 +78,7 @@ public class JsonAPITableExportOperationTest {
         user = mock(User.class);
         requestScope = mock(RequestScope.class);
         asyncExecutorService = mock(AsyncExecutorService.class);
-        engine = new FileResultStorageEngine(tempDir.toString());
+        engine = new FileResultStorageEngine(tempDir.toString(), true);
         when(asyncExecutorService.getElide()).thenReturn(elide);
         when(requestScope.getApiVersion()).thenReturn(NO_VERSION);
         when(requestScope.getUser()).thenReturn(user);
@@ -102,7 +102,7 @@ public class JsonAPITableExportOperationTest {
         TableExportResult queryResultObj = (TableExportResult) jsonAPIOperation.call();
 
         assertEquals(200, queryResultObj.getHttpStatus());
-        assertEquals("https://elide.io/export/edc4a871-dff2-4054-804e-d80075cf827d", queryResultObj.getUrl().toString());
+        assertEquals("https://elide.io/export/edc4a871-dff2-4054-804e-d80075cf827d.csv", queryResultObj.getUrl().toString());
         assertEquals(1, queryResultObj.getRecordCount());
         assertNull(queryResultObj.getMessage());
     }

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngineTest.java
@@ -67,7 +67,7 @@ public class FileResultStorageEngineTest {
     }
 
     private String readResultsFile(String path, String queryId) {
-        FileResultStorageEngine engine = new FileResultStorageEngine(path);
+        FileResultStorageEngine engine = new FileResultStorageEngine(path, false);
 
         return engine.getResultsByID(queryId).collect(() -> new StringBuilder(),
                 (resultBuilder, tempResult) -> {
@@ -80,7 +80,7 @@ public class FileResultStorageEngineTest {
     }
 
     private void storeResultsFile(String path, String queryId, Observable<String> storable) {
-        FileResultStorageEngine engine = new FileResultStorageEngine(path);
+        FileResultStorageEngine engine = new FileResultStorageEngine(path, false);
         TableExport query = new TableExport();
         query.setId(queryId);
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -116,7 +116,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                 // Create ResultStorageEngine
                 Path storageDestination = (Path) servletContext.getAttribute(STORAGE_DESTINATION_ATTR);
                 if (storageDestination != null) { // TableExport is enabled
-                    ResultStorageEngine resultStorageEngine = new FileResultStorageEngine(storageDestination.toAbsolutePath().toString());
+                    ResultStorageEngine resultStorageEngine = new FileResultStorageEngine(storageDestination.toAbsolutePath().toString(), false);
                     bind(resultStorageEngine).to(ResultStorageEngine.class).named("resultStorageEngine");
 
                     Map<ResultType, TableExportFormatter> supportedFormatters = new HashMap<>();

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
@@ -194,7 +194,7 @@ public class DynamicConfigValidator implements DynamicConfiguration, Validator {
         readConfigs(fileLoader.loadResources());
     }
 
-    public void readConfigs(Map<String, ConfigFile> resourceMap) throws IOException {
+    public void readConfigs(Map<String, ConfigFile> resourceMap) {
         this.modelVariables = readVariableConfig(Config.MODELVARIABLE, resourceMap);
         this.elideSecurityConfig = readSecurityConfig(resourceMap);
         this.dbVariables = readVariableConfig(Config.DBVARIABLE, resourceMap);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
@@ -165,7 +165,7 @@ public class ElideAsyncConfiguration {
     public ResultStorageEngine buildResultStorageEngine(Elide elide, ElideConfigProperties settings,
             AsyncAPIDAO asyncQueryDAO) {
         FileResultStorageEngine resultStorageEngine = new FileResultStorageEngine(settings.getAsync().getExport()
-                .getStorageDestination());
+                .getStorageDestination(), settings.getAsync().getExport().isExtensionEnabled());
         return resultStorageEngine;
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ExportControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ExportControllerProperties.java
@@ -21,6 +21,11 @@ public class ExportControllerProperties extends ControllerProperties {
     private boolean skipCSVHeader = false;
 
     /**
+     * Enable Adding Extension to table export attachments.
+     */
+    private boolean extensionEnabled = false;
+
+    /**
      * The URL path prefix for the controller.
      */
     private String path = "/export";

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -161,7 +161,7 @@ public class AsyncTest extends IntegrationTest {
                         .body("data.attributes.status", equalTo("COMPLETE"))
                         .body("data.attributes.result.message", equalTo(null))
                         .body("data.attributes.result.url",
-                                equalTo("https://elide.io" + "/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d"));
+                                equalTo("https://elide.io" + "/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d.csv"));
 
                 // Validate GraphQL Response
                 String responseGraphQL = given()
@@ -176,7 +176,7 @@ public class AsyncTest extends IntegrationTest {
 
                 String expectedResponse = "{\"data\":{\"tableExport\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9265d\","
                         + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"CSV\","
-                        + "\"result\":{\"url\":\"https://elide.io/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d\",\"httpStatus\":200,\"recordCount\":1}}}]}}}";
+                        + "\"result\":{\"url\":\"https://elide.io/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d.csv\",\"httpStatus\":200,\"recordCount\":1}}}]}}}";
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
@@ -184,7 +184,7 @@ public class AsyncTest extends IntegrationTest {
             assertEquals("PROCESSING", outputResponse, "Async Query has failed.");
         }
         when()
-                .get("/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d")
+                .get("/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d.csv")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
     }
@@ -235,7 +235,7 @@ public class AsyncTest extends IntegrationTest {
                         .body("data.attributes.status", equalTo("COMPLETE"))
                         .body("data.attributes.result.message", equalTo(null))
                         .body("data.attributes.result.url",
-                                equalTo("https://elide.io" + "/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d"));
+                                equalTo("https://elide.io" + "/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d.csv"));
 
                 // Validate GraphQL Response
                 String responseGraphQL = given()
@@ -250,7 +250,7 @@ public class AsyncTest extends IntegrationTest {
 
                 String expectedResponse = "{\"data\":{\"tableExport\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\","
                         + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"CSV\","
-                        + "\"result\":{\"url\":\"https://elide.io/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d\",\"httpStatus\":200,\"recordCount\":2}}}]}}}";
+                        + "\"result\":{\"url\":\"https://elide.io/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d.csv\",\"httpStatus\":200,\"recordCount\":2}}}]}}}";
 
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
@@ -258,7 +258,7 @@ public class AsyncTest extends IntegrationTest {
             assertEquals("PROCESSING", outputResponse, "Async Query has failed.");
         }
         when()
-                .get("/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d")
+                .get("/export/ba31ca4e-ed8f-4be0-a0f3-12088fa9264d.csv")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -26,6 +26,7 @@ elide:
     export:
       enabled: true
       path: /export
+      extensionEnabled: true
   dynamic-config:
     path: src/test/resources/configs
     enabled: true

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -165,7 +165,8 @@ public class ElideResourceConfig extends ResourceConfig {
 
                 ResultStorageEngine resultStorageEngine = asyncProperties.getResultStorageEngine();
                 if (resultStorageEngine == null) {
-                    resultStorageEngine = new FileResultStorageEngine(asyncProperties.getStorageDestination());
+                    resultStorageEngine = new FileResultStorageEngine(asyncProperties.getStorageDestination(),
+                            asyncProperties.enableExtension());
                 }
                 bind(resultStorageEngine).to(ResultStorageEngine.class).named("resultStorageEngine");
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneAsyncSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneAsyncSettings.java
@@ -118,6 +118,16 @@ public interface ElideStandaloneAsyncSettings {
     }
 
     /**
+     * Enable the addition of extensions to Export attachments.
+     * If false, the attachments will be downloaded without extensions.
+     *
+     * @return Default: False
+     */
+    default boolean enableExtension() {
+        return false;
+    }
+
+    /**
      * Skip generating Header when exporting in CSV format.
      *
      * @return Default: False


### PR DESCRIPTION
Resolves #2451  (if appropriate)

## Description
Add file extension support to Table Export. Alternative Approach to #2453

## Motivation and Context
See #2451 and #2437

## How Has This Been Tested?
Existing test cases and new test cases.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
