### PR TITLE
Add Injector as a Bean

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -262,9 +262,31 @@ public class ElideAutoConfiguration {
     }
 
     /**
+     * Creates the injector for dependency injection.
+     * @param beanFactory Injector to inject Elide models.
+     * @return a newly configured Injector.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @Scope(SCOPE_PROTOTYPE)
+    public Injector buildInjector(AutowireCapableBeanFactory beanFactory) {
+        return new Injector() {
+            @Override
+            public void inject(Object entity) {
+                beanFactory.autowireBean(entity);
+            }
+
+            @Override
+            public <T> T instantiate(Class<T> cls) {
+                return beanFactory.createBean(cls);
+            }
+        };
+    }
+
+    /**
      * Creates the entity dictionary for Elide which contains static metadata about Elide models.
      * Override to load check classes or life cycle hooks.
-     * @param beanFactory Injector to inject Elide models.
+     * @param injector Injector to inject Elide models.
      * @param dynamicConfig An instance of DynamicConfiguration.
      * @param settings Elide configuration settings.
      * @param entitiesToExclude set of Entities to exclude from binding.
@@ -273,7 +295,7 @@ public class ElideAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @Scope(SCOPE_PROTOTYPE)
-    public EntityDictionary buildDictionary(AutowireCapableBeanFactory beanFactory,
+    public EntityDictionary buildDictionary(Injector injector,
                                             ClassScanner scanner,
                                             @Autowired(required = false) DynamicConfiguration dynamicConfig,
                                             ElideConfigProperties settings,
@@ -291,17 +313,7 @@ public class ElideAutoConfiguration {
         EntityDictionary dictionary = new EntityDictionary(
                 checks, //Checks
                 new HashMap<>(), //Role Checks
-                new Injector() {
-                    @Override
-                    public void inject(Object entity) {
-                        beanFactory.autowireBean(entity);
-                    }
-
-                    @Override
-                    public <T> T instantiate(Class<T> cls) {
-                        return beanFactory.createBean(cls);
-                    }
-                },
+                injector,
                 CoerceUtil::lookup, //Serde Lookup
                 entitiesToExclude,
                 scanner);


### PR DESCRIPTION
## Description
Making Injector a bean so the Elide Apps can access them directly without relying on dictionary

## Motivation and Context
Making Injector a bean so the Elide Apps can access them directly without relying on dictionary. The RefreshScope changes create a cyclic dependency if someone is trying to use a dictionary.injector in any hooks, etc.

## How Has This Been Tested?
existing tests pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
