### PR TITLE
Fixes #2601

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -36,6 +37,7 @@ import com.yahoo.elide.core.type.ClassType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.UUID;
 
 /**
@@ -69,7 +71,7 @@ public class ErrorMapperTest {
     }
 
     @Test
-    public void testElideCreateNoErrorMapper() throws Exception {
+    public void testElideRuntimeExceptionNoErrorMapper() throws Exception {
         DataStore store = mock(DataStore.class);
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
         FieldTestModel mockModel = mock(FieldTestModel.class);
@@ -89,7 +91,30 @@ public class ErrorMapperTest {
     }
 
     @Test
-    public void testElideCreateWithErrorMapperUnmapped() throws Exception {
+    public void testElideIOExceptionNoErrorMapper() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel mockModel = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, null);
+
+        //Invalid JSON
+        String body = "{\"data\": {\"type\":\"testModel\"\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(eq(ClassType.of(FieldTestModel.class)), any())).thenReturn(mockModel);
+
+        ElideResponse response = elide.post(baseUrl, "/testModel", body, null, NO_VERSION);
+        assertEquals(400, response.getResponseCode());
+        assertEquals(
+                "{\"errors\":[{\"detail\":\"Unexpected character (&#39;&#34;&#39; (code 34)): was expecting comma to separate Object entries\\n at [Source: (String)&#34;{&#34;data&#34;: {&#34;type&#34;:&#34;testModel&#34;&#34;id&#34;:&#34;1&#34;,&#34;attributes&#34;: {&#34;field&#34;:&#34;Foo&#34;}}}&#34;; line: 1, column: 30]\"}]}",
+                response.getBody());
+
+        verify(tx).close();
+    }
+
+    @Test
+    public void testElideRuntimeExceptionWithErrorMapperUnmapped() throws Exception {
         DataStore store = mock(DataStore.class);
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
         FieldTestModel mockModel = mock(FieldTestModel.class);
@@ -109,7 +134,30 @@ public class ErrorMapperTest {
     }
 
     @Test
-    public void testElideCreateWithErrorMapperMapped() throws Exception {
+    public void testElideIOExceptionWithErrorMapperUnmapped() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel mockModel = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, MOCK_ERROR_MAPPER);
+
+        //Invalid JSON
+        String body = "{\"data\": {\"type\":\"testModel\"\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(eq(ClassType.of(FieldTestModel.class)), any())).thenReturn(mockModel);
+
+        ElideResponse response = elide.post(baseUrl, "/testModel", body, null, NO_VERSION);
+        assertEquals(400, response.getResponseCode());
+        assertEquals(
+                "{\"errors\":[{\"detail\":\"Unexpected character (&#39;&#34;&#39; (code 34)): was expecting comma to separate Object entries\\n at [Source: (String)&#34;{&#34;data&#34;: {&#34;type&#34;:&#34;testModel&#34;&#34;id&#34;:&#34;1&#34;,&#34;attributes&#34;: {&#34;field&#34;:&#34;Foo&#34;}}}&#34;; line: 1, column: 30]\"}]}",
+                response.getBody());
+
+        verify(tx).close();
+    }
+
+    @Test
+    public void testElideRuntimeExceptionWithErrorMapperMapped() throws Exception {
         DataStore store = mock(DataStore.class);
         DataStoreTransaction tx = mock(DataStoreTransaction.class);
         FieldTestModel mockModel = mock(FieldTestModel.class);
@@ -132,6 +180,31 @@ public class ErrorMapperTest {
         verify(tx).close();
     }
 
+    @Test
+    public void testElideIOExceptionWithErrorMapperMapped() throws Exception {
+        DataStore store = mock(DataStore.class);
+        DataStoreTransaction tx = mock(DataStoreTransaction.class);
+        FieldTestModel mockModel = mock(FieldTestModel.class);
+
+        Elide elide = getElide(store, dictionary, MOCK_ERROR_MAPPER);
+
+        //Invalid JSON:
+        String body = "{\"data\": {\"type\":\"testModel\"\"id\":\"1\",\"attributes\": {\"field\":\"Foo\"}}}";
+
+        when(store.beginTransaction()).thenReturn(tx);
+        when(tx.createNewObject(eq(ClassType.of(FieldTestModel.class)), any())).thenReturn(mockModel);
+
+        when(MOCK_ERROR_MAPPER.map(isA(IOException.class))).thenReturn(MAPPED_EXCEPTION);
+
+        ElideResponse response = elide.post(baseUrl, "/testModel", body, null, NO_VERSION);
+        assertEquals(422, response.getResponseCode());
+        assertEquals(
+                "{\"errors\":[{\"code\":\"SOME_ERROR\"}]}",
+                response.getBody());
+
+        verify(tx).close();
+    }
+
     private Elide getElide(DataStore dataStore, EntityDictionary dictionary, ErrorMapper errorMapper) {
         ElideSettings settings = getElideSettings(dataStore, dictionary, errorMapper);
         return new Elide(settings, new TransactionRegistry(), settings.getDictionary().getScanner(), false);
@@ -143,12 +216,5 @@ public class ErrorMapperTest {
                 .withErrorMapper(errorMapper)
                 .withVerboseErrors()
                 .build();
-    }
-
-    private RequestScope buildRequestScope(EntityDictionary dict, DataStoreTransaction tx) {
-        User user = new TestUser("1");
-
-        return new RequestScope(null, null, NO_VERSION, null, tx, user, null, null, UUID.randomUUID(),
-                getElideSettings(null, dict, MOCK_ERROR_MAPPER));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorMapperTest.java
@@ -21,7 +21,6 @@ import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
-import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.TransactionRegistry;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
@@ -30,15 +29,12 @@ import com.yahoo.elide.core.dictionary.TestDictionary;
 import com.yahoo.elide.core.lifecycle.FieldTestModel;
 import com.yahoo.elide.core.lifecycle.LegacyTestModel;
 import com.yahoo.elide.core.lifecycle.PropertyTestModel;
-import com.yahoo.elide.core.security.TestUser;
-import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.core.type.ClassType;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.UUID;
 
 /**
  * Tests the error mapping logic.

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -2956,7 +2956,6 @@ public class ResourceIT extends IntegrationTest {
                 .body(req)
                 .patch("/book")
                 .then()
-                .log().all()
                 .statusCode(HttpStatus.SC_OK)
                 .body(equalTo(expected));
     }


### PR DESCRIPTION
Resolves #2601

## Description
ErrorMapper interface was only invoked for runtime exceptions.  Now it will also be invoked for IOExceptions as well (allowing all exception handling to be customized).  
If no error mapper is defined or the error is not mapped, the behavior should remain the same.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
