### PR TITLE
Create Elide Bill Of Materials (7.x)

### DIFF
--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -103,7 +103,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>${version.jersey}</version>
             <scope>test</scope>
         </dependency>
         <!-- JUnit -->

--- a/elide-bom/pom.xml
+++ b/elide-bom/pom.xml
@@ -1,0 +1,125 @@
+<!--
+  ~ Copyright 2023, Yahoo Inc.
+  ~ Licensed under the Apache License, Version 2.0
+  ~ See LICENSE file in project root for terms.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>elide-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>Elide: BOM</name>
+    <description>Elide Bill of Materials</description>
+    <url>https://github.com/yahoo/elide</url>
+    <parent>
+        <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
+        <version>7.0.0-RC7-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <organization>
+        <name>Yahoo! Inc.</name>
+        <url>http://www.yahoo.com</url>
+    </organization>
+    <developers>
+        <developer>
+            <name>Yahoo Inc.</name>
+            <url>https://github.com/yahoo</url>
+        </developer>
+    </developers>
+    <scm>
+        <developerConnection>scm:git:ssh://git@github.com/yahoo/elide.git</developerConnection>
+        <url>https://github.com/yahoo/elide.git</url>
+        <tag>HEAD</tag>
+    </scm>
+    <dependencyManagement>
+        <dependencies>
+            <!-- modules -->
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-async</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-core</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-aggregation</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-hibernate</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-inmemorydb</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-jms</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-jpa</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-multiplex</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-noop</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-search</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-graphql</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-model-config</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-spring-boot-autoconfigure</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-spring-boot-starter</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-standalone</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-swagger</artifactId>
+                <version>7.0.0-RC7-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -186,7 +186,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>${version.jetty}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -138,21 +138,18 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-server</artifactId>
-            <version>${version.jetty}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-client</artifactId>
-            <version>${version.jetty}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
-            <version>${version.jetty}</version>
             <scope>test</scope>
         </dependency>
         <!-- dependencies for javax.websocket (JSR-356) websocket -->

--- a/elide-integration-tests/pom.xml
+++ b/elide-integration-tests/pom.xml
@@ -137,7 +137,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${version.junit}</version>
         </dependency>
 
         <dependency>

--- a/elide-model-config/pom.xml
+++ b/elide-model-config/pom.xml
@@ -12,8 +12,8 @@
     <description>Elide Dynamic Model Config</description>
     <url>https://github.com/yahoo/elide</url>
     <parent>
-        <artifactId>elide-parent-pom</artifactId>
         <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
         <version>7.0.0-RC7-SNAPSHOT</version>
     </parent>
 

--- a/elide-model-config/pom.xml
+++ b/elide-model-config/pom.xml
@@ -140,7 +140,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-model-config/pom.xml
+++ b/elide-model-config/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${version.jackson}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -41,7 +41,6 @@
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
         <spring.boot.version>3.0.1</spring.boot.version>
-        <groovy.version>3.0.13</groovy.version>
         <tomcat.version>10.1.4</tomcat.version>
     </properties>
 
@@ -80,36 +79,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-actuator</artifactId>
                 <version>${spring.boot.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>rest-assured</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>xml-path</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy</artifactId>
-                <version>${groovy.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-xml</artifactId>
-                <version>${groovy.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -12,8 +12,8 @@
     <description>Parent pom for spring packages</description>
     <url>https://github.com/yahoo/elide</url>
     <parent>
-        <artifactId>elide-parent-pom</artifactId>
         <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
         <version>7.0.0-RC7-SNAPSHOT</version>
     </parent>
 

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -50,6 +50,17 @@
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${metrics.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <!-- Elide dependency -->
         <dependency>
@@ -161,25 +172,21 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jakarta-servlet</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jakarta-servlets</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jetty11</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
 
@@ -194,13 +201,11 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-server</artifactId>
-            <version>${version.jetty}</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-servlet</artifactId>
-            <version>${version.jetty}</version>
         </dependency>
 
         <!-- Test -->
@@ -260,7 +265,6 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-jakarta-client</artifactId>
-            <version>${version.jetty}</version>
             <scope>test</scope>
         </dependency>
 

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -267,7 +267,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${version.jackson}</version>
         </dependency>
     </dependencies>
 

--- a/elide-swagger/pom.xml
+++ b/elide-swagger/pom.xml
@@ -12,8 +12,8 @@
     <description>Swagger Support for Elide</description>
     <url>https://github.com/yahoo/elide</url>
     <parent>
-        <artifactId>elide-parent-pom</artifactId>
         <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
         <version>7.0.0-RC7-SNAPSHOT</version>
     </parent>
 

--- a/elide-test/pom.xml
+++ b/elide-test/pom.xml
@@ -12,8 +12,8 @@
     <description>Test Helpers for Elide</description>
     <url>https://github.com/yahoo/elide</url>
     <parent>
-        <artifactId>elide-parent-pom</artifactId>
         <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
         <version>7.0.0-RC7-SNAPSHOT</version>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -215,25 +215,10 @@
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>
-                <artifactId>rest-assured</artifactId>
+                <artifactId>rest-assured-bom</artifactId>
                 <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>json-schema-validator</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>jackson-databind</artifactId>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jsr305</artifactId>
-                        <groupId>com.google.code.findbugs</groupId>
-                    </exclusion>
-                </exclusions>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- JPA -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <!-- dependency versions -->
         <version.antlr4>4.10.1</version.antlr4>
         <version.jetty>11.0.13</version.jetty>
-        <version.logback>1.2.11</version.logback>
+        <version.logback>1.4.5</version.logback>
         <version.restassured>5.3.0</version.restassured>
         <version.jackson>2.14.1</version.jackson>
         <version.jackson.databind>2.14.1</version.jackson.databind>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>elide-async</module>
         <module>elide-standalone</module>
         <module>elide-spring</module>
+        <module>elide-bom</module>
     </modules>
 
     <issueManagement>
@@ -245,44 +246,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
                 <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${version.jackson.databind}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-parameter-names</artifactId>
-                <version>${version.jackson}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,19 +86,18 @@
 
         <!-- dependency versions -->
         <version.antlr4>4.10.1</version.antlr4>
-        <version.jetty>11.0.13</version.jetty>
-        <version.logback>1.4.5</version.logback>
-        <version.restassured>5.3.0</version.restassured>
         <version.jackson>2.14.1</version.jackson>
         <version.jersey>3.1.0</version.jersey>
+        <version.jetty>11.0.13</version.jetty>
         <version.junit>5.9.1</version.junit>
-        <version.junit.platform>1.9.1</version.junit.platform>
+        <version.logback>1.4.5</version.logback>
         <version.lombok>1.18.24</version.lombok>
-        <jsonpath.version>2.7.0</jsonpath.version>
-        <hibernate6.version>6.1.5.Final</hibernate6.version>
-        <slf4j-api.version>2.0.3</slf4j-api.version>
-        <jedis.version>4.3.0</jedis.version>
+        <version.restassured>5.3.0</version.restassured>
         <embedded-redis.version>0.11.0</embedded-redis.version>
+        <hibernate6.version>6.1.5.Final</hibernate6.version>
+        <jedis.version>4.3.0</jedis.version>
+        <jsonpath.version>2.7.0</jsonpath.version>
+        <slf4j-api.version>2.0.3</slf4j-api.version>
         <maven-site-plugin-version>3.12.1</maven-site-plugin-version>
         <mpir.skip>true</mpir.skip>
 
@@ -153,18 +152,10 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
+                <artifactId>jetty-bom</artifactId>
                 <version>${version.jetty}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${version.jetty}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-continuation</artifactId>
-                <version>${version.jetty}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -187,49 +178,20 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jersey.containers</groupId>
-                <artifactId>jersey-container-servlet</artifactId>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
                 <version>${version.jersey}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.inject</groupId>
-                <artifactId>jersey-hk2</artifactId>
-                <version>${version.jersey}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${version.jetty}</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- JUnit -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-launcher</artifactId>
-                <version>${version.junit.platform}</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
         <version.logback>1.4.5</version.logback>
         <version.restassured>5.3.0</version.restassured>
         <version.jackson>2.14.1</version.jackson>
-        <version.jackson.databind>2.14.1</version.jackson.databind>
         <version.jersey>3.1.0</version.jersey>
         <version.junit>5.9.1</version.junit>
         <version.junit.platform>1.9.1</version.junit.platform>


### PR DESCRIPTION
## Description
Create the Elide Bill Of Materials.
See [Apache bill of materials (BOM) files](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies)

Update build to use dependency Bill Of Materials.

## Motivation and Context
[See Spring doc](https://docs.spring.io/spring-framework/docs/4.2.0.RELEASE/spring-framework-reference/html/overview.html#overview-maven-bom)

[Jackson BOM](https://github.com/FasterXML/jackson-bom#jackson-bom)

[Gradle bom import](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import)

Synchronizing Elide jars will only require
```xml
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>com.yahoo.elide</groupId>
            <artifactId>elide-bom</artifactId>
            <version>${elide.version}</version>
            <type>pom</type>
            <scope>import</scope>
        </dependency>
    </dependencies>
</dependencyManagement>
```

## How Has This Been Tested?
Built locally and used elide-bom with a local project.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.