### PR TITLE
Bumping Spring to work around CVE

### DIFF
--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
-        <spring.boot.version>2.6.5</spring.boot.version>
+        <spring.boot.version>2.6.6</spring.boot.version>
         <groovy.version>3.0.10</groovy.version>
         <tomcat.version>9.0.58</tomcat.version>
     </properties>


### PR DESCRIPTION
Should fix:
spring-beans-5.3.17.jar: CVE-2022-22965


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
