### PR TITLE
Aggregation store dynamic table sql

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -287,7 +287,7 @@ public class TableType implements Type<DynamicModelInstance> {
 
                 @Override
                 public Class<? extends TableSQLMaker> maker() {
-                    if (table.getMaker() == null || table.getMaker().isEmpty()) {
+                    if (StringUtils.isEmpty(table.getMaker())) {
                         return null;
                     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -293,7 +293,7 @@ public class TableType implements Type<DynamicModelInstance> {
                     }
 
                     try {
-                        return (Class<? extends TableSQLMaker>) Class.forName(table.getMaker());
+                        return Class.forName(table.getMaker()).asSubclass(TableSQLMaker.class);
                     } catch (ClassNotFoundException e) {
                         throw new IllegalStateException(e);
                     }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -272,8 +272,7 @@ public class TableType implements Type<DynamicModelInstance> {
 
         annotations.put(Include.class, getIncludeAnnotation(table));
 
-        if ((table.getSql() != null && !table.getSql().isEmpty())
-                || (table.getMaker() != null && !table.getMaker().isEmpty())) {
+        if (StringUtils.isNotEmpty(table.getSql()) || StringUtils.isNotEmpty(table.getMaker())) {
             annotations.put(FromSubquery.class, new FromSubquery() {
 
                 @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -272,7 +272,8 @@ public class TableType implements Type<DynamicModelInstance> {
 
         annotations.put(Include.class, getIncludeAnnotation(table));
 
-        if (table.getSql() != null && !table.getSql().isEmpty()) {
+        if ((table.getSql() != null && !table.getSql().isEmpty())
+                || (table.getMaker() != null && !table.getMaker().isEmpty())) {
             annotations.put(FromSubquery.class, new FromSubquery() {
 
                 @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -314,7 +314,7 @@ public class TableType implements Type<DynamicModelInstance> {
                 @Override
                 public String name() {
                     String tableName = table.getTable();
-                    if (table.getSchema() != null && ! table.getSchema().isEmpty()) {
+                    if (StringUtils.isNotEmpty(table.getSchema())) {
                         return table.getSchema() + "." + tableName;
 
                     }
@@ -377,7 +377,7 @@ public class TableType implements Type<DynamicModelInstance> {
 
             @Override
             public CardinalitySize size() {
-                if (table.getCardinality() == null || table.getCardinality().isEmpty()) {
+                if (StringUtils.isEmpty(table.getCardinality())) {
                     return CardinalitySize.UNKNOWN;
                 }
                 return CardinalitySize.valueOf(table.getCardinality().toUpperCase(Locale.ENGLISH));
@@ -530,7 +530,7 @@ public class TableType implements Type<DynamicModelInstance> {
 
             @Override
             public Class<? extends MetricProjectionMaker> maker() {
-                if (measure.getMaker() == null || measure.getMaker().isEmpty()) {
+                if (StringUtils.isEmpty(measure.getMaker())) {
                     return DefaultMetricProjectionMaker.class;
                 }
 
@@ -646,7 +646,7 @@ public class TableType implements Type<DynamicModelInstance> {
 
             @Override
             public CardinalitySize size() {
-                if (dimension.getCardinality() == null || dimension.getCardinality().isEmpty()) {
+                if (StringUtils.isEmpty(dimension.getCardinality())) {
                     return CardinalitySize.UNKNOWN;
                 }
                 return CardinalitySize.valueOf(dimension.getCardinality().toUpperCase(Locale.ENGLISH));

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -41,6 +41,7 @@ import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 import com.yahoo.elide.datastores.aggregation.metadata.enums.ValueType;
 import com.yahoo.elide.datastores.aggregation.query.DefaultMetricProjectionMaker;
 import com.yahoo.elide.datastores.aggregation.query.MetricProjectionMaker;
+import com.yahoo.elide.datastores.aggregation.query.TableSQLMaker;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable;
 import com.yahoo.elide.modelconfig.model.Argument;
@@ -282,6 +283,19 @@ public class TableType implements Type<DynamicModelInstance> {
                 @Override
                 public String sql() {
                     return table.getSql();
+                }
+
+                @Override
+                public Class<? extends TableSQLMaker> maker() {
+                    if (table.getMaker() == null || table.getMaker().isEmpty()) {
+                        return null;
+                    }
+
+                    try {
+                        return (Class<? extends TableSQLMaker>) Class.forName(table.getMaker());
+                    } catch (ClassNotFoundException e) {
+                        throw new IllegalStateException(e);
+                    }
                 }
 
                 @Override

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/dynamic/TableType.java
@@ -536,7 +536,7 @@ public class TableType implements Type<DynamicModelInstance> {
                 }
 
                 try {
-                    return (Class<? extends MetricProjectionMaker>) Class.forName(measure.getMaker());
+                    return Class.forName(measure.getMaker()).asSubclass(MetricProjectionMaker.class);
                 } catch (ClassNotFoundException e) {
                     throw new IllegalStateException(e);
                 }

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/DefaultTableSQLMaker.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/DefaultTableSQLMaker.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.query;
+
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery;
+import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
+
+/**
+ * Default table SQL maker that just returns the SQL defined in the FromSubquery annotation.
+ */
+public class DefaultTableSQLMaker implements TableSQLMaker {
+
+    @Override
+    public String make(Query clientQuery) {
+        SQLTable table = (SQLTable) clientQuery.getRoot();
+
+        FromSubquery fromSubquery = table.getCls().getAnnotation(FromSubquery.class);
+
+        return fromSubquery.sql();
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/TableSQLMaker.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/TableSQLMaker.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.datastores.aggregation.query;
+
+@FunctionalInterface
+public interface TableSQLMaker {
+
+    /**
+     * Constructs dynamic SQL given a specific client query.
+     * @param clientQuery the client query.
+     * @return A templated SQL query
+     */
+    String make(Query clientQuery);
+}

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/TableSQLMaker.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/TableSQLMaker.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.datastores.aggregation.query;
 
 @FunctionalInterface
 public interface TableSQLMaker {
-
     /**
      * Constructs dynamic SQL given a specific client query.
      * @param clientQuery the client query.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromSubquery.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromSubquery.java
@@ -5,6 +5,8 @@
  */
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation;
 
+import com.yahoo.elide.datastores.aggregation.query.TableSQLMaker;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -27,6 +29,13 @@ public @interface FromSubquery {
      * @return The SQL subquery.
      */
     String sql();
+
+    /**
+     * Generates the subquery SQL dynamically
+     *
+     * @return The class of the subquery generator.
+     */
+    Class<? extends TableSQLMaker> maker();
 
     /**
      * DB Connection Name for this query.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromSubquery.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/annotation/FromSubquery.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation;
 
+import com.yahoo.elide.datastores.aggregation.query.DefaultTableSQLMaker;
 import com.yahoo.elide.datastores.aggregation.query.TableSQLMaker;
 
 import java.lang.annotation.Documented;
@@ -22,7 +23,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface FromSubquery {
-
     /**
      * The SQL subquery.
      *
@@ -35,7 +35,7 @@ public @interface FromSubquery {
      *
      * @return The class of the subquery generator.
      */
-    Class<? extends TableSQLMaker> maker();
+    Class<? extends TableSQLMaker> maker() default DefaultTableSQLMaker.class;
 
     /**
      * DB Connection Name for this query.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialectFactory.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/dialects/SQLDialectFactory.java
@@ -72,7 +72,7 @@ public class SQLDialectFactory {
             return DRUID_DIALECT;
         }
         try {
-            return (SQLDialect) Class.forName(type).getConstructor().newInstance();
+            return Class.forName(type).asSubclass(SQLDialect.class).getConstructor().newInstance();
         } catch (ClassNotFoundException e) {
             throw new IllegalArgumentException("Unsupported SQL Dialect: " + type, e);
         } catch (Exception e) {

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/metadata/SQLTable.java
@@ -61,6 +61,8 @@ public class SQLTable extends Table implements Queryable {
 
     private Map<String, Argument> arguments;
 
+    private Type<?> cls;
+
     public SQLTable(Namespace namespace,
                     Type<?> cls,
                     EntityDictionary dictionary,
@@ -68,6 +70,7 @@ public class SQLTable extends Table implements Queryable {
         super(namespace, cls, dictionary);
         this.connectionDetails = connectionDetails;
         this.joins = new HashMap<>();
+        this.cls = cls;
         this.arguments = prepareArgMap(getArgumentDefinitions());
 
         EntityBinding binding = dictionary.getEntityBinding(cls);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TableArgumentValidator.java
@@ -12,6 +12,7 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition;
+import com.yahoo.elide.datastores.aggregation.query.Query;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.ExpressionParser;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.expression.TableArgReference;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.metadata.SQLTable;
@@ -63,8 +64,15 @@ public class TableArgumentValidator {
     private void verifyTableArgsInTableSql() {
         Type<?> tableClass = dictionary.getEntityClass(table.getName(), table.getVersion());
 
+        Query mockQuery =  Query.builder()
+                .source(table)
+                .dimensionProjections(table.getDimensionProjections())
+                .metricProjections(table.getMetricProjections())
+                .timeDimensionProjections(table.getTimeDimensionProjections())
+                .build();
+
         if (hasSql(tableClass)) {
-            String selectSql = resolveTableOrSubselect(dictionary, tableClass);
+            String selectSql = resolveTableOrSubselect(dictionary, tableClass, mockQuery);
             verifyTableArgsExists(selectSql, "in table's sql.");
         }
     }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -1521,6 +1521,144 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
         runQueryWithExpectedResult(graphQLRequest, expected);
     }
 
+    /**
+     * Verifies tableMaker logic.  Duplicates everything query for orderDetails (no maker) on
+     * orderDetails2 (maker).
+     * @throws Exception
+     */
+    @Test
+    public void testTableMaker() throws Exception {
+        String graphQLRequest = document(
+                selection(
+                        field(
+                                "SalesNamespace_orderDetails2",
+                                arguments(
+                                        argument("sort", "\"courierName,deliveryDate,orderTotal,customerRegion\""),
+                                        argument("filter", "\"deliveryYear=='2020';(deliveryTime>='2020-08-01';deliveryTime<'2020-12-31');(deliveryDate>='2020-09-01',orderTotal>50)\"")
+                                ),
+                                selections(
+                                        field("courierName"),
+                                        field("deliveryTime"),
+                                        field("deliveryHour"),
+                                        field("deliveryDate"),
+                                        field("deliveryMonth"),
+                                        field("deliveryYear"),
+                                        field("deliveryDefault"),
+                                        field("orderTime", "bySecond", arguments(
+                                                argument("grain", TimeGrain.SECOND)
+                                        )),
+                                        field("orderTime", "byDay", arguments(
+                                                argument("grain", TimeGrain.DAY)
+                                        )),
+                                        field("orderTime", "byMonth", arguments(
+                                                argument("grain", TimeGrain.MONTH)
+                                        )),
+                                        field("customerRegion"),
+                                        field("customerRegionRegion"),
+                                        field("orderTotal"),
+                                        field("zipCode"),
+                                        field("orderId")
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String expected = document(
+                selections(
+                        field(
+                                "SalesNamespace_orderDetails2",
+                                selections(
+                                        field("courierName", "FEDEX"),
+                                        field("deliveryTime", "2020-09-11T16:30:11"),
+                                        field("deliveryHour", "2020-09-11T16"),
+                                        field("deliveryDate", "2020-09-11"),
+                                        field("deliveryMonth", "2020-09"),
+                                        field("deliveryYear", "2020"),
+                                        field("bySecond", "2020-09-08T16:30:11"),
+                                        field("deliveryDefault", "2020-09-11"),
+                                        field("byDay", "2020-09-08"),
+                                        field("byMonth", "2020-09"),
+                                        field("customerRegion", "Virginia"),
+                                        field("customerRegionRegion", "Virginia"),
+                                        field("orderTotal", 84.11F),
+                                        field("zipCode", 20166),
+                                        field("orderId", "order-1b")
+                                ),
+                                selections(
+                                        field("courierName", "FEDEX"),
+                                        field("deliveryTime", "2020-09-11T16:30:11"),
+                                        field("deliveryHour", "2020-09-11T16"),
+                                        field("deliveryDate", "2020-09-11"),
+                                        field("deliveryMonth", "2020-09"),
+                                        field("deliveryYear", "2020"),
+                                        field("bySecond", "2020-09-08T16:30:11"),
+                                        field("deliveryDefault", "2020-09-11"),
+                                        field("byDay", "2020-09-08"),
+                                        field("byMonth", "2020-09"),
+                                        field("customerRegion", "Virginia"),
+                                        field("customerRegionRegion", "Virginia"),
+                                        field("orderTotal", 97.36F),
+                                        field("zipCode", 20166),
+                                        field("orderId", "order-1c")
+                                ),
+                                selections(
+                                        field("courierName", "UPS"),
+                                        field("deliveryTime", "2020-09-05T16:30:11"),
+                                        field("deliveryHour", "2020-09-05T16"),
+                                        field("deliveryDate", "2020-09-05"),
+                                        field("deliveryMonth", "2020-09"),
+                                        field("deliveryYear", "2020"),
+                                        field("bySecond", "2020-08-30T16:30:11"),
+                                        field("deliveryDefault", "2020-09-05"),
+                                        field("byDay", "2020-08-30"),
+                                        field("byMonth", "2020-08"),
+                                        field("customerRegion", "Virginia"),
+                                        field("customerRegionRegion", "Virginia"),
+                                        field("orderTotal", 103.72F),
+                                        field("zipCode", 20166),
+                                        field("orderId", "order-1a")
+                                ),
+                                selections(
+                                        field("courierName", "UPS"),
+                                        field("deliveryTime", "2020-09-13T16:30:11"),
+                                        field("deliveryHour", "2020-09-13T16"),
+                                        field("deliveryDate", "2020-09-13"),
+                                        field("deliveryMonth", "2020-09"),
+                                        field("deliveryYear", "2020"),
+                                        field("bySecond", "2020-09-09T16:30:11"),
+                                        field("deliveryDefault", "2020-09-13"),
+                                        field("byDay", "2020-09-09"),
+                                        field("byMonth", "2020-09"),
+                                        field("customerRegion", (String) null, false),
+                                        field("customerRegionRegion", (String) null, false),
+                                        field("orderTotal", 78.87F),
+                                        field("zipCode", 0),
+                                        field("orderId", "order-null-enum")
+                                ),
+                                selections(
+                                        field("courierName", "UPS"),
+                                        field("deliveryTime", "2020-09-13T16:30:11"),
+                                        field("deliveryHour", "2020-09-13T16"),
+                                        field("deliveryDate", "2020-09-13"),
+                                        field("deliveryMonth", "2020-09"),
+                                        field("deliveryYear", "2020"),
+                                        field("bySecond", "2020-09-09T16:30:11"),
+                                        field("deliveryDefault", "2020-09-13"),
+                                        field("byDay", "2020-09-09"),
+                                        field("byMonth", "2020-09"),
+                                        field("customerRegion", "Virginia"),
+                                        field("customerRegionRegion", "Virginia"),
+                                        field("orderTotal", 78.87F),
+                                        field("zipCode", 20170),
+                                        field("orderId", "order-3b")
+                                )
+                        )
+                )
+        ).toResponse();
+
+        runQueryWithExpectedResult(graphQLRequest, expected);
+    }
+
     @Test
     public void testGraphQLDynamicAggregationModelDateTime() throws Exception {
         String graphQLRequest = document(

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -169,6 +169,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
                 .body("data.attributes.friendlyName", equalTo("Sales"))
                 .body("data.relationships.tables.data.id", contains(
                         "SalesNamespace_orderDetails",
+                        "SalesNamespace_orderDetails2",
                         "SalesNamespace_deliveryDetails"));
         given()
                 .accept("application/vnd.api+json")

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/example/tables/OrderDetailsMaker.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/example/tables/OrderDetailsMaker.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package example.tables;
+
+import com.yahoo.elide.datastores.aggregation.query.Query;
+import com.yahoo.elide.datastores.aggregation.query.TableSQLMaker;
+
+public class OrderDetailsMaker implements TableSQLMaker {
+    /**
+     * Creates a subquery that mirrors the following table:
+     *
+     * CREATE TABLE IF NOT EXISTS order_details
+     * (
+     *   order_id VARCHAR(255) NOT NULL,
+     *   customer_id VARCHAR(255),
+     *   order_total NUMERIC(10,2),
+     *   created_on DATETIME,
+     *   PRIMARY KEY (order_id)
+     * );
+     * @param clientQuery the client query.
+     * @return SQL query
+     */
+    @Override
+    public String make(Query clientQuery) {
+        return "SELECT order_id, customer_id, order_total, created_on FROM order_details";
+    }
+}

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/OrderDetailsMakerExample.hjson
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/configs/models/tables/OrderDetailsMakerExample.hjson
@@ -1,0 +1,247 @@
+{
+  tables:
+  [
+    {
+      name: orderDetails2
+      maker: example.tables.OrderDetailsMaker
+      dbConnectionName: SalesDBConnection
+      cardinality: large
+      readAccess: guest user
+      namespace: SalesNamespace
+      filterTemplate : deliveryTime>={{start}};deliveryTime<{{end}}
+      arguments:
+      [
+        { // An argument that can be used to divide orderTotal to convert orders in Millions, Thousands, etc.
+          name: denominator
+          type: DECIMAL
+          default: 1
+        }
+      ]
+      joins:
+      [
+        {
+          name: customer
+          to: customerDetails
+          namespace: SalesNamespace
+          type: Left
+          // References Physical Columns
+          definition: '{{$customer_id}} = {{ customer.$id}}'
+        }
+        {
+          name: delivery
+          to: deliveryDetails
+          namespace: SalesNamespace
+          kind: toOne
+          // References Logical Columns, multiple join condition
+          definition: '''
+          {{ orderId}} = {{delivery.orderId}} AND
+          {{ delivery.$delivered_on }} >= '{{ $$table.args.start }}' AND
+          {{ delivery.$delivered_on }} < '{{ $$table.args.end }}'
+          '''
+        }
+      ]
+      measures:
+      [
+        {
+          name: orderRatio
+          type: DECIMAL
+          maker: example.metrics.MetricRatio
+          arguments:
+          [
+             {
+               name: numerator
+               type: TEXT
+               values: ['orderTotal', 'orderMax']
+               default: 'orderTotal'
+             }
+             {
+               name: denominator
+               type: TEXT
+               values: ['orderTotal', 'orderMax']
+               default: 'orderTotal'
+             }
+          ]
+        }
+        {
+          name: orderTotal
+          type: DECIMAL
+          // TODO : Use Arguments
+          definition: 'SUM({{ $order_total }})'
+          readAccess: admin.user
+          arguments:
+          [
+            { // An argument that can be used to divide orderTotal to convert orders in Millions, Thousands, etc.
+              name: precision
+              type: DECIMAL
+              default: 0.00
+            }
+          ]
+        },
+        {
+          name: orderMax
+          type: DECIMAL
+          // TODO : Use Arguments
+          maker: example.metrics.SalesViewOrderMax
+          readAccess: admin.user
+          arguments:
+          [
+            { // An argument that can be used to divide orderTotal to convert orders in Millions, Thousands, etc.
+              name: precision
+              type: DECIMAL
+              default: 0.00
+            }
+          ]
+        }
+      ]
+      dimensions:
+      [
+        {
+          name: orderId
+          type: TEXT
+          definition: '{{ $order_id }}'
+          readAccess: guest user
+        }
+        {
+          name: courierName
+          type: TEXT
+          definition: '{{delivery.$courier_name}}'
+          readAccess: operator
+        }
+        {
+          name: customerRegion
+          type: TEXT
+          definition: '{{customer.customerRegion}}'
+          readAccess: operator
+          cardinality: small
+        }
+        //Tests a reference to an enum Java dimension stored as VARCHAR coerced to a string.
+        {
+          name: customerRegionType1
+          type: ENUM_TEXT
+          definition: '{{customer.region.placeType}}'
+          readAccess: guest user
+        }
+        //Tests a reference to an enum Java dimension stored as INT coerced to the enum.
+        {
+          name: customerRegionType2
+          type: ENUM_ORDINAL
+          definition: '{{customer.region.ordinalPlaceType}}'
+          readAccess: guest user
+          values: ['COUNTRY', 'STATE', 'COUNTY', 'TOWN', 'PLACE']
+        }
+        {
+          name: customerRegionRegion
+          type: TEXT
+          definition: '{{customer.region.region}}'
+          readAccess: operator
+          tableSource: {
+            table: regionDetails
+            column: region
+          }
+        }
+        {
+          name: zipCode
+          type: INTEGER
+          definition: '{{zipCodeHidden}}'
+          readAccess: operator
+        }
+
+        {
+          name: zipCodeHidden
+          type: INTEGER
+          hidden: true
+          definition: '{{customer.zipCode}}'
+          readAccess: operator
+        }
+        {
+          name: orderTime
+          type: TIME
+          // Physical Column Reference in same table
+          definition: '{{$created_on}}'
+          readAccess: guest user
+          grains:
+          [
+            {
+              type: MONTH
+              sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy-MM-01'), 'yyyy-MM-dd')
+            },
+            {
+              type: SECOND
+              sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')
+            },
+            {
+              type: DAY
+              sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy-MM-dd'), 'yyyy-MM-dd')
+            }
+          ]
+        }
+        {
+          name: deliveryTime
+          type: TIME
+          // Physical Column Reference in referred table
+          definition: '{{delivery.$delivered_on}}'
+          readAccess: guest user
+          grains:
+          [{
+            type: SECOND
+          }]
+        }
+        {
+          name: deliveryDate
+          type: TIME
+          // Logical Column Reference in referred table, which references Physical column in referred table
+          definition: '{{delivery.time}}'
+          readAccess: guest user
+          grains:
+          [{
+            sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy-MM-dd'), 'yyyy-MM-dd')
+          }]
+        }
+        {
+          name: deliveryMonth
+          type: TIME
+          // Logical Column Reference in referred table, which references another Logical column in referred table, which references another Logical column in referred table, which references Physical column in referred table
+          definition: '{{delivery.month}}'
+          readAccess: guest user
+          grains:
+          [{
+            type: MONTH
+            sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy-MM-01'), 'yyyy-MM-dd')
+          }]
+        }
+        {
+          name: deliveryHour
+          type: TIME
+          // Logical Column Reference in same table, which references Physical column in referred table
+          definition: '{{deliveryTime}}'
+          readAccess: guest user
+          grains:
+          [{
+            type: HOUR
+            sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy-MM-dd HH'), 'yyyy-MM-dd HH')
+          }]
+        }
+        {
+          name: deliveryYear
+          type: TIME
+          // Logical Column Reference in same table, which references another Logical Column in referred table, which references another Logical column in referred table, which references another Logical column in referred table, which references Physical column in referred table
+          definition: '{{deliveryMonth}}'
+          readAccess: guest user
+          grains:
+          [{
+            type: YEAR
+            sql: PARSEDATETIME(FORMATDATETIME({{$$column.expr}}, 'yyyy-01-01'), 'yyyy-MM-dd')
+          }]
+          filterTemplate: 'deliveryYear=={{deliveryYear}}'
+        }
+        {
+          name: deliveryDefault
+          type: TIME
+          // Logical Column Reference in same table, which references another Logical Column in referred table, which references another Logical column in referred table, which references another Logical column in referred table, which references Physical column in referred table
+          definition: '{{delivery.time}}'
+          readAccess: guest user
+        }
+      ]
+    }
+  ]
+}

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Table.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/model/Table.java
@@ -46,6 +46,7 @@ import java.util.Set;
     "arguments",
     "extend",
     "sql",
+    "maker",
     "table",
     "dbConnectionName",
     "filterTemplate"
@@ -127,6 +128,9 @@ public class Table implements Named {
 
     @JsonProperty("sql")
     private String sql;
+
+    @JsonProperty("maker")
+    private String maker;
 
     @JsonProperty("table")
     private String table;

--- a/elide-model-config/src/main/resources/elideTableSchema.json
+++ b/elide-model-config/src/main/resources/elideTableSchema.json
@@ -537,6 +537,21 @@
                                 "description": "SQL query which is used to populate the table.",
                                 "type": "string"
                             },
+                            "dbConnectionName": {
+                                "title": "DB Connection Name",
+                                "description": "The database connection name for this model.",
+                                "type": "string",
+                                "format": "elideName"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "sql",
+                            "dimensions"
+                        ]
+                    },
+                    {
+                        "properties": {
                             "maker": {
                                 "title": "Table SQL maker function",
                                 "description": "JVM function to invoke to generate the SQL query which is used to populate the table.",
@@ -552,7 +567,7 @@
                         },
                         "required": [
                             "name",
-                            "sql",
+                            "maker",
                             "dimensions"
                         ]
                     },

--- a/elide-model-config/src/main/resources/elideTableSchema.json
+++ b/elide-model-config/src/main/resources/elideTableSchema.json
@@ -537,6 +537,12 @@
                                 "description": "SQL query which is used to populate the table.",
                                 "type": "string"
                             },
+                            "maker": {
+                                "title": "Table SQL maker function",
+                                "description": "JVM function to invoke to generate the SQL query which is used to populate the table.",
+                                "type": "string",
+                                "format": "javaClassName"
+                            },
                             "dbConnectionName": {
                                 "title": "DB Connection Name",
                                 "description": "The database connection name for this model.",


### PR DESCRIPTION
## Description
Creates a fourth way to define a table for analytic queries.  The four ways are:
1.  Specifying a physical database table by name
2. Extending an existing table
3. Specifying a SQL query
4. **NEW** - Specifying a maker class that constructs a SQL query similar to 3.

The new maker interface allows the modeler complete control to dynamically construct the table base on any part of the client query:

```java
@FunctionalInterface
public interface TableSQLMaker {
    /**
     * Constructs dynamic SQL given a specific client query.
     * @param clientQuery the client query.
     * @return A templated SQL query
     */
    String make(Query clientQuery);
}
```

## Motivation and Context

Instead of leveraging handlebars for dynamic table construction, this allows Elide the ability to validate table HJSON and also gives modelers a more powerful language abstraction for defining complex dynamic tables.

## How Has This Been Tested?
New IT test.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
