### PR TITLE
Updated Serde.deserialize to take the output class as an argument

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
@@ -84,7 +84,7 @@ public class CoerceUtil {
 
             @Override
             public <T> T convert(Class<T> aClass, Object o) {
-                return (T) serde.deserialize((S) o);
+                return (T) serde.deserialize(aClass, (S) o);
             }
 
         }, targetType);

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/Serde.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/converters/Serde.java
@@ -19,6 +19,16 @@ public interface Serde<S, T> {
     T deserialize(S val);
 
     /**
+     * Deserialize an instance of type S to type T.
+     * @param type The type to deserialize
+     * @param val The thing to deserialize
+     * @return The deserialized value
+     */
+    default T deserialize(Class<?> type, S val) {
+        return deserialize(val);
+    }
+
+    /**
      * Serializes an instance of type T as type S.
      * @param val The thing to serialize
      * @return The serialized value

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
@@ -190,7 +190,7 @@ public class CoerceUtilTest {
         CoerceUtil.register(WeekendDays.class, mockSerde);
 
         CoerceUtil.coerce("Monday", WeekendDays.class);
-        verify(mockSerde, times(1)).deserialize(WeekendDays.class, eq("Monday"));
+        verify(mockSerde, times(1)).deserialize(eq(WeekendDays.class), eq("Monday"));
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
@@ -190,7 +190,7 @@ public class CoerceUtilTest {
         CoerceUtil.register(WeekendDays.class, mockSerde);
 
         CoerceUtil.coerce("Monday", WeekendDays.class);
-        verify(mockSerde, times(1)).deserialize(eq("Monday"));
+        verify(mockSerde, times(1)).deserialize(WeekendDays.class, eq("Monday"));
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/ISO8601DateSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/ISO8601DateSerdeTest.java
@@ -24,20 +24,20 @@ public class ISO8601DateSerdeTest {
     @Test
     public void testDateDeserialization() throws Exception {
         ISO8601DateSerde serde = new ISO8601DateSerde();
-        assertEquals(serde.deserialize("1970-01-01T00:00Z"), new Date(0));
+        assertEquals(serde.deserialize(Date.class, "1970-01-01T00:00Z"), new Date(0));
     }
 
     @Test
     public void testSQLDateSerialization() throws Exception {
         ISO8601DateSerde serde = new ISO8601DateSerde();
-        assertEquals("1970-01-01T00:00Z", serde.serialize(new java.sql.Date(0)));
+        assertEquals(java.sql.Date.class, "1970-01-01T00:00Z", serde.serialize(new java.sql.Date(0)));
     }
 
     @Test
     public void testSQLDateDeserialization() throws Exception {
         ISO8601DateSerde serde =
             new ISO8601DateSerde("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"), java.sql.Date.class);
-        assertEquals(serde.deserialize("1970-01-01T00:00Z"), new java.sql.Date(0));
+        assertEquals(serde.deserialize(java.sql.Date.class, "1970-01-01T00:00Z"), new java.sql.Date(0));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class ISO8601DateSerdeTest {
     public void testSQLTimeDeserialization() throws Exception {
         ISO8601DateSerde serde =
             new ISO8601DateSerde("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"), java.sql.Time.class);
-        assertEquals(serde.deserialize("1970-01-01T00:00Z"), new java.sql.Time(0));
+        assertEquals(serde.deserialize(java.sql.Time.class, "1970-01-01T00:00Z"), new java.sql.Time(0));
     }
 
     @Test
@@ -64,7 +64,7 @@ public class ISO8601DateSerdeTest {
         ISO8601DateSerde serde =
                 new ISO8601DateSerde("yyyy-MM-dd", TimeZone.getTimeZone("UTC"), java.sql.Timestamp.class);
         java.sql.Timestamp expected = new java.sql.Timestamp(0);
-        java.sql.Timestamp actual = (java.sql.Timestamp) serde.deserialize("1970-01-01");
+        java.sql.Timestamp actual = (java.sql.Timestamp) serde.deserialize(java.sql.Timestamp.class, "1970-01-01");
         assertEquals(expected, actual);
     }
 
@@ -73,7 +73,7 @@ public class ISO8601DateSerdeTest {
         ISO8601DateSerde serde =
                 new ISO8601DateSerde("yyyy-MM-dd", TimeZone.getTimeZone("UTC"), java.sql.Timestamp.class);
         Timestamp expected = new Timestamp(0);
-        Timestamp actual = (Timestamp) serde.deserialize(new Date(0));
+        Timestamp actual = (Timestamp) serde.deserialize(Date.class, new Date(0));
         assertEquals(expected, actual);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/ISO8601DateSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/ISO8601DateSerdeTest.java
@@ -30,7 +30,7 @@ public class ISO8601DateSerdeTest {
     @Test
     public void testSQLDateSerialization() throws Exception {
         ISO8601DateSerde serde = new ISO8601DateSerde();
-        assertEquals(java.sql.Date.class, "1970-01-01T00:00Z", serde.serialize(new java.sql.Date(0)));
+        assertEquals("1970-01-01T00:00Z", serde.serialize(new java.sql.Date(0)));
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/InstantSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/InstantSerdeTest.java
@@ -17,7 +17,7 @@ public class InstantSerdeTest {
 
     @Test
     public void canDeserializeUtcIsoString() {
-        final Instant instant = serde.deserialize("2019-06-01T09:42:55Z");
+        final Instant instant = serde.deserialize(Instant.class, "2019-06-01T09:42:55Z");
 
         assertEquals(1559382175, instant.getEpochSecond());
         assertEquals(0, instant.getNano());
@@ -25,7 +25,7 @@ public class InstantSerdeTest {
 
     @Test
     public void canDeserializeOffsetIsoString() {
-        final Instant instant = serde.deserialize("2019-06-01T10:42:55+01:00");
+        final Instant instant = serde.deserialize(Instant.class, "2019-06-01T10:42:55+01:00");
 
         assertEquals(1559382175, instant.getEpochSecond());
         assertEquals(0, instant.getNano());
@@ -33,7 +33,7 @@ public class InstantSerdeTest {
 
     @Test
     public void canDeserializeSubSecondPrecisionUtcIsoString() {
-        final Instant instant = serde.deserialize("2019-06-01T09:42:55.123Z");
+        final Instant instant = serde.deserialize(Instant.class, "2019-06-01T09:42:55.123Z");
 
         assertEquals(1559382175, instant.getEpochSecond());
         assertEquals(123000000, instant.getNano());
@@ -60,7 +60,7 @@ public class InstantSerdeTest {
 
         assertThrows(
             IllegalArgumentException.class,
-            () -> serde.deserialize("2019-06-01T09:42:55.12X3Z")
+            () -> serde.deserialize(Instant.class, "2019-06-01T09:42:55.12X3Z")
         );
 
     }

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/OffsetDateTimeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/OffsetDateTimeTest.java
@@ -35,7 +35,7 @@ public class OffsetDateTimeTest {
                         ZoneOffset.ofHoursMinutes(5, 30));
         String actual = "1995-11-02T16:45:04.000000056+05:30";
         OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
-        Object expected = offsetDateTimeScalar.deserialize(actual);
+        Object expected = offsetDateTimeScalar.deserialize(OffsetDateTime.class, actual);
         assertEquals(expected, actualDate);
     }
 
@@ -44,7 +44,7 @@ public class OffsetDateTimeTest {
         final OffsetDateTimeSerde offsetDateTimeScalar = new OffsetDateTimeSerde();
         assertThrows(
             IllegalArgumentException.class,
-            () -> offsetDateTimeScalar.deserialize("2019-06-01T09:42:55.12X3Z")
+            () -> offsetDateTimeScalar.deserialize(OffsetDateTime.class, "2019-06-01T09:42:55.12X3Z")
         );
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/TimeZoneTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/TimeZoneTest.java
@@ -28,7 +28,7 @@ public class TimeZoneTest {
         TimeZone expectedTimeZone = TimeZone.getTimeZone("EST");
         String actual = "EST";
         TimeZoneSerde timeZoneSerde = new TimeZoneSerde();
-        Object actualTimeZone = timeZoneSerde.deserialize(actual);
+        Object actualTimeZone = timeZoneSerde.deserialize(TimeZone.class, actual);
         assertEquals(expectedTimeZone, actualTimeZone);
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/URLSerdeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/converters/URLSerdeTest.java
@@ -29,7 +29,7 @@ public class URLSerdeTest {
         URL expectedURL = new URL("https://elide.io");
         String actual = "https://elide.io";
         URLSerde urlSerde = new URLSerde();
-        Object actualURL = urlSerde.deserialize(actual);
+        Object actualURL = urlSerde.deserialize(URL.class, actual);
         assertEquals(expectedURL, actualURL);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DaySerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/DaySerdeTest.java
@@ -37,7 +37,7 @@ public class DaySerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Day expectedDate = new Day(localDate);
         Serde serde = new Day.DaySerde();
-        Object actualDate = serde.deserialize("2020-01-01");
+        Object actualDate = serde.deserialize(Day.class, "2020-01-01");
         assertEquals(expectedDate, actualDate);
     }
 
@@ -48,7 +48,7 @@ public class DaySerdeTest {
         Day expectedDate = new Day(localDate);
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Day.DaySerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Timestamp.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -59,7 +59,7 @@ public class DaySerdeTest {
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 01, 01, 00, 00, 00, 00, ZoneOffset.UTC);
 
         Serde serde = new Day.DaySerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Day.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -69,7 +69,7 @@ public class DaySerdeTest {
         String dateInString = "January-01-2020";
         Serde serde = new Day.DaySerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Day.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/HourSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/HourSerdeTest.java
@@ -38,7 +38,7 @@ public class HourSerdeTest {
         String dateInString = "2020-01-01T01";
         Hour expectedDate = new Hour(LocalDateTime.from(formatter.parse(dateInString)));
         Serde serde = new Hour.HourSerde();
-        Object actualDate = serde.deserialize(dateInString);
+        Object actualDate = serde.deserialize(Hour.class, dateInString);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -49,7 +49,7 @@ public class HourSerdeTest {
         Hour expectedDate = new Hour(LocalDateTime.from(formatter.parse(dateInString)));
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Hour.HourSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Hour.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -60,7 +60,7 @@ public class HourSerdeTest {
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 01, 01, 01, 00, 00, 00, ZoneOffset.UTC);
 
         Serde serde = new Hour.HourSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Hour.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -70,7 +70,7 @@ public class HourSerdeTest {
         String dateInString = "00 2020-01-01";
         Serde serde = new Hour.HourSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Hour.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/ISOWeekSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/ISOWeekSerdeTest.java
@@ -38,7 +38,7 @@ public class ISOWeekSerdeTest {
 
         ISOWeek expectedDate = new ISOWeek(localDate);
         Serde serde = new ISOWeek.ISOWeekSerde();
-        Object actualDate = serde.deserialize("2020-01-06");
+        Object actualDate = serde.deserialize(ISOWeek.class, "2020-01-06");
         assertEquals(expectedDate, actualDate);
     }
 
@@ -48,7 +48,7 @@ public class ISOWeekSerdeTest {
         ISOWeek timestamp = new ISOWeek(localDate);
         Serde serde = new ISOWeek.ISOWeekSerde();
         assertThrows(IllegalArgumentException.class, () ->
-            serde.deserialize(timestamp)
+            serde.deserialize(ISOWeek.class, timestamp)
         );
     }
 
@@ -60,7 +60,7 @@ public class ISOWeekSerdeTest {
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 01, 06, 00, 00, 00, 00, ZoneOffset.UTC);
 
         Serde serde = new ISOWeek.ISOWeekSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(ISOWeek.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -70,7 +70,7 @@ public class ISOWeekSerdeTest {
 
         Serde serde = new ISOWeek.ISOWeekSerde();
         assertThrows(IllegalArgumentException.class, () ->
-                serde.deserialize(dateTime)
+                serde.deserialize(ISOWeek.class, dateTime)
         );
     }
 
@@ -80,7 +80,7 @@ public class ISOWeekSerdeTest {
         ISOWeek expectedDate = new ISOWeek(localDate);
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new ISOWeek.ISOWeekSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(ISOWeek.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -90,7 +90,7 @@ public class ISOWeekSerdeTest {
         String dateInString = "January-2020-01";
         Serde serde = new ISOWeek.ISOWeekSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(ISOWeek.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MinuteSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MinuteSerdeTest.java
@@ -39,7 +39,7 @@ public class MinuteSerdeTest {
         Minute expectedDate = new Minute(LocalDateTime.from(formatter.parse(dateInString)));
         String actual = "2020-01-01T01:18";
         Serde serde = new Minute.MinuteSerde();
-        Object actualDate = serde.deserialize(actual);
+        Object actualDate = serde.deserialize(Minute.class, actual);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -50,7 +50,7 @@ public class MinuteSerdeTest {
         Minute expectedDate = new Minute(LocalDateTime.from(formatter.parse(dateInString)));
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Minute.MinuteSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Minute.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -61,7 +61,7 @@ public class MinuteSerdeTest {
 
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 01, 01, 01, 18, 0, 0, ZoneOffset.UTC);
         Serde serde = new Minute.MinuteSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Minute.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -71,7 +71,7 @@ public class MinuteSerdeTest {
         String dateInString = "00:18 2020-01-01";
         Serde serde = new Minute.MinuteSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Minute.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MonthSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/MonthSerdeTest.java
@@ -37,7 +37,7 @@ public class MonthSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Month expectedDate = new Month(localDate);
         Serde serde = new Month.MonthSerde();
-        Object actualDate = serde.deserialize("2020-01");
+        Object actualDate = serde.deserialize(Month.class, "2020-01");
         assertEquals(expectedDate, actualDate);
     }
 
@@ -47,7 +47,7 @@ public class MonthSerdeTest {
         Month expectedDate = new Month(localDate);
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Month.MonthSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Month.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -58,7 +58,7 @@ public class MonthSerdeTest {
 
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Serde serde = new Month.MonthSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Month.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -67,7 +67,7 @@ public class MonthSerdeTest {
         String dateInString = "January-2020";
         Serde serde = new Month.MonthSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Month.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/QuarterSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/QuarterSerdeTest.java
@@ -36,7 +36,7 @@ public class QuarterSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Quarter expectedDate = new Quarter(localDate);
         Serde serde = new Quarter.QuarterSerde();
-        Object actualDate = serde.deserialize("2020-01");
+        Object actualDate = serde.deserialize(Quarter.class, "2020-01");
         assertEquals(expectedDate, actualDate);
     }
 
@@ -46,7 +46,7 @@ public class QuarterSerdeTest {
         Quarter quarter = new Quarter(localDate);
         Serde serde = new Quarter.QuarterSerde();
         assertThrows(IllegalArgumentException.class, () ->
-            serde.deserialize(quarter)
+            serde.deserialize(Quarter.class, quarter)
         );
     }
 
@@ -56,7 +56,7 @@ public class QuarterSerdeTest {
         Quarter expectedDate = new Quarter(localDate);
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Quarter.QuarterSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Quarter.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -66,7 +66,7 @@ public class QuarterSerdeTest {
 
         Serde serde = new Quarter.QuarterSerde();
         assertThrows(IllegalArgumentException.class, () ->
-                serde.deserialize(dateTime)
+                serde.deserialize(Quarter.class, dateTime)
         );
     }
 
@@ -76,7 +76,7 @@ public class QuarterSerdeTest {
         Quarter expectedDate = new Quarter(localDate);
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Serde serde = new Quarter.QuarterSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Quarter.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -86,7 +86,7 @@ public class QuarterSerdeTest {
         String dateInString = "January-2020";
         Serde serde = new Quarter.QuarterSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Quarter.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SecondSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/SecondSerdeTest.java
@@ -39,7 +39,7 @@ public class SecondSerdeTest {
         Second expectedDate = new Second(LocalDateTime.from(formatter.parse(dateInString)));
         String actual = "2020-01-01T01:18:19";
         Serde serde = new Second.SecondSerde();
-        Object actualDate = serde.deserialize(actual);
+        Object actualDate = serde.deserialize(Second.class, actual);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -50,7 +50,7 @@ public class SecondSerdeTest {
         Second expectedDate = new Second(LocalDateTime.from(formatter.parse(dateInString)));
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Second.SecondSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Second.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -61,7 +61,7 @@ public class SecondSerdeTest {
 
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 1, 1, 1, 18, 19, 0, ZoneOffset.UTC);
         Serde serde = new Second.SecondSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Second.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -71,7 +71,7 @@ public class SecondSerdeTest {
         String dateInString = "00:18:19 2020-01-01";
         Serde serde = new Second.SecondSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Second.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/TimeSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/TimeSerdeTest.java
@@ -28,7 +28,7 @@ public class TimeSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Time expectedDate = new Time(localDate, true, false, false, false, false, false, (unused) -> "");
         Serde serde = new Time.TimeSerde();
-        Object actualDate = serde.deserialize(YEAR);
+        Object actualDate = serde.deserialize(Time.class, YEAR);
         assertEquals(expectedDate, actualDate);
         assertEquals(YEAR, serde.serialize(actualDate));
     }
@@ -38,7 +38,7 @@ public class TimeSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Time expectedDate = new Time(localDate, true, true, false, false, false, false, (unused) -> "");
         Serde serde = new Time.TimeSerde();
-        Object actualDate = serde.deserialize(MONTH);
+        Object actualDate = serde.deserialize(Time.class, MONTH);
         assertEquals(expectedDate, actualDate);
         assertEquals(MONTH, serde.serialize(actualDate));
     }
@@ -48,7 +48,7 @@ public class TimeSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Time expectedDate = new Time(localDate, true, true, true, false, false, false, (unused) -> "");
         Serde serde = new Time.TimeSerde();
-        Object actualDate = serde.deserialize(DATE);
+        Object actualDate = serde.deserialize(Time.class, DATE);
         assertEquals(expectedDate, actualDate);
         assertEquals(DATE, serde.serialize(actualDate));
     }
@@ -58,7 +58,7 @@ public class TimeSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Time expectedDate = new Time(localDate, true, true, true, true, true, true, (unused) -> "");
         Serde serde = new Time.TimeSerde();
-        Object actualDate = serde.deserialize(HOUR);
+        Object actualDate = serde.deserialize(Time.class, HOUR);
         assertEquals(expectedDate, actualDate);
         assertEquals(HOUR, serde.serialize(actualDate));
     }
@@ -68,7 +68,7 @@ public class TimeSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Time expectedDate = new Time(localDate, true, true, true, true, true, true, (unused) -> "");
         Serde serde = new Time.TimeSerde();
-        Object actualDate = serde.deserialize(MINUTE);
+        Object actualDate = serde.deserialize(Time.class, MINUTE);
         assertEquals(expectedDate, actualDate);
         assertEquals(MINUTE, serde.serialize(actualDate));
     }
@@ -78,7 +78,7 @@ public class TimeSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 01, 00, 00, 00);
         Time expectedDate = new Time(localDate, true, true, true, true, true, true, (unused) -> "");
         Serde serde = new Time.TimeSerde();
-        Object actualDate = serde.deserialize(SECOND);
+        Object actualDate = serde.deserialize(Time.class, SECOND);
         assertEquals(expectedDate, actualDate);
         assertEquals(SECOND, serde.serialize(actualDate));
     }
@@ -87,7 +87,7 @@ public class TimeSerdeTest {
     public void testInvalidDeserialization() {
         Serde serde = new Time.TimeSerde();
         assertThrows(IllegalArgumentException.class, () ->
-            serde.deserialize("2020R1")
+            serde.deserialize(Time.class, "2020R1")
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/WeekSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/WeekSerdeTest.java
@@ -37,7 +37,7 @@ public class WeekSerdeTest {
         LocalDateTime localDate = LocalDateTime.of(2020, java.time.Month.of(01), 05, 00, 00, 00);
         Week expectedDate = new Week(localDate);
         Serde serde = new Week.WeekSerde();
-        Object actualDate = serde.deserialize("2020-01-05");
+        Object actualDate = serde.deserialize(Week.class, "2020-01-05");
         assertEquals(expectedDate, actualDate);
     }
 
@@ -48,7 +48,7 @@ public class WeekSerdeTest {
         Week expectedDate = new Week(localDate);
         Serde serde = new Week.WeekSerde();
         assertThrows(IllegalArgumentException.class, () ->
-            serde.deserialize(expectedDate)
+            serde.deserialize(Week.class, expectedDate)
         );
     }
 
@@ -59,7 +59,7 @@ public class WeekSerdeTest {
         Week expectedDate = new Week(localDate);
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Week.WeekSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Week.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -69,7 +69,7 @@ public class WeekSerdeTest {
 
         Serde serde = new Week.WeekSerde();
         assertThrows(IllegalArgumentException.class, () ->
-                serde.deserialize(dateTime)
+                serde.deserialize(Week.class, dateTime)
         );
     }
 
@@ -81,7 +81,7 @@ public class WeekSerdeTest {
 
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 1, 5, 0, 0, 0, 0, ZoneOffset.UTC);
         Serde serde = new Week.WeekSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Week.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -91,7 +91,7 @@ public class WeekSerdeTest {
         String dateInString = "January-2020-01";
         Serde serde = new Week.WeekSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Week.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerdeTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/timegrains/serde/YearSerdeTest.java
@@ -38,7 +38,7 @@ public class YearSerdeTest {
 
         Year expectedDate = new Year(localDate);
         Serde serde = new Year.YearSerde();
-        Object actualDate = serde.deserialize("2020");
+        Object actualDate = serde.deserialize(Year.class, "2020");
         assertEquals(expectedDate, actualDate);
     }
 
@@ -49,7 +49,7 @@ public class YearSerdeTest {
         Year expectedDate = new Year(localDate);
         Timestamp timestamp = new Timestamp(expectedDate.getTime());
         Serde serde = new Year.YearSerde();
-        Object actualDate = serde.deserialize(timestamp);
+        Object actualDate = serde.deserialize(Year.class, timestamp);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -60,7 +60,7 @@ public class YearSerdeTest {
 
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Serde serde = new Year.YearSerde();
-        Object actualDate = serde.deserialize(dateTime);
+        Object actualDate = serde.deserialize(Year.class, dateTime);
         assertEquals(expectedDate, actualDate);
     }
 
@@ -70,7 +70,7 @@ public class YearSerdeTest {
         String dateInString = "January";
         Serde serde = new Year.YearSerde();
         assertThrows(DateTimeParseException.class, () ->
-            serde.deserialize(dateInString)
+            serde.deserialize(Year.class, dateInString)
         );
     }
 }

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/JMSDataStore.java
@@ -74,7 +74,7 @@ public class JMSDataStore implements DataStore {
 
         GsonBuilder gsonBuilder = new GsonBuilder();
         CoerceUtil.getSerdes().forEach((cls, serde) -> {
-            gsonBuilder.registerTypeAdapter(cls, new SubscriptionFieldSerde(serde));
+            gsonBuilder.registerTypeAdapter(cls, new SubscriptionFieldSerde(serde, cls));
         });
         gson = gsonBuilder.create();
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -75,7 +75,7 @@ public class GraphQLConversionUtils {
 
     private void registerCustomScalars() {
         CoerceUtil.getSerdes().forEach((type, serde) -> {
-            SerdeCoercing<?, ?> serdeCoercing = new SerdeCoercing<>(ERROR_MESSAGE, serde);
+            SerdeCoercing<?, ?> serdeCoercing = new SerdeCoercing<>(ERROR_MESSAGE, serde, type);
             ElideTypeConverter elideTypeConverter = serde.getClass().getAnnotation(ElideTypeConverter.class);
             String name = elideTypeConverter != null ? elideTypeConverter.name() : type.getSimpleName();
             String description = elideTypeConverter != null ? elideTypeConverter.description() : type.getSimpleName();

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
@@ -42,7 +42,7 @@ public class GraphQLScalars {
                 public Date parseValue(Object o) {
                     Serde<Object, Date> dateSerde = CoerceUtil.lookup(Date.class);
 
-                    return dateSerde.deserialize(o);
+                    return dateSerde.deserialize(Date.class, o);
                 }
 
                 @Override

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/SerdeCoercing.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/SerdeCoercing.java
@@ -21,6 +21,8 @@ public class SerdeCoercing<I, O> implements Coercing<I, O> {
     private String errorMessage;
     private Serde<O, I> serde;
 
+    private Class<?> type;
+
     @Override
     public O serialize(Object dataFetcherResult) {
         return serde.serialize((I) dataFetcherResult);
@@ -28,7 +30,7 @@ public class SerdeCoercing<I, O> implements Coercing<I, O> {
 
     @Override
     public I parseValue(Object input) {
-        return serde.deserialize((O) input);
+        return serde.deserialize(type, (O) input);
     }
 
     public I parseLiteral(Object o) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/hooks/SubscriptionFieldSerde.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/hooks/SubscriptionFieldSerde.java
@@ -25,8 +25,11 @@ import java.lang.reflect.Type;
 public class SubscriptionFieldSerde<T> implements JsonSerializer<T>, JsonDeserializer<T> {
     Serde<Object, T> elideSerde;
 
-    public SubscriptionFieldSerde(Serde<Object, T> elideSerde) {
+    Class<?> type;
+
+    public SubscriptionFieldSerde(Serde<Object, T> elideSerde, Class<?> type) {
         this.elideSerde = elideSerde;
+        this.type = type;
     }
 
     @Override
@@ -47,7 +50,7 @@ public class SubscriptionFieldSerde<T> implements JsonSerializer<T>, JsonDeseria
         if (jsonElement.isJsonPrimitive()) {
             JsonPrimitive primitive = jsonElement.getAsJsonPrimitive();
             if (primitive.isString()) {
-                return elideSerde.deserialize(primitive.getAsString());
+                return elideSerde.deserialize(this.type, primitive.getAsString());
             }
         }
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/hooks/SubscriptionScanner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/hooks/SubscriptionScanner.java
@@ -48,7 +48,7 @@ public class SubscriptionScanner {
 
         GsonBuilder gsonBuilder = new GsonBuilder();
         CoerceUtil.getSerdes().forEach((cls, serde) -> {
-            gsonBuilder.registerTypeAdapter(cls, new SubscriptionFieldSerde(serde));
+            gsonBuilder.registerTypeAdapter(cls, new SubscriptionFieldSerde(serde, cls));
         });
         gsonBuilder.addSerializationExclusionStrategy(new SubscriptionExclusionStrategy()).serializeNulls();
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLScalarsTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLScalarsTest.java
@@ -79,7 +79,7 @@ public class GraphQLScalarsTest {
         String input = "1995-11-02T16:45:04.000000056+05:30";
         OffsetDateTimeSerde offsetDateTimeSerde = new OffsetDateTimeSerde();
         SerdeCoercing serdeCoercing =
-                new SerdeCoercing("", offsetDateTimeSerde);
+                new SerdeCoercing("", offsetDateTimeSerde, OffsetDateTime.class);
         Object actualDate = serdeCoercing.parseLiteral(new StringValue(input));
         assertEquals(expectedDate, actualDate);
     }
@@ -90,7 +90,7 @@ public class GraphQLScalarsTest {
         String input = "EST";
         TimeZoneSerde timeZoneSerde = new TimeZoneSerde();
         SerdeCoercing serdeCoercing =
-                new SerdeCoercing("", timeZoneSerde);
+                new SerdeCoercing("", timeZoneSerde, TimeZone.class);
         Object actualTz = serdeCoercing.parseLiteral(new StringValue(input));
         assertEquals(expectedTz, actualTz);
     }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionSerdeTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionSerdeTest.java
@@ -31,7 +31,7 @@ public class SubscriptionSerdeTest {
 
         gson = new GsonBuilder()
                 .addSerializationExclusionStrategy(new SubscriptionExclusionStrategy())
-                .registerTypeAdapter(Date.class, new SubscriptionFieldSerde<>(serde))
+                .registerTypeAdapter(Date.class, new SubscriptionFieldSerde<>(serde, Date.class))
                 .serializeNulls().create();
     }
 


### PR DESCRIPTION
Resolves #2852 

## Description
Added new deserialize method to Serde:

```java
    default T deserialize(Class<?> type, S val) {
        return deserialize(val);
    }
```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
