### PR TITLE
Cleanup junit test dependencies (6.x)

### DIFF
--- a/elide-datastore/elide-datastore-inmemorydb/pom.xml
+++ b/elide-datastore/elide-datastore-inmemorydb/pom.xml
@@ -83,11 +83,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.rest-assured</groupId>

--- a/elide-datastore/pom.xml
+++ b/elide-datastore/pom.xml
@@ -98,6 +98,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/elide-swagger/pom.xml
+++ b/elide-swagger/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
## Description
Be sure JUnit is test scope and not compile.  The scope must be defined in dependencies.

## Motivation and Context
We do not want runtime dependency on JUnit

## How Has This Been Tested?
Local build

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.