### PR TITLE
Enforcing ErrorObjects.addError is called prior to any other function…

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ErrorObjects.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/exceptions/ErrorObjects.java
@@ -68,6 +68,9 @@ public class ErrorObjects {
         }
 
         public ErrorObjectsBuilder with(String key, Object value) {
+            if (currentError == null) {
+                throw new UnsupportedOperationException("Must add an error before calling with");
+            }
             currentError.put(key, value);
             return this;
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorObjectsTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/exceptions/ErrorObjectsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class ErrorObjectsTest {
+    @Test
+    public void testAddErrorLast() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            ErrorObjects errorObj = new ErrorObjects.ErrorObjectsBuilder()
+                    .with("foo", "bar")
+                    .addError().build();
+        });
+    }
+
+    @Test
+    public void testAddErrorFirst() {
+        ErrorObjects errorObj = new ErrorObjects.ErrorObjectsBuilder()
+                .addError()
+                .with("foo", "bar")
+                .build();
+
+        assertEquals(1, errorObj.getErrors().size());
+        assertEquals("bar", errorObj.getErrors().get(0).get("foo"));
+    }
+}


### PR DESCRIPTION
… calls

Resolves #2757

## Description
Ensures the ErrorObjects contract is enforced (addError is called prior to any 'with' calls).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
