### PR TITLE
Make CacheKey Unique for same model name across namespaces

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -76,6 +76,7 @@ import javax.persistence.Id;
 public class TableType implements Type<DynamicModelInstance> {
     public static final Pattern REFERENCE_PARENTHESES = Pattern.compile("\\{\\{(.+?)}}");
     private static final String SPACE = " ";
+    private static final String PERIOD = ".";
     public static final Pattern NEWLINE = Pattern.compile(System.lineSeparator(), Pattern.LITERAL);
 
     protected Table table;
@@ -96,7 +97,7 @@ public class TableType implements Type<DynamicModelInstance> {
 
     @Override
     public String getCanonicalName() {
-        return getName();
+        return getPackage().getName().concat(PERIOD).concat(getName());
     }
 
     @Override

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/cache/QueryKeyExtractorTest.java
@@ -14,15 +14,23 @@ import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.request.Sorting;
 import com.yahoo.elide.core.sort.SortingImpl;
 import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.datastores.aggregation.dynamic.NamespacePackage;
+import com.yahoo.elide.datastores.aggregation.dynamic.TableType;
 import com.yahoo.elide.datastores.aggregation.framework.SQLUnitTest;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Namespace;
 import com.yahoo.elide.datastores.aggregation.query.ImmutablePagination;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
+import com.yahoo.elide.modelconfig.model.Dimension;
+import com.yahoo.elide.modelconfig.model.NamespaceConfig;
+import com.yahoo.elide.modelconfig.model.Table;
+import com.yahoo.elide.modelconfig.model.Type;
+
 import example.PlayerStats;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -79,6 +87,108 @@ public class QueryKeyExtractorTest {
                         + "{example.PlayerStats;{{example.PlayerStats;java.lang.String;playerName;}}asc;}" // sort
                         + "{0;2;1;}", // pagination
                 QueryKeyExtractor.extractKey(query));
+    }
+
+    @Test
+    public void testDuplicateFullQuery() throws Exception {
+        // Build 1st Table
+        NamespaceConfig testNamespace = NamespaceConfig.builder()
+                .name("namespace1")
+                .build();
+        NamespacePackage testNamespacePackage = new NamespacePackage(testNamespace);
+
+        Table testTable = Table.builder()
+                .cardinality("medium")
+                .description("A test table")
+                .friendlyName("foo")
+                .table("table1")
+                .name("Table")
+                .schema("db1")
+                .category("category1")
+                .readAccess("Admin")
+                .dbConnectionName("dbConn")
+                .isFact(true)
+                .filterTemplate("a==b")
+                .namespace("namespace1")
+                .dimension(Dimension.builder()
+                        .name("dim1")
+                        .definition("{{dim1}}")
+                        .type(Type.BOOLEAN)
+                        .values(Collections.EMPTY_SET)
+                        .tags(Collections.EMPTY_SET)
+                        .build())
+                .build();
+        TableType testType = new TableType(testTable, testNamespacePackage);
+        dictionary.bindEntity(testType);
+
+        SQLTable testSqlTable = new SQLTable(new Namespace(testNamespacePackage) , testType, dictionary);
+
+        // Build 2nd Table
+        NamespaceConfig anotherTestNamespace = NamespaceConfig.builder()
+                .name("namespace2")
+                .build();
+        NamespacePackage anotherTestNamespacePackage = new NamespacePackage(anotherTestNamespace);
+
+        Table anotherTestTable = Table.builder() // Exactly same as testTable but different namespace
+                .cardinality("medium")
+                .description("A test table")
+                .friendlyName("foo")
+                .table("table1")
+                .name("Table")
+                .schema("db1")
+                .category("category1")
+                .readAccess("Admin")
+                .dbConnectionName("dbConn")
+                .isFact(true)
+                .filterTemplate("a==b")
+                .namespace("namespace2")
+                .dimension(Dimension.builder()
+                        .name("dim1")
+                        .definition("{{dim1}}")
+                        .type(Type.BOOLEAN)
+                        .values(Collections.EMPTY_SET)
+                        .tags(Collections.EMPTY_SET)
+                        .build())
+                .build();
+        TableType anotherTestType = new TableType(anotherTestTable, anotherTestNamespacePackage);
+        dictionary.bindEntity(anotherTestType);
+
+        SQLTable anotherTestSqlTable = new SQLTable(new Namespace(anotherTestNamespacePackage) , anotherTestType, dictionary);
+
+        // Build Query and Test
+        Query query = Query.builder()
+                .source(testSqlTable)
+                .dimensionProjection(testSqlTable.getDimensionProjection("dim1"))
+                .pagination(new ImmutablePagination(0, 2, false, true))
+                .build();
+
+        assertEquals("namespace1_Table;" // table name
+                        + "{}" // metrics
+                        + "{dim1;{}}" // Group by
+                        + "{}" // time dimensions
+                        + ";" // where
+                        + ";" // having
+                        + ";" // sort
+                        + "{0;2;1;}", // pagination
+                QueryKeyExtractor.extractKey(query));
+
+        Query anotherQuery = Query.builder()
+                .source(anotherTestSqlTable)
+                .dimensionProjection(anotherTestSqlTable.getDimensionProjection("dim1"))
+                .pagination(new ImmutablePagination(0, 2, false, true))
+                .build();
+
+        assertEquals("namespace2_Table;" // table name
+                        + "{}" // metrics
+                        + "{dim1;{}}" // Group by
+                        + "{}" // time dimensions
+                        + ";" // where
+                        + ";" // having
+                        + ";" // sort
+                        + "{0;2;1;}", // pagination
+                QueryKeyExtractor.extractKey(anotherQuery));
+
+        assertNotEquals(QueryKeyExtractor.extractKey(anotherQuery), QueryKeyExtractor.extractKey(query));
     }
 
     @Test


### PR DESCRIPTION
## Description
Make Cachekey Unique for Same Hjson model name across namespaces

## Motivation and Context
There are use cases of the same model name across diff namespaces that have exact same definition. We pull incorrect results from cache cos of that.

## How Has This Been Tested?
Existing and New Test cases.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
