### PR TITLE
Adds Spring Boot 3 Native Image support

### DIFF
--- a/checkstyle-style.xml
+++ b/checkstyle-style.xml
@@ -210,14 +210,14 @@
   <module name="RegexpHeader">
     <metadata name="net.sf.eclipsecs.core.comment" value="Checks that the file starts with a yahoo/apache copyright block."/>
     <property name="severity" value="error"/>
-    <property name="headerFile" value="java.header"/>
+    <property name="headerFile" value="${config_loc}/java.header"/>
     <property name="multiLines" value="2"/>
     <property name="fileExtensions" value="java,groovy,g4"/>
   </module>
   <module name="RegexpHeader">
     <metadata name="net.sf.eclipsecs.core.comment" value="Checks that the file starts with a yahoo/apache copyright block."/>
     <property name="severity" value="error"/>
-    <property name="headerFile" value="xml.header"/>
+    <property name="headerFile" value="${config_loc}/xml.header"/>
     <property name="fileExtensions" value="xml"/>
   </module>
   <module name="FileTabCharacter">
@@ -253,5 +253,8 @@
     <property name="severity" value="error"/>
     <property name="format" value="\s$"/>
     <property name="message" value="Trailing space"/>
+  </module>
+  <module name="SuppressionFilter">
+    <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
   </module>
 </module>

--- a/elide-async/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-async/native-image.properties
+++ b/elide-async/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-async/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json

--- a/elide-async/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-async/reflect-config.json
+++ b/elide-async/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-async/reflect-config.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIAdmin",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIOwner",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIStatusQueuedValue",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIStatusValue",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  }
+]

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/FileResultStorageEngineTest.java
@@ -56,7 +56,7 @@ public class FileResultStorageEngineTest {
 
         // verify contents of stored files are readable and match original
         String finalResult = readResultsFile(tempDir.toString(), queryId);
-        assertEquals(finalResult, validOutput);
+        assertEquals(finalResult, validOutput.replaceAll("\n", System.lineSeparator()));
     }
 
     // O/P Directory does not exist.

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
@@ -22,6 +22,7 @@ import redis.embedded.RedisServer;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Test cases for RedisResultStorageEngine.
@@ -112,7 +113,7 @@ public class RedisResultStorageEngineTest {
 
         observable.subscribe(subscriber);
         subscriber.assertComplete();
-        assertEquals(subscriber.getEvents().iterator().next(), expected);
+        assertEquals(subscriber.getEvents().iterator().next(), expected.stream().map(data -> data.replaceAll("\n", System.lineSeparator())).collect(Collectors.toList()));
     }
 
     private void storeResults(String queryId, Observable<String> storable) {

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -134,13 +134,20 @@
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.153</version>
+            <version>4.8.157</version>
         </dependency>
 
         <dependency>
             <groupId>org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>
             <version>1.2.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
+            <version>22.3.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--

--- a/elide-core/src/main/java/com/yahoo/elide/core/graal/ElideFeature.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/graal/ElideFeature.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.graal;
+
+import com.yahoo.elide.core.utils.ClassScannerCache;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * Native Image Feature for Elide.
+ */
+public class ElideFeature implements Feature {
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        ClassScannerCache.getInstance().values().stream().forEach(set -> set.stream().forEach(this::register));
+    }
+
+    void register(Class<?>... classes) {
+        Arrays.stream(classes).forEach(clazz -> {
+            System.out.println("Elide registering class " + clazz + " for reflection");
+
+            RuntimeReflection.register(clazz);
+
+            for (Field field : clazz.getFields()) {
+                RuntimeReflection.register(field);
+            }
+
+            for (Method method : clazz.getMethods()) {
+                RuntimeReflection.register(method);
+            }
+
+            for (Constructor<?> constructor : clazz.getConstructors()) {
+                RuntimeReflection.register(constructor);
+            }
+
+            for (Field field : clazz.getDeclaredFields()) {
+                RuntimeReflection.register(field);
+            }
+
+            for (Method method : clazz.getDeclaredMethods()) {
+                RuntimeReflection.register(method);
+            }
+
+            for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+                RuntimeReflection.register(constructor);
+            }
+        });
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/ClassScannerCache.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/ClassScannerCache.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.utils;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.utils.coerce.converters.ElideTypeConverter;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+/**
+ * Caches a set of classes with certain annotations.
+ *
+ * For the native code path this will be initialized at build time.
+ */
+public class ClassScannerCache {
+    private static final Map<String, Set<Class<?>>> INSTANCE;
+
+    private static final String [] CACHE_ANNOTATIONS  = {
+        //Elide Core Annotations
+        Include.class.getCanonicalName(),
+        SecurityCheck.class.getCanonicalName(),
+        ElideTypeConverter.class.getCanonicalName(),
+
+        //GraphQL annotations.  Strings here to avoid dependency.
+        "com.yahoo.elide.graphql.subscriptions.annotations.Subscription",
+
+        //Aggregation Store Annotations.  Strings here to avoid dependency.
+        "com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromTable",
+        "com.yahoo.elide.datastores.aggregation.queryengines.sql.annotation.FromSubquery",
+        "org.hibernate.annotations.Subselect",
+
+        //JPA
+        "jakarta.persistence.Entity",
+        "jakarta.persistence.Table"
+    };
+
+    static {
+        Map<String, Set<Class<?>>> result = new HashMap<>();
+        try (ScanResult scanResult = new ClassGraph().enableClassInfo().enableAnnotationInfo().scan()) {
+            for (String annotationName : CACHE_ANNOTATIONS) {
+                result.put(annotationName, scanResult.getClassesWithAnnotation(annotationName)
+                        .stream()
+                        .map(ClassInfo::loadClass)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)));
+            }
+        }
+        INSTANCE = result;
+    }
+
+    private ClassScannerCache() {
+    }
+
+    public static Map<String, Set<Class<?>>> getInstance() {
+        return INSTANCE;
+    }
+}

--- a/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/native-image.properties
+++ b/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/native-image.properties
@@ -1,0 +1,6 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json \
+       -H:ResourceConfigurationResources=${.}/resource-config.json \
+       --initialize-at-build-time=com.yahoo.elide.core.utils.ClassScannerCache \
+       --initialize-at-build-time=io.github.classgraph \
+       --initialize-at-build-time=nonapi.io.github.classgraph \
+       --features=com.yahoo.elide.core.graal.ElideFeature

--- a/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/reflect-config.json
+++ b/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/reflect-config.json
@@ -4,319 +4,142 @@
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jackson.jsonpointer.JsonPointerMessages",
+    "name": "com.github.fge.jackson.jsonpointer.JsonPointerMessages",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.core.messages.JsonSchemaCoreMessageBundle",
+    "name": "com.github.fge.jsonschema.core.messages.JsonSchemaCoreMessageBundle",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.core.messages.JsonSchemaSyntaxMessageBundle",
+    "name": "com.github.fge.jsonschema.core.messages.JsonSchemaSyntaxMessageBundle",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.AdditionalItemsValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.AdditionalItemsValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.AdditionalPropertiesValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.AdditionalPropertiesValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.DependenciesValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.DependenciesValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.EnumValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.EnumValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.MaxItemsValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.MaxItemsValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.MaxLengthValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.MaxLengthValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.MaximumValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.MaximumValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.MinItemsValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.MinItemsValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.MinLengthValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.MinLengthValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.MinimumValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.MinimumValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.PatternValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.PatternValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.common.UniqueItemsValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.common.UniqueItemsValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.DisallowKeywordValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv3.DisallowKeywordValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.DivisibleByValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv3.DivisibleByValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.DraftV3TypeValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv3.DraftV3TypeValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.ExtendsValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv3.ExtendsValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.PropertiesValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv3.PropertiesValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.AllOfValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.AllOfValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.AnyOfValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.AnyOfValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.DraftV4TypeValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.DraftV4TypeValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.MaxPropertiesValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.MaxPropertiesValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.MinPropertiesValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.MinPropertiesValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.MultipleOfValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.MultipleOfValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.NotValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.NotValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.OneOfValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.OneOfValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.RequiredKeywordValidator",
+    "name": "com.github.fge.jsonschema.keyword.validator.draftv4.RequiredKeywordValidator",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.messages.JsonSchemaConfigurationBundle",
+    "name": "com.github.fge.jsonschema.messages.JsonSchemaConfigurationBundle",
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.github.fge.jsonschema.messages.JsonSchemaValidationBundle",
+    "name": "com.github.fge.jsonschema.messages.JsonSchemaValidationBundle",
     "allDeclaredConstructors": true
   },
   {
-    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIAdmin",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIOwner",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIStatusQueuedValue",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIStatusValue",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Column",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Dimension",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Metric",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Namespace",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Table",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TableSource",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.datastores.aggregation.query.DefaultMetricProjectionMaker",
+    "name": "com.yahoo.elide.core.exceptions.ErrorObjects",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Day$DaySerde",
+    "name": "com.yahoo.elide.core.security.checks.prefab.Collections$AppendOnly",
     "allDeclaredMethods": true,
     "allDeclaredConstructors": true
   },
   {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Hour$HourSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.ISOWeek$ISOWeekSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Minute$MinuteSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Month$MonthSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Quarter$QuarterSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Second$SecondSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Time",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Time$TimeSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Week$WeekSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Year$YearSerde",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.datastores.multiplex.MultiplexManager",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.graphql.SerializeId",
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket$UserFactory",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.AbstractProtocolMessage",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.AbstractProtocolMessageWithID",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Complete",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.ConnectionAck",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.MessageType",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Next",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Subscribe",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Subscribe$Payload",
-    "allDeclaredFields": true,
+    "name": "com.yahoo.elide.core.security.checks.prefab.Collections$RemoveOnly",
     "allDeclaredMethods": true,
     "allDeclaredConstructors": true
   },
@@ -351,12 +174,6 @@
     "allDeclaredConstructors": true
   },
   {
-    "name": "com.yahoo.elide.core.exceptions.ErrorObjects",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
     "name": "com.yahoo.elide.jsonapi.serialization.DataSerializer",
     "allDeclaredConstructors": true
   },
@@ -370,112 +187,6 @@
   },
   {
     "name": "com.yahoo.elide.jsonapi.serialization.KeySerializer",
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.core.security.checks.prefab.Collections$AppendOnly",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.core.security.checks.prefab.Collections$RemoveOnly",
-    "allDeclaredMethods": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateArgsPropertiesValidator",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateDimPropertiesValidator",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateTimeDimPropertiesValidator",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.Argument",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.DBConfig",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.Dimension",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.ElideDBConfig",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.ElideNamespaceConfig",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.ElideSecurityConfig",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.ElideSQLDBConfig",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.ElideTableConfig",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.Grain",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.Join",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.Measure",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.NamespaceConfig",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.Rule",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.Table",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "com.yahoo.elide.modelconfig.model.TableSource",
-    "allDeclaredFields": true,
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "graphql.schema.GraphQLSchema",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
     "allDeclaredConstructors": true
   },
   {
@@ -659,14 +370,6 @@
     "allDeclaredConstructors": true
   },
   {
-    "name": "org.apache.calcite.avatica.AvaticaJdbc41Factory",
-    "allDeclaredConstructors": true
-  },
-  {
-    "name": "org.apache.calcite.jdbc.CalciteJdbc41Factory",
-    "allDeclaredConstructors": true
-  },
-  {
     "name": "java.util.LinkedHashSet",
     "allDeclaredConstructors": true
   },
@@ -681,5 +384,13 @@
   },
   {
     "name": "java.sql.Timestamp[]"
+  },
+  {
+    "name": "org.apache.calcite.avatica.AvaticaJdbc41Factory",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.calcite.jdbc.CalciteJdbc41Factory",
+    "allDeclaredConstructors": true
   }
 ]

--- a/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/reflect-config.json
+++ b/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/reflect-config.json
@@ -1,0 +1,685 @@
+[
+  {
+    "name": "com.github.benmanes.caffeine.cache.SSSMSW",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jackson.jsonpointer.JsonPointerMessages",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.core.messages.JsonSchemaCoreMessageBundle",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.core.messages.JsonSchemaSyntaxMessageBundle",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.AdditionalItemsValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.AdditionalPropertiesValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.DependenciesValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.EnumValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.MaxItemsValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.MaxLengthValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.MaximumValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.MinItemsValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.MinLengthValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.MinimumValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.PatternValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.common.UniqueItemsValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.DisallowKeywordValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.DivisibleByValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.DraftV3TypeValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.ExtendsValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv3.PropertiesValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.AllOfValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.AnyOfValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.DraftV4TypeValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.MaxPropertiesValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.MinPropertiesValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.MultipleOfValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.NotValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.OneOfValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.keyword.validator.draftv4.RequiredKeywordValidator",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.messages.JsonSchemaConfigurationBundle",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.github.fge.jsonschema.messages.JsonSchemaValidationBundle",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIAdmin",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIOwner",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIStatusQueuedValue",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.async.models.security.AsyncAPIInlineChecks$AsyncAPIStatusValue",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Column",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Dimension",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Metric",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Namespace",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Table",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TableSource",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.query.DefaultMetricProjectionMaker",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Day$DaySerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Hour$HourSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.ISOWeek$ISOWeekSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Minute$MinuteSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Month$MonthSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Quarter$QuarterSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Second$SecondSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Time",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Time$TimeSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Week$WeekSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.aggregation.timegrains.Year$YearSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.datastores.multiplex.MultiplexManager",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.SerializeId",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket$UserFactory",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.AbstractProtocolMessage",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.AbstractProtocolMessageWithID",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Complete",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.ConnectionAck",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.MessageType",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Next",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Subscribe",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name":"com.yahoo.elide.graphql.subscriptions.websocket.protocol.Subscribe$Payload",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.models.JsonApiDocument",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.models.Relationship",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.models.Resource",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.models.ResourceIdentifier",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.models.Meta",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.core.exceptions.ErrorObjects",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.serialization.DataSerializer",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.serialization.DataDeserializer",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.serialization.MetaDeserializer",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.jsonapi.serialization.KeySerializer",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.core.security.checks.prefab.Collections$AppendOnly",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.core.security.checks.prefab.Collections$RemoveOnly",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateArgsPropertiesValidator",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateDimPropertiesValidator",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateTimeDimPropertiesValidator",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Argument",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.DBConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Dimension",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideDBConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideNamespaceConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideSecurityConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideSQLDBConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideTableConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Grain",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Join",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Measure",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.NamespaceConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Rule",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Table",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.TableSource",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "graphql.schema.GraphQLSchema",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.jackson.mixin.IgnoreOriginalRefMixin",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.jackson.mixin.OperationResponseMixin",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.jackson.mixin.ResponseSchemaMixin",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.AbstractModel",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Info",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Model",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.ModelImpl",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Operation",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Path",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Response",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Responses",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Swagger",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.Tag",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.parameters.AbstractParameter",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.parameters.AbstractSerializableParameter",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.parameters.BodyParameter",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.parameters.Parameter",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.parameters.PathParameter",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.parameters.QueryParameter",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.parameters.SerializableParameter",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.AbstractNumericProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.AbstractProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.ArrayProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.BaseIntegerProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.DateTimeProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.LongProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.ObjectProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.Property",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.RefProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "io.swagger.models.properties.StringProperty",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.calcite.avatica.AvaticaJdbc41Factory",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "org.apache.calcite.jdbc.CalciteJdbc41Factory",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "java.util.LinkedHashSet",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "java.util.Calendar[]"
+  },
+  {
+    "name": "java.sql.Date[]"
+  },
+  {
+    "name": "java.sql.Time[]"
+  },
+  {
+    "name": "java.sql.Timestamp[]"
+  }
+]

--- a/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/resource-config.json
+++ b/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/resource-config.json
@@ -1,0 +1,33 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "draftv3/schema"
+      },
+      {
+        "pattern": "draftv4/hyper-schema"
+      },
+      {
+        "pattern": "draftv4/schema"
+      },
+      {
+        "pattern": "elideDBConfigSchema.json"
+      },
+      {
+        "pattern": "elideNamespaceConfigSchema.json"
+      },
+      {
+        "pattern": "elideSecuritySchema.json"
+      },
+      {
+        "pattern": "elideTableSchema.json"
+      },
+      {
+        "pattern": "elideVariableSchema.json"
+      },
+      {
+        "pattern": "helpers.nashorn.js"
+      }
+    ]
+  }
+}

--- a/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/resource-config.json
+++ b/elide-core/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-core/resource-config.json
@@ -11,21 +11,6 @@
         "pattern": "draftv4/schema"
       },
       {
-        "pattern": "elideDBConfigSchema.json"
-      },
-      {
-        "pattern": "elideNamespaceConfigSchema.json"
-      },
-      {
-        "pattern": "elideSecuritySchema.json"
-      },
-      {
-        "pattern": "elideTableSchema.json"
-      },
-      {
-        "pattern": "elideVariableSchema.json"
-      },
-      {
         "pattern": "helpers.nashorn.js"
       }
     ]

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
@@ -26,7 +26,7 @@ public class ClassScannerTest {
     @Test
     public void testGetAllClasses() {
         Set<Class<?>> classes = scanner.getAllClasses("com.yahoo.elide.core.utils");
-        assertEquals(33, classes.size());
+        assertEquals(34, classes.size());
         assertTrue(classes.contains(ClassScannerTest.class));
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-aggregation/native-image.properties
+++ b/elide-datastore/elide-datastore-aggregation/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-aggregation/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json

--- a/elide-datastore/elide-datastore-aggregation/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-aggregation/reflect-config.json
+++ b/elide-datastore/elide-datastore-aggregation/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-aggregation/reflect-config.json
@@ -1,0 +1,108 @@
+[
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.ArgumentDefinition",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Column",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Dimension",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Metric",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Namespace",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.Table",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TableSource",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimension",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.metadata.models.TimeDimensionGrain",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.query.DefaultMetricProjectionMaker",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Day$DaySerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Hour$HourSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.ISOWeek$ISOWeekSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Minute$MinuteSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Month$MonthSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Quarter$QuarterSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Second$SecondSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Time",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Time$TimeSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Week$WeekSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.datastores.aggregation.timegrains.Year$YearSerde",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  }
+]

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/SQLUnitTest.java
@@ -100,7 +100,7 @@ public abstract class SQLUnitTest {
     protected static MetaDataStore metaDataStore;
 
     private static final DataSource DUMMY_DATASOURCE = new HikariDataSource();
-    private static final String NEWLINE = System.lineSeparator();
+    private static final String NEWLINE = "\n";
     protected static SQLQueryEngine engine;
 
     protected QueryEngine.Transaction transaction;

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/AggregationDataStoreIntegrationTest.java
@@ -41,7 +41,6 @@ import jakarta.persistence.Persistence;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.SecurityContext;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Base64;
@@ -60,7 +59,7 @@ public abstract class AggregationDataStoreIntegrationTest extends GraphQLIntegra
 
     public static DynamicConfigValidator VALIDATOR;
 
-    public static HikariConfig config = new HikariConfig(File.separator + "jpah2db.properties");
+    public static HikariConfig config = new HikariConfig("/" + "jpah2db.properties");
 
     static {
         VALIDATOR = new DynamicConfigValidator(DefaultClassScanner.getInstance(), "src/test/resources/configs");

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/MetaDataStoreIntegrationTest.java
@@ -49,7 +49,6 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -106,7 +105,7 @@ public class MetaDataStoreIntegrationTest extends IntegrationTest {
     @Override
     protected DataStoreTestHarness createHarness() {
 
-        HikariConfig config = new HikariConfig(File.separator + "jpah2db.properties");
+        HikariConfig config = new HikariConfig("/" + "jpah2db.properties");
         DataSource defaultDataSource = new HikariDataSource(config);
         SQLDialect defaultDialect = SQLDialectFactory.getDefaultDialect();
         ConnectionDetails defaultConnectionDetails = new ConnectionDetails(defaultDataSource, defaultDialect);

--- a/elide-datastore/elide-datastore-multiplex/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-multiplex/native-image.properties
+++ b/elide-datastore/elide-datastore-multiplex/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-multiplex/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json

--- a/elide-datastore/elide-datastore-multiplex/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-multiplex/reflect-config.json
+++ b/elide-datastore/elide-datastore-multiplex/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-datastore-multiplex/reflect-config.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "com.yahoo.elide.datastores.multiplex.MultiplexManager",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  }
+]

--- a/elide-graphql/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-graphql/native-image.properties
+++ b/elide-graphql/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-graphql/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json

--- a/elide-graphql/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-graphql/reflect-config.json
+++ b/elide-graphql/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-graphql/reflect-config.json
@@ -1,0 +1,70 @@
+[
+  {
+    "name": "com.yahoo.elide.graphql.SerializeId",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket$UserFactory",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.AbstractProtocolMessage",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.AbstractProtocolMessageWithID",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.Complete",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.ConnectionAck",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.MessageType",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.Next",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.Subscribe",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.graphql.subscriptions.websocket.protocol.Subscribe$Payload",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "graphql.schema.GraphQLSchema",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  }
+]

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/TableExportIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/TableExportIT.java
@@ -158,11 +158,11 @@ public class TableExportIT extends AsyncApiIT {
                         equalTo("http://localhost:" + getPort() + "/export/edc4a871-dff2-4054-804e-d80075cf830a"))
                 .body("data.attributes.result.httpStatus", equalTo(200));
 
-
-        assertEquals("\"title\"\n"
+        String expected = "\"title\"\n"
                 + "\"For Whom the Bell Tolls\"\n"
                 + "\"Song of Ice and Fire\"\n"
-                + "\"Ender's Game\"\n", getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf830a"));
+                + "\"Ender's Game\"\n";
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf830a"));
     }
 
     /**
@@ -205,11 +205,12 @@ public class TableExportIT extends AsyncApiIT {
                         equalTo("http://localhost:" + getPort() + "/export/edc4a871-dff2-4054-804e-d80075cf831a"))
                 .body("data.attributes.result.httpStatus", equalTo(200));
 
-        assertEquals("[\n"
+        String expected = "[\n"
                 + "{\"title\":\"For Whom the Bell Tolls\"}\n"
                 + ",{\"title\":\"Song of Ice and Fire\"}\n"
                 + ",{\"title\":\"Ender's Game\"}\n"
-                + "]\n", getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf831a"));
+                + "]\n";
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf831a"));
 
     }
 
@@ -269,10 +270,11 @@ public class TableExportIT extends AsyncApiIT {
                 + "\"httpStatus\":200,\"recordCount\":3}}}]}}}";
 
         assertEquals(expectedResponse, responseGraphQL);
-        assertEquals("\"title\"\n"
+        String expected = "\"title\"\n"
                 + "\"Ender's Game\"\n"
                 + "\"Song of Ice and Fire\"\n"
-                + "\"For Whom the Bell Tolls\"\n", getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf828e"));
+                + "\"For Whom the Bell Tolls\"\n";
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf828e"));
     }
 
     /**
@@ -341,11 +343,12 @@ public class TableExportIT extends AsyncApiIT {
                  + "\"httpStatus\":200,\"recordCount\":3}}}]}}}";
 
         assertEquals(expectedResponse, responseGraphQL);
-        assertEquals("[\n"
+        String expected = "[\n"
                 + "{\"title\":\"Ender's Game\"}\n"
                 + ",{\"title\":\"Song of Ice and Fire\"}\n"
                 + ",{\"title\":\"For Whom the Bell Tolls\"}\n"
-                + "]\n", getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf829e"));
+                + "]\n";
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cf829e"));
     }
 
     /**
@@ -404,10 +407,11 @@ public class TableExportIT extends AsyncApiIT {
                 + "\"httpStatus\":200,\"recordCount\":3}}}]}}}";
 
         assertEquals(expectedResponse, responseGraphQL);
-        assertEquals("\"title\"\n"
+        String expected = "\"title\"\n"
                 + "\"Ender's Game\"\n"
                 + "\"Song of Ice and Fire\"\n"
-                + "\"For Whom the Bell Tolls\"\n", getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cab28e"));
+                + "\"For Whom the Bell Tolls\"\n";
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cab28e"));
     }
 
     /**
@@ -476,11 +480,12 @@ public class TableExportIT extends AsyncApiIT {
                  + "\"httpStatus\":200,\"recordCount\":3}}}]}}}";
 
         assertEquals(expectedResponse, responseGraphQL);
-        assertEquals("[\n"
+        String expected = "[\n"
                 + "{\"bookName\":\"Ender's Game\"}\n"
                 + ",{\"bookName\":\"Song of Ice and Fire\"}\n"
                 + ",{\"bookName\":\"For Whom the Bell Tolls\"}\n"
-                + "]\n", getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cab29e"));
+                + "]\n";
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), getStoredFileContents(getPort(), "edc4a871-dff2-4054-804e-d80075cab29e"));
     }
 
     /**

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/io/FileLoader.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/io/FileLoader.java
@@ -37,6 +37,7 @@ public class FileLoader {
     private static final Pattern DB_FILE = Pattern.compile("db/sql/[^/]+\\.hjson");
     private static final String CLASSPATH_PATTERN = "classpath*:";
     private static final String FILEPATH_PATTERN = "file:";
+    private static final String RESOURCEPATH_PATTERN = "resource:";
     private static final String RESOURCES = "resources";
     private static final int RESOURCES_LENGTH = 9; //"resources".length()
 
@@ -108,7 +109,15 @@ public class FileLoader {
                 log.error("Missing resource during HJSON configuration load: {}", resource.getURI());
                 continue;
             }
-            String path = resource.getURI().toString().substring(configDirURILength);
+            String resourceUri = resource.getURI().toString();
+            String path = null;
+            if (resourceUri.startsWith(RESOURCEPATH_PATTERN)) {
+                // Native image
+                int rootLength = resourceUri.indexOf(this.rootPath) + this.rootPath.length() + 1;
+                path = resourceUri.substring(rootLength);
+            } else {
+                path = resourceUri.substring(configDirURILength);
+            }
             resourceMap.put(path, ConfigFile.builder()
                     .type(toType(path))
                     .contentProvider(() -> CONTENT_PROVIDER.apply(resource))

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/ConfigDataStoreTransaction.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/store/ConfigDataStoreTransaction.java
@@ -17,7 +17,6 @@ import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.modelconfig.io.FileLoader;
 import com.yahoo.elide.modelconfig.store.models.ConfigFile;
 import com.yahoo.elide.modelconfig.validator.Validator;
-import org.apache.commons.io.FileUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -201,27 +200,27 @@ public class ConfigDataStoreTransaction implements DataStoreTransaction {
 
     private void deleteFile(String path) {
         Path deletePath = Path.of(fileLoader.getRootPath(), path);
-        File file = deletePath.toFile();
 
-        if (! file.exists()) {
+        if (! Files.exists(deletePath)) {
             return;
         }
 
-        if (! file.delete()) {
-            log.error("Error deleting file: {}", file.getPath());
-            throw new IllegalStateException("Unable to delete: " + path);
+        try {
+            Files.delete(deletePath);
+        } catch (IOException e) {
+            log.error("Error deleting file: {} with message: {}", deletePath, e.getMessage());
+            throw new IllegalStateException("Unable to delete: " + deletePath, e);
         }
     }
 
     private void updateFile(String path, String content) {
         Path updatePath = Path.of(fileLoader.getRootPath(), path);
-        File file = updatePath.toFile();
 
         try {
-            FileUtils.writeStringToFile(file, content, StandardCharsets.UTF_8);
+            Files.writeString(updatePath, content, StandardCharsets.UTF_8);
         } catch (IOException e) {
-            log.error("Error updating file: {} with message: {}", file.getPath(), e.getMessage());
-            throw new IllegalStateException(e);
+            log.error("Error updating file: {} with message: {}", updatePath, e.getMessage());
+            throw new IllegalStateException("Unable to update:" + updatePath, e);
         }
     }
     private void createFile(String path) {

--- a/elide-model-config/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-model-config/native-image.properties
+++ b/elide-model-config/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-model-config/native-image.properties
@@ -1,0 +1,2 @@
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json \
+       -H:ResourceConfigurationResources=${.}/resource-config.json

--- a/elide-model-config/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-model-config/reflect-config.json
+++ b/elide-model-config/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-model-config/reflect-config.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateArgsPropertiesValidator",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateDimPropertiesValidator",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.jsonformats.ValidateTimeDimPropertiesValidator",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Argument",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.DBConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Dimension",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideDBConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideNamespaceConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideSecurityConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideSQLDBConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.ElideTableConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Grain",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Join",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Measure",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.NamespaceConfig",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Rule",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.Table",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.yahoo.elide.modelconfig.model.TableSource",
+    "allDeclaredFields": true,
+    "allDeclaredConstructors": true
+  }
+]

--- a/elide-model-config/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-model-config/resource-config.json
+++ b/elide-model-config/src/main/resources/META-INF/native-image/com.yahoo.elide/elide-model-config/resource-config.json
@@ -1,0 +1,21 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "elideDBConfigSchema.json"
+      },
+      {
+        "pattern": "elideNamespaceConfigSchema.json"
+      },
+      {
+        "pattern": "elideSecuritySchema.json"
+      },
+      {
+        "pattern": "elideTableSchema.json"
+      },
+      {
+        "pattern": "elideVariableSchema.json"
+      }
+    ]
+  }
+}

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/DynamicConfigSchemaValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/DynamicConfigSchemaValidatorTest.java
@@ -36,7 +36,7 @@ public class DynamicConfigSchemaValidatorTest {
         String expectedMessage = "Schema validation failed for: security_invalid.hjson\n"
                         + "[ERROR]\n"
                         + "object instance has properties which are not allowed by the schema: [\"cardinality\",\"description\",\"name\",\"schema$\",\"table\"]";
-        assertEquals(expectedMessage, e.getMessage());
+        assertEquals(expectedMessage.replaceAll("\n", System.lineSeparator()), e.getMessage());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class DynamicConfigSchemaValidatorTest {
                         + "object instance has properties which are not allowed by the schema: [\"schema$\"]\n"
                         + "[ERROR]\n"
                         + "Instance[/cardinality] failed to validate against schema[/patternProperties/^([A-Za-z0-9_]+[.]?)+$]. instance type (null) does not match any allowed primitive type (allowed: [\"array\",\"boolean\",\"integer\",\"number\",\"object\",\"string\"])";
-        assertEquals(expectedMessage, e.getMessage());
+        assertEquals(expectedMessage.replaceAll("\n", System.lineSeparator()), e.getMessage());
     }
 
     // Table config test
@@ -147,7 +147,7 @@ public class DynamicConfigSchemaValidatorTest {
                         + "[ERROR]\n"
                         + "Instance[/tables/0/name] failed to validate against schema[/properties/tables/items/properties/name]. Name [Country@10] is not allowed. Name must start with an alphabetic character and can include alaphabets, numbers and '_' only.";
 
-        assertEquals(expectedMessage, e.getMessage());
+        assertEquals(expectedMessage.replaceAll("\n", System.lineSeparator()), e.getMessage());
     }
 
     // DB config test
@@ -178,7 +178,7 @@ public class DynamicConfigSchemaValidatorTest {
                         + "Instance[/dbconfigs/1/dialect] failed to validate against schema[/properties/dbconfigs/items/properties/dialect]. instance type (integer) does not match any allowed primitive type (allowed: [\"string\"])\n"
                         + "[ERROR]\n"
                         + "Instance[/dbconfigs/1/url] failed to validate against schema[/properties/dbconfigs/items/properties/url]. Input value [ojdbc:mysql://localhost/testdb?serverTimezone=UTC] is not a valid JDBC url, it must start with 'jdbc:'.";
-        assertEquals(expectedMessage, e.getMessage());
+        assertEquals(expectedMessage.replaceAll("\n", System.lineSeparator()), e.getMessage());
     }
 
     private String loadHjsonFromClassPath(String resource) throws Exception {

--- a/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
+++ b/elide-model-config/src/test/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidatorTest.java
@@ -176,7 +176,7 @@ public class DynamicConfigValidatorTest {
         });
 
         assertEquals("Invalid Hjson Syntax: Found '[' where a key name was "
-                + "expected (check your syntax or use quotes if the key name includes {}[],: or whitespace) at 3:7\n",
+                + "expected (check your syntax or use quotes if the key name includes {}[],: or whitespace) at 3:7\n".replaceAll("\n", System.lineSeparator()),
                 error);
     }
 
@@ -200,7 +200,7 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals("Undefined model: B is used as a Parent(extend) for another model.\n", error);
+        assertEquals("Undefined model: B is used as a Parent(extend) for another model.\n".replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -212,7 +212,7 @@ public class DynamicConfigValidatorTest {
         });
 
         assertEquals("Invalid Hjson Syntax: Found '[' where a key name was expected "
-                + "(check your syntax or use quotes if the key name includes {}[],: or whitespace) at 3:11\n",
+                + "(check your syntax or use quotes if the key name includes {}[],: or whitespace) at 3:11\n".replaceAll("\n", System.lineSeparator()),
                 error);
     }
 
@@ -224,7 +224,7 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals("Duplicate!! Role name: 'prefab.role.all' is already defined. Please use different role.\n", error);
+        assertEquals("Duplicate!! Role name: 'prefab.role.all' is already defined. Please use different role.\n".replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -240,7 +240,7 @@ public class DynamicConfigValidatorTest {
                         + "Instance[/roles/0] failed to validate against schema[/properties/roles/items]. Role [admin,] is not allowed. Role must start with an alphabetic character and can include alaphabets, numbers, spaces and '.' only.\n"
                         + "[ERROR]\n"
                         + "Instance[/roles/1] failed to validate against schema[/properties/roles/items]. Role [guest,] is not allowed. Role must start with an alphabetic character and can include alaphabets, numbers, spaces and '.' only.\n";
-        assertEquals(expectedError, error);
+        assertEquals(expectedError.replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -251,7 +251,7 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals("Found undefined security checks: [guest, member, user]\n", error);
+        assertEquals("Found undefined security checks: [guest, member, user]\n".replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -265,7 +265,7 @@ public class DynamicConfigValidatorTest {
         String expected = "Schema validation failed for: models/namespaces/test_namespace.hjson\n"
                 + "[ERROR]\n"
                 + "Instance[/namespaces/0/name] failed to validate against schema[/properties/namespaces/items/properties/name]. Name [Default] clashes with the 'default' namespace. Either change the case or pick a different namespace name.\n";
-        assertEquals(expected, error);
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -276,7 +276,7 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals("Found undefined security checks: [namespaceRead]\n", error);
+        assertEquals("Found undefined security checks: [namespaceRead]\n".replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -287,7 +287,7 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals("Namespace: TestNamespace is not included in dynamic configs\n", error);
+        assertEquals("Namespace: TestNamespace is not included in dynamic configs\n".replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -303,7 +303,7 @@ public class DynamicConfigValidatorTest {
                         + "[ERROR]\n"
                         + "Instance[/tables/0/joins/1/type] failed to validate against schema[/definitions/join/properties/type]. Join type [full outer] is not allowed. Supported value is one of [left, inner, full, cross].\n";
 
-        assertEquals(expected, error);
+        assertEquals(expected.replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -330,7 +330,7 @@ public class DynamicConfigValidatorTest {
             assertEquals(2, exitStatus);
         });
 
-        assertEquals(expectedMessage, error);
+        assertEquals(expectedMessage.replaceAll("\n", System.lineSeparator()), error);
     }
 
     @Test
@@ -364,7 +364,7 @@ public class DynamicConfigValidatorTest {
         });
 
         assertEquals("foobar is used as a variable in either table or security config files "
-                        + "but is not defined in variables config file.\n", error);
+                        + "but is not defined in variables config file.\n".replaceAll("\n", System.lineSeparator()), error);
     }
 
     public void testBadTableSource() throws Exception {
@@ -389,7 +389,7 @@ public class DynamicConfigValidatorTest {
 
         //Java 11 introduces (and prints) the following deprecation warning:
         //"Warning: Nashorn engine is planned to be removed from a future JDK release"
-        assertTrue(error.contains("Multiple DB configs found with the same name: OracleConnection\n"));
+        assertTrue(error.contains("Multiple DB configs found with the same name: OracleConnection\n".replaceAll("\n", System.lineSeparator())));
     }
 
     @Test

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -233,7 +233,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jakarta-server</artifactId>
-            <version>2.27.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -285,4 +284,51 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>nativeTest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <version>${spring.boot.version}</version>
+                        <executions>
+                            <execution>
+                                <id>process-test-aot</id>
+                                <goals>
+                                     <goal>process-test-aot</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>0.9.20</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                            <metadataRepository>
+                                <enabled>true</enabled>
+                            </metadataRepository>
+                            <buildArgs>
+                                <buildArg>--report-unsupported-elements-at-runtime</buildArg>
+                            </buildArgs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>native-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.spring.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import lombok.Data;
 
@@ -19,41 +20,49 @@ public class ElideConfigProperties {
     /**
      * Settings for the JSON-API controller.
      */
+    @NestedConfigurationProperty
     private JsonApiControllerProperties jsonApi;
 
     /**
      * Settings for the GraphQL controller.
      */
+    @NestedConfigurationProperty
     private GraphQLControllerProperties graphql;
 
     /**
      * Settings for the Swagger document controller.
      */
+    @NestedConfigurationProperty
     private SwaggerControllerProperties swagger;
 
     /**
      * Settings for the Async.
      */
+    @NestedConfigurationProperty
     private AsyncProperties async = new AsyncProperties();
 
     /**
      * Settings for subscriptions.
      */
+    @NestedConfigurationProperty
     private SubscriptionProperties subscription = new SubscriptionProperties();
 
     /**
      * Settings for the Dynamic Configuration.
      */
+    @NestedConfigurationProperty
     private DynamicConfigProperties dynamicConfig = new DynamicConfigProperties();
 
     /**
      * Settings for the Aggregation Store.
      */
+    @NestedConfigurationProperty
     private AggregationStoreProperties aggregationStore = new AggregationStoreProperties();
 
     /**
      * Settings for the JPA Store.
      */
+    @NestedConfigurationProperty
     private JpaStoreProperties jpaStore = new JpaStoreProperties();
 
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ExportController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ExportController.java
@@ -7,8 +7,6 @@ package com.yahoo.elide.spring.controllers;
 
 import com.yahoo.elide.async.service.storageengine.ResultStorageEngine;
 import com.yahoo.elide.core.exceptions.HttpStatus;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,12 +31,10 @@ import java.io.IOException;
 @Slf4j
 @RestController
 @RequestMapping(value = "${elide.async.export.path:/export}")
-@ConditionalOnExpression("${elide.async.enabled:false} && ${elide.async.export.enabled:false}")
 public class ExportController {
 
     private ResultStorageEngine resultStorageEngine;
 
-    @Autowired
     public ExportController(ResultStorageEngine resultStorageEngine) {
         log.debug("Started ~~");
         this.resultStorageEngine = resultStorageEngine;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ExportController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ExportController.java
@@ -9,7 +9,6 @@ import com.yahoo.elide.async.service.storageengine.ResultStorageEngine;
 import com.yahoo.elide.core.exceptions.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,7 +31,6 @@ import java.io.IOException;
  * {@link org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody}.
  */
 @Slf4j
-@Configuration
 @RestController
 @RequestMapping(value = "${elide.async.export.path:/export}")
 @ConditionalOnExpression("${elide.async.enabled:false} && ${elide.async.export.enabled:false}")

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -45,7 +44,6 @@ import java.util.concurrent.Callable;
  * Spring rest controller for Elide GraphQL.
  */
 @Slf4j
-@Configuration
 @RestController
 @RequestMapping(value = "${elide.graphql.path}")
 @EnableConfigurationProperties(ElideConfigProperties.class)

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -19,10 +19,6 @@ import com.yahoo.elide.spring.security.AuthenticationUser;
 import com.yahoo.elide.utils.HeaderUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -46,9 +42,6 @@ import java.util.concurrent.Callable;
 @Slf4j
 @RestController
 @RequestMapping(value = "${elide.graphql.path}")
-@EnableConfigurationProperties(ElideConfigProperties.class)
-@ConditionalOnExpression("${elide.graphql.enabled:false}")
-@RefreshScope
 public class GraphqlController {
 
     private final ElideConfigProperties settings;
@@ -58,7 +51,6 @@ public class GraphqlController {
 
     private static final String JSON_CONTENT_TYPE = "application/json";
 
-    @Autowired
     public GraphqlController(
             QueryRunners runners,
             JsonApiMapper jsonApiMapper,

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -16,9 +16,6 @@ import com.yahoo.elide.spring.config.ElideConfigProperties;
 import com.yahoo.elide.spring.security.AuthenticationUser;
 import com.yahoo.elide.utils.HeaderUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -51,8 +48,6 @@ import java.util.concurrent.Callable;
 @Slf4j
 @RestController
 @RequestMapping(value = "${elide.json-api.path}")
-@ConditionalOnExpression("${elide.json-api.enabled:false}")
-@RefreshScope
 public class JsonApiController {
 
     private final Elide elide;
@@ -61,7 +56,6 @@ public class JsonApiController {
     public static final String JSON_API_CONTENT_TYPE = JSONAPI_CONTENT_TYPE;
     public static final String JSON_API_PATCH_CONTENT_TYPE = JSONAPI_CONTENT_TYPE_WITH_JSON_PATCH_EXTENSION;
 
-    @Autowired
     public JsonApiController(RefreshableElide refreshableElide, ElideConfigProperties settings) {
         log.debug("Started ~~");
         this.settings = settings;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -51,7 +50,6 @@ import java.util.concurrent.Callable;
  */
 @Slf4j
 @RestController
-@Configuration
 @RequestMapping(value = "${elide.json-api.path}")
 @ConditionalOnExpression("${elide.json-api.enabled:false}")
 @RefreshScope

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
@@ -11,9 +11,6 @@ import com.yahoo.elide.swagger.SwaggerBuilder;
 import com.yahoo.elide.utils.HeaderUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.owasp.encoder.Encode;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,10 +36,8 @@ import java.util.stream.Collectors;
  * Spring REST controller for exposing Swagger documentation.
  */
 @Slf4j
-@RefreshScope
 @RestController
 @RequestMapping(value = "${elide.swagger.path}")
-@ConditionalOnExpression("${elide.swagger.enabled:false}")
 public class SwaggerController {
 
     //Maps api version & path to swagger document.
@@ -75,7 +70,6 @@ public class SwaggerController {
      *
      * @param docs A list of documents to register.
      */
-    @Autowired
     public SwaggerController(SwaggerRegistrations docs) {
         log.debug("Started ~~");
         documents = new HashMap<>();

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/SwaggerController.java
@@ -14,7 +14,6 @@ import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +41,6 @@ import java.util.stream.Collectors;
 @Slf4j
 @RefreshScope
 @RestController
-@Configuration
 @RequestMapping(value = "${elide.swagger.path}")
 @ConditionalOnExpression("${elide.swagger.enabled:false}")
 public class SwaggerController {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,9 +1,4 @@
-org.springframework.cloud.autoconfigure.RefreshAutoConfiguration
 com.yahoo.elide.spring.config.ElideAutoConfiguration
 com.yahoo.elide.spring.config.ElideAsyncConfiguration
 com.yahoo.elide.spring.config.ElideSubscriptionConfiguration
 com.yahoo.elide.spring.config.ElideSubscriptionScanningConfiguration
-com.yahoo.elide.spring.controllers.JsonApiController
-com.yahoo.elide.spring.controllers.GraphqlController
-com.yahoo.elide.spring.controllers.SwaggerController
-com.yahoo.elide.spring.controllers.ExportController

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests for ElideAutoConfiguration.
+ */
+class ElideAutoConfigurationTest {
+    private static final String TARGET_NAME_PREFIX = "scopedTarget.";
+    private static final String SCOPE_REFRESH = "refresh";
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ElideAutoConfiguration.class, DataSourceAutoConfiguration.class,
+                    HibernateJpaAutoConfiguration.class, RefreshAutoConfiguration.class));
+
+    @Test
+    void nonRefreshable() {
+        Set<String> nonRefreshableBeans = new HashSet<>();
+
+        contextRunner.withPropertyValues("spring.cloud.refresh.enabled=false", "elide.json-api.enabled=true",
+                "elide.swagger.enabled=true", "elide.graphql.enabled=true").run(context -> {
+                    Arrays.stream(context.getBeanDefinitionNames()).forEach(beanDefinitionName -> {
+                        if (context.getBeanFactory() instanceof BeanDefinitionRegistry beanDefinitionRegistry) {
+                            BeanDefinition beanDefinition = beanDefinitionRegistry
+                                    .getBeanDefinition(beanDefinitionName);
+                            assertThat(beanDefinition.getScope()).isNotEqualTo(SCOPE_REFRESH);
+                            nonRefreshableBeans.add(beanDefinitionName);
+                        }
+                    });
+                });
+        assertThat(nonRefreshableBeans).contains("refreshableElide", "graphqlController", "queryRunners",
+                "swaggerController", "swaggerRegistrations", "jsonApiController");
+    }
+
+    enum RefreshableInput {
+        GRAPHQL(new String[] { "elide.graphql.enabled=true" },
+                new String[] { "refreshableElide", "graphqlController", "queryRunners" }),
+        SWAGGER(new String[] { "elide.swagger.enabled=true" },
+                new String[] { "refreshableElide", "swaggerController", "swaggerRegistrations" }),
+        JSONAPI(new String[] { "elide.json-api.enabled=true" },
+                new String[] { "refreshableElide", "jsonApiController" });
+
+        String[] propertyValues;
+        String[] beanNames;
+
+        RefreshableInput(String[] propertyValues, String[] beanNames) {
+            this.propertyValues = propertyValues;
+            this.beanNames = beanNames;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(RefreshableInput.class)
+    void refreshable(RefreshableInput refreshableInput) {
+        contextRunner.withPropertyValues(refreshableInput.propertyValues).run(context -> {
+
+            Set<String> refreshableBeans = new HashSet<>();
+
+            Arrays.stream(context.getBeanDefinitionNames()).forEach(beanDefinitionName -> {
+                if (context.getBeanFactory() instanceof BeanDefinitionRegistry beanDefinitionRegistry) {
+                    BeanDefinition beanDefinition = beanDefinitionRegistry.getBeanDefinition(beanDefinitionName);
+                    if (SCOPE_REFRESH.equals(beanDefinition.getScope())) {
+                        refreshableBeans.add(beanDefinitionName.replace(TARGET_NAME_PREFIX, ""));
+                        assertThat(context.getBean(beanDefinitionName)).isNotNull();
+                    }
+                }
+            });
+
+            assertThat(refreshableBeans).contains(refreshableInput.beanNames);
+        });
+    }
+
+    @RestController
+    public static class UserGraphqlController {
+    }
+
+    @Configuration
+    public static class UserGraphqlControllerConfiguration {
+        @Bean
+        public UserGraphqlController graphqlController() {
+            return new UserGraphqlController();
+        }
+    }
+
+    @RestController
+    public static class UserSwaggerController {
+    }
+
+    @Configuration
+    public static class UserSwaggerControllerConfiguration {
+        @Bean
+        public UserSwaggerController swaggerController() {
+            return new UserSwaggerController();
+        }
+    }
+
+    @RestController
+    public static class UserJsonApiController {
+    }
+
+    @Configuration
+    public static class UserJsonApiControllerConfiguration {
+        @Bean
+        public UserJsonApiController jsonApiController() {
+            return new UserJsonApiController();
+        }
+    }
+
+    enum OverrideControllerInput {
+        GRAPHQL(new String[] { "elide.graphql.enabled=true" }, UserGraphqlControllerConfiguration.class,
+                "graphqlController"),
+        SWAGGER(new String[] { "elide.swagger.enabled=true" }, UserSwaggerControllerConfiguration.class,
+                "swaggerController"),
+        JSONAPI(new String[] { "elide.json-api.enabled=true" }, UserJsonApiControllerConfiguration.class,
+                "jsonApiController");
+
+        String[] propertyValues;
+        Class<?> userConfiguration;
+        String beanName;
+
+        OverrideControllerInput(String[] propertyValues, Class<?> userConfiguration, String beanName) {
+            this.propertyValues = propertyValues;
+            this.userConfiguration = userConfiguration;
+            this.beanName = beanName;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(OverrideControllerInput.class)
+    void overrideController(OverrideControllerInput input) {
+        contextRunner.withPropertyValues("spring.cloud.refresh.enabled=false").withPropertyValues(input.propertyValues)
+                .withConfiguration(UserConfigurations.of(input.userConfiguration)).run(context -> {
+                    if (context.getBeanFactory() instanceof BeanDefinitionRegistry beanDefinitionRegistry) {
+                        BeanDefinition beanDefinition = beanDefinitionRegistry.getBeanDefinition(input.beanName);
+                        assertThat(beanDefinition.getFactoryBeanName())
+                                .endsWith(input.userConfiguration.getSimpleName());
+                    }
+                });
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/SubscriptionTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/SubscriptionTest.java
@@ -13,6 +13,7 @@ import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
 import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
 import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketTestClient;
@@ -65,6 +66,11 @@ public class SubscriptionTest extends IntegrationTest {
 
             assertEquals(1, results.size());
             assertEquals(0, results.get(0).getErrors().size());
+
+            when()
+                    .delete("/json/group/com.example.repository2")
+                    .then()
+                    .statusCode(HttpStatus.SC_NO_CONTENT);
         }
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -48,7 +48,7 @@ spring:
         physical-strategy: 'org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl'
       ddl-auto: 'create'
   datasource:
-    url: 'jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1'
+    url: 'jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;TIME ZONE=UTC'
     username: 'sa'
     password: ''
     driver-class-name: 'org.h2.Driver'

--- a/elide-spring/pom.xml
+++ b/elide-spring/pom.xml
@@ -40,8 +40,9 @@
 
     <properties>
         <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>
-        <spring.boot.version>3.0.4</spring.boot.version>
+        <spring.boot.version>3.0.5</spring.boot.version>
         <tomcat.version>10.1.5</tomcat.version>
+        <artemis.version>2.28.0</artemis.version>
     </properties>
 
     <modules>
@@ -79,6 +80,62 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-actuator</artifactId>
                 <version>${spring.boot.version}</version>
+            </dependency>
+            <!-- Override artemis versions in spring-boot-dependencies -->
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jakarta-client</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jakarta-server</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-core-client</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-commons</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-selector</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-server</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-server</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-journal</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-quorum-api</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jakarta-service-extensions</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jdbc-store</artifactId>
+                <version>${artemis.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
@@ -49,6 +49,7 @@ import jakarta.ws.rs.core.MediaType;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,7 +70,8 @@ public class ElideStandaloneConfigStoreTest {
 
     @BeforeAll
     public void init() throws Exception {
-        configRoot = Files.createTempDirectory("test");
+        configRoot = Paths.get(Files.createTempDirectory("test").toFile().getAbsolutePath(), "1", "2", "3", "4", "5"); // for path traversal attempt
+        Files.createDirectories(configRoot);
         settings = new ElideStandaloneTestSettings() {
 
             @Override

--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,6 @@
 
         <!-- TODO: Need to update locations to be relative to the projects using them -->
         <parent.pom.dir>${project.basedir}/..</parent.pom.dir>
-        <checkstyle.config.location>${parent.pom.dir}/checkstyle-style.xml</checkstyle.config.location>
-        <checkstyle.suppressions.location>${parent.pom.dir}/checkstyle-suppressions.xml
-        </checkstyle.suppressions.location>
 
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <dependency.details.enabled>false</dependency.details.enabled>
@@ -315,6 +312,7 @@
                             <id>validate</id>
                             <phase>validate</phase>
                             <configuration>
+                                <configLocation>${parent.pom.dir}/checkstyle-style.xml</configLocation>
                                 <includeTestSourceDirectory>true</includeTestSourceDirectory>
                                 <includes>**\/*</includes>
                                 <resourceIncludes>**\/*</resourceIncludes>
@@ -322,6 +320,7 @@
                                     <sourceDirectory>src/main/java</sourceDirectory>
                                 </sourceDirectories>
                                 <propertyExpansion>basedir=${project.basedir}</propertyExpansion>
+                                <propertyExpansion>config_loc=${parent.pom.dir}</propertyExpansion>
                                 <failsOnError>true</failsOnError>
                                 <consoleOutput>true</consoleOutput>
                                 <encoding>UTF-8</encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version.logback>1.4.5</version.logback>
         <version.lombok>1.18.24</version.lombok>
         <version.restassured>5.3.0</version.restassured>
-        <embedded-redis.version>1.0.0</embedded-redis.version>
+        <embedded-redis.version>0.11.0</embedded-redis.version>
         <hibernate6.version>6.1.5.Final</hibernate6.version>
         <jedis.version>4.3.0</jedis.version>
         <jsonpath.version>2.7.0</jsonpath.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version.logback>1.4.5</version.logback>
         <version.lombok>1.18.24</version.lombok>
         <version.restassured>5.3.0</version.restassured>
-        <embedded-redis.version>0.11.0</embedded-redis.version>
+        <embedded-redis.version>1.0.0</embedded-redis.version>
         <hibernate6.version>6.1.5.Final</hibernate6.version>
         <jedis.version>4.3.0</jedis.version>
         <jsonpath.version>2.7.0</jsonpath.version>


### PR DESCRIPTION
Resolves #2934 

## Description
- Adds missing `NestedConfigurationProperty` annotation to ElideConfigProperties. Previously it just affected some non essential meta data but during AOT processing this means the reflection meta data configuration is not generated for the nested configuration classes which then silently fail to bind the config properties.
- Modified `FileLoader` for Graal as it use resources with the resource protocol.
- Created a statically initialized cache for `DefaultClassScanner`  and configured to be loaded at build time `--initialize-at-build-time` along with ClassGraph itself
- Created a `org.graalvm.nativeimage.hosted.Feature` to register the reflection metadata of classes scanned by ClassGraph
- Modified `AutoConfiguration` to make `@RefreshScope` optional as there are issues as a native image. See https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_aot_and_native_image_support_2.
- Added `native-image.properties` to register the appropriate metadata of Elide and some of its dependencies

## Motivation and Context
- Need to get it to compile and run as a native Spring Boot image

## How Has This Been Tested?
- Tested manually by running with the Spring Boot sample

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
