### PR TITLE
Add support for `hasMember` predicate to evaluate `null` in collections

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/Operator.java
@@ -305,7 +305,7 @@ public enum Operator {
     // In with strict equality
     private static <T> Predicate<T> in(Path fieldPath, List<Object> values, RequestScope requestScope) {
         return (T entity) -> {
-            BiPredicate predicate = (a, b) -> a.equals(b);
+            BiPredicate<Object, Object> predicate = (a, b) -> a.equals(b);
 
             return evaluate(entity, fieldPath, values, predicate, requestScope);
         };
@@ -317,7 +317,7 @@ public enum Operator {
             RequestScope requestScope, UnaryOperator<String> transform) {
         return (T entity) -> {
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 if (!a.getClass().isAssignableFrom(String.class)) {
                     throw new IllegalStateException("Cannot case insensitive compare non-string values");
                 }
@@ -341,7 +341,7 @@ public enum Operator {
                 throw new BadRequestException("PREFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -360,7 +360,7 @@ public enum Operator {
                 throw new BadRequestException("NOTPREFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -380,7 +380,7 @@ public enum Operator {
                 throw new BadRequestException("POSTFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -398,7 +398,7 @@ public enum Operator {
                 throw new BadRequestException("NOTPOSTFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -418,7 +418,7 @@ public enum Operator {
                 throw new BadRequestException("INFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -436,7 +436,7 @@ public enum Operator {
                 throw new BadRequestException("NOTINFIX can only take one argument");
             }
 
-            BiPredicate predicate = (a, b) -> {
+            BiPredicate<Object, Object> predicate = (a, b) -> {
                 String lhs = transform.apply(CoerceUtil.coerce(a, String.class));
                 String rhs = transform.apply(CoerceUtil.coerce(b, String.class));
 
@@ -498,11 +498,11 @@ public enum Operator {
         return (T entity) -> {
 
             Object val = getFieldValue(entity, fieldPath, requestScope);
-            if (val instanceof Collection<?>) {
-                return ((Collection<?>) val).isEmpty();
+            if (val instanceof Collection<?> collection) {
+                return collection.isEmpty();
             }
-            if (val instanceof Map<?, ?>) {
-                return ((Map<?, ?>) val).isEmpty();
+            if (val instanceof Map<?, ?> map) {
+                return map.isEmpty();
             }
 
             return false;
@@ -595,8 +595,8 @@ public enum Operator {
             }
             Object fieldVal = getFieldValue(entity, fieldPath, requestScope);
 
-            if (fieldVal instanceof Collection) {
-                return ((Collection) fieldVal).stream()
+            if (fieldVal instanceof Collection<?> collection) {
+                return collection.stream()
                         .anyMatch(fieldValueElement ->
                             fieldValueElement != null
                             && values.stream()
@@ -619,13 +619,13 @@ public enum Operator {
     }
 
     private static boolean evaluate(Object entity, Path fieldPath, List<Object> values,
-                             BiPredicate predicate, RequestScope requestScope) {
+                             BiPredicate<Object, Object> predicate, RequestScope requestScope) {
         Type<?> valueClass = fieldPath.lastElement().get().getFieldType();
 
         Object leftHandSide = getFieldValue(entity, fieldPath, requestScope);
 
-        if (leftHandSide instanceof Collection && !valueClass.isAssignableFrom(COLLECTION_TYPE)) {
-            return ((Collection) leftHandSide).stream()
+        if (leftHandSide instanceof Collection<?> collection && !valueClass.isAssignableFrom(COLLECTION_TYPE)) {
+            return collection.stream()
                     .anyMatch(leftHandSideElement ->
                         values.stream()
                             .map(value -> CoerceUtil.coerce(value, valueClass))

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/FilterPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/FilterPredicate.java
@@ -14,7 +14,6 @@ import com.yahoo.elide.core.filter.Operator;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import com.yahoo.elide.core.filter.expression.FilterExpressionVisitor;
 import com.yahoo.elide.core.type.Type;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 
@@ -23,6 +22,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -82,7 +82,7 @@ public class FilterPredicate implements FilterExpression, Function<RequestScope,
     public FilterPredicate(Path path, Operator op, List<Object> values) {
         this.operator = op;
         this.path = new Path(path);
-        this.values = ImmutableList.copyOf(values);
+        this.values = Collections.unmodifiableList(new ArrayList<>(values));
         this.field = path.lastElement()
                 .map(PathElement::getFieldName)
                 .orElse(null);

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/HasMemberPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/HasMemberPredicate.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter.predicates;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+import com.yahoo.elide.core.filter.Operator;
+
+import java.util.Collections;
+
+/**
+ * HasMember Predicate class.
+ * <p>
+ * This determines if a collection association path contains a particular value
+ * in the collection.
+ * <p>
+ * This can be used to determine if an entity in a to-many association does not
+ * have a null field value in the collection.
+ */
+public class HasMemberPredicate extends FilterPredicate {
+
+    /**
+     * Determines if a collection association path contains a particular value in
+     * the collection.
+     *
+     * @param path  the collection association path
+     * @param value to verify is a member which can be null to check if an entity in
+     *              a to-many association has a null field value
+     */
+    public HasMemberPredicate(Path path, Object value) {
+        super(path, Operator.HASMEMBER, Collections.singletonList(value));
+    }
+
+    /**
+     * Determines if a collection association path contains a particular value in
+     * the collection.
+     *
+     * @param pathElement the collection association path
+     * @param value       to verify is a member which can be null to check if an
+     *                    entity in a to-many association has a null field value
+     */
+    public HasMemberPredicate(PathElement pathElement, Object value) {
+        this(new Path(Collections.singletonList(pathElement)), value);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/HasNoMemberPredicate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/predicates/HasNoMemberPredicate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.filter.predicates;
+
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.Path.PathElement;
+import com.yahoo.elide.core.filter.Operator;
+
+import java.util.Collections;
+
+/**
+ * HasNoMember Predicate class.
+ * <p>
+ * This determines if a collection association path does not contain a
+ * particular value in the collection.
+ * <p>
+ * This can be used to determine if an entity in a to-many association does not
+ * have a null field value in the collection.
+ */
+public class HasNoMemberPredicate extends FilterPredicate {
+
+    /**
+     * Determines if a collection association path does not contain a particular
+     * value in the collection.
+     *
+     * @param path  the collection association path
+     * @param value to verify is not a a member which can be null to check if an
+     *              entity in to-many association does not have a null field value
+     */
+    public HasNoMemberPredicate(Path path, Object value) {
+        super(path, Operator.HASNOMEMBER, Collections.singletonList(value));
+    }
+
+    /**
+     * Determines if a collection association path does not contain a particular
+     * value in the collection.
+     *
+     * @param pathElement the collection association path
+     * @param value       to verify is not a member which can be null to check if an
+     *                    entity in a to-many association does not have a null field
+     *                    value
+     */
+    public HasNoMemberPredicate(PathElement pathElement, Object value) {
+        this(new Path(Collections.singletonList(pathElement)), value);
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -295,6 +295,48 @@ public class OperatorTest {
     }
 
     @Test
+    public void memberOfNullTest() throws Exception {
+        author = new Author();
+        author.setId(1L);
+        author.setName("AuthorForTest");
+
+        Book book = new Book();
+        book.setId(1L);
+        book.setLanguage("en");
+        author.getBooks().add(book);
+
+        // When language is not null
+        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertTrue(fn.test(author));
+
+        // When language is null
+        book.setLanguage(null);
+        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertFalse(fn.test(author));
+
+        // When any book language is null should still return true
+        Book book2 = new Book();
+        book2.setId(2L);
+        book2.setLanguage("de");
+        author.getBooks().add(book2);
+        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertTrue(fn.test(author));
+        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertFalse(fn.test(author));
+
+        // When all book language is not null should return false
+        book.setLanguage("en");
+        fn = Operator.HASMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertFalse(fn.test(author));
+        fn = Operator.HASNOMEMBER.contextualize(constructPath(Author.class, "books.language"), Collections.singletonList(null), requestScope);
+        assertTrue(fn.test(author));
+    }
+
+    @Test
     public void prefixAndPostfixAndInfixTest() throws Exception {
         author = new Author();
         author.setId(1L);

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/filter/HasMemberJPQLGenerator.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/filter/HasMemberJPQLGenerator.java
@@ -55,6 +55,19 @@ public class HasMemberJPQLGenerator implements JPQLPredicateGenerator {
         Preconditions.checkArgument(path.lastElement().isPresent());
         Preconditions.checkArgument(! (path.lastElement().get().getType() instanceof Collection));
 
+        Object value = predicate.getParameters().get(0).getValue();
+        if (value == null || "null".equals(value)) {
+            // Builds the JPQL clause where the value IS NULL
+            return String.format("%sEXISTS (SELECT 1 FROM %s WHERE %s = %s AND (%s IS NULL OR %s = %s))",
+                    notMember,
+                    getFromClause(path),
+                    getInnerQueryIdField(path),
+                    getOuterQueryIdField(path, aliasGenerator),
+                    getInnerFilterFieldReference(path),
+                    getInnerFilterFieldReference(path),
+                    predicate.getParameters().get(0).getPlaceholder());
+        }
+
         //Creates JPQL like:
         //EXISTS (SELECT 1
         //FROM example.Book

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/jpql/filter/HasMemberJPQLGeneratorTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/jpql/filter/HasMemberJPQLGeneratorTest.java
@@ -122,4 +122,38 @@ public class HasMemberJPQLGeneratorTest {
 
         assertEquals(expected, actual);
     }
+
+    @Test
+    void testHasMemberBookAuthorNameNull() throws Exception {
+        HasMemberJPQLGenerator generator = new HasMemberJPQLGenerator(dictionary);
+
+        FilterExpression expression = dialect.parseFilterExpression("authors.name=hasmember=null",
+                ClassType.of(Book.class),
+                true);
+
+        String actual = generator.generate((FilterPredicate) expression, aliasGenerator);
+        actual = actual.replaceFirst(":\\w+", ":XXX");
+
+        String expected = """
+                EXISTS (SELECT 1 FROM example.Book _INNER_example_Book LEFT JOIN _INNER_example_Book.authors _INNER_example_Book_authors WHERE _INNER_example_Book.id = example_Book.id AND (_INNER_example_Book_authors.name IS NULL OR _INNER_example_Book_authors.name = :XXX))""";
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testHasNoMemberBookAuthorNameNull() throws Exception {
+        HasMemberJPQLGenerator generator = new HasMemberJPQLGenerator(dictionary, true);
+
+        FilterExpression expression = dialect.parseFilterExpression("authors.name=hasnomember=null",
+                ClassType.of(Book.class),
+                true);
+
+        String actual = generator.generate((FilterPredicate) expression, aliasGenerator);
+        actual = actual.replaceFirst(":\\w+", ":XXX");
+
+        String expected = """
+                NOT EXISTS (SELECT 1 FROM example.Book _INNER_example_Book LEFT JOIN _INNER_example_Book.authors _INNER_example_Book_authors WHERE _INNER_example_Book.id = example_Book.id AND (_INNER_example_Book_authors.name IS NULL OR _INNER_example_Book_authors.name = :XXX))""";
+
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
## Description
This adds support for `hasMember` predicate to evaluate collections in a to-many association that a `null` value is present.

This is the alternative to the changes for the `isNull` predicate which can be closed if this is acceptable.

## Motivation and Context
Previously the `hasMember` predicate does not support checking null field values.

## How Has This Been Tested?
Added unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
