### PR TITLE
Test Case Fix after H2 version upgrade

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTest.java
@@ -26,7 +26,7 @@ public class IntegrationTest {
 
     @BeforeAll
     public void setUp() {
-        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+        TimeZone.setDefault(TimeZone.getTimeZone(System.getProperty("user.timezone")));
         RestAssured.port = port;
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTest.java
@@ -26,7 +26,7 @@ public class IntegrationTest {
 
     @BeforeAll
     public void setUp() {
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
         RestAssured.port = port;
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }


### PR DESCRIPTION
## Description
Change JVM TZ for spring test cases

## Motivation and Context
With latest H2 upgrade, the test case results were not consistent if JVM TZ is different than OS timezone.

## How Has This Been Tested?
existing test should pass now,

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
