### PR TITLE
Ignoring Elide models embedded in complex attributes

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -2194,6 +2194,9 @@ public class EntityDictionary {
                 //We can't bind an attribute type if Elide can't create it...
                 || ! hasNoArgConstructor
 
+                //We don't bind Elide models as attributes.
+                ||  lookupIncludeClass(type) != null
+
                 //If there is a Serde, we assume the type is opaque to Elide....
                 || serdeLookup.apply(clazz) != null) {
             return false;

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -1112,6 +1112,8 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertTrue(isComplexAttribute(ClassType.of(Book.class), "price"));
         //Test Java Type with no default constructor.
         assertFalse(isComplexAttribute(ClassType.of(Price.class), "currency"));
+        //Test embedded Elide model
+        assertFalse(isComplexAttribute(ClassType.of(Price.class), "book"));
         //Test String
         assertFalse(isComplexAttribute(ClassType.of(Book.class), "title"));
         //Test primitive

--- a/elide-core/src/test/java/example/Price.java
+++ b/elide-core/src/test/java/example/Price.java
@@ -19,4 +19,7 @@ import java.util.Currency;
 public class Price {
     private BigDecimal units;
     private Currency currency;
+
+    //Ignored by Elide....
+    Book book;
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -39,7 +39,6 @@
 
     <properties>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
-        <version.tomcat>9.0.58</version.tomcat>
     </properties>
 
     <dependencies>
@@ -124,13 +123,11 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>${version.tomcat}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${version.tomcat}</version>
             <optional>true</optional>
         </dependency>
 

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -39,6 +39,7 @@
 
     <properties>
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
+        <version.tomcat>9.0.58</version.tomcat>
     </properties>
 
     <dependencies>
@@ -123,11 +124,13 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
+            <version>${version.tomcat}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
+            <version>${version.tomcat}</version>
             <optional>true</optional>
         </dependency>
 

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -42,6 +42,7 @@
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
         <spring.boot.version>2.6.2</spring.boot.version>
         <groovy.version>3.0.9</groovy.version>
+        <tomcat.version>9.0.58</tomcat.version>
     </properties>
 
     <modules>
@@ -51,6 +52,20 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <!-- Version added for CVE-2022-23181 -->
+                <version>${tomcat.version}</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <!-- Version added for CVE-2022-23181 -->
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+                <optional>true</optional>
+            </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-websocket</artifactId>


### PR DESCRIPTION
## Description

Ignored Elide models that are embedded in complex attributes.  Currently, Elide has strange behavior where it sometimes will bind the model as an attribute and later ignore it as an exposed entity.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
