### PR TITLE
Only build query runner if graphQL is enabled

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -220,6 +220,7 @@ public class ElideAutoConfiguration {
     @Bean
     @RefreshScope
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "elide.graphql.enabled", havingValue = "true")
     public QueryRunners getQueryRunners(RefreshableElide refreshableElide) {
         return new QueryRunners(refreshableElide);
     }


### PR DESCRIPTION
Resolves #2761

## How Has This Been Tested?
Manually tested starting spring boot with graphQL enabled (and also disabled) to see if a bad enumeration prevents startup.  With this fix, it does not when graphQL is disabled.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
