### PR TITLE
Add support for `isNull` predicate to evaluate collections

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -450,7 +450,19 @@ public enum Operator {
     //
     // Null checking
     private static <T> Predicate<T> isNull(Path fieldPath, RequestScope requestScope) {
-        return (T entity) -> getFieldValue(entity, fieldPath, requestScope) == null;
+        return (T entity) -> {
+            Object val = getFieldValue(entity, fieldPath, requestScope, true);
+            if (val == null) {
+                return true;
+            } else if (val instanceof Collection<?> collection) {
+                for (Object item : collection) {
+                    if (item == null) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
     }
 
     private static <T> Predicate<T> lt(Path fieldPath, List<Object> values, RequestScope requestScope) {
@@ -498,11 +510,11 @@ public enum Operator {
         return (T entity) -> {
 
             Object val = getFieldValue(entity, fieldPath, requestScope);
-            if (val instanceof Collection<?>) {
-                return ((Collection<?>) val).isEmpty();
+            if (val instanceof Collection<?> collection) {
+                return collection.isEmpty();
             }
-            if (val instanceof Map<?, ?>) {
-                return ((Map<?, ?>) val).isEmpty();
+            if (val instanceof Map<?, ?> map) {
+                return map.isEmpty();
             }
 
             return false;
@@ -540,6 +552,20 @@ public enum Operator {
      * @return the value of the field
      */
     private static <T> Object getFieldValue(T entity, Path fieldPath, RequestScope requestScope) {
+        return getFieldValue(entity, fieldPath, requestScope, false);
+    }
+
+    /**
+     * Return value of field/path for given entity. For example this.book.author
+     *
+     * @param <T> the type of entity to retrieve a value from
+     * @param entity Entity bean
+     * @param fieldPath field value/path
+     * @param requestScope Request scope
+     * @param allow null values
+     * @return the value of the field
+     */
+    private static <T> Object getFieldValue(T entity, Path fieldPath, RequestScope requestScope, boolean nullable) {
         Object val = entity;
         for (Path.PathElement field : fieldPath.getPathElements()) {
             if ("this".equals(field.getFieldName())) {
@@ -548,14 +574,14 @@ public enum Operator {
             if (val == null) {
                 break;
             }
-            if (val instanceof Collection) {
-                val = ((Collection) val).stream()
+            if (val instanceof Collection<?> collection) {
+                val = collection.stream()
                         .filter(Objects::nonNull)
                         .map(target -> PersistentResource.getValue(target, field.getFieldName(), requestScope))
-                        .filter(Objects::nonNull)
+                        .filter(test -> Objects.nonNull(test) || nullable)
                         .flatMap(result -> {
-                            if (result instanceof Collection) {
-                                return ((Collection) result).stream();
+                            if (result instanceof Collection<?> resultCollection) {
+                                return resultCollection.stream();
                             }
                             return Stream.of(result);
                         })

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -562,7 +562,7 @@ public enum Operator {
      * @param entity Entity bean
      * @param fieldPath field value/path
      * @param requestScope Request scope
-     * @param allow null values
+     * @param nullable allow null values
      * @return the value of the field
      */
     private static <T> Object getFieldValue(T entity, Path fieldPath, RequestScope requestScope, boolean nullable) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -305,7 +305,7 @@ public enum Operator {
     // In with strict equality
     private static <T> Predicate<T> in(Path fieldPath, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
-            BiPredicate predicate = (a, b) -> a.equals(b);
+            BiPredicate<Object, Object> predicate = (a, b) -> a.equals(b);
 
             return evaluate(entity, fieldPath, values, predicate, requestScope);
         };
@@ -317,7 +317,7 @@ public enum Operator {
             RequestScope requestScope, UnaryOperator<String> transform) {
         return (T entity) -> {
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 if (!a.getClass().isAssignableFrom(String.class)) {
                     throw new IllegalStateException("Cannot case insensitive compare non-string values");
                 }
@@ -341,7 +341,7 @@ public enum Operator {
                 throw new BadRequestException("PREFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -360,7 +360,7 @@ public enum Operator {
                 throw new BadRequestException("NOTPREFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -380,7 +380,7 @@ public enum Operator {
                 throw new BadRequestException("POSTFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -398,7 +398,7 @@ public enum Operator {
                 throw new BadRequestException("NOTPOSTFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -418,7 +418,7 @@ public enum Operator {
                 throw new BadRequestException("INFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -436,7 +436,7 @@ public enum Operator {
                 throw new BadRequestException("NOTINFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -531,11 +531,11 @@ public enum Operator {
                     .map(last -> CoerceUtil.coerce(values.get(0), last.getFieldType()))
                     .orElseGet(() -> CoerceUtil.coerce(values.get(0), String.class));
 
-            if (val instanceof Collection<?>) {
-                return ((Collection<?>) val).contains(filterStr);
+            if (val instanceof Collection<?> collection) {
+                return collection.contains(filterStr);
             }
-            if (val instanceof Map<?, ?>) {
-                return ((Map<?, ?>) val).containsKey(filterStr);
+            if (val instanceof Map<?, ?> map) {
+                return map.containsKey(filterStr);
             }
 
             return false;
@@ -601,8 +601,8 @@ public enum Operator {
             }
             Object fieldVal = getFieldValue(entity, fieldPath, requestScope);
 
-            if (fieldVal instanceof Collection) {
-                return ((Collection) fieldVal).stream()
+            if (fieldVal instanceof Collection<?> collection) {
+                return collection.stream()
                         .anyMatch(fieldValueElement ->
                             fieldValueElement != null
                             && values.stream()
@@ -625,13 +625,13 @@ public enum Operator {
     }
 
     private static boolean evaluate(Object entity, Path fieldPath, List<Object> values,
-                             BiPredicate predicate, RequestScope requestScope) {
+                             BiPredicate<Object, Object> predicate, RequestScope requestScope) {
         Type<?> valueClass = fieldPath.lastElement().get().getFieldType();
 
         Object leftHandSide = getFieldValue(entity, fieldPath, requestScope);
 
-        if (leftHandSide instanceof Collection && !valueClass.isAssignableFrom(COLLECTION_TYPE)) {
-            return ((Collection) leftHandSide).stream()
+        if (leftHandSide instanceof Collection<?> collection && !valueClass.isAssignableFrom(COLLECTION_TYPE)) {
+            return collection.stream()
                     .anyMatch(leftHandSideElement ->
                         values.stream()
                             .map(value -> CoerceUtil.coerce(value, valueClass))

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -151,6 +151,48 @@ public class OperatorTest {
     }
 
     @Test
+    public void isnullAndNotnullCollectionTest() throws Exception {
+        author = new Author();
+        author.setId(1L);
+        author.setName("AuthorForTest");
+
+        Book book = new Book();
+        book.setId(1L);
+        book.setLanguage("en");
+        author.getBooks().add(book);
+
+        // When language is not null
+        fn = Operator.ISNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOTNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertTrue(fn.test(author));
+
+        // When language is null
+        book.setLanguage(null);
+        fn = Operator.ISNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.NOTNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertFalse(fn.test(author));
+
+        // When any book language is null should still return true
+        Book book2 = new Book();
+        book2.setId(2L);
+        book2.setLanguage("de");
+        author.getBooks().add(book2);
+        fn = Operator.ISNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.NOTNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertFalse(fn.test(author));
+
+        // When all book language is not null should return false
+        book.setLanguage("en");
+        fn = Operator.ISNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.NOTNULL.contextualize(constructPath(Author.class, "books.language"), null, requestScope);
+        assertTrue(fn.test(author));
+    }
+
+    @Test
     public void complexAttributeTest() throws Exception {
         author = new Author();
         author.setId(1L);


### PR DESCRIPTION
## Description
This adds support for `isNull` predicate to evaluate collections that a null value is present.

## Motivation and Context
Previously the `isNull` predicate would always return false for collections as the it checks that the collection itself is null. This is modified such that if the collection contains a null value it will return true.

## How Has This Been Tested?
A unit test has been added.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.