### PR TITLE
Add Spring `PlatformTransactionManager` aware transaction support

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/framework/AggregationDataStoreTestHarness.java
@@ -57,7 +57,8 @@ public abstract class AggregationDataStoreTestHarness implements DataStoreTestHa
 
         return new JpaDataStore(
                 () -> entityManagerFactory.createEntityManager(),
-                em -> new NonJtaTransaction(em, txCancel)
+                em -> new NonJtaTransaction(em, txCancel),
+                entityManagerFactory::getMetamodel
         );
     }
 

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/SupplierEntityManager.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/SupplierEntityManager.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jpa;
+
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.Query;
+import jakarta.persistence.StoredProcedureQuery;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.metamodel.Metamodel;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * EntityManager used to proxy to a target entity manager.
+ */
+public class SupplierEntityManager implements EntityManager {
+
+    private Supplier<EntityManager> entityManagerSupplier;
+
+    public SupplierEntityManager() {
+    }
+
+    public SupplierEntityManager(Supplier<EntityManager> entityManagerSupplier) {
+        setEntityManagerSupplier(entityManagerSupplier);
+    }
+
+    public SupplierEntityManager(EntityManager entityManager) {
+        setEntityManager(entityManager);
+    }
+
+    public Supplier<EntityManager> getEntityManagerSupplier() {
+        return this.entityManagerSupplier;
+    }
+
+    public void setEntityManagerSupplier(Supplier<EntityManager> entityManagerSupplier) {
+        this.entityManagerSupplier = entityManagerSupplier;
+    }
+
+    public EntityManager getEntityManager() {
+        if (this.entityManagerSupplier != null) {
+            return this.entityManagerSupplier.get();
+        }
+        return null;
+    }
+
+    public void setEntityManager(EntityManager entityManager) {
+        this.entityManagerSupplier = () -> entityManager;
+    }
+
+    @Override
+    public void persist(Object entity) {
+        getEntityManager().persist(entity);
+    }
+
+    @Override
+    public <T> T merge(T entity) {
+        return getEntityManager().merge(entity);
+    }
+
+    @Override
+    public void remove(Object entity) {
+        getEntityManager().remove(entity);
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey) {
+        return getEntityManager().find(entityClass, primaryKey);
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, Map<String, Object> properties) {
+        return getEntityManager().find(entityClass, primaryKey, properties);
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode) {
+        return getEntityManager().find(entityClass, primaryKey, lockMode);
+    }
+
+    @Override
+    public <T> T find(Class<T> entityClass, Object primaryKey, LockModeType lockMode, Map<String, Object> properties) {
+        return getEntityManager().find(entityClass, primaryKey, lockMode, properties);
+    }
+
+    @Override
+    public <T> T getReference(Class<T> entityClass, Object primaryKey) {
+        return getEntityManager().getReference(entityClass, primaryKey);
+    }
+
+    @Override
+    public void flush() {
+        getEntityManager().flush();
+    }
+
+    @Override
+    public void setFlushMode(FlushModeType flushMode) {
+        getEntityManager().setFlushMode(flushMode);
+    }
+
+    @Override
+    public FlushModeType getFlushMode() {
+        return getEntityManager().getFlushMode();
+    }
+
+    @Override
+    public void lock(Object entity, LockModeType lockMode) {
+        getEntityManager().lock(entity, lockMode);
+    }
+
+    @Override
+    public void lock(Object entity, LockModeType lockMode, Map<String, Object> properties) {
+        getEntityManager().lock(entity, lockMode, properties);
+    }
+
+    @Override
+    public void refresh(Object entity) {
+        getEntityManager().refresh(entity);
+    }
+
+    @Override
+    public void refresh(Object entity, Map<String, Object> properties) {
+        getEntityManager().refresh(entity, properties);
+    }
+
+    @Override
+    public void refresh(Object entity, LockModeType lockMode) {
+        getEntityManager().refresh(entity, lockMode);
+    }
+
+    @Override
+    public void refresh(Object entity, LockModeType lockMode, Map<String, Object> properties) {
+        getEntityManager().refresh(entity, lockMode, properties);
+    }
+
+    @Override
+    public void clear() {
+        getEntityManager().clear();
+    }
+
+    @Override
+    public void detach(Object entity) {
+        getEntityManager().detach(entity);
+    }
+
+    @Override
+    public boolean contains(Object entity) {
+        return getEntityManager().contains(entity);
+    }
+
+    @Override
+    public LockModeType getLockMode(Object entity) {
+        return getEntityManager().getLockMode(entity);
+    }
+
+    @Override
+    public void setProperty(String propertyName, Object value) {
+        getEntityManager().setProperty(propertyName, value);
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return getEntityManager().getProperties();
+    }
+
+    @Override
+    public Query createQuery(String qlString) {
+        return getEntityManager().createQuery(qlString);
+    }
+
+    @Override
+    public <T> TypedQuery<T> createQuery(CriteriaQuery<T> criteriaQuery) {
+        return getEntityManager().createQuery(criteriaQuery);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Query createQuery(CriteriaUpdate updateQuery) {
+        return getEntityManager().createQuery(updateQuery);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Query createQuery(CriteriaDelete deleteQuery) {
+        return getEntityManager().createQuery(deleteQuery);
+    }
+
+    @Override
+    public <T> TypedQuery<T> createQuery(String qlString, Class<T> resultClass) {
+        return getEntityManager().createQuery(qlString, resultClass);
+    }
+
+    @Override
+    public Query createNamedQuery(String name) {
+        return getEntityManager().createNamedQuery(name);
+    }
+
+    @Override
+    public <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass) {
+        return getEntityManager().createNamedQuery(name, resultClass);
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString) {
+        return getEntityManager().createNativeQuery(sqlString);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Query createNativeQuery(String sqlString, Class resultClass) {
+        return getEntityManager().createNativeQuery(sqlString, resultClass);
+    }
+
+    @Override
+    public Query createNativeQuery(String sqlString, String resultSetMapping) {
+        return getEntityManager().createNativeQuery(sqlString, resultSetMapping);
+    }
+
+    @Override
+    public StoredProcedureQuery createNamedStoredProcedureQuery(String name) {
+        return getEntityManager().createNamedStoredProcedureQuery(name);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName) {
+        return getEntityManager().createStoredProcedureQuery(procedureName);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName, Class... resultClasses) {
+        return getEntityManager().createStoredProcedureQuery(procedureName, resultClasses);
+    }
+
+    @Override
+    public StoredProcedureQuery createStoredProcedureQuery(String procedureName, String... resultSetMappings) {
+        return getEntityManager().createStoredProcedureQuery(procedureName, resultSetMappings);
+    }
+
+    @Override
+    public void joinTransaction() {
+        getEntityManager().joinTransaction();
+    }
+
+    @Override
+    public boolean isJoinedToTransaction() {
+        return getEntityManager().isJoinedToTransaction();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) {
+        return getEntityManager().unwrap(cls);
+    }
+
+    @Override
+    public Object getDelegate() {
+        return getEntityManager().getDelegate();
+    }
+
+    @Override
+    public void close() {
+        EntityManager entityManager = getEntityManager();
+        if (entityManager != null) {
+            entityManager.close();
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        EntityManager entityManager = getEntityManager();
+        if (entityManager != null) {
+            return entityManager.isOpen();
+        }
+        return false;
+    }
+
+    @Override
+    public EntityTransaction getTransaction() {
+        return getEntityManager().getTransaction();
+    }
+
+    @Override
+    public EntityManagerFactory getEntityManagerFactory() {
+        return getEntityManager().getEntityManagerFactory();
+    }
+
+    @Override
+    public CriteriaBuilder getCriteriaBuilder() {
+        return getEntityManager().getCriteriaBuilder();
+    }
+
+    @Override
+    public Metamodel getMetamodel() {
+        return getEntityManager().getMetamodel();
+    }
+
+    @Override
+    public <T> EntityGraph<T> createEntityGraph(Class<T> rootType) {
+        return getEntityManager().createEntityGraph(rootType);
+    }
+
+    @Override
+    public EntityGraph<?> createEntityGraph(String graphName) {
+        return getEntityManager().createEntityGraph(graphName);
+    }
+
+    @Override
+    public EntityGraph<?> getEntityGraph(String graphName) {
+        return getEntityManager().getEntityGraph(graphName);
+    }
+
+    @Override
+    public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
+        return getEntityManager().getEntityGraphs(entityClass);
+    }
+}

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreHarness.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreHarness.java
@@ -116,7 +116,8 @@ public class JpaDataStoreHarness implements DataStoreTestHarness {
 
         store = new JpaDataStore(
                 () -> emf.createEntityManager(),
-                entityManager -> new NonJtaTransaction(entityManager, txCancel, logger, delegateToInMemoryStore, true)
+                entityManager -> new NonJtaTransaction(entityManager, txCancel, logger, delegateToInMemoryStore, true),
+                emf::getMetamodel
         );
     }
 

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/JpaDataStoreTest.java
@@ -60,7 +60,7 @@ public class JpaDataStoreTest {
         EntityManager managerMock = mock(EntityManager.class);
         when(managerMock.getMetamodel()).thenReturn(mockModel);
 
-        JpaDataStore store = new JpaDataStore(() -> managerMock, unused -> null);
+        JpaDataStore store = new JpaDataStore(() -> managerMock, unused -> null, () -> mockModel);
         EntityDictionary dictionary = EntityDictionary.builder().build();
 
 

--- a/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/SupplierEntityManagerTest.java
+++ b/elide-datastore/elide-datastore-jpa/src/test/java/com/yahoo/elide/datastores/jpa/SupplierEntityManagerTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jpa;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Verifies the SupplierEntityManager delegates.
+ */
+class SupplierEntityManagerTest {
+
+    EntityManager targetEntityManager;
+
+    SupplierEntityManager entityManager;
+
+    @BeforeEach
+    void setup() {
+        this.targetEntityManager = mock(EntityManager.class);
+        this.entityManager = new SupplierEntityManager();
+        this.entityManager.setEntityManager(this.targetEntityManager);
+    }
+
+    @Test
+    void isOpenDefault() {
+        try (SupplierEntityManager supplierEntityManager = new SupplierEntityManager()) {
+            assertFalse(supplierEntityManager.isOpen());
+        }
+    }
+
+    @Test
+    void persist() {
+        Object entity = new Object();
+        this.entityManager.persist(entity);
+        verify(this.targetEntityManager).persist(entity);
+    }
+
+    @Test
+    void merge() {
+        Object entity = new Object();
+        this.entityManager.merge(entity);
+        verify(this.targetEntityManager).merge(entity);
+    }
+
+    @Test
+    void remove() {
+        Object entity = new Object();
+        this.entityManager.remove(entity);
+        verify(this.targetEntityManager).remove(entity);
+    }
+
+    @Test
+    void findClassObject() {
+        Object entity = new Object();
+        Object primaryKey = new Object();
+        this.entityManager.find(entity.getClass(), primaryKey);
+        verify(this.targetEntityManager).find(entity.getClass(), primaryKey);
+    }
+
+    @Test
+    void findClassObjectMap() {
+        Object entity = new Object();
+        Object primaryKey = new Object();
+        Map<String, Object> properties = new HashMap<>();
+        this.entityManager.find(entity.getClass(), primaryKey, properties);
+        verify(this.targetEntityManager).find(entity.getClass(), primaryKey, properties);
+    }
+
+    @Test
+    void findClassObjectLockModeType() {
+        Object entity = new Object();
+        Object primaryKey = new Object();
+        LockModeType lockMode = LockModeType.NONE;
+        this.entityManager.find(entity.getClass(), primaryKey, lockMode);
+        verify(this.targetEntityManager).find(entity.getClass(), primaryKey, lockMode);
+    }
+
+    @Test
+    void findClassObjectLockModeTypeMap() {
+        Object entity = new Object();
+        Object primaryKey = new Object();
+        LockModeType lockMode = LockModeType.NONE;
+        Map<String, Object> properties = new HashMap<>();
+        this.entityManager.find(entity.getClass(), primaryKey, lockMode, properties);
+        verify(this.targetEntityManager).find(entity.getClass(), primaryKey, lockMode, properties);
+    }
+
+    @Test
+    void getReference() {
+        Object entity = new Object();
+        Object primaryKey = new Object();
+        this.entityManager.getReference(entity.getClass(), primaryKey);
+        verify(this.targetEntityManager).getReference(entity.getClass(), primaryKey);
+    }
+
+    @Test
+    void flush() {
+        this.entityManager.flush();
+        verify(this.targetEntityManager).flush();
+    }
+
+    @Test
+    void setFlushMode() {
+        FlushModeType flushMode = FlushModeType.COMMIT;
+        this.entityManager.setFlushMode(flushMode);
+        verify(this.targetEntityManager).setFlushMode(flushMode);
+    }
+
+    @Test
+    void getFlushMode() {
+        FlushModeType flushMode = FlushModeType.COMMIT;
+        when(this.targetEntityManager.getFlushMode()).thenReturn(flushMode);
+        assertEquals(flushMode, this.entityManager.getFlushMode());
+    }
+
+    @Test
+    void lockObjectLockMode() {
+        Object entity = new Object();
+        LockModeType lockMode = LockModeType.NONE;
+        this.entityManager.lock(entity, lockMode);
+        verify(this.targetEntityManager).lock(entity, lockMode);
+    }
+
+    @Test
+    void lockObjectLockModeTypeMap() {
+        Object entity = new Object();
+        LockModeType lockMode = LockModeType.NONE;
+        Map<String, Object> properties = new HashMap<>();
+        this.entityManager.lock(entity, lockMode, properties);
+        verify(this.targetEntityManager).lock(entity, lockMode, properties);
+    }
+
+    @Test
+    void refreshObject() {
+        Object entity = new Object();
+        this.entityManager.refresh(entity);
+        verify(this.targetEntityManager).refresh(entity);
+    }
+
+    @Test
+    void refreshObjectMap() {
+        Object entity = new Object();
+        Map<String, Object> properties = new HashMap<>();
+        this.entityManager.refresh(entity, properties);
+        verify(this.targetEntityManager).refresh(entity, properties);
+    }
+
+    @Test
+    void refreshObjectLockModeType() {
+        Object entity = new Object();
+        LockModeType lockMode = LockModeType.NONE;
+        this.entityManager.refresh(entity, lockMode);
+        verify(this.targetEntityManager).refresh(entity, lockMode);
+    }
+
+    @Test
+    void refreshObjectLockModeTypeMap() {
+        Object entity = new Object();
+        LockModeType lockMode = LockModeType.NONE;
+        Map<String, Object> properties = new HashMap<>();
+        this.entityManager.refresh(entity, lockMode, properties);
+        verify(this.targetEntityManager).refresh(entity, lockMode, properties);
+    }
+
+    @Test
+    void clear() {
+        this.entityManager.clear();
+        verify(this.targetEntityManager).clear();
+    }
+
+    @Test
+    void detach() {
+        Object entity = new Object();
+        this.entityManager.detach(entity);
+        verify(this.targetEntityManager).detach(entity);
+    }
+
+    @Test
+    void contains() {
+        Object entity = new Object();
+        when(this.targetEntityManager.contains(entity)).thenReturn(true);
+        assertTrue(this.entityManager.contains(entity));
+    }
+
+    @Test
+    void getLockMode() {
+        Object entity = new Object();
+        when(this.targetEntityManager.getLockMode(entity)).thenReturn(LockModeType.NONE);
+        assertEquals(LockModeType.NONE, this.entityManager.getLockMode(entity));
+    }
+
+    @Test
+    void setProperty() {
+        Object value = new Object();
+        this.entityManager.setProperty("propertyName", value);
+        verify(this.targetEntityManager).setProperty("propertyName", value);
+
+    }
+
+    @Test
+    void getProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        when(this.targetEntityManager.getProperties()).thenReturn(properties);
+        assertEquals(properties, this.entityManager.getProperties());
+    }
+
+    @Test
+    void createQueryString() {
+        String qlString = "";
+        this.entityManager.createQuery(qlString);
+        verify(this.targetEntityManager).createQuery(qlString);
+    }
+
+    @Test
+    void createQueryCriteriaQuery() {
+        CriteriaQuery<?> criteriaQuery = null;
+        this.entityManager.createQuery(criteriaQuery);
+        verify(this.targetEntityManager).createQuery(criteriaQuery);
+    }
+
+    @Test
+    void createQueryCriteriaUpdate() {
+        CriteriaUpdate<?> updateQuery = null;
+        this.entityManager.createQuery(updateQuery);
+        verify(this.targetEntityManager).createQuery(updateQuery);
+    }
+
+    @Test
+    void createQueryCriteriaDelete() {
+        CriteriaDelete<?> deleteQuery = null;
+        this.entityManager.createQuery(deleteQuery);
+        verify(this.targetEntityManager).createQuery(deleteQuery);
+    }
+
+    @Test
+    void createQueryStringClass() {
+        String qlString = "";
+        String result = "";
+        this.entityManager.createQuery(qlString, result.getClass());
+        verify(this.targetEntityManager).createQuery(qlString, result.getClass());
+    }
+
+    @Test
+    void createNamedQueryString() {
+        this.entityManager.createNamedQuery("name");
+        verify(this.targetEntityManager).createNamedQuery("name");
+    }
+
+    @Test
+    void createNamedQueryStringClass() {
+        String name = "";
+        String result = "";
+        this.entityManager.createNamedQuery(name, result.getClass());
+        verify(this.targetEntityManager).createNamedQuery(name, result.getClass());
+    }
+
+    @Test
+    void createNativeQueryString() {
+        String sqlString = "";
+        this.entityManager.createNativeQuery(sqlString);
+        verify(this.targetEntityManager).createNativeQuery(sqlString);
+    }
+
+    @Test
+    void createNativeQueryStringClass() {
+        String sqlString = "";
+        String result = "";
+        this.entityManager.createNativeQuery(sqlString, result.getClass());
+        verify(this.targetEntityManager).createNativeQuery(sqlString, result.getClass());
+    }
+
+    @Test
+    void createNativeQueryStringString() {
+        String sqlString = "";
+        String resultSetMapping = "";
+        this.entityManager.createNativeQuery(sqlString, resultSetMapping);
+        verify(this.targetEntityManager).createNativeQuery(sqlString, resultSetMapping);
+    }
+
+    @Test
+    void createNamedStoredProcedureQuery() {
+        String name = "";
+        this.entityManager.createNamedStoredProcedureQuery(name);
+        verify(this.targetEntityManager).createNamedStoredProcedureQuery(name);
+    }
+
+    @Test
+    void createStoredProcedureQueryString() {
+        String procedureName = "";
+        this.entityManager.createStoredProcedureQuery(procedureName);
+        verify(this.targetEntityManager).createStoredProcedureQuery(procedureName);
+    }
+
+    @Test
+    void createStoredProcedureQueryStringClass() {
+        String procedureName = "";
+        Class<?>[] resultClasses = new Class[] { String.class };
+        this.entityManager.createStoredProcedureQuery(procedureName, resultClasses);
+        verify(this.targetEntityManager).createStoredProcedureQuery(procedureName, resultClasses);
+    }
+
+    @Test
+    void createStoredProcedureQueryStringString() {
+        String procedureName = "";
+        String[] resultSetMappings = new String[] { "" };
+        this.entityManager.createStoredProcedureQuery(procedureName, resultSetMappings);
+        verify(this.targetEntityManager).createStoredProcedureQuery(procedureName, resultSetMappings);
+    }
+
+    @Test
+    void joinTransaction() {
+        this.entityManager.joinTransaction();
+        verify(this.targetEntityManager).joinTransaction();
+    }
+
+    @Test
+    void isJoinedToTransaction() {
+        this.entityManager.isJoinedToTransaction();
+        verify(this.targetEntityManager).isJoinedToTransaction();
+    }
+
+    @Test
+    void unwrap() {
+        Class<?> cls = null;
+        this.entityManager.unwrap(cls);
+        verify(this.targetEntityManager).unwrap(cls);
+    }
+
+    @Test
+    void getDelegate() {
+        this.entityManager.getDelegate();
+        verify(this.targetEntityManager).getDelegate();
+    }
+
+    @Test
+    void close() {
+        this.entityManager.close();
+        verify(this.targetEntityManager).close();
+    }
+
+    @Test
+    void isOpen() {
+        this.entityManager.isOpen();
+        verify(this.targetEntityManager).isOpen();
+    }
+
+    @Test
+    void getTransaction() {
+        this.entityManager.getTransaction();
+        verify(this.targetEntityManager).getTransaction();
+    }
+
+    @Test
+    void getEntityManagerFactory() {
+        this.entityManager.getEntityManagerFactory();
+        verify(this.targetEntityManager).getEntityManagerFactory();
+    }
+
+    @Test
+    void getCriteriaBuilder() {
+        this.entityManager.getCriteriaBuilder();
+        verify(this.targetEntityManager).getCriteriaBuilder();
+    }
+
+    @Test
+    void getMetamodel() {
+        this.entityManager.getMetamodel();
+        verify(this.targetEntityManager).getMetamodel();
+    }
+
+    @Test
+    void createEntityGraphClass() {
+        Class<?> rootType = null;
+        this.entityManager.createEntityGraph(rootType);
+        verify(this.targetEntityManager).createEntityGraph(rootType);
+    }
+
+    @Test
+    void createEntityGraphString() {
+        String graphName = "";
+        this.entityManager.createEntityGraph(graphName);
+        verify(this.targetEntityManager).createEntityGraph(graphName);
+    }
+
+    @Test
+    void getEntityGraph() {
+        String graphName = "";
+        this.entityManager.getEntityGraph(graphName);
+        verify(this.targetEntityManager).getEntityGraph(graphName);
+    }
+
+    @Test
+    void getEntityGraphs() {
+        Class<?> entityClass = null;
+        this.entityManager.getEntityGraphs(entityClass);
+        verify(this.targetEntityManager).getEntityGraphs(entityClass);
+    }
+}

--- a/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DependencyBinder.java
+++ b/elide-datastore/elide-datastore-search/src/test/java/com/yahoo/elide/datastores/search/DependencyBinder.java
@@ -50,7 +50,7 @@ public class DependencyBinder extends ResourceConfig {
                 EntityManagerFactory emf = Persistence.createEntityManagerFactory("searchDataStoreTest");
                 DataStore jpaStore = new JpaDataStore(
                         emf::createEntityManager,
-                        em -> new NonJtaTransaction(em, txCancel));
+                        em -> new NonJtaTransaction(em, txCancel), emf::getMetamodel);
 
                 EntityDictionary dictionary = EntityDictionary.builder().build();
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/BasicEntityManagerProxy.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/BasicEntityManagerProxy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.orm.jpa;
+
+import com.yahoo.elide.datastores.jpa.SupplierEntityManager;
+
+import org.springframework.orm.jpa.EntityManagerProxy;
+import jakarta.persistence.EntityManager;
+
+import java.util.function.Supplier;
+
+/**
+ * Basic EntityManagerProxy implementation.
+ */
+public class BasicEntityManagerProxy extends SupplierEntityManager implements EntityManagerProxy {
+    public BasicEntityManagerProxy() {
+        super();
+    }
+
+    public BasicEntityManagerProxy(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    public BasicEntityManagerProxy(Supplier<EntityManager> entityManagerSupplier) {
+        super(entityManagerSupplier);
+    }
+
+    @Override
+    public EntityManager getTargetEntityManager() throws IllegalStateException {
+        EntityManager entityManager = getEntityManager();
+        if (entityManager instanceof EntityManagerProxy entityManagerProxy) {
+            return entityManagerProxy.getTargetEntityManager();
+        }
+        return entityManager;
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/EntityManagerProxySupplier.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/EntityManagerProxySupplier.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.orm.jpa;
+
+import com.yahoo.elide.datastores.jpa.JpaDataStore.EntityManagerSupplier;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * EntityManagerSupplier for Spring.
+ */
+public class EntityManagerProxySupplier implements EntityManagerSupplier {
+
+    @Override
+    public EntityManager get() {
+        return new BasicEntityManagerProxy();
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransaction.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransaction.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.orm.jpa;
+
+import com.yahoo.elide.core.RequestScope;
+import com.yahoo.elide.datastores.jpa.SupplierEntityManager;
+import com.yahoo.elide.datastores.jpa.transaction.AbstractJpaTransaction;
+import com.yahoo.elide.datastores.jpql.porting.QueryLogger;
+
+import org.springframework.orm.jpa.EntityManagerHolder;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * JpaTransaction that uses the Spring PlatformTransactionManager for transaction management.
+ *
+ * <p>The retrieved EntityManager is closed by the PlatformTransactionManager implementation.
+ * @see org.springframework.orm.jpa.JpaTransactionManager
+ */
+public class PlatformJpaTransaction extends AbstractJpaTransaction {
+
+    private final PlatformTransactionManager transactionManager;
+
+    private final TransactionDefinition definition;
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    private TransactionStatus status;
+
+    public PlatformJpaTransaction(PlatformTransactionManager transactionManager, TransactionDefinition definition,
+            EntityManagerFactory entityManagerFactory, EntityManager em, Consumer<EntityManager> jpaTransactionCancel,
+            QueryLogger logger, boolean delegateToInMemoryStore, boolean isScrollEnabled) {
+        super(em, jpaTransactionCancel, logger, delegateToInMemoryStore, isScrollEnabled);
+        this.transactionManager = transactionManager;
+        this.definition = definition;
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    @Override
+    public void begin() {
+        this.status = this.transactionManager.getTransaction(this.definition);
+        if (this.em instanceof SupplierEntityManager supplierEntityManager) {
+            EntityManagerHolder entityManagerHolder = (EntityManagerHolder) Objects
+                .requireNonNull(TransactionSynchronizationManager.getResource(this.entityManagerFactory));
+            supplierEntityManager.setEntityManager(entityManagerHolder.getEntityManager());
+        } else {
+            throw new IllegalStateException("Expected entity manager to be supplied by EntityManagerProxySupplier");
+        }
+    }
+
+    @Override
+    public void commit(RequestScope scope) {
+        if (isOpen()) {
+            super.commit(scope);
+            this.transactionManager.commit(this.status);
+        }
+    }
+
+    @Override
+    public void rollback() {
+        if (isOpen()) {
+            try {
+                super.rollback();
+            } finally {
+                this.transactionManager.rollback(this.status);
+            }
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return this.em.isOpen() && this.status != null && !this.status.isCompleted();
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransactionSupplier.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransactionSupplier.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.orm.jpa;
+
+import static com.yahoo.elide.datastores.jpa.JpaDataStore.DEFAULT_LOGGER;
+
+import com.yahoo.elide.datastores.jpa.JpaDataStore.JpaTransactionSupplier;
+import com.yahoo.elide.datastores.jpa.transaction.JpaTransaction;
+import org.hibernate.Session;
+
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.util.function.Consumer;
+
+/**
+ * JpaTransactionSupplier that creates PlatformJpaTransactions.
+ *
+ * @see PlatformJpaTransaction
+ */
+public class PlatformJpaTransactionSupplier implements JpaTransactionSupplier {
+
+    private final boolean delegateToInMemoryStore;
+
+    private final PlatformTransactionManager transactionManager;
+
+    private final TransactionDefinition transactionDefinition;
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    private final Consumer<EntityManager> txCancel = em -> em.unwrap(Session.class).cancelQuery();
+
+    public PlatformJpaTransactionSupplier(TransactionDefinition transactionDefinition,
+            PlatformTransactionManager transactionManager,
+            EntityManagerFactory entityManagerFactory, boolean delegateToInMemoryStore) {
+        this.transactionDefinition = transactionDefinition;
+        this.delegateToInMemoryStore = delegateToInMemoryStore;
+        this.transactionManager = transactionManager;
+        this.entityManagerFactory = entityManagerFactory;
+
+    }
+
+    @Override
+    public JpaTransaction get(EntityManager entityManager) {
+        return new PlatformJpaTransaction(this.transactionManager,
+                this.transactionDefinition, this.entityManagerFactory, entityManager, this.txCancel, DEFAULT_LOGGER,
+                this.delegateToInMemoryStore, true);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTest.java
@@ -7,21 +7,35 @@ package com.yahoo.elide.spring.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.yahoo.elide.core.datastore.DataStore;
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+
+import example.models.jpa.ArtifactGroup;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.EntityManagerFactoryUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -34,7 +48,7 @@ class ElideAutoConfigurationTest {
     private static final String SCOPE_REFRESH = "refresh";
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(ElideAutoConfiguration.class, DataSourceAutoConfiguration.class,
-                    HibernateJpaAutoConfiguration.class, RefreshAutoConfiguration.class));
+                    HibernateJpaAutoConfiguration.class, TransactionAutoConfiguration.class, RefreshAutoConfiguration.class));
 
     @Test
     void nonRefreshable() {
@@ -97,7 +111,7 @@ class ElideAutoConfigurationTest {
     public static class UserGraphqlController {
     }
 
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     public static class UserGraphqlControllerConfiguration {
         @Bean
         public UserGraphqlController graphqlController() {
@@ -109,7 +123,7 @@ class ElideAutoConfigurationTest {
     public static class UserSwaggerController {
     }
 
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     public static class UserSwaggerControllerConfiguration {
         @Bean
         public UserSwaggerController swaggerController() {
@@ -121,7 +135,7 @@ class ElideAutoConfigurationTest {
     public static class UserJsonApiController {
     }
 
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     public static class UserJsonApiControllerConfiguration {
         @Bean
         public UserJsonApiController jsonApiController() {
@@ -159,5 +173,92 @@ class ElideAutoConfigurationTest {
                                 .endsWith(input.userConfiguration.getSimpleName());
                     }
                 });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EntityScan(basePackages = "example.models.jpa")
+    public static class EntityConfiguration {
+    }
+
+    @Test
+    void dataStoreTransaction() {
+        contextRunner.withPropertyValues("spring.cloud.refresh.enabled=false")
+                .withUserConfiguration(EntityConfiguration.class).run(context -> {
+
+            DataStore dataStore = context.getBean(DataStore.class);
+            PlatformTransactionManager transactionManager = context.getBean(PlatformTransactionManager.class);
+            EntityManagerFactory entityManagerFactory = context.getBean(EntityManagerFactory.class);
+
+            TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+            try (DataStoreTransaction transaction = dataStore.beginTransaction()) {
+                ArtifactGroup artifactGroup = new ArtifactGroup();
+                artifactGroup.setName("Group");
+                transaction.createObject(artifactGroup, null);
+                transaction.flush(null);
+
+                ArtifactGroup found = transactionTemplate.execute(status -> {
+                    assertThat(status.isNewTransaction()).isFalse();
+                    EntityManager entityManager = EntityManagerFactoryUtils.getTransactionalEntityManager(entityManagerFactory);
+                    return entityManager.find(ArtifactGroup.class, artifactGroup.getName());
+                });
+                assertThat(artifactGroup).isEqualTo(found);
+                // Not committed so should rollback
+            }
+
+            transactionTemplate.execute(status -> {
+                assertThat(status.isNewTransaction()).isTrue();
+                EntityManager entityManager = EntityManagerFactoryUtils.getTransactionalEntityManager(entityManagerFactory);
+                ArtifactGroup found = entityManager.find(ArtifactGroup.class, "Group");
+                assertThat(found).isNull();
+
+                try (DataStoreTransaction transaction = dataStore.beginTransaction()) {
+                    ArtifactGroup artifactGroup = new ArtifactGroup();
+                    artifactGroup.setName("Group");
+                    transaction.createObject(artifactGroup, null);
+                    transaction.commit(null);
+                } catch (IOException e) {
+                }
+
+                found = entityManager.find(ArtifactGroup.class, "Group");
+                assertThat(found).isNotNull();
+                status.setRollbackOnly(); // Rollback
+                return null;
+            });
+
+            // Verify it has been rolled back
+            transactionTemplate.execute(status -> {
+                assertThat(status.isNewTransaction()).isTrue();
+                EntityManager entityManager = EntityManagerFactoryUtils.getTransactionalEntityManager(entityManagerFactory);
+                ArtifactGroup found = entityManager.find(ArtifactGroup.class, "Group");
+                assertThat(found).isNull();
+                return null;
+            });
+
+            try (DataStoreTransaction transaction = dataStore.beginTransaction()) {
+                ArtifactGroup artifactGroup = new ArtifactGroup();
+                artifactGroup.setName("Group");
+                transaction.createObject(artifactGroup, null);
+                transaction.flush(null);
+
+                ArtifactGroup found = transactionTemplate.execute(status -> {
+                    assertThat(status.isNewTransaction()).isFalse();
+                    EntityManager entityManager = EntityManagerFactoryUtils.getTransactionalEntityManager(entityManagerFactory);
+                    return entityManager.find(ArtifactGroup.class, artifactGroup.getName());
+                });
+                assertThat(artifactGroup).isEqualTo(found);
+                transaction.commit(null);
+            }
+
+            // Verify that it has been committed
+            transactionTemplate.execute(status -> {
+                assertThat(status.isNewTransaction()).isTrue();
+                EntityManager entityManager = EntityManagerFactoryUtils.getTransactionalEntityManager(entityManagerFactory);
+                ArtifactGroup found = entityManager.find(ArtifactGroup.class, "Group");
+                assertThat(found).isNotNull();
+                return null;
+            });
+
+        });
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/orm/jpa/BasicEntityManagerProxyTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/orm/jpa/BasicEntityManagerProxyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.orm.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.jpa.EntityManagerProxy;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * Tests for BasicEntityManagerProxy.
+ */
+@ExtendWith(MockitoExtension.class)
+class BasicEntityManagerProxyTest {
+
+    @Mock
+    EntityManagerProxy entityManagerProxy;
+
+    @Mock
+    EntityManager entityManager;
+
+    @Test
+    void targetEntityManagerProxy() {
+        try (BasicEntityManagerProxy proxy = new BasicEntityManagerProxy(entityManagerProxy)) {
+            proxy.getTargetEntityManager();
+            verify(entityManagerProxy).getTargetEntityManager();
+        }
+    }
+
+    @Test
+    void targetEntityManagerProxySupplier() {
+        try (BasicEntityManagerProxy proxy = new BasicEntityManagerProxy(() -> entityManagerProxy)) {
+            proxy.getTargetEntityManager();
+            verify(entityManagerProxy).getTargetEntityManager();
+        }
+    }
+
+    @Test
+    void targetEntityManager() {
+        try (BasicEntityManagerProxy proxy = new BasicEntityManagerProxy(entityManager)) {
+            assertThat(proxy.getTargetEntityManager()).isEqualTo(entityManager);
+        }
+    }
+
+    @Test
+    void targetEntityManagerNull() {
+        try (BasicEntityManagerProxy proxy = new BasicEntityManagerProxy()) {
+            assertThat(proxy.getTargetEntityManager()).isNull();
+        }
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransactionTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransactionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.orm.jpa;
+
+import static com.yahoo.elide.datastores.jpa.JpaDataStore.DEFAULT_LOGGER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.jpa.EntityManagerHolder;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+
+import java.io.IOException;
+
+/**
+ * Tests for PlatformJpaTransaction.
+ */
+@ExtendWith(MockitoExtension.class)
+class PlatformJpaTransactionTest {
+    @Mock
+    PlatformTransactionManager transactionManager;
+
+    @Mock
+    EntityManagerFactory entityManagerFactory;
+
+    @Mock
+    EntityManager entityManager;
+
+    @Test
+    void entityManagerShouldBeSupplierEntityManager() throws IOException {
+        try (PlatformJpaTransaction jpaTransaction = new PlatformJpaTransaction(transactionManager,
+                new DefaultTransactionDefinition(), entityManagerFactory, entityManager, entityManager -> {
+                }, DEFAULT_LOGGER, true, true)) {
+            assertThatThrownBy(() -> jpaTransaction.begin()).isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    /**
+     * The PlatformTransactionManager is responsible for closing the entity manager
+     * and the PlatformJpaTransaction should not close it.
+     *
+     * @throws IOException when close
+     */
+    @Test
+    void closeShouldNotCloseEntityManager() throws IOException {
+        SimpleTransactionStatus status = new SimpleTransactionStatus();
+        when(entityManager.isOpen()).thenReturn(true);
+        when(transactionManager.getTransaction(any())).thenReturn(status);
+        doAnswer(invocation -> {
+            TransactionSynchronizationManager.unbindResource(this.entityManagerFactory);
+            status.setCompleted();
+            return null;
+        }).when(transactionManager).rollback(any());
+        EntityManagerHolder holder = new EntityManagerHolder(entityManager);
+        TransactionSynchronizationManager.bindResource(this.entityManagerFactory, holder);
+        BasicEntityManagerProxy proxy = new BasicEntityManagerProxy();
+        try (PlatformJpaTransaction jpaTransaction = new PlatformJpaTransaction(transactionManager,
+                new DefaultTransactionDefinition(), entityManagerFactory, proxy, entityManager -> {
+                }, DEFAULT_LOGGER, true, true)) {
+            jpaTransaction.begin();
+        }
+        assertThat(proxy.getTargetEntityManager()).isEqualTo(entityManager);
+        verify(entityManager, times(0)).close();
+        assertThat(TransactionSynchronizationManager.getResource(this.entityManagerFactory)).isNull();
+    }
+}

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -439,7 +439,8 @@ public interface ElideStandaloneSettings {
 
         DataStore jpaDataStore = new JpaDataStore(
                 () -> entityManagerFactory.createEntityManager(),
-                em -> new NonJtaTransaction(em, TXCANCEL, DEFAULT_LOGGER, true, true));
+                em -> new NonJtaTransaction(em, TXCANCEL, DEFAULT_LOGGER, true, true),
+                entityManagerFactory::getMetamodel);
 
         stores.add(jpaDataStore);
 
@@ -462,7 +463,8 @@ public interface ElideStandaloneSettings {
     default DataStore getDataStore(EntityManagerFactory entityManagerFactory) {
         DataStore jpaDataStore = new JpaDataStore(
                 () -> entityManagerFactory.createEntityManager(),
-                em -> new NonJtaTransaction(em, TXCANCEL, DEFAULT_LOGGER, true, true));
+                em -> new NonJtaTransaction(em, TXCANCEL, DEFAULT_LOGGER, true, true),
+                entityManagerFactory::getMetamodel);
 
         return jpaDataStore;
     }


### PR DESCRIPTION
Resolves #1118

## Description
- Adds a `JpaTransaction` implementation that integrates with Spring's `PlatformTransactionManager`.
- Adds a `EntityManagerSupplier` that supplies `EntityManager` proxies that will delegate to the one in the active transaction.
- Adds the autoconfiguration to configure a `JpaTransactionSupplier` and `EntityManagerSupplier`.
- Modified the `JpaDataStore` to change the retrieval of the `Metamodel` to get from the `EntityManagerFactory` instead.

## Motivation and Context
Processing will now be able to join the ongoing transaction managed by Spring.

## How Has This Been Tested?
Added the relevant unit and integration tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
