### PR TITLE
Fix setting `DataFetcherExceptionHandler`

### DIFF
--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncExecutorServiceTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncExecutorServiceTest.java
@@ -9,6 +9,8 @@ import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,13 +32,19 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.utils.DefaultClassScanner;
+
 import org.apache.http.NoHttpResponseException;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import graphql.execution.DataFetcherExceptionHandler;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
+
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 
@@ -49,6 +57,12 @@ public class AsyncExecutorServiceTest {
     private User testUser;
     private RequestScope scope;
     private ResultStorageEngine resultStorageEngine;
+    private DataFetcherExceptionHandler dataFetcherExceptionHandler = spy(new SimpleDataFetcherExceptionHandler());
+
+    @BeforeEach
+    void resetMocks() {
+        reset(dataFetcherExceptionHandler);
+    }
 
     @BeforeAll
     public void setupMockElide() {
@@ -66,7 +80,7 @@ public class AsyncExecutorServiceTest {
         scope = mock(RequestScope.class);
         resultStorageEngine = mock(FileResultStorageEngine.class);
         service = new AsyncExecutorService(elide, Executors.newFixedThreadPool(5), Executors.newFixedThreadPool(5),
-                        asyncAPIDao);
+                        asyncAPIDao, Optional.of(dataFetcherExceptionHandler));
 
     }
 

--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/websocket/SubscriptionWebSocketConfigurator.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/websocket/SubscriptionWebSocketConfigurator.java
@@ -26,6 +26,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import graphql.ExecutionResult;
 import graphql.GraphQLError;
+import graphql.execution.DataFetcherExceptionHandler;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
 import jakarta.jms.ConnectionFactory;
 import jakarta.websocket.server.ServerEndpointConfig;
 import lombok.AccessLevel;
@@ -72,6 +74,9 @@ public class SubscriptionWebSocketConfigurator extends ServerEndpointConfig.Conf
 
     @Builder.Default
     protected boolean sendPingOnSubscribe = false;
+
+    @Builder.Default
+    protected DataFetcherExceptionHandler dataFetcherExceptionHandler = new SimpleDataFetcherExceptionHandler();
 
     @Override
     public <T> T getEndpointInstance(Class<T> endpointClass) throws InstantiationException {
@@ -134,6 +139,7 @@ public class SubscriptionWebSocketConfigurator extends ServerEndpointConfig.Conf
                 .userFactory(userFactory)
                 .sendPingOnSubscribe(sendPingOnSubscribe)
                 .verboseErrors(verboseErrors)
+                .dataFetcherExceptionHandler(dataFetcherExceptionHandler)
                 .build();
     }
 }

--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -57,14 +57,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.apollographql.federation</groupId>
+            <artifactId>federation-graphql-java-support</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>19.2</version>
         </dependency>
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java-extended-scalars</artifactId>
-            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>
@@ -130,11 +132,6 @@
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.apollographql.federation</groupId>
-            <artifactId>federation-graphql-java-support</artifactId>
-            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -16,7 +16,7 @@ import com.yahoo.elide.utils.HeaderUtils;
 import com.yahoo.elide.utils.ResourceUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import graphql.execution.SimpleDataFetcherExceptionHandler;
+import graphql.execution.DataFetcherExceptionHandler;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -50,13 +50,14 @@ public class GraphQLEndpoint {
     private final HeaderUtils.HeaderProcessor headerProcessor;
 
     @Inject
-    public GraphQLEndpoint(@Named("elide") Elide elide) {
+    public GraphQLEndpoint(@Named("elide") Elide elide,
+            @Named("dataFetcherExceptionHandler") DataFetcherExceptionHandler dataFetcherExceptionHandler) {
         log.debug("Started ~~");
         this.elide = elide;
         this.headerProcessor = elide.getElideSettings().getHeaderProcessor();
         this.runners = new HashMap<>();
         for (String apiVersion : elide.getElideSettings().getDictionary().getApiVersions()) {
-            runners.put(apiVersion, new QueryRunner(elide, apiVersion, new SimpleDataFetcherExceptionHandler()));
+            runners.put(apiVersion, new QueryRunner(elide, apiVersion, dataFetcherExceptionHandler));
         }
     }
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -17,6 +17,7 @@ import com.yahoo.elide.utils.ResourceUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import graphql.execution.DataFetcherExceptionHandler;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -35,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -51,13 +53,14 @@ public class GraphQLEndpoint {
 
     @Inject
     public GraphQLEndpoint(@Named("elide") Elide elide,
-            @Named("dataFetcherExceptionHandler") DataFetcherExceptionHandler dataFetcherExceptionHandler) {
+            Optional<DataFetcherExceptionHandler> optionalDataFetcherExceptionHandler) {
         log.debug("Started ~~");
         this.elide = elide;
         this.headerProcessor = elide.getElideSettings().getHeaderProcessor();
         this.runners = new HashMap<>();
         for (String apiVersion : elide.getElideSettings().getDictionary().getApiVersions()) {
-            runners.put(apiVersion, new QueryRunner(elide, apiVersion, dataFetcherExceptionHandler));
+            runners.put(apiVersion, new QueryRunner(elide, apiVersion,
+                    optionalDataFetcherExceptionHandler.orElseGet(SimpleDataFetcherExceptionHandler::new)));
         }
     }
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/QueryRunner.java
@@ -100,6 +100,7 @@ public class QueryRunner {
                 nonEntityDictionary, elide.getElideSettings(), fetcher, apiVersion);
 
         api = GraphQL.newGraphQL(builder.build())
+                .defaultDataFetcherExceptionHandler(exceptionHandler)
                 .queryExecutionStrategy(new AsyncSerialExecutionStrategy(exceptionHandler))
                 .build();
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -7,6 +7,8 @@
 package com.yahoo.elide.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 
 import com.yahoo.elide.ElideResponse;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,7 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
                 + "}";
 
         assertQueryFailsWith(query, "Exception while fetching data (/book) : Data model writes are only allowed in mutations");
+        verify(dataFetcherExceptionHandler).handleException(any());
     }
 
     @Test

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherUpdateTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherUpdateTest.java
@@ -5,6 +5,9 @@
  */
 package com.yahoo.elide.graphql;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -48,6 +51,7 @@ public class FetcherUpdateTest extends PersistentResourceFetcherTest {
         // Update 1, create for id 42, create new book with title "abc"
         String expectedMessage = "Exception while fetching data (/book) : Unknown identifier [42] for book";
         runErrorComparisonTest("rootCollectionInvalidIds", expectedMessage);
+        verify(dataFetcherExceptionHandler).handleException(any());
     }
 
     @Test
@@ -55,6 +59,7 @@ public class FetcherUpdateTest extends PersistentResourceFetcherTest {
         // Update 1, create for id 42, create new book with title "abc"
         String expectedMessage = "Exception while fetching data (/book) : UPDATE data objects must include ids";
         runErrorComparisonTest("rootCollectionMissingIds", expectedMessage);
+        verify(dataFetcherExceptionHandler).handleException(any());
     }
 
     @Test

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -69,6 +69,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -146,7 +147,7 @@ public class GraphQLEndpointTest {
                 );
 
         elide.doScans();
-        endpoint = new GraphQLEndpoint(elide, dataFetcherExceptionHandler);
+        endpoint = new GraphQLEndpoint(elide, Optional.of(dataFetcherExceptionHandler));
 
         DataStoreTransaction tx = inMemoryStore.beginTransaction();
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -20,6 +20,7 @@ import static com.yahoo.elide.test.graphql.GraphQLDSL.variableDefinitions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -31,6 +32,7 @@ import com.yahoo.elide.core.datastore.inmemory.HashMapDataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.utils.DefaultClassScanner;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -43,6 +45,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import graphql.execution.DataFetcherExceptionHandler;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
 
 import graphqlEndpointTestModels.Author;
 import graphqlEndpointTestModels.Book;
@@ -80,6 +85,7 @@ public class GraphQLEndpointTest {
     private final AuditLogger audit = Mockito.mock(AuditLogger.class);
     private final UriInfo uriInfo = Mockito.mock(UriInfo.class);
     private final HttpHeaders requestHeaders = Mockito.mock(HttpHeaders.class);
+    private final DataFetcherExceptionHandler dataFetcherExceptionHandler = Mockito.spy(new SimpleDataFetcherExceptionHandler());
 
     private Elide elide;
 
@@ -140,7 +146,7 @@ public class GraphQLEndpointTest {
                 );
 
         elide.doScans();
-        endpoint = new GraphQLEndpoint(elide);
+        endpoint = new GraphQLEndpoint(elide, dataFetcherExceptionHandler);
 
         DataStoreTransaction tx = inMemoryStore.beginTransaction();
 
@@ -185,6 +191,8 @@ public class GraphQLEndpointTest {
         tx.save(noShare, null);
 
         tx.commit(null);
+
+        reset(dataFetcherExceptionHandler);
     }
 
     @Test
@@ -414,6 +422,7 @@ public class GraphQLEndpointTest {
 
         Response response = endpoint.post(uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
+        verify(dataFetcherExceptionHandler).handleException(any());
 
         graphQLRequest = document(
                 selection(

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
@@ -42,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import graphql.GraphQL;
 import graphql.GraphQLError;
+import graphql.execution.DataFetcherExceptionHandler;
 import graphql.execution.SimpleDataFetcherExceptionHandler;
 
 import java.io.IOException;
@@ -74,6 +77,8 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
     protected HashMapDataStore hashMapDataStore;
     protected ElideSettings settings;
 
+    protected DataFetcherExceptionHandler dataFetcherExceptionHandler = spy(new SimpleDataFetcherExceptionHandler());
+
     @BeforeAll
     public void initializeQueryRunner() {
         RSQLFilterDialect filterDialect = RSQLFilterDialect.builder().dictionary(dictionary).build();
@@ -94,7 +99,7 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
         Elide elide = new Elide(settings);
         elide.doScans();
 
-        runner = new QueryRunner(elide, NO_VERSION, new SimpleDataFetcherExceptionHandler());
+        runner = new QueryRunner(elide, NO_VERSION, dataFetcherExceptionHandler);
     }
 
     protected void initializeMocks() {
@@ -183,6 +188,8 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
         tx.save(publisher1, null);
         tx.save(publisher2, null);
         tx.commit(null);
+
+        reset(dataFetcherExceptionHandler);
     }
 
     protected void assertQueryEquals(String graphQLRequest, String expectedResponse) throws Exception {

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -41,9 +41,12 @@ import example.TestCheckMappings;
 import example.models.triggers.Invoice;
 import example.models.triggers.InvoiceCompletionHook;
 import example.models.triggers.services.BillingService;
+
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
+
+import graphql.execution.SimpleDataFetcherExceptionHandler;
 
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletContext;
@@ -55,6 +58,7 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfig {
@@ -113,7 +117,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
 
                 ExecutorService executorService = (ExecutorService) servletContext.getAttribute(ASYNC_EXECUTOR_ATTR);
                 AsyncExecutorService asyncExecutorService = new AsyncExecutorService(elide,
-                        executorService, executorService, asyncAPIDao);
+                        executorService, executorService, asyncAPIDao, Optional.of(new SimpleDataFetcherExceptionHandler()));
 
                 // Create ResultStorageEngine
                 Path storageDestination = (Path) servletContext.getAttribute(STORAGE_DESTINATION_ATTR);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.core.audit.Slf4jLogger;
 import com.yahoo.elide.core.exceptions.ErrorMapper;
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfigurator;
 import com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -18,6 +19,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
+
+import graphql.execution.DataFetcherExceptionHandler;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.websocket.server.ServerEndpointConfig;
@@ -36,7 +39,8 @@ public class ElideSubscriptionConfiguration {
             ElideConfigProperties config,
             SubscriptionWebSocket.UserFactory userFactory,
             ConnectionFactory connectionFactory,
-            ErrorMapper errorMapper
+            ErrorMapper errorMapper,
+            DataFetcherExceptionHandler dataFetcherExceptionHandler
     ) {
         return ServerEndpointConfig.Builder
                 .create(SubscriptionWebSocket.class, config.getSubscription().getPath())
@@ -52,6 +56,7 @@ public class ElideSubscriptionConfiguration {
                         .auditLogger(new Slf4jLogger())
                         .verboseErrors(config.isVerboseErrors())
                         .errorMapper(errorMapper)
+                        .dataFetcherExceptionHandler(dataFetcherExceptionHandler)
                         .build())
                 .build();
     }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -160,8 +160,8 @@ public class ElideResourceConfig extends ResourceConfig {
 
             ExecutorService executor = (ExecutorService) servletContext.getAttribute(ASYNC_EXECUTOR_ATTR);
             ExecutorService updater = (ExecutorService) servletContext.getAttribute(ASYNC_UPDATER_ATTR);
-            AsyncExecutorService asyncExecutorService =
-                    new AsyncExecutorService(elide, executor, updater, asyncAPIDao);
+            AsyncExecutorService asyncExecutorService = new AsyncExecutorService(elide, executor, updater, asyncAPIDao,
+                    Optional.of(settings.getDataFetcherExceptionHandler()));
             bind(asyncExecutorService).to(AsyncExecutorService.class);
 
             if (asyncProperties.enableExport()) {
@@ -231,7 +231,7 @@ public class ElideResourceConfig extends ResourceConfig {
                         classScanner,
                         settings.getModelPackageName(),
                         asyncProperties.enabled())).to(Set.class).named("elideAllModels");
-                bind(settings.dataFetcherExceptionHandler()).to(DataFetcherExceptionHandler.class)
+                bind(settings.getDataFetcherExceptionHandler()).to(DataFetcherExceptionHandler.class)
                         .named("dataFetcherExceptionHandler");
             }
         });

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -42,12 +42,14 @@ import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDiale
 import com.yahoo.elide.modelconfig.DynamicConfiguration;
 import com.yahoo.elide.standalone.Util;
 import com.yahoo.elide.swagger.resources.DocEndpoint;
+
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.TypeLiteral;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
+import graphql.execution.DataFetcherExceptionHandler;
 
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManagerFactory;
@@ -229,6 +231,8 @@ public class ElideResourceConfig extends ResourceConfig {
                         classScanner,
                         settings.getModelPackageName(),
                         asyncProperties.enabled())).to(Set.class).named("elideAllModels");
+                bind(settings.dataFetcherExceptionHandler()).to(DataFetcherExceptionHandler.class)
+                        .named("dataFetcherExceptionHandler");
             }
         });
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -51,11 +51,15 @@ import com.yahoo.elide.modelconfig.store.models.ConfigChecks;
 import com.yahoo.elide.modelconfig.validator.DynamicConfigValidator;
 import com.yahoo.elide.swagger.SwaggerBuilder;
 import com.yahoo.elide.swagger.resources.DocEndpoint;
+
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;
+
+import graphql.execution.DataFetcherExceptionHandler;
+import graphql.execution.SimpleDataFetcherExceptionHandler;
 
 import io.swagger.models.Info;
 import io.swagger.models.Swagger;
@@ -606,5 +610,14 @@ public interface ElideStandaloneSettings {
      */
     default JsonApiMapper getObjectMapper() {
         return new JsonApiMapper();
+    }
+
+    /**
+     * Gets the DataFetcherExceptionHandler for GraphQL.
+     *
+     * @return the DataFetcherExceptionHandler for GraphQL
+     */
+    default DataFetcherExceptionHandler dataFetcherExceptionHandler() {
+        return new SimpleDataFetcherExceptionHandler();
     }
 }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -617,7 +617,7 @@ public interface ElideStandaloneSettings {
      *
      * @return the DataFetcherExceptionHandler for GraphQL
      */
-    default DataFetcherExceptionHandler dataFetcherExceptionHandler() {
+    default DataFetcherExceptionHandler getDataFetcherExceptionHandler() {
         return new SimpleDataFetcherExceptionHandler();
     }
 }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
@@ -160,6 +160,7 @@ public interface ElideStandaloneSubscriptionSettings {
                         .auditLogger(settings.getAuditLogger())
                         .verboseErrors(settings.verboseErrors())
                         .errorMapper(settings.getErrorMapper())
+                        .dataFetcherExceptionHandler(settings.dataFetcherExceptionHandler())
                         .build())
                 .build();
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
@@ -160,7 +160,7 @@ public interface ElideStandaloneSubscriptionSettings {
                         .auditLogger(settings.getAuditLogger())
                         .verboseErrors(settings.verboseErrors())
                         .errorMapper(settings.getErrorMapper())
-                        .dataFetcherExceptionHandler(settings.dataFetcherExceptionHandler())
+                        .dataFetcherExceptionHandler(settings.getDataFetcherExceptionHandler())
                         .build())
                 .build();
 

--- a/elide-test/pom.xml
+++ b/elide-test/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>19.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,8 @@
         <version.lombok>1.18.24</version.lombok>
         <version.restassured>5.3.0</version.restassured>
         <embedded-redis.version>0.11.0</embedded-redis.version>
+        <federation-graphql-java-support-api>3.0.1</federation-graphql-java-support-api>
+        <graphql-java.version>20.2</graphql-java.version>
         <hibernate6.version>6.1.5.Final</hibernate6.version>
         <jedis.version>4.3.2</jedis.version>
         <jsonpath.version>2.8.0</jsonpath.version>
@@ -111,6 +113,21 @@
     <!-- Dependency settings -->
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.apollographql.federation</groupId>
+                <artifactId>federation-graphql-java-support</artifactId>
+                <version>${federation-graphql-java-support-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.graphql-java</groupId>
+                <artifactId>graphql-java</artifactId>
+                <version>${graphql-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.graphql-java</groupId>
+                <artifactId>graphql-java-extended-scalars</artifactId>
+                <version>${graphql-java.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>


### PR DESCRIPTION
Resolves #2954

## Description
- Sets the configured `DataFetcherExceptionHandler` for mutation and subscription
- Adds configuration for standalone

## How Has This Been Tested?
Modified existing tests with a spy to check that the configured `DataFetcherExceptionHandler` is called for errors.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
