### PR TITLE
Redis Result Storage Engine

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 6.0.7
+**Fixes**
+   * [view commit](https://github.com/yahoo/elide/commit/7a3552d76f8887ab62a60a968412ca442bf745a1) make getColumnProjection() method use different name for column Id for different source when alias are involved (#2500) 
+   * [view commit](https://github.com/yahoo/elide/commit/4c9bff306e4d0d0f9644c705a241edc7104cc1fe) Bump h2 from 2.0.202 to 2.0.206 (#2476) 
+
 ## 6.0.6
 **Features**
    * [view commit](https://github.com/yahoo/elide/commit/4caaae234214edf6a61bea57531de79520604d54) File Extension Support for Export Attachments (#2475) 

--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -80,6 +80,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>4.0.1</version>
+        </dependency>
+
         <!-- Test -->
         <!-- For Export End-Point Test -->
         <dependency>

--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -87,6 +87,12 @@
         </dependency>
 
         <!-- Test -->
+        <dependency>
+            <groupId>com.github.codemonstur</groupId>
+            <artifactId>embedded-redis</artifactId>
+            <version>0.11.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- For Export End-Point Test -->
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/TableExportOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/TableExportOperation.java
@@ -103,7 +103,11 @@ public abstract class TableExportOperation implements Callable<AsyncAPIResult> {
             Observable<String> interimResults = concatStringWithObservable(preResult, results, true);
             Observable<String> finalResults = concatStringWithObservable(postResult, interimResults, false);
 
-            storeResults(exportObj, engine, finalResults);
+            TableExportResult result = storeResults(exportObj, engine, finalResults);
+
+            if (result != null && result.getMessage() != null) {
+                throw new IllegalStateException(result.getMessage());
+            }
 
             exportResult.setUrl(new URL(generateDownloadURL(exportObj, scope)));
             exportResult.setRecordCount(recordNumber);
@@ -171,9 +175,9 @@ public abstract class TableExportOperation implements Callable<AsyncAPIResult> {
      * @param exportObj TableExport type object.
      * @param resultStorageEngine ResultStorageEngine instance.
      * @param result Observable of String Results to store.
-     * @return TableExport object.
+     * @return TableExportResult object.
      */
-    protected TableExport storeResults(TableExport exportObj, ResultStorageEngine resultStorageEngine,
+    protected TableExportResult storeResults(TableExport exportObj, ResultStorageEngine resultStorageEngine,
             Observable<String> result) {
         return resultStorageEngine.storeResults(exportObj, result);
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngine.java
@@ -36,6 +36,7 @@ public class FileResultStorageEngine implements ResultStorageEngine {
     /**
      * Constructor.
      * @param basePath basePath for storing the files. Can be absolute or relative.
+     * @param enableExtension Enable file extensions.
      */
     public FileResultStorageEngine(String basePath, boolean enableExtension) {
         this.basePath = basePath;

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.async.service.storageengine;
+
+import com.yahoo.elide.async.models.TableExport;
+import io.reactivex.Observable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import javax.inject.Singleton;
+
+/**
+ * Implementation of ResultStorageEngine that stores results on Redis Cluster.
+ * It supports Async Module to store results with Table Export query.
+ */
+@Singleton
+@Slf4j
+@Getter
+public class RedisResultStorageEngine implements ResultStorageEngine {
+    @Setter private JedisPool jedisPool;
+    @Setter private boolean enableExtension;
+    @Setter private long expirationSeconds;
+
+    /**
+     * Constructor.
+     * @param jedisPool Jedis Connection Pool to Redis clusteer.
+     * @param enableExtension Enable file extensions.
+     * @param expirationSeconds Expiration Time for results on Redis.
+     */
+    public RedisResultStorageEngine(JedisPool jedisPool, boolean enableExtension, long expirationSeconds) {
+        this.jedisPool = jedisPool;
+        this.enableExtension = enableExtension;
+    }
+
+    @Override
+    public TableExport storeResults(TableExport tableExport, Observable<String> result) {
+        log.debug("store TableExportResults for Download");
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            result
+                .map(record -> record.concat(System.lineSeparator()))
+                .subscribe(
+                        recordCharArray -> {
+                            jedis.rpush(tableExport.getId(), recordCharArray);
+                        },
+                        throwable -> {
+                            throw new IllegalStateException(STORE_ERROR, throwable);
+                        }
+                );
+            jedis.expire(tableExport.getId(), expirationSeconds);
+        } catch (Exception e) {
+            throw new IllegalStateException(STORE_ERROR, e);
+        }
+
+        return tableExport;
+    }
+
+    @Override
+    public Observable<String> getResultsByID(String tableExportID) {
+        log.debug("getTableExportResultsByID");
+        
+        try (Jedis jedis = jedisPool.getResource()) {
+            long recordCount = jedis.llen(tableExportID);
+
+            if (recordCount == 0) {
+            	throw new IllegalStateException(RETRIEVE_ERROR);
+            } else {
+                return Observable.fromIterable(() -> jedis.lrange(tableExportID, 0, -1).iterator());
+            }
+        }
+
+        /* Alternative approach to go through list one by one.
+        
+        // Workaround for Local variable defined in an enclosing scope must be final or effectively final -> use Array.
+
+        long[] recordRead = {0};
+        long[] recordCount = {0};
+
+        try (Jedis jedis = jedisPool.getResource()) {
+            recordCount[0] = jedis.llen(tableExportID);
+            if (recordCount[0] == 0) {
+                throw new IllegalStateException(RETRIEVE_ERROR);
+            }
+        }
+
+        return Observable.using(
+                () -> jedisPool.getResource(),
+                jedis -> Observable.fromIterable(() -> new Iterator<String>() {
+                    @Override
+                    public boolean hasNext() {
+                            return recordRead[0] < recordCount[0];
+                    }
+
+                    @Override
+                    public String next() {
+                        long readCount = recordRead[0];
+                        String record = jedis.lindex(tableExportID, readCount++);
+                        recordRead[0] = readCount;
+                        return record;
+                    }
+                }),
+                Jedis::close);
+        */
+    }
+
+    @Override
+    public boolean isExtensionEnabled() {
+        return this.enableExtension;
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
@@ -35,7 +35,7 @@ public class RedisResultStorageEngine implements ResultStorageEngine {
 
     /**
      * Constructor.
-     * @param jedisPool Jedis Connection Pool to Redis clusteer.
+     * @param jedis Jedis Connection Pool to Redis clusteer.
      * @param enableExtension Enable file extensions.
      * @param expirationSeconds Expiration Time for results on Redis.
      * @param batchSize Batch Size for retrieving from Redis.

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
@@ -101,16 +101,15 @@ public class RedisResultStorageEngine implements ResultStorageEngine {
 
                         Iterator<String> itr = jedis.lrange(tableExportID, recordRead[0], end).iterator();
 
+                        // Combine the list into a single string.
                         while (itr.hasNext()) {
                             String str = itr.next();
                             record.append(str).append(System.lineSeparator());
                         }
                         recordRead[0] = recordRead[0] + BATCH_SIZE;
 
-                        if (recordRead[0] > recordCount) {
-                            return record.substring(0, record.length() - 1);
-                        }
-                        return record.toString();
+                        // Removing the last line separator because ExportEndPoint will add 1 more.
+                        return record.substring(0, record.length() - System.lineSeparator().length());
                     }
                 });
             }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
@@ -9,8 +9,6 @@ package com.yahoo.elide.async.service.storageengine;
 import com.yahoo.elide.async.models.FileExtensionType;
 import com.yahoo.elide.async.models.TableExport;
 
-import org.apache.commons.lang3.StringUtils;
-
 import io.reactivex.Observable;
 import lombok.Getter;
 import lombok.Setter;
@@ -94,7 +92,7 @@ public class RedisResultStorageEngine implements ResultStorageEngine {
                     }
                     @Override
                     public String next() {
-                        String record = StringUtils.EMPTY;
+                        StringBuilder record = new StringBuilder();
                         long end = recordRead[0] + BATCH_SIZE - 1;
 
                         if (end >= recordCount) {
@@ -105,14 +103,14 @@ public class RedisResultStorageEngine implements ResultStorageEngine {
 
                         while (itr.hasNext()) {
                             String str = itr.next();
-                            record = record.concat(str).concat(System.lineSeparator());
+                            record.append(str).append(System.lineSeparator());
                         }
                         recordRead[0] = recordRead[0] + BATCH_SIZE;
 
                         if (recordRead[0] > recordCount) {
-                            record = record.substring(0, record.length() - 1);
+                            return record.substring(0, record.length() - 1);
                         }
-                        return record;
+                        return record.toString();
                     }
                 });
             }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
@@ -8,6 +8,9 @@ package com.yahoo.elide.async.service.storageengine;
 
 import com.yahoo.elide.async.models.FileExtensionType;
 import com.yahoo.elide.async.models.TableExport;
+
+import org.apache.commons.lang3.StringUtils;
+
 import io.reactivex.Observable;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,12 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
-import java.time.Instant;
 import java.util.Iterator;
 
 import javax.inject.Singleton;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * Implementation of ResultStorageEngine that stores results on Redis Cluster.
@@ -77,14 +77,15 @@ public class RedisResultStorageEngine implements ResultStorageEngine {
     @Override
     public Observable<String> getResultsByID(String tableExportID) {
         log.debug("getTableExportResultsByID");
-        
+
         try (Jedis jedis = jedisPool.getResource()) {
             long recordCount = jedis.llen(tableExportID);
 
             if (recordCount == 0) {
                 throw new IllegalStateException(RETRIEVE_ERROR);
             } else {
-                // Workaround for Local variable defined in an enclosing scope must be final or effectively final -> use Array.
+                // Workaround for Local variable defined in an enclosing scope must be final or effectively final;
+                // use Array.
                 long[] recordRead = {0};
                 return Observable.fromIterable(() -> new Iterator<String>() {
                     @Override
@@ -94,7 +95,7 @@ public class RedisResultStorageEngine implements ResultStorageEngine {
                     @Override
                     public String next() {
                         String record = StringUtils.EMPTY;
-                        long end = recordRead[0] + BATCH_SIZE -1;
+                        long end = recordRead[0] + BATCH_SIZE - 1;
 
                         if (end >= recordCount) {
                             end = recordCount - 1;
@@ -108,8 +109,8 @@ public class RedisResultStorageEngine implements ResultStorageEngine {
                         }
                         recordRead[0] = recordRead[0] + BATCH_SIZE;
 
-                        if(recordRead[0] > recordCount) {
-                            record = record.substring(0, record.length()-1);
+                        if (recordRead[0] > recordCount) {
+                            record = record.substring(0, record.length() - 1);
                         }
                         return record;
                     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, Yahoo Inc.
+ * Copyright 2022, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/ResultStorageEngine.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/storageengine/ResultStorageEngine.java
@@ -7,6 +7,8 @@
 package com.yahoo.elide.async.service.storageengine;
 
 import com.yahoo.elide.async.models.TableExport;
+import com.yahoo.elide.async.models.TableExportResult;
+
 import io.reactivex.Observable;
 
 /**
@@ -20,9 +22,9 @@ public interface ResultStorageEngine {
      * Stores the result of the query.
      * @param tableExport TableExport object
      * @param result is the observable result obtained by running the query
-     * @return String to store as attachment. Can be null.
+     * @return TableExportResult.
      */
-    public TableExport storeResults(TableExport tableExport, Observable<String> result);
+    public TableExportResult storeResults(TableExport tableExport, Observable<String> result);
 
     /**
      * Searches for the async query results by ID and returns the record.

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
@@ -26,17 +26,17 @@ public class RedisResultStorageEngineTest {
     private static final int PORT = 6379;
     private JedisPool jedisPool;
     private RedisServer redisServer;
-    
+
     @BeforeEach
     public void setup() throws IOException {
-    	redisServer = new RedisServer(PORT);
-    	redisServer.start();
-    	jedisPool = new JedisPool("localhost", PORT);
+        redisServer = new RedisServer(PORT);
+        redisServer.start();
+        jedisPool = new JedisPool("localhost", PORT);
     }
 
     @AfterEach
     public void destroy() throws IOException {
-    	redisServer.stop();
+        redisServer.stop();
     }
 
     @Test
@@ -75,7 +75,7 @@ public class RedisResultStorageEngineTest {
     // Redis server does not exist.
     @Test
     public void testStoreResultsFail() throws IOException {
-    	destroy();
+        destroy();
         assertThrows(IllegalStateException.class, () ->
                 storeResults("store_results_fail",
                         Observable.fromArray(new String[]{"hi", "hello"}))
@@ -83,7 +83,7 @@ public class RedisResultStorageEngineTest {
     }
 
     private String readResults(String queryId) {
-    	RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, false, 120);
+        RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, false, 120);
 
         return engine.getResultsByID(queryId).collect(() -> new StringBuilder(),
                 (resultBuilder, tempResult) -> {

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
@@ -23,7 +23,10 @@ import java.io.IOException;
  * Test cases for RedisResultStorageEngine.
  */
 public class RedisResultStorageEngineTest {
+    private static final String HOST = "localhost";
     private static final int PORT = 6379;
+    private static final int EXPIRATION_SECONDS = 120;
+    private static final boolean EXTENSION_SUPPORT = false;
     private JedisPool jedisPool;
     private RedisServer redisServer;
 
@@ -31,7 +34,7 @@ public class RedisResultStorageEngineTest {
     public void setup() throws IOException {
         redisServer = new RedisServer(PORT);
         redisServer.start();
-        jedisPool = new JedisPool("localhost", PORT);
+        jedisPool = new JedisPool(HOST, PORT);
     }
 
     @AfterEach
@@ -83,7 +86,7 @@ public class RedisResultStorageEngineTest {
     }
 
     private String readResults(String queryId) {
-        RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, false, 120);
+        RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, EXTENSION_SUPPORT, EXPIRATION_SECONDS);
 
         return engine.getResultsByID(queryId).collect(() -> new StringBuilder(),
                 (resultBuilder, tempResult) -> {
@@ -96,7 +99,7 @@ public class RedisResultStorageEngineTest {
     }
 
     private void storeResults(String queryId, Observable<String> storable) {
-        RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, false, 120);
+        RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, EXTENSION_SUPPORT, EXPIRATION_SECONDS);
         TableExport query = new TableExport();
         query.setId(queryId);
 

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
@@ -15,7 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import io.reactivex.Observable;
 import io.reactivex.observers.TestObserver;
-import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.embedded.RedisServer;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class RedisResultStorageEngineTest {
     private static final int EXPIRATION_SECONDS = 120;
     private static final int BATCH_SIZE = 2;
     private static final boolean EXTENSION_SUPPORT = false;
-    private JedisPool jedisPool;
+    private JedisPooled jedisPool;
     private RedisServer redisServer;
     RedisResultStorageEngine engine;
 
@@ -39,7 +40,7 @@ public class RedisResultStorageEngineTest {
     public void setup() throws IOException {
         redisServer = new RedisServer(PORT);
         redisServer.start();
-        jedisPool = new JedisPool(HOST, PORT);
+        jedisPool = new JedisPooled(HOST, PORT);
         engine = new RedisResultStorageEngine(jedisPool, EXTENSION_SUPPORT, EXPIRATION_SECONDS, BATCH_SIZE);
     }
 
@@ -83,7 +84,7 @@ public class RedisResultStorageEngineTest {
     @Test
     public void testStoreResultsFail() throws IOException {
         destroy();
-        assertThrows(IllegalStateException.class, () ->
+        assertThrows(JedisConnectionException.class, () ->
                 storeResults("store_results_fail",
                         Observable.fromArray(new String[]{"hi", "hello"}))
         );

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service.storageengine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.yahoo.elide.async.models.TableExport;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import io.reactivex.Observable;
+import redis.clients.jedis.JedisPool;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+/**
+ * Test cases for RedisResultStorageEngine.
+ */
+public class RedisResultStorageEngineTest {
+    private static final int PORT = 6379;
+    private JedisPool jedisPool;
+    private RedisServer redisServer;
+    
+    @BeforeEach
+    public void setup() throws IOException {
+    	redisServer = new RedisServer(PORT);
+    	redisServer.start();
+    	jedisPool = new JedisPool("localhost", PORT);
+    }
+
+    @AfterEach
+    public void destroy() throws IOException {
+    	redisServer.stop();
+    }
+
+    @Test
+    public void testReadNonExistent() {
+        assertThrows(IllegalStateException.class, () ->
+                readResults("nonexisting_results")
+        );
+    }
+
+    @Test
+    public void testStoreEmptyResults() {
+        String queryId = "store_empty_results_success";
+        String validOutput = "";
+        String[] input = validOutput.split("\n");
+
+        storeResults(queryId, Observable.fromArray(input));
+
+        // verify contents of stored files are readable and match original
+        String finalResult = readResults(queryId);
+        assertEquals(validOutput, finalResult);
+    }
+
+    @Test
+    public void testStoreResults() {
+        String queryId = "store_results_success";
+        String validOutput = "hi\nhello";
+        String[] input = validOutput.split("\n");
+
+        storeResults(queryId, Observable.fromArray(input));
+
+        // verify contents of stored files are readable and match original
+        String finalResult = readResults(queryId);
+        assertEquals(validOutput, finalResult);
+    }
+
+    // Redis server does not exist.
+    @Test
+    public void testStoreResultsFail() throws IOException {
+    	destroy();
+        assertThrows(IllegalStateException.class, () ->
+                storeResults("store_results_fail",
+                        Observable.fromArray(new String[]{"hi", "hello"}))
+        );
+    }
+
+    private String readResults(String queryId) {
+    	RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, false, 120);
+
+        return engine.getResultsByID(queryId).collect(() -> new StringBuilder(),
+                (resultBuilder, tempResult) -> {
+                    if (resultBuilder.length() > 0) {
+                        resultBuilder.append(System.lineSeparator());
+                    }
+                    resultBuilder.append(tempResult);
+                }
+            ).map(StringBuilder::toString).blockingGet();
+    }
+
+    private void storeResults(String queryId, Observable<String> storable) {
+        RedisResultStorageEngine engine = new RedisResultStorageEngine(jedisPool, false, 120);
+        TableExport query = new TableExport();
+        query.setId(queryId);
+
+        engine.storeResults(query, storable);
+    }
+}

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, Yahoo Inc.
+ * Copyright 2022, Yahoo Inc.
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */


### PR DESCRIPTION
## Description
Adds an implementation of Redis Result Storage Engine.

## Motivation and Context
In a distributed setup File Result Storage Engine can not be used because it saves the file locally. Using Redis for storing the Export Results in such cases.

## How Has This Been Tested?
New Test Cases.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
