### PR TITLE
Calcluate duplicate paths correctly (#3022)

### DIFF
--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
@@ -8,7 +8,7 @@ package com.yahoo.elide.swagger;
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 
-import com.yahoo.elide.core.Path;
+
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.RelationshipType;
 import com.yahoo.elide.core.filter.Operator;
@@ -20,6 +20,7 @@ import com.yahoo.elide.swagger.models.media.Data;
 import com.yahoo.elide.swagger.models.media.Datum;
 import com.yahoo.elide.swagger.models.media.Relationship;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.antlr.v4.runtime.tree.ParseTree;
 
@@ -45,7 +46,6 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.tags.Tag;
 
 import lombok.Getter;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
@@ -8,6 +8,11 @@ package com.yahoo.elide.swagger;
 import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Exclude;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
 
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.RelationshipType;
@@ -20,9 +25,9 @@ import com.yahoo.elide.swagger.models.media.Data;
 import com.yahoo.elide.swagger.models.media.Datum;
 import com.yahoo.elide.swagger.models.media.Relationship;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.tuple.Pair;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.apache.commons.lang3.tuple.Pair;
 
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
@@ -516,7 +516,7 @@ class OpenApiBuilderTest {
     void testTagGeneration() throws Exception {
 
         /* Check for the global tag definitions */
-        assertEquals(4, openApi.getTags().size());
+        assertEquals(5, openApi.getTags().size());
 
         String bookTag = openApi.getTags().stream()
                 .filter((tag) -> tag.getName().equals("book"))

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
@@ -31,6 +31,7 @@ import com.yahoo.elide.swagger.models.media.Data;
 import com.yahoo.elide.swagger.models.media.Datum;
 import com.yahoo.elide.swagger.models.media.Relationship;
 
+import example.models.Agent;
 import example.models.Author;
 import example.models.Book;
 import example.models.Product;
@@ -86,6 +87,7 @@ class OpenApiBuilderTest {
 
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Author.class);
+        dictionary.bindEntity(Agent.class);
         dictionary.bindEntity(Publisher.class);
         dictionary.bindEntity(Product.class);
         Info info = new Info().title("Test Service").version(NO_VERSION);
@@ -119,12 +121,20 @@ class OpenApiBuilderTest {
         assertTrue(openApi.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}"));
         assertTrue(openApi.getPaths().containsKey("/publisher/{publisherId}/relationships/exclusiveAuthors"));
 
+        assertTrue(openApi.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}/agent"));
+        assertTrue(openApi.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}/agent/{agentId}"));
+        assertTrue(openApi.getPaths().containsKey("/publisher/{publisherId}/exclusiveAuthors/{authorId}/relationships/agent"));
+
         assertTrue(openApi.getPaths().containsKey("/book"));
         assertTrue(openApi.getPaths().containsKey("/book/{bookId}"));
 
         assertTrue(openApi.getPaths().containsKey("/book/{bookId}/authors"));
         assertTrue(openApi.getPaths().containsKey("/book/{bookId}/authors/{authorId}"));
         assertTrue(openApi.getPaths().containsKey("/book/{bookId}/relationships/authors"));
+
+        assertTrue(openApi.getPaths().containsKey("/book/{bookId}/authors/{authorId}/agent"));
+        assertTrue(openApi.getPaths().containsKey("/book/{bookId}/authors/{authorId}/agent/{agentId}"));
+        assertTrue(openApi.getPaths().containsKey("/book/{bookId}/authors/{authorId}/relationships/agent"));
 
         assertTrue(openApi.getPaths().containsKey("/book/{bookId}/publisher"));
         assertTrue(openApi.getPaths().containsKey("/book/{bookId}/publisher/{publisherId}"));
@@ -133,7 +143,7 @@ class OpenApiBuilderTest {
         assertTrue(openApi.getPaths().containsKey("/product"));
         assertTrue(openApi.getPaths().containsKey("/product/{productId}"));
 
-        assertEquals(18, openApi.getPaths().size());
+        assertEquals(24, openApi.getPaths().size());
     }
 
     @Test
@@ -147,7 +157,9 @@ class OpenApiBuilderTest {
             if (url.contains("relationship")) { //Relationship URL
 
                 /* The relationship is a one to one (so there is no DELETE op */
-                if ("/book/{bookId}/relationships/publisher".equals(url)) {
+                if ("/book/{bookId}/relationships/publisher".equals(url)
+                        || "/book/{bookId}/authors/{authorId}/relationships/agent".equals(url)
+                        || "/publisher/{publisherId}/exclusiveAuthors/{authorId}/relationships/agent".equals(url)) {
                     assertNull(path.getDelete());
                     assertNull(path.getPost());
                 } else {

--- a/elide-swagger/src/test/java/example/models/Agent.java
+++ b/elide-swagger/src/test/java/example/models/Agent.java
@@ -1,0 +1,26 @@
+package example.models;
+
+import com.yahoo.elide.annotation.Include;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Set;
+
+@Entity
+@Include(rootLevel = false, description = "The Agent", friendlyName = "Agent")
+public class Agent {
+    @OneToMany
+    @Size(max = 10)
+    @Schema(description = "Writers", requiredMode = Schema.RequiredMode.REQUIRED, accessMode = Schema.AccessMode.READ_ONLY,
+            example = "[\"author1\", \"author2\", \"author3\"]")
+    public Set<Author> getAuthors() {
+        return null;
+    }
+
+    @NotNull
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+    public String name;
+}

--- a/elide-swagger/src/test/java/example/models/Agent.java
+++ b/elide-swagger/src/test/java/example/models/Agent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2023, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
 package example.models;
 
 import com.yahoo.elide.annotation.Include;

--- a/elide-swagger/src/test/java/example/models/Author.java
+++ b/elide-swagger/src/test/java/example/models/Author.java
@@ -6,10 +6,10 @@
 package example.models;
 
 import com.yahoo.elide.annotation.Include;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
 import java.util.Set;
@@ -27,6 +27,11 @@ public class Author {
 
     @OneToMany
     public Set<Book> getBooks() {
+        return null;
+    }
+
+    @ManyToOne
+    public Agent getAgent() {
         return null;
     }
 


### PR DESCRIPTION
Resolves #3022

## Description
The code was not taking into account the node type when determine the shortest path so it was comparing apples and oranges. Rather than group by root type  group by leaf type and name and calculate the shortest path to that named type across all roots.

Also the determination of shortest path was string length not the number of hops. Changed that to be the number of hops so that the naming of the relationships doesn't affect the length.

## Motivation and Context
The swagger generation only included nodes one level deep (the nodes with the shortest path) and omitted deeper nodes. For asimple graph a->b->c the swagger would only include a (the root node) and b (the non-root node with the shortest path). It would omit c.

## How Has This Been Tested?
The unit tests have been updated to cover this scenario.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
