### PR TITLE
Serdes now take precedence over type converters for enums.

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
@@ -116,7 +116,11 @@ public class CoerceUtil {
              */
             public Converter lookup(Class<?> sourceType, Class<?> targetType) {
                 if (targetType.isEnum()) {
-                    return TO_ENUM_CONVERTER;
+
+                    //Only use the default ENUM converter if there is no registered Serde for the given Enum type.
+                    if (! SERDES.containsKey(targetType)) {
+                        return TO_ENUM_CONVERTER;
+                    }
                 }
                 if (Map.class.isAssignableFrom(sourceType)) {
                     return FROM_MAP_CONVERTER;

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
@@ -24,7 +24,7 @@ public class ClassScannerTest {
     @Test
     public void testGetAllClasses() {
         Set<Class<?>> classes = scanner.getAllClasses("com.yahoo.elide.core.utils");
-        assertEquals(32, classes.size());
+        assertEquals(33, classes.size());
         assertTrue(classes.contains(ClassScannerTest.class));
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
@@ -8,6 +8,8 @@ package com.yahoo.elide.core.utils.coerce;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.utils.coerce.converters.EpochToDateConverter;
 import com.yahoo.elide.core.utils.coerce.converters.ISO8601DateSerde;
@@ -31,6 +33,7 @@ import java.util.UUID;
 public class CoerceUtilTest {
 
     public enum Seasons { WINTER, SPRING }
+    public enum WeekendDays { SATURDAY, SUNDAY }
 
     private static Map<Class, Serde> oldSerdes = new HashMap<>();
 
@@ -175,6 +178,15 @@ public class CoerceUtilTest {
 
         Time timeLong = CoerceUtil.coerce(0L, Time.class);
         assertEquals(new Time(0), timeLong);
+    }
+
+    @Test
+    public void testCustomEnumSerde() {
+        Serde<String, WeekendDays> mockSerde = (Serde<String, WeekendDays>) mock(Serde.class);
+        CoerceUtil.register(WeekendDays.class, mockSerde);
+
+        CoerceUtil.coerce("Monday", WeekendDays.class);
+        verify(mockSerde, times(1)).deserialize(eq("Monday"));
     }
 
     @Test


### PR DESCRIPTION
Resolves #2734

## Description
Before Serdes, Elide did type coercion only for a set of standard types - dates, enums, etc.  This logic still takes precedence even over user defined Serdes.

## Motivation and Context
The developer should be able to override Elide's type coercion with their own Serde.

## How Has This Been Tested?
Unit Test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
