### PR TITLE
Minimum to expose _service.sdl for Apollo federation.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
@@ -47,6 +47,7 @@ public class ElideSettings {
     @Getter private final Map<Class, Serde> serdes;
     @Getter private final boolean enableJsonLinks;
     @Getter private final boolean strictQueryParams;
+    @Getter private final boolean enableGraphQLFederation;
     @Getter private final String baseUrl;
     @Getter private final String jsonApiPath;
     @Getter private final String graphQLApiPath;

--- a/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideSettingsBuilder.java
@@ -63,6 +63,8 @@ public class ElideSettingsBuilder {
     private int defaultPageSize = PaginationImpl.DEFAULT_PAGE_LIMIT;
     private int updateStatusCode;
     private boolean enableJsonLinks;
+
+    private boolean enableGraphQLFederation;
     private boolean strictQueryParams = true;
     private String baseUrl = "";
     private String jsonApiPath;
@@ -85,6 +87,7 @@ public class ElideSettingsBuilder {
         updateStatusCode = HttpStatus.SC_NO_CONTENT;
         this.serdes = new LinkedHashMap<>();
         this.enableJsonLinks = false;
+        this.enableGraphQLFederation = false;
 
         //By default, Elide supports epoch based dates.
         this.withEpochDates();
@@ -128,6 +131,7 @@ public class ElideSettingsBuilder {
                 serdes,
                 enableJsonLinks,
                 strictQueryParams,
+                enableGraphQLFederation,
                 baseUrl,
                 jsonApiPath,
                 graphQLApiPath,
@@ -257,6 +261,11 @@ public class ElideSettingsBuilder {
 
     public ElideSettingsBuilder withStrictQueryParams(boolean enabled) {
         this.strictQueryParams = enabled;
+        return this;
+    }
+
+    public ElideSettingsBuilder withGraphQLFederation(boolean enabled) {
+        this.enableGraphQLFederation = enabled;
         return this;
     }
 }

--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -131,7 +131,11 @@
             <artifactId>javax.persistence-api</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.apollographql.federation</groupId>
+            <artifactId>federation-graphql-java-support</artifactId>
+            <version>2.0.0-alpha.5</version>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -11,6 +11,7 @@ import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
 import static graphql.schema.GraphQLObjectType.newObject;
 
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.RelationshipType;
 import com.yahoo.elide.core.type.ClassType;
@@ -74,6 +75,8 @@ public class ModelBuilder {
     private Set<Type<?>> excludedEntities;
     private Set<GraphQLObjectType> objectTypes;
 
+    private boolean enableFederation;
+
     /**
      * Class constructor, constructs the custom arguments to handle mutations.
      * @param entityDictionary elide entity dictionary
@@ -82,6 +85,7 @@ public class ModelBuilder {
      */
     public ModelBuilder(EntityDictionary entityDictionary,
                         NonEntityDictionary nonEntityDictionary,
+                        ElideSettings settings,
                         DataFetcher dataFetcher, String apiVersion) {
         objectTypes = new HashSet<>();
         this.generator = new GraphQLConversionUtils(entityDictionary, nonEntityDictionary);
@@ -90,6 +94,7 @@ public class ModelBuilder {
         this.nameUtils = new GraphQLNameUtils(entityDictionary);
         this.dataFetcher = dataFetcher;
         this.apiVersion = apiVersion;
+        this.enableFederation = settings.isEnableGraphQLFederation();
 
         relationshipOpArg = newArgument()
                 .name(ARGUMENT_OPERATION)
@@ -221,7 +226,8 @@ public class ModelBuilder {
                 .build();
 
         //Enable Apollo Federation
-        return Federation.transform(schema).build();
+        schema = (enableFederation) ? Federation.transform(schema).build() : schema;
+        return schema;
     }
 
     /**

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/ModelBuilder.java
@@ -10,10 +10,12 @@ import static graphql.schema.GraphQLArgument.newArgument;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLInputObjectField.newInputObjectField;
 import static graphql.schema.GraphQLObjectType.newObject;
+
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.RelationshipType;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
+import com.apollographql.federation.graphqljava.Federation;
 import org.apache.commons.collections4.CollectionUtils;
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
@@ -218,7 +220,8 @@ public class ModelBuilder {
                                 inputObjectRegistry.values())))
                 .build();
 
-        return schema;
+        //Enable Apollo Federation
+        return Federation.transform(schema).build();
     }
 
     /**

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -85,7 +85,7 @@ public class QueryRunner {
 
         PersistentResourceFetcher fetcher = new PersistentResourceFetcher(nonEntityDictionary);
         ModelBuilder builder = new ModelBuilder(elide.getElideSettings().getDictionary(),
-                nonEntityDictionary, fetcher, apiVersion);
+                nonEntityDictionary, elide.getElideSettings(), fetcher, apiVersion);
 
         api = GraphQL.newGraphQL(builder.build())
                 .queryExecutionStrategy(new AsyncSerialExecutionStrategy())

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -162,10 +162,13 @@ public class GraphQLEntityProjectionMaker {
             Field rootSelectionField = (Field) rootSelection;
             String entityName = rootSelectionField.getName();
             String aliasName = rootSelectionField.getAlias();
+
+            //_service comes from Apollo federation spec
             if ("_service".equals(entityName) || SCHEMA.hasName(entityName) || TYPE.hasName(entityName)) {
-                // '__schema' and '__type' would not be handled by entity projection
+                // '_service' and '__schema' and '__type' would not be handled by entity projection
                 return;
             }
+
             Type<?> entityType = getRootEntity(rootSelectionField.getName(), apiVersion);
             if (entityType == null) {
                 throw new InvalidEntityBodyException(String.format("Unknown entity {%s}.",

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -162,7 +162,7 @@ public class GraphQLEntityProjectionMaker {
             Field rootSelectionField = (Field) rootSelection;
             String entityName = rootSelectionField.getName();
             String aliasName = rootSelectionField.getAlias();
-            if (SCHEMA.hasName(entityName) || TYPE.hasName(entityName)) {
+            if ("_service".equals(entityName) || SCHEMA.hasName(entityName) || TYPE.hasName(entityName)) {
                 // '__schema' and '__type' would not be handled by entity projection
                 return;
             }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -278,6 +278,15 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     }
 
     @Test
+    public void testFederationServiceIntrospection() throws Exception {
+        String graphQLRequest = "{ _service { sdl }}";
+
+        ElideResponse response = runGraphQLRequest(graphQLRequest, new HashMap<>());
+
+        assertTrue(! response.getBody().contains("errors"));
+    }
+
+    @Test
     public void testSchemaIntrospection() throws Exception {
         String graphQLRequest = "{"
                 + "__schema {"

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.core.dictionary.ArgumentType;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.request.Sorting;
@@ -102,8 +104,10 @@ public class ModelBuilderTest {
     @Test
     public void testInternalModelConflict() {
         DataFetcher fetcher = mock(DataFetcher.class);
+        ElideSettings settings = mock(ElideSettings.class);
         ModelBuilder builder = new ModelBuilder(dictionary,
-                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup),
+                settings, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 
@@ -124,8 +128,10 @@ public class ModelBuilderTest {
     @Test
     public void testPageInfoObject() {
         DataFetcher fetcher = mock(DataFetcher.class);
+        ElideSettings settings = mock(ElideSettings.class);
         ModelBuilder builder = new ModelBuilder(dictionary,
-                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup),
+                settings, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 
@@ -136,8 +142,10 @@ public class ModelBuilderTest {
     @Test
     public void testRelationshipParameters() {
         DataFetcher fetcher = mock(DataFetcher.class);
+        ElideSettings settings = mock(ElideSettings.class);
         ModelBuilder builder = new ModelBuilder(dictionary,
-                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup),
+                settings, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
         GraphQLObjectType root = schema.getQueryType();
@@ -173,8 +181,10 @@ public class ModelBuilderTest {
     @Test
     public void testBuild() {
         DataFetcher fetcher = mock(DataFetcher.class);
+        ElideSettings settings = mock(ElideSettings.class);
         ModelBuilder builder = new ModelBuilder(dictionary,
-                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup),
+                settings, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 
@@ -251,8 +261,10 @@ public class ModelBuilderTest {
         dictionary.addArgumentsToAttribute(ClassType.of(Book.class), FIELD_PUBLISH_DATE, arguments);
 
         DataFetcher fetcher = mock(DataFetcher.class);
+        ElideSettings settings = mock(ElideSettings.class);
         ModelBuilder builder = new ModelBuilder(dictionary,
-                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup),
+                settings, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 
@@ -270,8 +282,10 @@ public class ModelBuilderTest {
         dictionary.addArgumentToEntity(ClassType.of(Author.class), new ArgumentType("filterAuthor", ClassType.STRING_TYPE));
 
         DataFetcher fetcher = mock(DataFetcher.class);
+        ElideSettings settings = mock(ElideSettings.class);
         ModelBuilder builder = new ModelBuilder(dictionary,
-                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(DefaultClassScanner.getInstance(), CoerceUtil::lookup),
+                settings, fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -81,6 +81,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
                 .withEntityDictionary(dictionary)
                 .withJoinFilterDialect(filterDialect)
                 .withSubqueryFilterDialect(filterDialect)
+                .withGraphQLFederation(true)
                 .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"))
                 .build();
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.spring.config;
 import static com.yahoo.elide.datastores.jpa.JpaDataStore.DEFAULT_LOGGER;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.RefreshableElide;
 import com.yahoo.elide.async.models.AsyncQuery;
@@ -193,6 +194,10 @@ public class ElideAutoConfiguration {
                 && settings.getAsync().getExport() != null
                 && settings.getAsync().getExport().isEnabled()) {
             builder.withExportApiPath(settings.getAsync().getExport().getPath());
+        }
+
+        if (settings.getGraphql() != null && settings.getGraphql().enableFederation) {
+            builder.withGraphQLFederation(true);
         }
 
         if (settings.getJsonApi() != null

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -8,7 +8,6 @@ package com.yahoo.elide.spring.config;
 import static com.yahoo.elide.datastores.jpa.JpaDataStore.DEFAULT_LOGGER;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 import com.yahoo.elide.Elide;
-import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.ElideSettingsBuilder;
 import com.yahoo.elide.RefreshableElide;
 import com.yahoo.elide.async.models.AsyncQuery;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -23,7 +23,7 @@ public class ElideConfigProperties {
     /**
      * Settings for the GraphQL controller.
      */
-    private ControllerProperties graphql;
+    private GraphQLControllerProperties graphql;
 
     /**
      * Settings for the Swagger document controller.

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/GraphQLControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/GraphQLControllerProperties.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Extra controller properties for the GraphQL endpoint.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class GraphQLControllerProperties extends ControllerProperties {
+
+    /**
+     * Turns on/off Apollo federation schema
+     */
+    boolean enableFederation = false;
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/GraphQLControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/GraphQLControllerProperties.java
@@ -16,7 +16,7 @@ import lombok.EqualsAndHashCode;
 public class GraphQLControllerProperties extends ControllerProperties {
 
     /**
-     * Turns on/off Apollo federation schema
+     * Turns on/off Apollo federation schema.
      */
     boolean enableFederation = false;
 }


### PR DESCRIPTION
Related to #2638 

Phase 1 of enabling the Apollo Federation specification.  Phase 1 simply exposes Elide models so they can be discovered by Apollo federation gateways.   Phase 2 will add support for @key allowing subgraphs to reference Elide model types in their schemas.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
