### PR TITLE
Update to `jakarta.el`

### DIFF
--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -116,14 +116,9 @@
         </dependency>
 
         <dependency>
-            <groupId>de.odysseus.juel</groupId>
-            <artifactId>juel-impl</artifactId>
-            <version>2.2.7</version>
-        </dependency>
-        <dependency>
-            <groupId>de.odysseus.juel</groupId>
-            <artifactId>juel-api</artifactId>
-            <version>2.2.7</version>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-el</artifactId>
+            <version>10.1.8</version>
         </dependency>
         <dependency>
             <groupId>org.fusesource.jansi</groupId>


### PR DESCRIPTION
## Description

Upgrades from `javax.el` to `jakarta.el`.
The `tomcat-embed-el` implementation was picked over the glassfish RI due to https://github.com/spring-projects/spring-boot/issues/24744. This is inline with the current dependencies for Spring Boot where the `spring-boot-starter-validation` includes `tomcat-embed-el`.

## Motivation and Context
Allows the use of a single EL implementation.

## How Has This Been Tested?
The pre-existing `LogMessageImplTest` continues to pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
