### PR TITLE
Do not throw NPE for create type: null (4.x)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.8.1
+**Fixes**
+   * [view commit](https://github.com/yahoo/elide/commit/e651fee8125b082f9e656a70adebe32183373a01) Do not throw NPE for create type: null (4.x) #2882
+   
 ## 4.8.0
 **Fixes**
    * [view commit](https://github.com/yahoo/elide/commit/233591723cd04a3b6da54c5234a824712ca613b4) (Similar to https://github.com/yahoo/elide/pull/2342) Revised JSON-API path grammar to accept colon, space, and ampersand in ID fields (#2344) 

--- a/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/EntityDictionary.java
@@ -226,6 +226,9 @@ public class EntityDictionary {
      * @return binding class
      */
     public Class<?> getEntityClass(String entityName) {
+        if (entityName == null) {
+            return null;
+        }
         return bindJsonApiToEntity.get(entityName);
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/Operation.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/Operation.java
@@ -14,7 +14,7 @@ class Operation {
         CREATE,
         DELETE,
         UPDATE
-    };
+    }
 
     @Getter private final String id;
     @Getter private final Object instance;

--- a/elide-core/src/main/java/com/yahoo/elide/parsers/expression/CanPaginateVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/parsers/expression/CanPaginateVisitor.java
@@ -135,12 +135,12 @@ public class CanPaginateVisitor
     /**
      *  All states except for CANNOT_PAGINATE allow for pagination.
      */
-      public enum PaginationStatus {
+    public enum PaginationStatus {
         CAN_PAGINATE,
         USER_CHECK_FALSE,
         USER_CHECK_TRUE,
         CANNOT_PAGINATE
-    };
+    }
 
     private final EntityDictionary dictionary;
     private final RequestScope scope;

--- a/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/EpochToDateConverter.java
+++ b/elide-core/src/main/java/com/yahoo/elide/utils/coerce/converters/EpochToDateConverter.java
@@ -37,7 +37,7 @@ public class EpochToDateConverter<T extends Date> implements Converter, Serde<Ob
                 return numberToDate(cls, (Number) value);
             }
             throw new UnsupportedOperationException(value.getClass().getSimpleName() + " is not a valid epoch");
-        } catch (IndexOutOfBoundsException | ReflectiveOperationException
+        } catch (IndexOutOfBoundsException
                 | UnsupportedOperationException | IllegalArgumentException e) {
             throw new InvalidAttributeException("Unknown " + cls.getSimpleName() + " value " + value, e);
         }
@@ -53,7 +53,7 @@ public class EpochToDateConverter<T extends Date> implements Converter, Serde<Ob
         return val.getTime();
     }
 
-    private static <T> T numberToDate(Class<T> cls, Number epoch) throws ReflectiveOperationException {
+    private static <T> T numberToDate(Class<T> cls, Number epoch) {
         if (ClassUtils.isAssignable(cls, java.sql.Date.class)) {
             return cls.cast(new java.sql.Date(epoch.longValue()));
         } else if (ClassUtils.isAssignable(cls, Timestamp.class)) {
@@ -67,7 +67,7 @@ public class EpochToDateConverter<T extends Date> implements Converter, Serde<Ob
         }
     }
 
-    private static <T> T stringToDate(Class<T> cls, String epoch) throws ReflectiveOperationException {
+    private static <T> T stringToDate(Class<T> cls, String epoch) {
         return numberToDate(cls, Long.parseLong(epoch));
     }
 }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -93,7 +93,7 @@ public class DefaultFilterDialectTest {
     }
 
     @Test
-    public void testInvalidType() throws ParseException {
+    public void testInvalidType() {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 
         queryParams.add(
@@ -105,7 +105,7 @@ public class DefaultFilterDialectTest {
     }
 
     @Test
-    public void testInvalidAttribute() throws ParseException {
+    public void testInvalidAttribute() {
         MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
 
         queryParams.add(

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -465,7 +465,7 @@ public class JsonApiTest {
     }
 
     @Test
-    public void compareNullAndEmpty() throws JsonProcessingException {
+    public void compareNullAndEmpty() {
         Data<Resource> empty = new Data<>((Resource) null);
 
         JsonApiDocument jsonApiEmpty = new JsonApiDocument();
@@ -479,7 +479,7 @@ public class JsonApiTest {
     }
 
     @Test
-    public void compareOrder() throws JsonProcessingException {
+    public void compareOrder() {
         Parent parent1 = new Parent();
         parent1.setId(123L);
         Parent parent2 = new Parent();

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -88,6 +88,16 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>2.19.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.19.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <hibernate3.version>3.6.10.Final</hibernate3.version>
         <version.mysql>8.0.22</version.mysql>
         <hibernate5.version>5.4.30.Final</hibernate5.version>
-        <slf4j-api.version>1.7.30</slf4j-api.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
         <maven-site-plugin-version>3.7.1</maven-site-plugin-version>
         <mpir.skip>true</mpir.skip>
 
@@ -134,7 +134,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>log4j-over-slf4j</artifactId>
-                <version>1.7.30</version>
+                <version>${slf4j-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Description
Received NPE when creating a resource with type=null.
Cleaned up IDE warnings.
CVE-2021-44228 Bump log4j2 and slf4j

## Motivation and Context
Invalid data should not cause NPE.  This will generate 500 Internal Server Error instead of 400 Invalid Request.

## How Has This Been Tested?
Included unit test.  Also local service testing.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.