### PR TITLE
Refactoring Expression Visitor so all expression types have visit met…

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AnyFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/AnyFieldExpression.java
@@ -32,7 +32,7 @@ public class AnyFieldExpression implements Expression {
 
     @Override
     public <T> T accept(ExpressionVisitor<T> visitor) {
-        return visitor.visitExpression(this);
+        return visitor.visitAnyFieldExpression(this);
     }
 
     @Override

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/BooleanExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/BooleanExpression.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.core.security.permissions.expressions;
+
+import static org.fusesource.jansi.Ansi.ansi;
+
+import com.yahoo.elide.core.security.permissions.ExpressionResult;
+import org.fusesource.jansi.Ansi;
+
+/**
+ * Expression that returns always true (PASS) or false (FAILURE).
+ */
+public class BooleanExpression implements Expression {
+    private boolean value;
+    public BooleanExpression(boolean value) {
+        this.value = value;
+    }
+    @Override
+    public ExpressionResult evaluate(EvaluationMode mode) {
+        if (value == true) {
+            return ExpressionResult.PASS;
+        }
+        return ExpressionResult.FAIL;
+    }
+
+    @Override
+    public <T> T accept(ExpressionVisitor<T> visitor) {
+        return visitor.visitBooleanExpression(this);
+    }
+
+    @Override
+    public String toString() {
+        Ansi.Color color = value ? Ansi.Color.GREEN : Ansi.Color.RED;
+        String label = value ? "SUCCESS" : "FAILURE";
+        return ansi().fg(color).a(label).reset().toString();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/Expression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/Expression.java
@@ -5,9 +5,7 @@
  */
 package com.yahoo.elide.core.security.permissions.expressions;
 
-import static org.fusesource.jansi.Ansi.ansi;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
-import org.fusesource.jansi.Ansi;
 
 /**
  * Interface describing an expression.
@@ -37,37 +35,7 @@ public interface Expression {
      * Static Expressions that return PASS or FAIL.
      */
     public static class Results {
-        public static final Expression SUCCESS = new Expression() {
-            @Override
-            public ExpressionResult evaluate(EvaluationMode ignored) {
-                return ExpressionResult.PASS;
-            }
-
-            @Override
-            public <T> T accept(ExpressionVisitor<T> visitor) {
-                return visitor.visitExpression(this);
-            }
-
-            @Override
-            public String toString() {
-                return ansi().fg(Ansi.Color.GREEN).a("SUCCESS").reset().toString();
-            }
-        };
-        public static final Expression FAILURE = new Expression() {
-            @Override
-            public ExpressionResult evaluate(EvaluationMode ignored) {
-                return ExpressionResult.FAIL;
-            }
-
-            @Override
-            public <T> T accept(ExpressionVisitor<T> visitor) {
-                return visitor.visitExpression(this);
-            }
-
-            @Override
-            public String toString() {
-                return ansi().fg(Ansi.Color.RED).a("FAILURE").reset().toString();
-            }
-        };
+        public static final Expression SUCCESS = new BooleanExpression(true);
+        public static final Expression FAILURE = new BooleanExpression(false);
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
@@ -11,7 +11,8 @@ package com.yahoo.elide.core.security.permissions.expressions;
  * @param <T> The return type of the visitor
  */
 public interface ExpressionVisitor<T> {
-    T visitExpression(Expression expression);
+    T visitSpecificFieldExpression(SpecificFieldExpression expression);
+    T visitAnyFieldExpression(AnyFieldExpression expression);
     T visitCheckExpression(CheckExpression checkExpression);
     T visitAndExpression(AndExpression andExpression);
     T visitOrExpression(OrExpression orExpression);

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/ExpressionVisitor.java
@@ -13,6 +13,7 @@ package com.yahoo.elide.core.security.permissions.expressions;
 public interface ExpressionVisitor<T> {
     T visitSpecificFieldExpression(SpecificFieldExpression expression);
     T visitAnyFieldExpression(AnyFieldExpression expression);
+    T visitBooleanExpression(BooleanExpression expression);
     T visitCheckExpression(CheckExpression checkExpression);
     T visitAndExpression(AndExpression andExpression);
     T visitOrExpression(OrExpression orExpression);

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/SpecificFieldExpression.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/permissions/expressions/SpecificFieldExpression.java
@@ -41,7 +41,7 @@ public class SpecificFieldExpression implements Expression {
 
     @Override
     public <T> T accept(ExpressionVisitor<T> visitor) {
-        return visitor.visitExpression(this);
+        return visitor.visitSpecificFieldExpression(this);
     }
 
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
@@ -23,6 +23,11 @@ public class PermissionExpressionNormalizationVisitor implements ExpressionVisit
     }
 
     @Override
+    public Expression visitBooleanExpression(BooleanExpression expression) {
+        return expression;
+    }
+
+    @Override
     public Expression visitCheckExpression(CheckExpression checkExpression) {
         return checkExpression;
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionExpressionNormalizationVisitor.java
@@ -6,19 +6,19 @@
 
 package com.yahoo.elide.core.security.visitors;
 
-import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
-import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
-import com.yahoo.elide.core.security.permissions.expressions.Expression;
-import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
-import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
-import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
+import com.yahoo.elide.core.security.permissions.expressions.*;
 
 /**
  * Expression Visitor to normalize Permission expression.
  */
 public class PermissionExpressionNormalizationVisitor implements ExpressionVisitor<Expression> {
     @Override
-    public Expression visitExpression(Expression expression) {
+    public Expression visitSpecificFieldExpression(SpecificFieldExpression expression) {
+        return expression;
+    }
+
+    @Override
+    public Expression visitAnyFieldExpression(AnyFieldExpression expression) {
         return expression;
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
@@ -202,4 +202,9 @@ public class PermissionToFilterExpressionVisitor implements ExpressionVisitor<Fi
     public FilterExpression visitAnyFieldExpression(AnyFieldExpression expression) {
         return NO_EVALUATION_EXPRESSION;
     }
+
+    @Override
+    public FilterExpression visitBooleanExpression(BooleanExpression expression) {
+        return NO_EVALUATION_EXPRESSION;
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/visitors/PermissionToFilterExpressionVisitor.java
@@ -18,12 +18,7 @@ import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.FilterExpressionCheck;
 import com.yahoo.elide.core.security.checks.UserCheck;
-import com.yahoo.elide.core.security.permissions.expressions.AndExpression;
-import com.yahoo.elide.core.security.permissions.expressions.CheckExpression;
-import com.yahoo.elide.core.security.permissions.expressions.Expression;
-import com.yahoo.elide.core.security.permissions.expressions.ExpressionVisitor;
-import com.yahoo.elide.core.security.permissions.expressions.NotExpression;
-import com.yahoo.elide.core.security.permissions.expressions.OrExpression;
+import com.yahoo.elide.core.security.permissions.expressions.*;
 import com.yahoo.elide.core.type.Type;
 
 import java.util.Objects;
@@ -199,7 +194,12 @@ public class PermissionToFilterExpressionVisitor implements ExpressionVisitor<Fi
     }
 
     @Override
-    public FilterExpression visitExpression(Expression expression) {
+    public FilterExpression visitSpecificFieldExpression(SpecificFieldExpression expression) {
+        return NO_EVALUATION_EXPRESSION;
+    }
+
+    @Override
+    public FilterExpression visitAnyFieldExpression(AnyFieldExpression expression) {
         return NO_EVALUATION_EXPRESSION;
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionVisitorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/parsers/expression/PermissionExpressionVisitorTest.java
@@ -158,7 +158,7 @@ public class PermissionExpressionVisitorTest {
 
         @Override
         public <T> T accept(ExpressionVisitor<T> visitor) {
-            return visitor.visitExpression(this);
+            return null;
         }
     }
 }


### PR DESCRIPTION
…hods.

This PR expands the ExpressionVisitor to cover root and leaf expression types added by Elide.  Primary driver is to allow the creation of visitors after Elide has decorated the AST with its internal expression types.

 * Adding explicit visit methods for specific and any field expressions to ExpressionVisitor.
 * Added BooleanExpression to represent PASS and FAILURE scenarios.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
