### PR TITLE
fix: support big number aggregations

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -560,7 +560,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("playerRank", 1)
                                 ),
                                 selections(
-                                        field("highScore", 2412),
+                                        field("highScore", 3147483647L),
                                         field("overallRating", "Great"),
                                         field("countryIsoCode", "USA"),
                                         field("playerRank", 2)
@@ -676,7 +676,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("playerLevel", 1)
                                 ),
                                 selections(
-                                        field("highScore", 2412),
+                                        field("highScore", 3147483647L),
                                         field("playerLevel", 2)
                                 )
                         )
@@ -1017,7 +1017,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                         field(
                                 "playerStats",
                                 selections(
-                                        field("highScore", 2412),
+                                        field("highScore", 3147483647L),
                                         field("countryIsoCode", "USA")
                                 ),
                                 selections(
@@ -1166,7 +1166,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("countryViewIsoCode", "HKG")
                                 ),
                                 selections(
-                                        field("highScore", 2412),
+                                        field("highScore", 3147483647L),
                                         field("countryViewIsoCode", "USA")
                                 )
                         )
@@ -1253,7 +1253,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.id", hasItems("0", "1", "2"))
-                .body("data.attributes.highScore", hasItems(1000, 1234, 2412))
+                .body("data.attributes.highScore", hasItems(1000, 1234, 3147483647L))
                 .body("data.attributes.countryIsoCode", hasItems("USA", "HKG"));
     }
 
@@ -1862,7 +1862,7 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("countryAlias", "HKG")
                                 ),
                                 selections(
-                                        field("highScore", 2412),
+                                        field("highScore", 3147483647L),
                                         field("countryAlias", "USA")
                                 )
                         )
@@ -1916,8 +1916,8 @@ public class AggregationDataStoreIntegrationTest extends GraphQLIntegrationTest 
                                         field("byDay", "2019-07-12")
                                 ),
                                 selections(
-                                        field("highScoreAlias", 2412),
-                                        field("avgScoreAlias", 2412),
+                                        field("highScoreAlias", 3147483647L),
+                                        field("avgScoreAlias", 3147483647L),
                                         field("ratingAlias", "Great"),
                                         field("countryAlias", "USA"),
                                         field("byDay", "2019-07-11")

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/QueryEngineTest.java
@@ -67,7 +67,7 @@ public class QueryEngineTest extends SQLUnitTest {
         PlayerStats stats0 = new PlayerStats();
         stats0.setId("0");
         stats0.setLowScore(241);
-        stats0.setHighScore(2412);
+        stats0.setHighScore(3147483647L);
         stats0.setRecordedDate(new Day(Date.valueOf("2019-07-11")));
 
         PlayerStats stats1 = new PlayerStats();
@@ -102,7 +102,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStatsView stats2 = new PlayerStatsView();
         stats2.setId("0");
-        stats2.setHighScore(2412);
+        stats2.setHighScore(3147483647L);
 
         assertEquals(ImmutableList.of(stats2), results);
     }
@@ -131,7 +131,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStatsView stats2 = new PlayerStatsView();
         stats2.setId("0");
-        stats2.setHighScore(2412);
+        stats2.setHighScore(3147483647L);
         stats2.setCountryName("United States");
 
         assertEquals(ImmutableList.of(stats2), results);
@@ -182,7 +182,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStatsView stats2 = new PlayerStatsView();
         stats2.setId("0");
-        stats2.setHighScore(2412);
+        stats2.setHighScore(3147483647L);
 
         assertEquals(ImmutableList.of(stats2), results);
     }
@@ -305,7 +305,7 @@ public class QueryEngineTest extends SQLUnitTest {
         //Jon Doe,1234,72,Good,840,2019-07-12 00:00:00
         PlayerStats stats1 = new PlayerStats();
         stats1.setId("0");
-        stats1.setDailyAverageScorePerPeriod(2412.0f);
+        stats1.setDailyAverageScorePerPeriod(3.147483647E9);
         stats1.setOverallRating("Great");
         stats1.setRecordedDate(new Day(Date.valueOf("2019-07-11")));
 
@@ -359,7 +359,7 @@ public class QueryEngineTest extends SQLUnitTest {
         stats0.setId("1");
         stats0.setOverallRating("Great");
         stats0.setCountryIsoCode("USA");
-        stats0.setHighScore(2412);
+        stats0.setHighScore(3147483647L);
 
         PlayerStats stats1 = new PlayerStats();
         stats1.setId("0");
@@ -429,7 +429,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStats stats1 = new PlayerStats();
         stats1.setId("1");
-        stats1.setHighScore(2412);
+        stats1.setHighScore(3147483647L);
         stats1.setCountryIsoCode("USA");
 
         PlayerStats stats2 = new PlayerStats();
@@ -464,7 +464,7 @@ public class QueryEngineTest extends SQLUnitTest {
         PlayerStats stats2 = new PlayerStats();
         stats2.setId("1");
         stats2.setOverallRating("Great");
-        stats2.setHighScore(2412);
+        stats2.setHighScore(3147483647L);
 
         assertEquals(ImmutableList.of(stats1, stats2), results);
     }
@@ -506,7 +506,7 @@ public class QueryEngineTest extends SQLUnitTest {
         stats3.setId("2");
         stats3.setOverallRating("Great");
         stats3.setCountryIsoCode("USA");
-        stats3.setHighScore(2412);
+        stats3.setHighScore(3147483647L);
 
         assertEquals(ImmutableList.of(stats1, stats2, stats3), results);
     }
@@ -529,7 +529,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStats stats0 = new PlayerStats();
         stats0.setId("0");
-        stats0.setHighScore(2412);
+        stats0.setHighScore(3147483647L);
         stats0.setRecordedDate(new Day(Date.valueOf("2019-07-11")));
 
         PlayerStats stats1 = new PlayerStats();
@@ -569,7 +569,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStats stats0 = new PlayerStats();
         stats0.setId("0");
-        stats0.setHighScore(2412);
+        stats0.setHighScore(3147483647L);
         stats0.setRecordedDate(new Day(Date.valueOf("2019-07-11")));
 
         assertEquals(ImmutableList.of(stats0), results);
@@ -623,7 +623,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStats stats1 = new PlayerStats();
         stats1.setId("1");
-        stats1.setHighScore(2412);
+        stats1.setHighScore(3147483647L);
         stats1.setCountryNickName("Uncle Sam");
 
         PlayerStats stats2 = new PlayerStats();
@@ -646,7 +646,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStats stats1 = new PlayerStats();
         stats1.setId("1");
-        stats1.setHighScore(2412);
+        stats1.setHighScore(3147483647L);
         stats1.setCountryUnSeats(1);
 
         PlayerStats stats2 = new PlayerStats();
@@ -686,7 +686,7 @@ public class QueryEngineTest extends SQLUnitTest {
         assertEquals(1234, results.get(1).getHighScore());
         assertEquals(new Day(Date.valueOf("2019-07-12")), results.get(1).fetch("byDay", null));
         assertEquals(new Month(Date.valueOf("2019-07-01")), results.get(1).fetch("byMonth", null));
-        assertEquals(2412, results.get(2).getHighScore());
+        assertEquals(3147483647L, results.get(2).getHighScore());
         assertEquals(new Day(Date.valueOf("2019-07-11")), results.get(2).fetch("byDay", null));
         assertEquals(new Month(Date.valueOf("2019-07-01")), results.get(2).fetch("byMonth", null));
     }
@@ -721,7 +721,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         List<PlayerStats> results = toList(engine.executeQuery(query, transaction).getData());
         assertEquals(1, results.size());
-        assertEquals(2412, results.get(0).getHighScore());
+        assertEquals(3147483647L, results.get(0).getHighScore());
         assertEquals(new Day(Date.valueOf("2019-07-11")), results.get(0).fetch("byDay", null));
         assertEquals(new Month(Date.valueOf("2019-07-01")), results.get(0).fetch("byMonth", null));
     }
@@ -764,7 +764,7 @@ public class QueryEngineTest extends SQLUnitTest {
         assertEquals(new Day(Date.valueOf("2019-07-12")), results.get(1).fetch("byDay", null));
         assertEquals(new Month(Date.valueOf("2019-07-01")), results.get(1).fetch("byMonth", null));
 
-        assertEquals(2412, results.get(2).getHighScore());
+        assertEquals(3147483647L, results.get(2).getHighScore());
         assertEquals(new Day(Date.valueOf("2019-07-11")), results.get(2).fetch("byDay", null));
         assertEquals(new Month(Date.valueOf("2019-07-01")), results.get(2).fetch("byMonth", null));
     }
@@ -799,7 +799,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         List<PlayerStats> results = toList(engine.executeQuery(query, transaction).getData());
         assertEquals(3, results.size());
-        assertEquals(2412, results.get(0).getHighScore());
+        assertEquals(3147483647L, results.get(0).getHighScore());
         assertEquals(new Day(Date.valueOf("2019-07-11")), results.get(0).fetch("byDay", null));
         assertEquals(new Month(Date.valueOf("2019-07-01")), results.get(0).fetch("byMonth", null));
 
@@ -829,7 +829,7 @@ public class QueryEngineTest extends SQLUnitTest {
 
         PlayerStats stats0 = new PlayerStats();
         stats0.setId("0");
-        stats0.setDailyAverageScorePerPeriod((float) 1548.6666);
+        stats0.setDailyAverageScorePerPeriod(1.0491619603333334E9);
         stats0.setRecordedDate(new Month(Date.valueOf("2019-07-01")));
 
         assertEquals(ImmutableList.of(stats0), results);

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/SubselectTest.java
@@ -55,7 +55,7 @@ public class SubselectTest extends SQLUnitTest {
 
         PlayerStats stats1 = new PlayerStats();
         stats1.setId("1");
-        stats1.setHighScore(2412);
+        stats1.setHighScore(3147483647L);
         stats1.setSubCountryIsoCode("USA");
 
         PlayerStats stats2 = new PlayerStats();
@@ -90,7 +90,7 @@ public class SubselectTest extends SQLUnitTest {
         PlayerStats stats2 = new PlayerStats();
         stats2.setId("1");
         stats2.setOverallRating("Great");
-        stats2.setHighScore(2412);
+        stats2.setHighScore(3147483647L);
 
         assertEquals(2, results.size());
         assertEquals(stats1, results.get(0));
@@ -134,7 +134,7 @@ public class SubselectTest extends SQLUnitTest {
         stats3.setId("2");
         stats3.setOverallRating("Great");
         stats3.setSubCountryIsoCode("USA");
-        stats3.setHighScore(2412);
+        stats3.setHighScore(3147483647L);
 
         assertEquals(3, results.size());
         assertEquals(stats1, results.get(0));

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/example/PlayerStats.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/example/PlayerStats.java
@@ -73,7 +73,7 @@ public class PlayerStats extends ParameterizedModel {
     /**
      * A metric.
      */
-    private float dailyAverageScorePerPeriod;
+    private double dailyAverageScorePerPeriod;
 
     /**
      * A degenerate dimension.
@@ -178,11 +178,11 @@ public class PlayerStats extends ParameterizedModel {
     }
 
     @MetricFormula(maker = DailyAverageScorePerPeriodMaker.class)
-    public float getDailyAverageScorePerPeriod() {
+    public double getDailyAverageScorePerPeriod() {
         return fetch("dailyAverageScorePerPeriod", dailyAverageScorePerPeriod);
     }
 
-    public void setDailyAverageScorePerPeriod(final float dailyAverageScorePerPeriod) {
+    public void setDailyAverageScorePerPeriod(final double dailyAverageScorePerPeriod) {
         this.dailyAverageScorePerPeriod = dailyAverageScorePerPeriod;
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/graphql/responses/testGraphQLSchema.json
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/graphql/responses/testGraphQLSchema.json
@@ -39,14 +39,14 @@
               {
                 "name": "highScore",
                 "type": {
-                  "name": "Int",
+                  "name": "BigInteger",
                   "fields": null
                 }
               },
               {
                 "name": "lowScore",
                 "type": {
-                  "name": "Int",
+                  "name": "BigInteger",
                   "fields": null
                 }
               },

--- a/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_tables.sql
+++ b/elide-datastore/elide-datastore-aggregation/src/test/resources/prepare_tables.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS playerStats
     );
 TRUNCATE TABLE playerStats;
 INSERT INTO playerStats VALUES (1, 1234, 35, 'Good', '840', '840', 1, 2, '2019-07-12 00:00:00', '2019-10-12 00:00:00', 1, 'STATE');
-INSERT INTO playerStats VALUES (2, 2412, 241, 'Great', '840', '840', 2, 3, '2019-07-11 00:00:00', '2020-07-12 00:00:00', 1, 'STATE');
+INSERT INTO playerStats VALUES (2, 3147483647, 241, 'Great', '840', '840', 2, 3, '2019-07-11 00:00:00', '2020-07-12 00:00:00', 1, 'STATE');
 INSERT INTO playerStats VALUES (3, 1000, 72, 'Good', '344', '344', 3, 1, '2019-07-13 00:00:00', '2020-01-12 00:00:00', 1, 'STATE');
 
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -6,6 +6,8 @@
 
 package com.yahoo.elide.graphql;
 
+import static graphql.scalars.ExtendedScalars.GraphQLBigDecimal;
+import static graphql.scalars.ExtendedScalars.GraphQLBigInteger;
 import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLEnumType.newEnum;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
@@ -95,11 +97,11 @@ public class GraphQLConversionUtils {
         } else if (clazz.equals(ClassType.of(boolean.class)) || clazz.equals(ClassType.of(Boolean.class))) {
             return Scalars.GraphQLBoolean;
         } else if (clazz.equals(ClassType.of(long.class)) || clazz.equals(ClassType.of(Long.class))) {
-            return Scalars.GraphQLInt;
+            return GraphQLBigInteger;
         } else if (clazz.equals(ClassType.of(float.class)) || clazz.equals(ClassType.of(Float.class))) {
             return Scalars.GraphQLFloat;
         } else if (clazz.equals(ClassType.of(double.class)) || clazz.equals(ClassType.of(Double.class))) {
-            return Scalars.GraphQLFloat;
+            return GraphQLBigDecimal;
         } else if (clazz.equals(ClassType.of(short.class)) || clazz.equals(ClassType.of(Short.class))) {
             return Scalars.GraphQLInt;
         } else if (clazz.equals(ClassType.of(String.class)) || clazz.equals(ClassType.of(Object.class))) {

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.graphql;
 
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 import static graphql.Assert.assertNotNull;
+import static graphql.scalars.ExtendedScalars.GraphQLBigInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -204,7 +205,7 @@ public class ModelBuilderTest {
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_TITLE).getType());
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_GENRE).getType());
         assertEquals(Scalars.GraphQLString, bookType.getFieldDefinition(FIELD_LANGUAGE).getType());
-        assertEquals(Scalars.GraphQLInt, bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getType());
+        assertEquals(GraphQLBigInteger, bookType.getFieldDefinition(FIELD_PUBLISH_DATE).getType());
         assertEquals(JavaPrimitives.GraphQLBigDecimal, bookType.getFieldDefinition(FIELD_WEIGHT_LBS).getType());
 
         GraphQLObjectType addressType = (GraphQLObjectType) authorType.getFieldDefinition("homeAddress").getType();
@@ -231,7 +232,7 @@ public class ModelBuilderTest {
         assertEquals(Scalars.GraphQLString, bookInputType.getField(FIELD_TITLE).getType());
         assertEquals(Scalars.GraphQLString, bookInputType.getField(FIELD_GENRE).getType());
         assertEquals(Scalars.GraphQLString, bookInputType.getField(FIELD_LANGUAGE).getType());
-        assertEquals(Scalars.GraphQLInt, bookInputType.getField(FIELD_PUBLISH_DATE).getType());
+        assertEquals(GraphQLBigInteger, bookInputType.getField(FIELD_PUBLISH_DATE).getType());
 
         GraphQLList authorsInputType = (GraphQLList) bookInputType.getField(FIELD_AUTHORS).getType();
         assertEquals(authorInputType, authorsInputType.getWrappedType());


### PR DESCRIPTION

## Description

This PR fixes an issue when aggregating large numbers:

```
Can&#39;t serialize value (/RADM_NWFPty/edges[0]/node/col0) : Expected type &#39;Int&#39; but was &#39;Long&#39;.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
