### PR TITLE
Aggregation Store: Fix filter by alias with parameterized metric.

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/DefaultQueryValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/DefaultQueryValidator.java
@@ -69,8 +69,8 @@ public class DefaultQueryValidator implements QueryValidator {
 
                 Predicate<ColumnProjection> filterByNameAndArgs =
                         (column) -> (column.getAlias().equals(projection.getAlias())
-                                || column.getName().equals(projection.getName())
-                                && column.getArguments().equals(projection.getArguments()));
+                                || column.getName().equals(projection.getName()))
+                                && column.getArguments().equals(projection.getArguments());
 
                 //Query by (alias or name) and arguments.   The filter may or may not be using the alias.
                 if (query.getColumnProjection(filterByNameAndArgs) == null) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslator.java
@@ -7,13 +7,10 @@ package com.yahoo.elide.datastores.aggregation;
 
 import static com.yahoo.elide.core.request.Argument.getArgumentMapFromArgumentSet;
 import com.yahoo.elide.core.RequestScope;
-import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.PredicateExtractionVisitor;
-import com.yahoo.elide.core.request.Attribute;
 import com.yahoo.elide.core.request.EntityProjection;
-import com.yahoo.elide.core.request.Relationship;
 import com.yahoo.elide.datastores.aggregation.filter.visitor.FilterConstraints;
 import com.yahoo.elide.datastores.aggregation.filter.visitor.SplitFilterExpressionVisitor;
 import com.yahoo.elide.datastores.aggregation.metadata.models.Dimension;
@@ -47,7 +44,6 @@ public class EntityProjectionTranslator {
     private List<MetricProjection> metrics;
     private FilterExpression whereFilter;
     private FilterExpression havingFilter;
-    private EntityDictionary dictionary;
     private Boolean bypassCache;
     private RequestScope scope;
 
@@ -57,7 +53,6 @@ public class EntityProjectionTranslator {
         this.engine = engine;
         this.queriedTable = table;
         this.entityProjection = entityProjection;
-        this.dictionary = scope.getDictionary();
         this.bypassCache  = bypassCache;
         this.scope = scope;
         dimensionProjections = resolveNonTimeDimensions();
@@ -124,7 +119,7 @@ public class EntityProjectionTranslator {
             if (queriedTable.getMetric(fieldName) != null) {
 
                 //If the query doesn't contain this metric.
-                if (metrics.stream().noneMatch((metric -> metric.getAlias().equals(fieldName)))) {
+                if (metrics.stream().noneMatch((metric -> metric.getName().equals(fieldName)))) {
 
                     //Construct a new projection and add it to the query.
                     MetricProjection havingMetric = engine.constructMetricProjection(
@@ -201,33 +196,5 @@ public class EntityProjectionTranslator {
                         attribute.getAlias(),
                         getArgumentMapFromArgumentSet(attribute.getArguments())))
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Gets relationship names from {@link EntityProjection}.
-     * @return relationships list of {@link Relationship} names
-     */
-    private Set<String> getRelationships() {
-        return entityProjection.getRelationships().stream()
-                .map(Relationship::getName).collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
-     * Gets attribute names from {@link EntityProjection}.
-     * @return relationships list of {@link Attribute} names
-     */
-    private Set<String> getAttributes() {
-        return entityProjection.getAttributes().stream()
-                .map(Attribute::getName).collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    /**
-     * Helper method to get all field names from the {@link EntityProjection}.
-     * @return allFields set of all field names
-     */
-    private Set<String> getAllFields() {
-        Set<String> allFields = getAttributes();
-        allFields.addAll(getRelationships());
-        return allFields;
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -99,6 +100,17 @@ public interface Queryable {
     default ColumnProjection getColumnProjection(String name, Map<String, Argument> arguments) {
         return getColumnProjections().stream()
                 .filter(dim -> dim.getAlias().equals(name) && dim.getArguments().equals(arguments))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Retrieves a column by predicate
+     * @return The column.
+     */
+    default ColumnProjection getColumnProjection(Predicate<ColumnProjection> filterPredicate) {
+        return getColumnProjections().stream()
+                .filter(filterPredicate)
                 .findFirst()
                 .orElse(null);
     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/Queryable.java
@@ -105,7 +105,8 @@ public interface Queryable {
     }
 
     /**
-     * Retrieves a column by predicate
+     * Retrieves a column by filter predicate
+     * @param filterPredicate A predicate to search for column projections.
      * @return The column.
      */
     default ColumnProjection getColumnProjection(Predicate<ColumnProjection> filterPredicate) {

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/EntityProjectionTranslatorTest.java
@@ -6,7 +6,6 @@
 package com.yahoo.elide.datastores.aggregation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.filter.dialect.ParseException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
@@ -23,7 +22,6 @@ import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.query.TimeDimensionProjection;
 import example.PlayerStats;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -56,11 +54,6 @@ public class EntityProjectionTranslatorTest extends SQLUnitTest {
     @BeforeAll
     public static void init() {
         SQLUnitTest.init();
-    }
-
-    @BeforeEach
-    public void setUp() {
-        when(scope.getDictionary()).thenReturn(dictionary);
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -380,6 +380,40 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
     }
 
     @Test
+    public void parameterizedGraphQLFilterTest() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "SalesNamespace_orderDetails",
+                                arguments(
+                                        argument("filter", "\"orderRatio[numerator:orderMax][denominator:orderMax]>=.5;deliveryTime>='2020-01-01';deliveryTime<'2020-12-31'\"")
+                                ),
+                                selections(
+                                        field("orderRatio", "ratio1", arguments(
+                                                argument("numerator", "\"orderMax\""),
+                                                argument("denominator", "\"orderMax\"")
+                                        ))
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "SalesNamespace_orderDetails",
+                                selections(
+                                        field("ratio1", 1.0)
+                                )
+                        )
+                )
+        ).toResponse();
+
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
+
+    @Test
     public void parameterizedGraphQLColumnTest() throws Exception {
         String graphQLRequest = document(
                 selection(

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -448,6 +448,41 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
     }
 
     @Test
+    public void parameterizedGraphQLSortWithAliasTest() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "SalesNamespace_orderDetails",
+                                arguments(
+                                        argument("filter", "\"deliveryTime>='2020-01-01';deliveryTime<'2020-12-31'\""),
+                                        argument("sort", "\"ratio1\"")
+                                ),
+                                selections(
+                                        field("orderRatio", "ratio1", arguments(
+                                                argument("numerator", "\"orderMax\""),
+                                                argument("denominator", "\"orderMax\"")
+                                        ))
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "SalesNamespace_orderDetails",
+                                selections(
+                                        field("ratio1", 1.0)
+                                )
+                        )
+                )
+        ).toResponse();
+
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
+
+    @Test
     public void parameterizedGraphQLColumnTest() throws Exception {
         String graphQLRequest = document(
                 selection(

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -380,13 +380,47 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
     }
 
     @Test
-    public void parameterizedGraphQLFilterTest() throws Exception {
+    public void parameterizedGraphQLFilterNoAliasTest() throws Exception {
         String graphQLRequest = document(
                 selection(
                         field(
                                 "SalesNamespace_orderDetails",
                                 arguments(
                                         argument("filter", "\"orderRatio[numerator:orderMax][denominator:orderMax]>=.5;deliveryTime>='2020-01-01';deliveryTime<'2020-12-31'\"")
+                                ),
+                                selections(
+                                        field("orderRatio", "ratio1", arguments(
+                                                argument("numerator", "\"orderMax\""),
+                                                argument("denominator", "\"orderMax\"")
+                                        ))
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "SalesNamespace_orderDetails",
+                                selections(
+                                        field("ratio1", 1.0)
+                                )
+                        )
+                )
+        ).toResponse();
+
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
+
+    @Test
+    public void parameterizedGraphQLFilterWithAliasTest() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "SalesNamespace_orderDetails",
+                                arguments(
+                                        argument("filter", "\"ratio1>=.5;deliveryTime>='2020-01-01';deliveryTime<'2020-12-31'\"")
                                 ),
                                 selections(
                                         field("orderRatio", "ratio1", arguments(

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
@@ -105,7 +105,6 @@ public abstract class GraphQLIntegrationTest extends IntegrationTest {
                 .header("ApiVersion", apiVersion)
                 .post("/graphQL")
                 .then()
-                .log().all()
                 .statusCode(HttpStatus.SC_OK);
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/GraphQLIntegrationTest.java
@@ -105,6 +105,7 @@ public abstract class GraphQLIntegrationTest extends IntegrationTest {
                 .header("ApiVersion", apiVersion)
                 .post("/graphQL")
                 .then()
+                .log().all()
                 .statusCode(HttpStatus.SC_OK);
     }
 


### PR DESCRIPTION
## Description

There was a bug where the aggregation store was rejecting queries (as invalid) because it could not pair up a measure in the query (with an alias) with a filter predicate on the same measure (with or without the alias). 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
