### PR TITLE
Add negated prefix, postfix and infix operators. (#2788)

### DIFF
--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.BadRequestException;
@@ -18,8 +19,10 @@ import com.yahoo.elide.core.filter.dialect.jsonapi.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.PredicateExtractionVisitor;
 import com.yahoo.elide.core.filter.predicates.FilterPredicate;
+
 import example.Author;
 import example.Book;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -193,6 +197,48 @@ public class FilterPredicateTest {
         FilterPredicate predicate = predicates.get("book").iterator().next();
         assertEquals("title", predicate.getField());
         assertEquals(Operator.INFIX, predicate.getOperator());
+        assertEquals(Arrays.asList("abc", "def"), predicate.getValues());
+    }
+
+    @Test
+    void testSingleFieldWithNotPrefixOperator() {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        queryParams.add("filter[book.title][notprefix]", "abc");
+
+        Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
+        assertTrue(predicates.containsKey("book"));
+
+        FilterPredicate predicate = predicates.get("book").iterator().next();
+        assertEquals("title", predicate.getField());
+        assertEquals(Operator.NOT_PREFIX, predicate.getOperator());
+        assertEquals(Collections.singletonList("abc"), predicate.getValues());
+    }
+
+    @Test
+    void testSingleFieldWithNotPostfixOperator() {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        queryParams.add("filter[book.title][notpostfix]", "abc,def");
+
+        Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
+        assertTrue(predicates.containsKey("book"));
+
+        FilterPredicate predicate = predicates.get("book").iterator().next();
+        assertEquals("title", predicate.getField());
+        assertEquals(Operator.NOT_POSTFIX, predicate.getOperator());
+        assertEquals(Arrays.asList("abc", "def"), predicate.getValues());
+    }
+
+    @Test
+    void testSingleFieldWithNotInfixOperator() {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        queryParams.add("filter[book.title][notinfix]", "abc,def");
+
+        Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
+        assertTrue(predicates.containsKey("book"));
+
+        FilterPredicate predicate = predicates.get("book").iterator().next();
+        assertEquals("title", predicate.getField());
+        assertEquals(Operator.NOT_INFIX, predicate.getOperator());
         assertEquals(Arrays.asList("abc", "def"), predicate.getValues());
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -336,11 +336,11 @@ public class OperatorTest {
 
         // When notprefix, notinfix, notpostfix are correctly matched if case-insensitive
         fn = Operator.NOT_PREFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("author"), requestScope);
-        assertFalse(fn.test(author));
+        assertTrue(fn.test(author));
         fn = Operator.NOT_INFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("for"), requestScope);
-        assertFalse(fn.test(author));
+        assertTrue(fn.test(author));
         fn = Operator.NOT_POSTFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("test"), requestScope);
-        assertFalse(fn.test(author));
+        assertTrue(fn.test(author));
 
         // When notprefix, notinfix, notpostfix are not matched
         fn = Operator.NOT_PREFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("error"), requestScope);

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
@@ -19,9 +20,11 @@ import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.DefaultClassScanner;
 import com.yahoo.elide.core.utils.coerce.CoerceUtil;
+
 import example.Address;
 import example.Author;
 import example.Book;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -35,7 +38,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 public class OperatorTest {
-    private EntityDictionary dictionary;
+    private final EntityDictionary dictionary;
     private final RequestScope requestScope;
     private Author author;
     private Predicate fn;
@@ -160,7 +163,7 @@ public class OperatorTest {
         fn = Operator.IN.contextualize(constructPath(Author.class, "homeAddress.street1"), Arrays.asList("Foo", "Bar"), requestScope);
         assertTrue(fn.test(author));
 
-        fn = Operator.IN.contextualize(constructPath(Author.class, "homeAddress.street1"), Arrays.asList("Baz"), requestScope);
+        fn = Operator.IN.contextualize(constructPath(Author.class, "homeAddress.street1"), List.of("Baz"), requestScope);
         assertFalse(fn.test(author));
     }
 
@@ -183,7 +186,7 @@ public class OperatorTest {
 
         //name is null and books are null
         author.setBooks(null);
-        author.setAwards(Arrays.asList());
+        author.setAwards(List.of());
         fn = Operator.ISEMPTY.contextualize(constructPath(Author.class, "awards"), null, requestScope);
         assertTrue(fn.test(author));
         fn = Operator.ISEMPTY.contextualize(constructPath(Author.class, "books"), null, requestScope);
@@ -204,7 +207,7 @@ public class OperatorTest {
         author2.setName("Jane");
         book.setAuthors(Arrays.asList(author1, author2));
 
-        fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Jon"), requestScope);
+        fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), List.of("Jon"), requestScope);
         assertTrue(fn.test(book));
 
         fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Nobody", "Jon"), requestScope);
@@ -216,7 +219,7 @@ public class OperatorTest {
         fn = Operator.IN.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Nobody1", "Nobody2"), requestScope);
         assertFalse(fn.test(book));
 
-        fn = Operator.NOT.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Jon"), requestScope);
+        fn = Operator.NOT.contextualize(constructPath(Book.class, "authors.name"), List.of("Jon"), requestScope);
         assertFalse(fn.test(book));
 
         fn = Operator.NOT.contextualize(constructPath(Book.class, "authors.name"), Arrays.asList("Nobody", "Jon"), requestScope);
@@ -278,14 +281,14 @@ public class OperatorTest {
         author.setAwards(Arrays.asList("Booker Prize", "National Book Awards"));
         author.getBooks().add(new Book());
 
-        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "awards"), Arrays.asList("Booker Prize"), requestScope);
+        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "awards"), List.of("Booker Prize"), requestScope);
         assertTrue(fn.test(author));
-        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "awards"), Arrays.asList(""), requestScope);
+        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "awards"), List.of(""), requestScope);
         assertFalse(fn.test(author));
 
-        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "awards"), Arrays.asList("National Book Awards"), requestScope);
+        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "awards"), List.of("National Book Awards"), requestScope);
         assertFalse(fn.test(author));
-        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "awards"), Arrays.asList("1"), requestScope);
+        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "awards"), List.of("1"), requestScope);
         assertTrue(fn.test(author));
 
         assertThrows(
@@ -322,6 +325,30 @@ public class OperatorTest {
         assertFalse(fn.test(author));
         fn = Operator.POSTFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("error"), requestScope);
         assertFalse(fn.test(author));
+
+        // When notprefix, notinfix, notpostfix are correctly matched
+        fn = Operator.NOT_PREFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("Author"), requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOT_INFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("For"), requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOT_POSTFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("Test"), requestScope);
+        assertFalse(fn.test(author));
+
+        // When notprefix, notinfix, notpostfix are correctly matched if case-insensitive
+        fn = Operator.NOT_PREFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("author"), requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOT_INFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("for"), requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOT_POSTFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("test"), requestScope);
+        assertFalse(fn.test(author));
+
+        // When notprefix, notinfix, notpostfix are not matched
+        fn = Operator.NOT_PREFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("error"), requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.NOT_INFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("error"), requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.NOT_POSTFIX.contextualize(constructPath(Author.class, "name"), Collections.singletonList("error"), requestScope);
+        assertTrue(fn.test(author));
 
         // When values is null
         author.setName(null);

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/filter/FilterTranslator.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/filter/FilterTranslator.java
@@ -69,111 +69,111 @@ import java.util.stream.Collectors;
 public class FilterTranslator implements FilterOperation<String> {
     private static final String COMMA = ", ";
 
-    private static final Map<Operator, JPQLPredicateGenerator> globalOperatorGenerators;
-    private static final Map<Triple<Operator, Type<?>, String>, JPQLPredicateGenerator> globalPredicateOverrides;
+    private static final Map<Operator, JPQLPredicateGenerator> GLOBAL_OPERATOR_GENERATORS;
+    private static final Map<Triple<Operator, Type<?>, String>, JPQLPredicateGenerator> GLOBAL_PREDICATE_OVERRIDES;
 
     static {
-        globalPredicateOverrides = new HashMap<>();
+        GLOBAL_PREDICATE_OVERRIDES = new HashMap<>();
 
-        globalOperatorGenerators = new EnumMap<>(Operator.class);
+        GLOBAL_OPERATOR_GENERATORS = new EnumMap<>(Operator.class);
 
-        globalOperatorGenerators.put(IN, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(IN, new CaseAwareJPQLGenerator(
                 "%s IN (%s)",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.MANY)
         );
 
-        globalOperatorGenerators.put(IN_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(IN_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s IN (%s)",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.MANY)
         );
 
-        globalOperatorGenerators.put(NOT, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT, new CaseAwareJPQLGenerator(
                 "%s NOT IN (%s)",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.MANY)
         );
 
-        globalOperatorGenerators.put(NOT_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s NOT IN (%s)",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.MANY)
         );
 
-        globalOperatorGenerators.put(PREFIX, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(PREFIX, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(NOT_PREFIX, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT_PREFIX, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(PREFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(PREFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(NOT_PREFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT_PREFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(POSTFIX, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(POSTFIX, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(NOT_POSTFIX, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT_POSTFIX, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(POSTFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(POSTFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(NOT_POSTFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT_POSTFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(INFIX, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(INFIX, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(NOT_INFIX, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT_INFIX, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.NONE,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(INFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(INFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(NOT_INFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
+        GLOBAL_OPERATOR_GENERATORS.put(NOT_INFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.LOWER,
                 CaseAwareJPQLGenerator.ArgumentCount.ONE)
         );
 
-        globalOperatorGenerators.put(LT, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(LT, (predicate, aliasGenerator) -> {
             Preconditions.checkState(!predicate.getParameters().isEmpty());
             return String.format("%s < %s", aliasGenerator.apply(predicate.getPath()),
                     predicate.getParameters().size() == 1
@@ -181,7 +181,7 @@ public class FilterTranslator implements FilterOperation<String> {
                             : leastClause(predicate.getParameters()));
         });
 
-        globalOperatorGenerators.put(LE, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(LE, (predicate, aliasGenerator) -> {
             Preconditions.checkState(!predicate.getParameters().isEmpty());
             return String.format("%s <= %s", aliasGenerator.apply(predicate.getPath()),
                     predicate.getParameters().size() == 1
@@ -189,7 +189,7 @@ public class FilterTranslator implements FilterOperation<String> {
                     : leastClause(predicate.getParameters()));
         });
 
-        globalOperatorGenerators.put(GT, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(GT, (predicate, aliasGenerator) -> {
             Preconditions.checkState(!predicate.getParameters().isEmpty());
             return String.format("%s > %s", aliasGenerator.apply(predicate.getPath()),
                     predicate.getParameters().size() == 1
@@ -198,7 +198,7 @@ public class FilterTranslator implements FilterOperation<String> {
 
         });
 
-        globalOperatorGenerators.put(GE, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(GE, (predicate, aliasGenerator) -> {
             Preconditions.checkState(!predicate.getParameters().isEmpty());
             return String.format("%s >= %s", aliasGenerator.apply(predicate.getPath()),
                     predicate.getParameters().size() == 1
@@ -206,31 +206,31 @@ public class FilterTranslator implements FilterOperation<String> {
                     : greatestClause(predicate.getParameters()));
         });
 
-        globalOperatorGenerators.put(ISNULL, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(ISNULL, (predicate, aliasGenerator) -> {
             return String.format("%s IS NULL", aliasGenerator.apply(predicate.getPath()));
         });
 
-        globalOperatorGenerators.put(NOTNULL, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(NOTNULL, (predicate, aliasGenerator) -> {
             return String.format("%s IS NOT NULL", aliasGenerator.apply(predicate.getPath()));
         });
 
-        globalOperatorGenerators.put(TRUE, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(TRUE, (predicate, aliasGenerator) -> {
             return "(1 = 1)";
         });
 
-        globalOperatorGenerators.put(FALSE, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(FALSE, (predicate, aliasGenerator) -> {
             return "(1 = 0)";
         });
 
-        globalOperatorGenerators.put(ISEMPTY, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(ISEMPTY, (predicate, aliasGenerator) -> {
             return String.format("%s IS EMPTY", aliasGenerator.apply(predicate.getPath()));
         });
 
-        globalOperatorGenerators.put(NOTEMPTY, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(NOTEMPTY, (predicate, aliasGenerator) -> {
             return String.format("%s IS NOT EMPTY", aliasGenerator.apply(predicate.getPath()));
         });
 
-        globalOperatorGenerators.put(BETWEEN, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(BETWEEN, (predicate, aliasGenerator) -> {
             List<FilterPredicate.FilterParameter> parameters = predicate.getParameters();
             Preconditions.checkState(!parameters.isEmpty());
             Preconditions.checkArgument(parameters.size() == 2);
@@ -240,7 +240,7 @@ public class FilterTranslator implements FilterOperation<String> {
                     parameters.get(1).getPlaceholder());
         });
 
-        globalOperatorGenerators.put(NOTBETWEEN, (predicate, aliasGenerator) -> {
+        GLOBAL_OPERATOR_GENERATORS.put(NOTBETWEEN, (predicate, aliasGenerator) -> {
             List<FilterPredicate.FilterParameter> parameters = predicate.getParameters();
             Preconditions.checkState(!parameters.isEmpty());
             Preconditions.checkArgument(parameters.size() == 2);
@@ -262,7 +262,7 @@ public class FilterTranslator implements FilterOperation<String> {
      */
     public static void registerJPQLGenerator(Operator op,
                                              JPQLPredicateGenerator generator) {
-        globalOperatorGenerators.put(op, generator);
+        GLOBAL_OPERATOR_GENERATORS.put(op, generator);
     }
 
     /**
@@ -276,7 +276,7 @@ public class FilterTranslator implements FilterOperation<String> {
                                              Type<?> entityClass,
                                              String fieldName,
                                              JPQLPredicateGenerator generator) {
-        globalPredicateOverrides.put(Triple.of(op, entityClass, fieldName), generator);
+        GLOBAL_PREDICATE_OVERRIDES.put(Triple.of(op, entityClass, fieldName), generator);
     }
 
     /**
@@ -289,7 +289,7 @@ public class FilterTranslator implements FilterOperation<String> {
     public static JPQLPredicateGenerator lookupJPQLGenerator(Operator op,
                                                              Type<?> entityClass,
                                                              String fieldName) {
-        return globalPredicateOverrides.get(Triple.of(op, entityClass, fieldName));
+        return GLOBAL_PREDICATE_OVERRIDES.get(Triple.of(op, entityClass, fieldName));
     }
 
     /**
@@ -299,7 +299,7 @@ public class FilterTranslator implements FilterOperation<String> {
      * @return Returns null if no generator is registered.
      */
     public static JPQLPredicateGenerator lookupJPQLGenerator(Operator op) {
-        return globalOperatorGenerators.get(op);
+        return GLOBAL_OPERATOR_GENERATORS.get(op);
     }
 
     private final EntityDictionary dictionary;
@@ -310,15 +310,15 @@ public class FilterTranslator implements FilterOperation<String> {
      */
     public FilterTranslator(EntityDictionary dictionary) {
         this.dictionary = dictionary;
-        if (! globalOperatorGenerators.containsKey(HASMEMBER)) {
-            globalOperatorGenerators.put(HASMEMBER, new HasMemberJPQLGenerator(dictionary));
+        if (! GLOBAL_OPERATOR_GENERATORS.containsKey(HASMEMBER)) {
+            GLOBAL_OPERATOR_GENERATORS.put(HASMEMBER, new HasMemberJPQLGenerator(dictionary));
         }
 
-        if (! globalOperatorGenerators.containsKey(HASNOMEMBER)) {
-            globalOperatorGenerators.put(HASNOMEMBER, new HasMemberJPQLGenerator(dictionary, true));
+        if (! GLOBAL_OPERATOR_GENERATORS.containsKey(HASNOMEMBER)) {
+            GLOBAL_OPERATOR_GENERATORS.put(HASNOMEMBER, new HasMemberJPQLGenerator(dictionary, true));
         }
-        this.operatorGenerators = new HashMap<>(globalOperatorGenerators);
-        this.predicateOverrides = new HashMap<>(globalPredicateOverrides);
+        this.operatorGenerators = new HashMap<>(GLOBAL_OPERATOR_GENERATORS);
+        this.predicateOverrides = new HashMap<>(GLOBAL_PREDICATE_OVERRIDES);
     }
 
     /**

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/jpql/filter/FilterTranslatorTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/jpql/filter/FilterTranslatorTest.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.datastores.jpql.filter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.yahoo.elide.core.Path;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
@@ -20,8 +21,10 @@ import com.yahoo.elide.core.filter.predicates.FilterPredicate;
 import com.yahoo.elide.core.filter.predicates.InPredicate;
 import com.yahoo.elide.core.filter.predicates.NotEmptyPredicate;
 import com.yahoo.elide.core.type.ClassType;
+
 import example.Author;
 import example.Book;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -35,8 +38,8 @@ import java.util.stream.Collectors;
  */
 public class FilterTranslatorTest {
 
-    private EntityDictionary dictionary;
-    private RSQLFilterDialect dialect;
+    private final EntityDictionary dictionary;
+    private final RSQLFilterDialect dialect;
 
     public FilterTranslatorTest() {
         dictionary = EntityDictionary.builder().build();
@@ -74,7 +77,7 @@ public class FilterTranslatorTest {
 
     @Test
     public void testHQLQueryVisitor() throws Exception {
-        List<Path.PathElement> p0Path = Arrays.asList(
+        List<Path.PathElement> p0Path = List.of(
                 new Path.PathElement(Book.class, Author.class, "authors")
         );
         FilterPredicate p0 = new NotEmptyPredicate(new Path(p0Path));
@@ -85,12 +88,12 @@ public class FilterTranslatorTest {
         );
         FilterPredicate p1 = new InPredicate(new Path(p1Path), "foo", "bar");
 
-        List<Path.PathElement> p2Path = Arrays.asList(
+        List<Path.PathElement> p2Path = List.of(
                 new Path.PathElement(Book.class, String.class, "name")
         );
         FilterPredicate p2 = new InPredicate(new Path(p2Path), "blah");
 
-        List<Path.PathElement> p3Path = Arrays.asList(
+        List<Path.PathElement> p3Path = List.of(
                 new Path.PathElement(Book.class, String.class, "genre")
         );
         FilterPredicate p3 = new InPredicate(new Path(p3Path), "scifi");
@@ -121,7 +124,7 @@ public class FilterTranslatorTest {
                 new Path.PathElement(Book.class, Author.class, "authors"),
                 new Path.PathElement(Author.class, Long.class, "id")
         );
-        List<Path.PathElement> publishDate = Arrays.asList(
+        List<Path.PathElement> publishDate = List.of(
                 new Path.PathElement(Book.class, Long.class, "publishDate")
         );
         FilterPredicate authorPred = new FilterPredicate(new Path(authorId), Operator.BETWEEN, Arrays.asList(1, 15));
@@ -150,17 +153,17 @@ public class FilterTranslatorTest {
         // Assert excepetion if parameter length is not 2
         assertThrows(IllegalArgumentException.class,
                 () -> filterOp.apply(
-                        new FilterPredicate(new Path(authorId), Operator.BETWEEN, Arrays.asList(3))
+                        new FilterPredicate(new Path(authorId), Operator.BETWEEN, List.of(3))
                 ));
     }
 
     @Test
     public void testMemberOfOperator() throws Exception {
-        List<Path.PathElement> path = Arrays.asList(
+        List<Path.PathElement> path = List.of(
                 new Path.PathElement(Book.class, String.class, "awards")
         );
-        FilterPredicate p1 = new FilterPredicate(new Path(path), Operator.HASMEMBER, Arrays.asList("awards1"));
-        FilterPredicate p2 = new FilterPredicate(new Path(path), Operator.HASNOMEMBER, Arrays.asList("awards2"));
+        FilterPredicate p1 = new FilterPredicate(new Path(path), Operator.HASMEMBER, List.of("awards1"));
+        FilterPredicate p2 = new FilterPredicate(new Path(path), Operator.HASNOMEMBER, List.of("awards2"));
 
         AndFilterExpression and = new AndFilterExpression(p1, p2);
 
@@ -179,7 +182,15 @@ public class FilterTranslatorTest {
     @Test
     public void testEmptyFieldOnPrefix() throws Exception {
         FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
-                Operator.PREFIX_CASE_INSENSITIVE, Arrays.asList("value"));
+                Operator.PREFIX_CASE_INSENSITIVE, List.of("value"));
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
+        assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
+    }
+
+    @Test
+    public void testEmptyFieldOnNotPrefix() throws Exception {
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
+                Operator.NOT_PREFIX_CASE_INSENSITIVE, List.of("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
     }
@@ -187,7 +198,15 @@ public class FilterTranslatorTest {
     @Test
     public void testEmptyFieldOnInfix() throws Exception {
         FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
-                Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
+                Operator.INFIX_CASE_INSENSITIVE, List.of("value"));
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
+        assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
+    }
+
+    @Test
+    public void testEmptyFieldOnNotInfix() throws Exception {
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
+                Operator.NOT_INFIX_CASE_INSENSITIVE, List.of("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
     }
@@ -195,7 +214,15 @@ public class FilterTranslatorTest {
     @Test
     public void testEmptyFieldOnPostfix() throws Exception {
         FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
-                Operator.POSTFIX_CASE_INSENSITIVE, Arrays.asList("value"));
+                Operator.POSTFIX_CASE_INSENSITIVE, List.of("value"));
+        FilterTranslator filterOp = new FilterTranslator(dictionary);
+        assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
+    }
+
+    @Test
+    public void testEmptyFieldOnNotPostfix() throws Exception {
+        FilterPredicate pred = new FilterPredicate(new Path.PathElement(Book.class, String.class, ""),
+                Operator.NOT_POSTFIX_CASE_INSENSITIVE, List.of("value"));
         FilterTranslator filterOp = new FilterTranslator(dictionary);
         assertThrows(InvalidValueException.class, () -> filterOp.apply(pred));
     }
@@ -209,7 +236,7 @@ public class FilterTranslatorTest {
             FilterTranslator.registerJPQLGenerator(Operator.INFIX_CASE_INSENSITIVE, ClassType.of(Author.class), "name", generator);
 
             FilterPredicate pred = new FilterPredicate(new Path.PathElement(Author.class, String.class, "name"),
-                    Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
+                    Operator.INFIX_CASE_INSENSITIVE, List.of("value"));
 
             String actual = new FilterTranslator(dictionary).apply(pred);
             assertEquals("FOO", actual);
@@ -228,7 +255,7 @@ public class FilterTranslatorTest {
             FilterTranslator.registerJPQLGenerator(Operator.INFIX_CASE_INSENSITIVE, generator);
 
             FilterPredicate pred = new FilterPredicate(new Path.PathElement(Author.class, String.class, "name"),
-                    Operator.INFIX_CASE_INSENSITIVE, Arrays.asList("value"));
+                    Operator.INFIX_CASE_INSENSITIVE, List.of("value"));
 
             String actual = new FilterTranslator(dictionary).apply(pred);
             assertEquals("FOO", actual);
@@ -247,7 +274,7 @@ public class FilterTranslatorTest {
         );
 
         FilterPredicate pred = new FilterPredicate(new Path.PathElement(Author.class, String.class, "name"),
-                    Operator.INFIX, Arrays.asList("value"));
+                Operator.INFIX, List.of("value"));
 
         Map<Operator, JPQLPredicateGenerator> overrides = new HashMap<>();
         overrides.put(Operator.INFIX, generator);


### PR DESCRIPTION
Resolves #2788

## Description
Added negated operators for prefix, prefixi, postfix, postfixi, infix and infixi operators.

## Motivation and Context
Excluding values that do not contain a specific prefix, postfix or infix is currently not possible; it raises a InvalidOperatorNegationException since there is no negated operator defined for these operators.

## How Has This Been Tested?
I have added unit tests similar to those for the prefix operator. I have also tested the change with real API queries using Postman.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
