### PR TITLE
fix: apply distinct for non-paginated queries with many relationship

### DIFF
--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/RootCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/RootCollectionFetchQueryBuilder.java
@@ -56,8 +56,7 @@ public class RootCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
                     + getJoinClauseFromSort(entityProjection.getSorting())
                     + extractToOneMergeJoins(entityClass, entityAlias);
 
-            boolean requiresDistinct = entityProjection.getPagination() != null
-                    && containsOneToMany(filterExpression);
+            boolean requiresDistinct = containsOneToMany(filterExpression);
 
             boolean sortOverRelationship = entityProjection.getSorting() != null
                     && entityProjection.getSorting().getSortingPaths().keySet()

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionFetchQueryBuilderTest.java
@@ -139,7 +139,7 @@ public class RootCollectionFetchQueryBuilderTest {
 
 
         String expected =
-                "SELECT example_Author FROM example.Author AS example_Author  "
+                "SELECT DISTINCT example_Author FROM example.Author AS example_Author  "
                         + "LEFT JOIN example_Author.books example_Author_books  "
                         + "LEFT JOIN example_Author_books.chapters example_Author_books_chapters   "
                         + "LEFT JOIN example_Author_books.publisher example_Author_books_publisher   "


### PR DESCRIPTION
Resolves #2844 

## Description
Applies distinct to queries with a many relationship regardless of whether it is a paginated query.
Updates the `testRootFetchWithJoinFilter` test with the new expectation that distinct will be applied to the query.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
