### PR TITLE
Revert "Update: Make `-` a valid TEXT value type character"

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/enums/ValueType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/enums/ValueType.java
@@ -29,7 +29,7 @@ public enum ValueType {
     INTEGER("^[+-]?\\d+$"),
     DECIMAL("^[+-]?((\\d+(\\.\\d+)?)|(\\.\\d+))$"),
     MONEY("^[+-]?((\\d+(\\.\\d+)?)|(\\.\\d+))$"),
-    TEXT("^[a-zA-Z0-9_-]+$"),  //Very restricted to prevent SQL Injection
+    TEXT("^[a-zA-Z0-9_]+$"),  //Very restricted to prevent SQL Injection
     COORDINATE("^(-?\\d+(\\.\\d+)?)|(-?\\d+(\\.\\d+)?),\\s*(-?\\d+(\\.\\d+)?)$"),
     BOOLEAN("^(?i)true|false(?-i)|0|1$"),
     ID("^[a-zA-Z0-9_]+$"),

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/metadata/enums/ValueTypeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/metadata/enums/ValueTypeTest.java
@@ -168,7 +168,6 @@ public class ValueTypeTest {
         assertTrue(ValueType.TEXT.matches("XYZ"));
         assertTrue(ValueType.TEXT.matches("123abc"));
         assertTrue(ValueType.TEXT.matches("___XYZ123abcABC"));
-        assertTrue(ValueType.TEXT.matches("r2-d2"));
     }
 
     @Test


### PR DESCRIPTION
Reverts yahoo/elide#2565

This could open a security hole because '--' is SQL comment.  Parameterized columns/tables is the only place in Elide where we cannot rely on prepared statements to prevent SQL injection.   Parameters need to be more or less ASCII labels with no white space or other control characters or match a very strict REGEX (like a date).  