### PR TITLE
Fix graphiql comment bug and config store issues creating multiple files in a single request.

### DIFF
--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -98,6 +98,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
          <dependency>
              <groupId>org.apache.ant</groupId>
              <artifactId>ant</artifactId>

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -116,7 +116,26 @@ public class QueryRunner {
      * @return is a mutation.
      */
     public static boolean isMutation(String query) {
-        return query != null && query.trim().startsWith(MUTATION);
+        if (query == null) {
+            return false;
+        }
+
+        String[] lines = query.split("\n");
+
+        StringBuilder withoutComments = new StringBuilder();
+
+        for (String line : lines) {
+            //Remove GraphiQL comment lines....
+            if (line.matches("^(\\s*)#.*")) {
+                continue;
+            }
+            withoutComments.append(line);
+            withoutComments.append("\n");
+        }
+
+        query = withoutComments.toString().trim();
+
+        return query.startsWith(MUTATION);
     }
 
     /**

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/QueryRunnerTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/QueryRunnerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.graphql;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class QueryRunnerTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "#abcd\nmutation",
+            "#abcd\n\nmutation",
+            "   #abcd\n\nmutation",
+            "#abcd\n  #befd\n mutation",
+            "mutation"
+    })
+    public void testIsMutation(String input) {
+        assertTrue(QueryRunner.isMutation(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "#abcd\n  #befd\n query",
+            "query",
+            "QUERY",
+            "MUTATION",
+            ""
+    })
+    public void testIsNotMutation(String input) {
+        assertFalse(QueryRunner.isMutation(input));
+    }
+
+    @Test
+    public void testNullMutation() {
+        assertFalse(QueryRunner.isMutation(null));
+    }
+}

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/ConfigDataStoreTransaction.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/ConfigDataStoreTransaction.java
@@ -229,8 +229,8 @@ public class ConfigDataStoreTransaction implements DataStoreTransaction {
         File file = createPath.toFile();
 
         if (file.exists()) {
-            log.error("File already exits: {}", file.getPath());
-            throw new IllegalStateException("File already exists: " + file.getPath());
+            log.debug("File already exits: {}", file.getPath());
+            return;
         }
 
         try {

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/models/ConfigFile.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/models/ConfigFile.java
@@ -39,6 +39,7 @@ import javax.persistence.Id;
 @DeletePermission(expression = ConfigChecks.CAN_DELETE_CONFIG)
 @CreatePermission(expression = ConfigChecks.CAN_CREATE_CONFIG)
 public class ConfigFile {
+
     public enum ConfigFileType {
         NAMESPACE,
         TABLE,
@@ -105,12 +106,12 @@ public class ConfigFile {
             return false;
         }
         ConfigFile that = (ConfigFile) o;
-        return id.equals(that.id);
+        return Objects.equals(path, that.path) && Objects.equals(version, that.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(path, version);
     }
 
     public static String toId(String path, String version) {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
@@ -337,6 +337,63 @@ public class ConfigStoreTest {
     }
 
     @Test
+    public void testTwoNamespaceCreationStatements() {
+        String query = "{ \"query\": \" mutation saveChanges {\\n  one: config(op: UPSERT, data: {id:\\\"one\\\", path: \\\"models/namespaces/oneDemoNamespaces.hjson\\\", type: NAMESPACE, content: \\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace2\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"}) {\\n    edges {\\n      node {\\n        id\\n      }\\n    }\\n  }\\n  two: config(op: UPSERT, data: {id: \\\"two\\\", path: \\\"models/namespaces/twoDemoNamespaces.hjson\\\", type: NAMESPACE, content: \\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace3\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"}) {\\n    edges {\\n      node {\\n        id\\n      }\\n    }\\n  }\\n} \" }";
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(query)
+                .when()
+                .post("http://localhost:" + port + "/graphql")
+                .then()
+                .body(equalTo(
+                        GraphQLDSL.document(
+                                selections(
+                                        field(
+                                                "one",
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvb25lRGVtb05hbWVzcGFjZXMuaGpzb24=")
+                                                )
+                                        ),
+                                        field(
+                                                "two",
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvdHdvRGVtb05hbWVzcGFjZXMuaGpzb24=")
+                                                )
+                                        )
+                                )
+                        ).toResponse().replace(" ", "")
+                ))
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        mutation(
+                                selection(
+                                        field("config",
+                                                arguments(
+                                                        argument("op", "DELETE"),
+                                                        argument("ids", "[\\\"bW9kZWxzL25hbWVzcGFjZXMvb25lRGVtb05hbWVzcGFjZXMuaGpzb24=\\\", \\\"bW9kZWxzL25hbWVzcGFjZXMvdHdvRGVtb05hbWVzcGFjZXMuaGpzb24=\\\"]")
+                                                ),
+                                                selections(
+                                                        field("id"),
+                                                        field("path")
+                                                )
+                                        )
+                                )
+                        )
+                ).toQuery() + "\" }")
+                .when()
+                .post("http://localhost:" + port + "/graphql")
+                .then()
+                .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
+                .statusCode(200);
+
+    }
+
+    @Test
     public void testJsonApiCreateFetchAndDelete() {
         String hjson = "{            \n"
                 + "  tables: [{     \n"

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
@@ -259,6 +259,84 @@ public class ConfigStoreTest {
     }
 
     @Test
+    public void testTwoNamespaceCreateAndDelete() {
+        String hjson1 = "\\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace2\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"";
+
+        String hjson2 = "\\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace3\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"";
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        mutation(
+                                selection(
+                                        field("config",
+                                                arguments(
+                                                        argument("op", "UPSERT"),
+                                                        argument("data", String.format("["
+                                                                        + "{ type: NAMESPACE, path: \\\"models/namespaces/namespace2.hjson\\\", content: %s },"
+                                                                        + "{ type: NAMESPACE, path: \\\"models/namespaces/namespace3.hjson\\\", content: %s }"
+                                                                        + "]"
+                                                                , hjson1, hjson2))
+                                                ),
+                                                selections(
+                                                        field("id"),
+                                                        field("path")
+                                                )
+                                        )
+                                )
+                        )
+                ).toQuery() + "\" }")
+                .when()
+                .post("http://localhost:" + port + "/graphql")
+                .then()
+                .body(equalTo(
+                        GraphQLDSL.document(
+                                selection(
+                                        field(
+                                                "config",
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMi5oanNvbg=="),
+                                                        field("path", "models/namespaces/namespace2.hjson")
+                                                ),
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMy5oanNvbg=="),
+                                                        field("path", "models/namespaces/namespace3.hjson")
+                                                )
+                                        )
+                                )
+                        ).toResponse()
+                ))
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        mutation(
+                                selection(
+                                        field("config",
+                                                arguments(
+                                                        argument("op", "DELETE"),
+                                                        argument("ids", "[\\\"bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMi5oanNvbg==\\\", \\\"bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMy5oanNvbg==\\\"]")
+                                                ),
+                                                selections(
+                                                        field("id"),
+                                                        field("path")
+                                                )
+                                        )
+                                )
+                        )
+                ).toQuery() + "\" }")
+                .when()
+                .post("http://localhost:" + port + "/graphql")
+                .then()
+                .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
+                .statusCode(200);
+
+    }
+
+    @Test
     public void testJsonApiCreateFetchAndDelete() {
         String hjson = "{            \n"
                 + "  tables: [{     \n"

--- a/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
@@ -185,6 +185,63 @@ public class ElideStandaloneConfigStoreTest {
     }
 
     @Test
+    public void testTwoNamespaceCreationStatements() {
+        String query = "{ \"query\": \" mutation saveChanges {\\n  one: config(op: UPSERT, data: {id:\\\"one\\\", path: \\\"models/namespaces/oneDemoNamespaces.hjson\\\", type: NAMESPACE, content: \\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace2\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"}) {\\n    edges {\\n      node {\\n        id\\n      }\\n    }\\n  }\\n  two: config(op: UPSERT, data: {id: \\\"two\\\", path: \\\"models/namespaces/twoDemoNamespaces.hjson\\\", type: NAMESPACE, content: \\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace3\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"}) {\\n    edges {\\n      node {\\n        id\\n      }\\n    }\\n  }\\n} \" }";
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(query)
+                .when()
+                .post("/graphql/api/v1")
+                .then()
+                .body(equalTo(
+                        GraphQLDSL.document(
+                                selections(
+                                        field(
+                                                "one",
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvb25lRGVtb05hbWVzcGFjZXMuaGpzb24=")
+                                                )
+                                        ),
+                                        field(
+                                                "two",
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvdHdvRGVtb05hbWVzcGFjZXMuaGpzb24=")
+                                                )
+                                        )
+                                )
+                        ).toResponse().replace(" ", "")
+                ))
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        mutation(
+                                selection(
+                                        field("config",
+                                                arguments(
+                                                        argument("op", "DELETE"),
+                                                        argument("ids", "[\\\"bW9kZWxzL25hbWVzcGFjZXMvb25lRGVtb05hbWVzcGFjZXMuaGpzb24=\\\", \\\"bW9kZWxzL25hbWVzcGFjZXMvdHdvRGVtb05hbWVzcGFjZXMuaGpzb24=\\\"]")
+                                                ),
+                                                selections(
+                                                        field("id"),
+                                                        field("path")
+                                                )
+                                        )
+                                )
+                        )
+                ).toQuery() + "\" }")
+                .when()
+                .post("/graphql/api/v1")
+                .then()
+                .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
+                .statusCode(200);
+
+    }
+
+    @Test
     public void testTwoNamespaceCreateAndDelete() {
         String hjson1 = "\\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace2\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"";
 

--- a/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
@@ -185,6 +185,84 @@ public class ElideStandaloneConfigStoreTest {
     }
 
     @Test
+    public void testTwoNamespaceCreateAndDelete() {
+        String hjson1 = "\\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace2\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"";
+
+        String hjson2 = "\\\"{\\\\n  namespaces:\\\\n  [\\\\n    {\\\\n      name: DemoNamespace3\\\\n      description: Namespace for Demo Purposes\\\\n      friendlyName: Demo Namespace\\\\n    }\\\\n  ]\\\\n}\\\"";
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        mutation(
+                                selection(
+                                        field("config",
+                                                arguments(
+                                                        argument("op", "UPSERT"),
+                                                        argument("data", String.format("["
+                                                                        + "{ type: NAMESPACE, path: \\\"models/namespaces/namespace2.hjson\\\", content: %s },"
+                                                                        + "{ type: NAMESPACE, path: \\\"models/namespaces/namespace3.hjson\\\", content: %s }"
+                                                                + "]"
+                                                                , hjson1, hjson2))
+                                                ),
+                                                selections(
+                                                        field("id"),
+                                                        field("path")
+                                                )
+                                        )
+                                )
+                        )
+                ).toQuery() + "\" }")
+                .when()
+                .post("/graphql/api/v1")
+                .then()
+                .body(equalTo(
+                        GraphQLDSL.document(
+                                selection(
+                                        field(
+                                                "config",
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMi5oanNvbg=="),
+                                                        field("path", "models/namespaces/namespace2.hjson")
+                                                ),
+                                                selections(
+                                                        field("id", "bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMy5oanNvbg=="),
+                                                        field("path", "models/namespaces/namespace3.hjson")
+                                                )
+                                        )
+                                )
+                        ).toResponse()
+                ))
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .body("{ \"query\" : \"" + GraphQLDSL.document(
+                        mutation(
+                                selection(
+                                        field("config",
+                                                arguments(
+                                                        argument("op", "DELETE"),
+                                                        argument("ids", "[\\\"bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMi5oanNvbg==\\\", \\\"bW9kZWxzL25hbWVzcGFjZXMvbmFtZXNwYWNlMy5oanNvbg==\\\"]")
+                                                ),
+                                                selections(
+                                                        field("id"),
+                                                        field("path")
+                                                )
+                                        )
+                                )
+                        )
+                ).toQuery() + "\" }")
+                .when()
+                .post("/graphql/api/v1")
+                .then()
+                .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
+                .statusCode(200);
+
+    }
+
+    @Test
     public void testGraphQLCreateFetchAndDelete() {
         String hjson = "\\\"{\\\\n"
                 + "  tables: [{\\\\n"

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -2,30 +2,15 @@
 <suppressions
     xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
 
-    <!-- Invalid web socket CVE (flagging wrong package) -->
-    <suppress until="2021-12-01Z">
-        <cve>CVE-2020-11050</cve>
-    </suppress>
-
-    <!-- Invalid Spring Security CVE -->
-    <suppress until="2021-12-01Z">
-        <cve>CVE-2018-1258</cve>
-    </suppress>
-
-    <!-- Hibernate 3 CVE errors (only in the legacy hibernate 3 data store).  Use Hibernate 3 at your own risk. -->
-    <suppress until="2031-06-01Z">
-        <cve>CVE-2020-25638</cve>
-        <cve>CVE-2019-14900</cve>
-    </suppress>
 
     <!-- Tomcat - Only related to 'Windows Language Pack Installer" -->
-    <suppress>
+    <suppress until="2022-12-31">
         <cve>CVE-2020-0822</cve>
     </suppress>
 
-    <!-- Tomcat - Memory leak with websockets" -->
-    <suppress until="2021-12-31">
-        <cve>CVE-2021-42340</cve>
+    <!-- Jackson Databind - Looks like error in matching algorithm -->
+    <suppress until="2022-12-31">
+        <cve>CVE-2020-36518</cve>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
## Description
Fixes the following bugs:
1. Graphiql can send down comments along with a request.  Elide would incorrectly interpret the comments as not a mutation (even if mutation keyword was later in the query).
2. ConfigFile data model used ID for equals and hashcode which caused a NPE when trying to create multiple models in a single request.  
3. ConfigDataStore createFile was not idempotent.  If the same file was created multiple times in a single request, the request would fail.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
