### PR TITLE
Header filtering config

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -17,11 +17,13 @@ import com.yahoo.elide.core.security.PermissionExecutor;
 import com.yahoo.elide.core.utils.coerce.converters.Serde;
 import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.jsonapi.links.JSONApiLinks;
+import com.yahoo.elide.utils.HeaderUtils;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -39,6 +41,7 @@ public class ElideSettings {
     @Getter private final List<SubqueryFilterDialect> subqueryFilterDialects;
     @Getter private final FilterDialect graphqlDialect;
     @Getter private final JSONApiLinks jsonApiLinks;
+    @Getter private final HeaderUtils.HeaderProcessor headerProcessor;
     @Getter private final int defaultMaxPageSize;
     @Getter private final int defaultPageSize;
     @Getter private final int updateStatusCode;

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -23,7 +23,6 @@ import lombok.Getter;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -81,6 +81,7 @@ public class ElideSettingsBuilder {
         this.jsonApiMapper = new JsonApiMapper();
         this.joinFilterDialects = new ArrayList<>();
         this.subqueryFilterDialects = new ArrayList<>();
+        this.headerProcessor = HeaderUtils::lowercaseAndRemoveAuthHeaders;
         updateStatusCode = HttpStatus.SC_NO_CONTENT;
         this.serdes = new LinkedHashMap<>();
         this.enableJsonLinks = false;

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -30,6 +30,7 @@ import com.yahoo.elide.core.utils.coerce.converters.TimeZoneSerde;
 import com.yahoo.elide.core.utils.coerce.converters.URLSerde;
 import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.jsonapi.links.JSONApiLinks;
+import com.yahoo.elide.utils.HeaderUtils;
 
 import java.net.URL;
 import java.time.Instant;
@@ -56,6 +57,7 @@ public class ElideSettingsBuilder {
     private List<SubqueryFilterDialect> subqueryFilterDialects;
     private FilterDialect graphqlFilterDialect;
     private JSONApiLinks jsonApiLinks;
+    private HeaderUtils.HeaderProcessor headerProcessor;
     private Map<Class, Serde> serdes;
     private int defaultMaxPageSize = PaginationImpl.MAX_PAGE_LIMIT;
     private int defaultPageSize = PaginationImpl.DEFAULT_PAGE_LIMIT;
@@ -118,6 +120,7 @@ public class ElideSettingsBuilder {
                 subqueryFilterDialects,
                 graphqlFilterDialect,
                 jsonApiLinks,
+                headerProcessor,
                 defaultMaxPageSize,
                 defaultPageSize,
                 updateStatusCode,
@@ -228,6 +231,11 @@ public class ElideSettingsBuilder {
     public ElideSettingsBuilder withJSONApiLinks(JSONApiLinks links) {
         this.enableJsonLinks = true;
         this.jsonApiLinks = links;
+        return this;
+    }
+
+    public ElideSettingsBuilder withHeaderProcessor(HeaderUtils.HeaderProcessor headerProcessor) {
+        this.headerProcessor = headerProcessor;
         return this;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
@@ -43,11 +43,13 @@ import javax.ws.rs.core.UriInfo;
 @Path("/")
 public class JsonApiEndpoint {
     protected final Elide elide;
+    protected final HeaderUtils.HeaderProcessor headerProcessor;
 
     @Inject
     public JsonApiEndpoint(
             @Named("elide") Elide elide) {
         this.elide = elide;
+        this.headerProcessor = elide.getElideSettings().getHeaderProcessor();
     }
 
     /**
@@ -71,8 +73,7 @@ public class JsonApiEndpoint {
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         return build(elide.post(getBaseUrlEndpoint(uriInfo), path, jsonapiDocument,
                 queryParams, requestHeaders, user, apiVersion, UUID.randomUUID()));
@@ -96,8 +97,7 @@ public class JsonApiEndpoint {
         @Context SecurityContext securityContext) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
         return build(elide.get(getBaseUrlEndpoint(uriInfo), path, queryParams,
@@ -129,8 +129,7 @@ public class JsonApiEndpoint {
         String jsonapiDocument) {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         return build(elide.patch(getBaseUrlEndpoint(uriInfo), contentType, accept, path,
                                  jsonapiDocument, queryParams, requestHeaders, user, apiVersion, UUID.randomUUID()));
@@ -158,8 +157,7 @@ public class JsonApiEndpoint {
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String apiVersion =
                 HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         return build(elide.delete(getBaseUrlEndpoint(uriInfo), path, jsonApiDocument, queryParams, requestHeaders,
                                   user, apiVersion, UUID.randomUUID()));

--- a/elide-core/src/main/java/com/yahoo/elide/utils/HeaderUtils.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/HeaderUtils.java
@@ -19,6 +19,11 @@ import java.util.stream.Collectors;
  */
 public class HeaderUtils {
 
+    @FunctionalInterface
+    public interface HeaderProcessor {
+        Map<String, List<String>> process(Map<String, List<String>> headers);
+    }
+
     /**
      * Resolve value of api version from request headers.
      * @param headers HttpHeaders

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -44,11 +44,13 @@ import javax.ws.rs.core.UriInfo;
 public class GraphQLEndpoint {
     private final Map<String, QueryRunner> runners;
     private final Elide elide;
+    private final HeaderUtils.HeaderProcessor headerProcessor;
 
     @Inject
     public GraphQLEndpoint(@Named("elide") Elide elide) {
         log.debug("Started ~~");
         this.elide = elide;
+        this.headerProcessor = elide.getElideSettings().getHeaderProcessor();
         this.runners = new HashMap<>();
         for (String apiVersion : elide.getElideSettings().getDictionary().getApiVersions()) {
             runners.put(apiVersion, new QueryRunner(elide, apiVersion));
@@ -71,8 +73,7 @@ public class GraphQLEndpoint {
             @Context SecurityContext securityContext,
             String graphQLDocument) {
         String apiVersion = HeaderUtils.resolveApiVersion(headers.getRequestHeaders());
-        Map<String, List<String>> requestHeaders =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(headers.getRequestHeaders());
+        Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
         QueryRunner runner = runners.getOrDefault(apiVersion, null);
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -75,4 +75,9 @@ public class ElideConfigProperties {
      * Turns on/off verbose error responses.
      */
     private boolean verboseErrors = false;
+
+    /**
+     * Remove Authorization headers from RequestScope to prevent accidental logging of security credentials.
+     */
+    private boolean stripAuthorizatonHeaders = true;
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -54,6 +54,7 @@ public class GraphqlController {
     private final ElideConfigProperties settings;
     private final QueryRunners runners;
     private final ObjectMapper mapper;
+    private final HeaderUtils.HeaderProcessor headerProcessor;
 
     private static final String JSON_CONTENT_TYPE = "application/json";
 
@@ -61,10 +62,12 @@ public class GraphqlController {
     public GraphqlController(
             QueryRunners runners,
             JsonApiMapper jsonApiMapper,
+            HeaderUtils.HeaderProcessor headerProcessor,
             ElideConfigProperties settings) {
         log.debug("Started ~~");
         this.runners = runners;
         this.settings = settings;
+        this.headerProcessor = headerProcessor;
         this.mapper = jsonApiMapper.getObjectMapper();
     }
 
@@ -81,8 +84,7 @@ public class GraphqlController {
                                                  @RequestBody String graphQLDocument, Authentication principal) {
         final User user = new AuthenticationUser(principal);
         final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
-        final Map<String, List<String>> requestHeadersCleaned =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(requestHeaders);
+        final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final QueryRunner runner = runners.getRunner(apiVersion);
         final String baseUrl = getBaseUrlEndpoint();
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -57,6 +57,7 @@ public class JsonApiController {
 
     private final Elide elide;
     private final ElideConfigProperties settings;
+    private final HeaderUtils.HeaderProcessor headerProcessor;
     public static final String JSON_API_CONTENT_TYPE = JSONAPI_CONTENT_TYPE;
     public static final String JSON_API_PATCH_CONTENT_TYPE = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 
@@ -65,6 +66,7 @@ public class JsonApiController {
         log.debug("Started ~~");
         this.settings = settings;
         this.elide = refreshableElide.getElide();
+        this.headerProcessor = elide.getElideSettings().getHeaderProcessor();
     }
 
     private <K, V> MultivaluedHashMap<K, V> convert(MultiValueMap<K, V> springMVMap) {
@@ -78,8 +80,7 @@ public class JsonApiController {
                                                      @RequestParam MultiValueMap<String, String> allRequestParams,
                                                      HttpServletRequest request, Authentication authentication) {
         final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
-        final Map<String, List<String>> requestHeadersCleaned =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(requestHeaders);
+        final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
         final User user = new AuthenticationUser(authentication);
         final String baseUrl = getBaseUrlEndpoint();
@@ -101,8 +102,7 @@ public class JsonApiController {
                                                       @RequestBody String body,
                                                       HttpServletRequest request, Authentication authentication) {
         final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
-        final Map<String, List<String>> requestHeadersCleaned =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(requestHeaders);
+        final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
         final User user = new AuthenticationUser(authentication);
         final String baseUrl = getBaseUrlEndpoint();
@@ -123,8 +123,7 @@ public class JsonApiController {
                                                        @RequestBody String body,
                                                        HttpServletRequest request, Authentication authentication) {
         final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
-        final Map<String, List<String>> requestHeadersCleaned =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(requestHeaders);
+        final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
         final User user = new AuthenticationUser(authentication);
         final String baseUrl = getBaseUrlEndpoint();
@@ -147,8 +146,7 @@ public class JsonApiController {
                                                         HttpServletRequest request,
                                                         Authentication authentication) {
         final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
-        final Map<String, List<String>> requestHeadersCleaned =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(requestHeaders);
+        final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
         final User user = new AuthenticationUser(authentication);
         final String baseUrl = getBaseUrlEndpoint();
@@ -172,8 +170,7 @@ public class JsonApiController {
             HttpServletRequest request,
             Authentication authentication) {
         final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
-        final Map<String, List<String>> requestHeadersCleaned =
-                HeaderUtils.lowercaseAndRemoveAuthHeaders(requestHeaders);
+        final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String pathname = getJsonApiPath(request, settings.getJsonApi().getPath());
         final User user = new AuthenticationUser(authentication);
         final String baseUrl = getBaseUrlEndpoint();

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderIdentityTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderIdentityTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.tests;
+
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attr;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.datum;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.linkage;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import com.yahoo.elide.RefreshableElide;
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * Example functional test.
+ */
+@SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
+@Sql(
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+        scripts = "classpath:db/test_init.sql",
+        statements = "INSERT INTO ArtifactGroup (name, commonName, description, deprecated) VALUES\n"
+                + "\t\t('com.example.repository','Example Repository','The code for this project', false);"
+)
+@Import(IntegrationTestSetup.class)
+@TestPropertySource(
+        properties = {
+                "elide.json-api.enableLinks=true",
+                "elide.async.export.enabled=false",
+                "elide.stripAuthorizatonHeaders=false"
+        }
+)
+@ActiveProfiles("default")
+public class HeaderIdentityTest extends IntegrationTest {
+    public static final String SORT_PARAM = "sort";
+    private String baseUrl;
+
+    @SpyBean
+    private RefreshableElide elide;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @BeforeAll
+    @Override
+    public void setUp() {
+        super.setUp();
+        baseUrl = "https://elide.io/json/";
+    }
+
+    @BeforeEach
+    public void resetMocks() {
+        reset(elide.getElide());
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersGetTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.ACCEPT_LANGUAGE, "en-US")
+                .queryParam(SORT_PARAM, "name", "description")
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("group"),
+                                        id("com.example.repository2"),
+                                        attributes(
+                                                attr("commonName", "New group.")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .post("/json/group")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide.getElide()).post(any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersPostTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .when()
+                .get("/json/group")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide.getElide()).get(any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersPatchTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("group"),
+                                        id("com.example.repository"),
+                                        attributes(
+                                                attr("commonName", "Changed It.")
+                                        )
+                                )
+                        )
+                )
+                .when()
+                .patch("/json/group/com.example.repository")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide.getElide()).patch(any(), any(), any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersDeleteTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .when()
+                .delete("/json/group/com.example.repository")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide.getElide()).delete(
+                any(),
+                any(),
+                any(),
+                requestParamsCaptor.capture(),
+                requestHeadersCleanedCaptor.capture(),
+                any(),
+                any(),
+                any()
+        );
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+
+    @Test
+    public void jsonVerifyParamsAndHeadersDeleteRelationshipTest() {
+        given()
+                .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
+                .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
+                .queryParam(SORT_PARAM, "name", "description")
+                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .body(datum(
+                        linkage(type("product"), id("foo"))
+                ))
+                .when()
+                .delete("/json/group/com.example.repository")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(elide.getElide()).delete(
+                any(),
+                any(),
+                any(),
+                requestParamsCaptor.capture(),
+                requestHeadersCleanedCaptor.capture(),
+                any(),
+                any(),
+                any()
+        );
+
+        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
+        assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
+
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("authorization"));
+        assertTrue(requestHeadersCleanedCaptor.getValue().containsKey("proxy-authorization"));
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTestSetup.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/IntegrationTestSetup.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.jsonapi.links.DefaultJSONApiLinks;
 import com.yahoo.elide.spring.config.ElideConfigProperties;
+import com.yahoo.elide.utils.HeaderUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +34,7 @@ public class IntegrationTestSetup {
     public RefreshableElide initializeElide(EntityDictionary dictionary,
                                             DataStore dataStore,
                                             ElideConfigProperties settings,
+                                            HeaderUtils.HeaderProcessor headerProcessor,
                                             JsonApiMapper mapper,
                                             ErrorMapper errorMapper) {
 
@@ -46,6 +48,7 @@ public class IntegrationTestSetup {
                 .withSubqueryFilterDialect(RSQLFilterDialect.builder().dictionary(dictionary).build())
                 .withAuditLogger(new Slf4jLogger())
                 .withBaseUrl(settings.getBaseUrl())
+                .withHeaderProcessor(headerProcessor)
                 .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"))
                 .withJsonApiPath(settings.getJsonApi().getPath())
                 .withGraphQLApiPath(settings.getGraphql().getPath());


### PR DESCRIPTION
## Description
Adds configuration to enable/disable security credential stripping in HTTP headers.

## Motivation and Context
Elide automatically removes Authorization headers from client requests before the framework is invoked.  Some users want to leverage the credentials in these headers to invoke other services from life cycle hooks or data stores.

## How Has This Been Tested?
New IT tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
