### PR TITLE
Allow elide-graphql to be excluded when elide.graphql.enabled=false

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -217,12 +217,16 @@ public class ElideAutoConfiguration {
         return new RefreshableElide(elide);
     }
 
-    @Bean
-    @RefreshScope
-    @ConditionalOnMissingBean
+
+    @Configuration
     @ConditionalOnProperty(name = "elide.graphql.enabled", havingValue = "true")
-    public QueryRunners getQueryRunners(RefreshableElide refreshableElide) {
-        return new QueryRunners(refreshableElide);
+    public static class GraphQLConfiguration {
+        @Bean
+        @RefreshScope
+        @ConditionalOnMissingBean
+        public QueryRunners getQueryRunners(RefreshableElide refreshableElide) {
+            return new QueryRunners(refreshableElide);
+        }
     }
 
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
@@ -10,9 +10,9 @@ import com.yahoo.elide.core.audit.Slf4jLogger;
 import com.yahoo.elide.core.exceptions.ErrorMapper;
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfigurator;
 import com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket;
-import com.yahoo.elide.jsonapi.JsonApiMapper;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +25,7 @@ import javax.websocket.server.ServerEndpointConfig;
  * Configures GraphQL subscription web sockets for Elide.
  */
 @Configuration
+@ConditionalOnProperty(name = "elide.graphql.enabled", havingValue = "true")
 @EnableConfigurationProperties(ElideConfigProperties.class)
 public class ElideSubscriptionConfiguration {
     @Bean
@@ -34,8 +35,7 @@ public class ElideSubscriptionConfiguration {
             ElideConfigProperties config,
             SubscriptionWebSocket.UserFactory userFactory,
             ConnectionFactory connectionFactory,
-            ErrorMapper errorMapper,
-            JsonApiMapper mapper
+            ErrorMapper errorMapper
     ) {
         return ServerEndpointConfig.Builder
                 .create(SubscriptionWebSocket.class, config.getSubscription().getPath())


### PR DESCRIPTION
Resolves #2786

## How Has This Been Tested?
Tested manually on a Spring Boot project by including/excluding the elide-graphql and toggling the elide.graphql.enabled configuration.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
