### PR TITLE
Removing unwanted exception traces for build logs

### DIFF
--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -120,6 +120,8 @@
             <version>${hibernate6.version}</version>
         </dependency>
 
+
+
         <!-- Jetty for embedded web server -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -209,6 +211,27 @@
         </dependency>
 
         <!-- Test -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <version>5.0.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.2</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
@@ -18,6 +18,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 
 import java.util.Optional;
 
@@ -63,6 +67,15 @@ public class ElideStandaloneMetadataStoreMissingTest {
         });
     }
 
+    private void setLoggingLevel(Level level) {
+        Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        logger.setLevel(level);
+    }
+
+    private Level getLoggingLevel() {
+        return ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).getLevel();
+    }
+
     @AfterAll
     public void shutdown() throws Exception {
         elide.stop();
@@ -70,6 +83,13 @@ public class ElideStandaloneMetadataStoreMissingTest {
 
     @Test
     public void testMetadataStoreMissing() {
-       assertThrows(MultiException.class, () -> elide.start(false));
+        Level old = getLoggingLevel();
+
+        try {
+            setLoggingLevel(Level.OFF);
+            assertThrows(MultiException.class, () -> elide.start(false));
+        } finally {
+            setLoggingLevel(old);
+        }
     }
 }

--- a/elide-standalone/src/test/resources/logback.xml
+++ b/elide-standalone/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter
       class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>INFO</level>
+      <level>OFF</level>
     </filter>
     <encoder>
       <pattern>%msg%n</pattern>

--- a/elide-standalone/src/test/resources/logback.xml
+++ b/elide-standalone/src/test/resources/logback.xml
@@ -8,7 +8,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <filter
       class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>OFF</level>
+      <level>INFO</level>
     </filter>
     <encoder>
       <pattern>%msg%n</pattern>


### PR DESCRIPTION
Removes unwanted exception logging for elide-standalone and elide-async tests in the build output.

- Adds hibernate validator dependencies to pom to remove one set of exceptions
- Disables test logging for ElideStandaloneMetadataStoreMissingTest exceptions 
- Disables test logging for RedisResultStorageEngineTest exceptions

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
