### PR TITLE
use alias to get column projection in query plan translator and while nesting projection

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryPlanTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/QueryPlanTranslator.java
@@ -171,7 +171,7 @@ public class QueryPlanTranslator implements QueryVisitor<Query.QueryBuilder> {
                 directReferencedColumns.stream(),
                 indirectReferenceColumns.stream()
         ).forEach(column -> {
-            if (query.getColumnProjection(column.getName(), column.getArguments()) == null) {
+            if (query.getColumnProjection(column.getAlias(), column.getArguments()) == null) {
                 builder.column(column.withProjected(false));
             }
         });

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLColumnProjection.java
@@ -111,7 +111,7 @@ public interface SQLColumnProjection extends ColumnProjection {
 
         boolean requiresJoin = requiresJoin(references);
 
-        boolean inProjection = source.getColumnProjection(getName(), getArguments(), true) != null;
+        boolean inProjection = source.getColumnProjection(getAlias(), getArguments(), true) != null;
 
         ColumnProjection outerProjection;
         Set<ColumnProjection> innerProjections;

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLMetricProjection.java
@@ -165,7 +165,7 @@ public class SQLMetricProjection implements MetricProjection, SQLColumnProjectio
                         + dialect.getEndQuote()
                         + "?", "{{\\$" + "$1" + "}}");
 
-        boolean inProjection = source.getColumnProjection(name, arguments, true) != null;
+        boolean inProjection = source.getColumnProjection(getAlias(), arguments, true) != null;
 
         ColumnProjection outerProjection = SQLMetricProjection.builder()
                 .projected(inProjection)

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/query/SQLTimeDimensionProjection.java
@@ -104,7 +104,7 @@ public class SQLTimeDimensionProjection implements SQLColumnProjection, TimeDime
 
         boolean requiresJoin = SQLColumnProjection.requiresJoin(references);
 
-        boolean inProjection = source.getColumnProjection(getName(), getArguments(), true) != null;
+        boolean inProjection = source.getColumnProjection(getAlias(), getArguments(), true) != null;
 
         ColumnProjection outerProjection;
         Set<ColumnProjection> innerProjections;

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.SQLQueryEngine;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialectFactory;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.query.AggregateBeforeJoinOptimizer;
 import com.yahoo.elide.datastores.jpa.JpaDataStore;
 import com.yahoo.elide.datastores.jpa.transaction.NonJtaTransaction;
 import com.yahoo.elide.datastores.multiplex.MultiplexManager;
@@ -23,6 +24,7 @@ import com.yahoo.elide.modelconfig.validator.DynamicConfigValidator;
 import org.hibernate.Session;
 import lombok.AllArgsConstructor;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -68,7 +70,8 @@ public class AggregationDataStoreTestHarness implements DataStoreTestHarness {
         AggregationDataStore aggregationDataStore = aggregationDataStoreBuilder
                 .queryEngine(new SQLQueryEngine(metaDataStore,
                         (name) -> connectionDetailsMap.getOrDefault(name, defaultConnectionDetails),
-                        new HashSet<>(), new DefaultQueryValidator(metaDataStore.getMetadataDictionary())))
+                        new HashSet<>(Arrays.asList(new AggregateBeforeJoinOptimizer(metaDataStore))),
+                        new DefaultQueryValidator(metaDataStore.getMetadataDictionary())))
                 .queryLogger(new Slf4jQueryLogger())
                 .build();
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -49,6 +49,8 @@ import com.yahoo.elide.jsonapi.resources.JsonApiEndpoint;
 import com.yahoo.elide.modelconfig.DBPasswordExtractor;
 import com.yahoo.elide.modelconfig.model.DBConfig;
 import com.yahoo.elide.modelconfig.validator.DynamicConfigValidator;
+import com.yahoo.elide.test.graphql.elements.Arguments;
+
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import example.PlayerStats;
@@ -1718,6 +1720,46 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("byDay", "2019-07-13"),
                                         field("byMonth", "2019-07"),
                                         field("byQuarter", "2019-07")
+                                )
+                        )
+                )
+        ).toResponse();
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
+
+    /**
+     * Check if AggregationBeforeJoinOptimizer works with alias
+     * @throws Exception
+     */
+    @Test
+    public void testJoinBeforeAggregationWithAlias() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "playerStats",
+                                arguments(
+                                        argument("sort", "\"highScore\"")
+                                ),
+                                selections(
+                                        field("highScore"),
+                                        field("countryIsoCode", "countryAlias", Arguments.emptyArgument())
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "playerStats",
+                                selections(
+                                        field("highScore", 1000),
+                                        field("countryAlias", "HKG")
+                                ),
+                                selections(
+                                        field("highScore", 2412),
+                                        field("countryAlias", "USA")
                                 )
                         )
                 )


### PR DESCRIPTION
## Description
Use alias to check if the column is already present in the query. 

## Motivation and Context
The AggregationBeforeJoin optimizer assumes the projectionWithAlias is not found in the query since getColumnProjection returns null for projection name. So the given projection is marked as hidden by the optimizer. 

## How Has This Been Tested?
Integration Test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
