### PR TITLE
Create Elide Bill Of Materials (5.x)

### DIFF
--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -72,12 +72,6 @@
             <groupId>com.github.opendevl</groupId>
             <artifactId>json2flat</artifactId>
             <version>1.0.3</version>
-            <exclusions>
-                <exclusion>
-                	<groupId>com.fasterxml.jackson.core</groupId>
-                	<artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Test -->
@@ -90,7 +84,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.33</version>
             <scope>test</scope>
         </dependency>
         <!-- JUnit -->

--- a/elide-bom/pom.xml
+++ b/elide-bom/pom.xml
@@ -1,0 +1,124 @@
+<!--
+  ~ Copyright 2023, Yahoo Inc.
+  ~ Licensed under the Apache License, Version 2.0
+  ~ See LICENSE file in project root for terms.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>elide-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>Elide: BOM</name>
+    <description>Elide Bill of Materials</description>
+    <url>https://github.com/yahoo/elide</url>
+    <parent>
+        <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
+        <version>5.1.3-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <organization>
+        <name>Yahoo! Inc.</name>
+        <url>http://www.yahoo.com</url>
+    </organization>
+    <developers>
+        <developer>
+            <name>Yahoo Inc.</name>
+            <url>https://github.com/yahoo</url>
+        </developer>
+    </developers>
+    <scm>
+        <developerConnection>scm:git:ssh://git@github.com/yahoo/elide.git</developerConnection>
+        <url>https://github.com/yahoo/elide.git</url>
+        <tag>HEAD</tag>
+    </scm>
+    <dependencyManagement>
+        <dependencies>
+            <!-- modules -->
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-async</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-core</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-aggregation</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-hibernate3</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-hibernate5</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-hibernate</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-inmemorydb</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-jpa</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-multiplex</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-noop</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-datastore-search</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-graphql</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-spring-boot-autoconfigure</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-spring-boot-starter</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-standalone</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.elide</groupId>
+                <artifactId>elide-swagger</artifactId>
+                <version>5.1.3-SNAPSHOT</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -191,7 +191,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>${version.jetty}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-datastore/elide-datastore-aggregation/pom.xml
+++ b/elide-datastore/elide-datastore-aggregation/pom.xml
@@ -89,15 +89,7 @@
         <dependency>
             <groupId>org.apache.calcite</groupId>
             <artifactId>calcite-core</artifactId>
-            <version>1.27.0</version>
-            <exclusions>
-                <!-- Excluded for CVE errors -->
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <!-- Excluded for conflict with elide-async's version -->
-            </exclusions>
+            <version>1.33.0</version>
         </dependency>
         <!-- Avoid CVE-2020-13956 -->
         <dependency>

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -121,11 +121,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/elide-datastore/elide-datastore-hibernate3/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate3/pom.xml
@@ -115,7 +115,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate3</artifactId>
-            <version>${version.jackson}</version>
         </dependency>
 
         <!-- Integration test -->

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -137,11 +137,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/elide-datastore/elide-datastore-hibernate5/pom.xml
+++ b/elide-datastore/elide-datastore-hibernate5/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate5</artifactId>
-            <version>${version.jackson}</version>
         </dependency>
 
         <!-- Integration test -->

--- a/elide-datastore/elide-datastore-inmemorydb/pom.xml
+++ b/elide-datastore/elide-datastore-inmemorydb/pom.xml
@@ -83,11 +83,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/elide-datastore/elide-datastore-multiplex/pom.xml
+++ b/elide-datastore/elide-datastore-multiplex/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate5</artifactId>
-            <version>${version.jackson}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/elide-datastore/elide-datastore-search/pom.xml
+++ b/elide-datastore/elide-datastore-search/pom.xml
@@ -107,16 +107,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.bytebuddy</groupId>
-                    <artifactId>byte-buddy</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.bytebuddy</groupId>
-                    <artifactId>byte-buddy-agent</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/elide-datastore/pom.xml
+++ b/elide-datastore/pom.xml
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/elide-integration-tests/pom.xml
+++ b/elide-integration-tests/pom.xml
@@ -24,31 +24,27 @@
         </license>
     </licenses>
 
-    <properties>
-        <elide.version>5.1.3-SNAPSHOT</elide.version>
-    </properties>
-
     <dependencies>
         <!-- Elide dependencies for integration testing -->
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-core</artifactId>
-            <version>${elide.version}</version>
+            <version>5.1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-graphql</artifactId>
-            <version>${elide.version}</version>
+            <version>5.1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-test-helpers</artifactId>
-            <version>${elide.version}</version>
+            <version>5.1.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-async</artifactId>
-            <version>${elide.version}</version>
+            <version>5.1.3-SNAPSHOT</version>
         </dependency>
 
         <!-- Additional dependencies -->
@@ -111,7 +107,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate3</artifactId>
-            <version>${version.jackson}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -149,7 +144,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${version.junit}</version>
         </dependency>
 
         <dependency>

--- a/elide-model-config/pom.xml
+++ b/elide-model-config/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <hjson.version>3.0.0</hjson.version>
-        <handlebars.version>4.2.0</handlebars.version>
+        <handlebars.version>4.3.1</handlebars.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-cli.version>1.4</commons-cli.version>

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -124,16 +124,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-websocket</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -12,8 +12,8 @@
     <description>Parent pom for spring packages</description>
     <url>https://github.com/yahoo/elide</url>
     <parent>
-        <artifactId>elide-parent-pom</artifactId>
         <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-parent-pom</artifactId>
         <version>5.1.3-SNAPSHOT</version>
     </parent>
 
@@ -40,7 +40,7 @@
 
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
-        <spring.boot.version>2.5.4</spring.boot.version>
+        <spring.boot.version>2.5.14</spring.boot.version>
         <groovy.version>3.0.8</groovy.version>
     </properties>
 
@@ -51,24 +51,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>rest-assured</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>xml-path</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy</artifactId>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -54,6 +54,17 @@
         <max_jdk_version>1.8</max_jdk_version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${metrics.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <!-- Elide dependency -->
         <dependency>
@@ -154,19 +165,16 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-servlets</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-servlet</artifactId>
-            <version>${metrics.version}</version>
         </dependency>
 
         <!-- Various Utility Libraries -->
@@ -220,7 +228,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${version.jackson}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>elide-async</module>
         <module>elide-standalone</module>
         <module>elide-spring</module>
+        <module>elide-bom</module>
     </modules>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -85,16 +85,16 @@
 
         <!-- dependency versions -->
         <version.antlr4>4.9.2</version.antlr4>
-        <version.logback>1.2.5</version.logback>
-        <version.jetty>9.4.43.v20210629</version.jetty>
-        <version.restassured>4.4.0</version.restassured>
         <version.jackson>2.12.5</version.jackson>
         <version.jersey>2.32</version.jersey>
+        <version.jetty>9.4.50.v20221201</version.jetty>
         <version.junit>5.7.2</version.junit>
-        <version.junit.platform>1.7.2</version.junit.platform>
-        <jsonpath.version>2.6.0</jsonpath.version>
+        <version.logback>1.2.11</version.logback>
+        <version.lombok>1.18.24</version.lombok>
+        <version.restassured>5.3.0</version.restassured>
         <hibernate3.version>3.6.10.Final</hibernate3.version>
         <hibernate5.version>5.5.5.Final</hibernate5.version>
+        <jsonpath.version>2.7.0</jsonpath.version>
         <slf4j-api.version>1.7.32</slf4j-api.version>
         <maven-site-plugin-version>3.9.1</maven-site-plugin-version>
         <mpir.skip>true</mpir.skip>
@@ -115,7 +115,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.20</version>
+                <version>${version.lombok}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>log4j-over-slf4j</artifactId>
-                <version>1.7.32</version>
+                <version>${slf4j-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -150,18 +150,10 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
+                <artifactId>jetty-bom</artifactId>
                 <version>${version.jetty}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${version.jetty}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-continuation</artifactId>
-                <version>${version.jetty}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -184,49 +176,20 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jersey.containers</groupId>
-                <artifactId>jersey-container-servlet</artifactId>
+                <groupId>org.glassfish.jersey</groupId>
+                <artifactId>jersey-bom</artifactId>
                 <version>${version.jersey}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.inject</groupId>
-                <artifactId>jersey-hk2</artifactId>
-                <version>${version.jersey}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${version.jetty}</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- JUnit -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-params</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-launcher</artifactId>
-                <version>${version.junit.platform}</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -242,66 +205,18 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
                 <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-parameter-names</artifactId>
-                <version>${version.jackson}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.rest-assured</groupId>
-                <artifactId>rest-assured</artifactId>
+                <artifactId>rest-assured-bom</artifactId>
                 <version>${version.restassured}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.rest-assured</groupId>
-                <artifactId>json-schema-validator</artifactId>
-                <version>${version.restassured}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>jackson-databind</artifactId>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jsr305</artifactId>
-                        <groupId>com.google.code.findbugs</groupId>
-                    </exclusion>
-                </exclusions>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- JPA -->
             <dependency>
@@ -369,7 +284,7 @@
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                            </configuration>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Description
Create the Elide Bill Of Materials.
See [Apache bill of materials (BOM) files](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies)

Update build to use dependency Bill Of Materials.

## Motivation and Context
[See Spring doc](https://docs.spring.io/spring-framework/docs/4.2.0.RELEASE/spring-framework-reference/html/overview.html#overview-maven-bom)

[Jackson BOM](https://github.com/FasterXML/jackson-bom#jackson-bom)

[Gradle bom import](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import)

Synchronizing Elide jars will only require
```xml
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>com.yahoo.elide</groupId>
            <artifactId>elide-bom</artifactId>
            <version>${elide.version}</version>
            <type>pom</type>
            <scope>import</scope>
        </dependency>
    </dependencies>
</dependencyManagement>
```

## How Has This Been Tested?
Built locally and used elide-bom with a local project.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.