### PR TITLE
Bump version.jersey from 3.1.0 to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <!-- dependency versions -->
         <version.antlr4>4.10.1</version.antlr4>
         <version.jackson>2.14.1</version.jackson>
-        <version.jersey>3.1.0</version.jersey>
+        <version.jersey>3.1.1</version.jersey>
         <version.jetty>11.0.13</version.jetty>
         <version.junit>5.9.1</version.junit>
         <version.logback>1.4.5</version.logback>


### PR DESCRIPTION
Bumps `version.jersey` from 3.1.0 to 3.1.1.

Updates `jersey-container-servlet` from 3.1.0 to 3.1.1

Updates `jersey-hk2` from 3.1.0 to 3.1.1

Updates `jersey-server` from 3.1.0 to 3.1.1

Resolves #<issue number> (if appropriate)


# Reopen https://github.com/yahoo/elide/pull/2877 
@aklish Dependabot got confused after so many changes.  I would still like to update the version.