### PR TITLE
Defer inline checks when processing relationships

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/RequestScope.java
@@ -84,6 +84,11 @@ public class RequestScope implements com.yahoo.elide.core.security.RequestScope 
     private FilterExpression globalFilterExpression;
 
     /**
+     * Used to defer inline checks for the {@link PermissionExecutor}.
+     */
+    @Getter @Setter private boolean deferInlineChecks;
+
+    /**
      * Create a new RequestScope with specified update status code.
      *
      * @param baseUrlEndPoint base URL with prefix endpoint

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/executors/ActivePermissionExecutor.java
@@ -103,7 +103,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
             // for newly created object in PatchRequest limit to User checks
-            if (resource.isNewlyCreated()) {
+            if (resource.isNewlyCreated() || requestScope.isDeferInlineChecks()) {
                 return executeUserChecksDeferInline(annotationClass, expression);
             }
             return executeExpressions(expression, annotationClass, Expression.EvaluationMode.INLINE_CHECKS_ONLY);
@@ -189,7 +189,7 @@ public class ActivePermissionExecutor implements PermissionExecutor {
                         changeSpec);
 
         Function<Expression, ExpressionResult> expressionExecutor = (expression) -> {
-            if (requestScope.getNewPersistentResources().contains(resource)) {
+            if (requestScope.getNewPersistentResources().contains(resource) || requestScope.isDeferInlineChecks()) {
                 return executeUserChecksDeferInline(expressionAnnotation, expression);
             }
             return executeExpressions(expression, expressionAnnotation, Expression.EvaluationMode.INLINE_CHECKS_ONLY);

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiAtomicOperations.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiAtomicOperations.java
@@ -456,6 +456,7 @@ public class JsonApiAtomicOperations {
      * @param requestScope request scope
      */
     private void postProcessRelationships(JsonApiAtomicOperationsRequestScope requestScope) {
+        requestScope.setDeferInlineChecks(true);
         actions.forEach(action -> action.postProcess(requestScope));
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiJsonPatch.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiJsonPatch.java
@@ -307,6 +307,7 @@ public class JsonApiJsonPatch {
      * @param requestScope request scope
      */
     private void postProcessRelationships(JsonApiJsonPatchRequestScope requestScope) {
+        requestScope.setDeferInlineChecks(true);
         actions.forEach(action -> action.postProcess(requestScope));
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/checks/AuthorHasUserAccessibleBooks.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/checks/AuthorHasUserAccessibleBooks.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.checks;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.filter.Operator;
+import com.yahoo.elide.core.filter.expression.FilterExpression;
+import com.yahoo.elide.core.filter.predicates.FilterPredicate;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.FilterExpressionCheck;
+import com.yahoo.elide.core.type.Type;
+
+import example.models.jpa.PermissionAuthor;
+import example.models.jpa.PermissionAuthorBook;
+import example.models.jpa.PermissionBook;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Check to test that relationship updates have inline checks deferred.
+ */
+@SecurityCheck("author has user accessible books")
+public class AuthorHasUserAccessibleBooks extends FilterExpressionCheck<PermissionAuthor> {
+
+    @Override
+    public FilterExpression getFilterExpression(Type<?> entityClass, RequestScope requestScope) {
+        Path.PathElement author = new Path.PathElement(PermissionAuthor.class, PermissionAuthorBook.class, "authorBooks");
+        Path.PathElement book = new Path.PathElement(PermissionAuthorBook.class, PermissionBook.class, "book");
+        Path.PathElement id = new Path.PathElement(PermissionBook.class, Long.class, "id");
+
+        List<Path.PathElement> pathList = new ArrayList<>();
+        pathList.add(author);
+        pathList.add(book);
+        pathList.add(id);
+        Path paths = new Path(pathList);
+
+        // For simplicity this hard codes the book id to 1 and 2 instead of retrieving from the principal
+        return new FilterPredicate(paths, Operator.IN, Arrays.asList(1, 2));
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/PermissionAuthor.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/PermissionAuthor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.models.jpa;
+
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Model for author.
+ * <p>
+ * Used for testing deferred inline checks for
+ * {@link example.checks.AuthorHasUserAccessibleBooks}.
+ */
+@Entity
+@Table(name = "permissionauthor")
+@Include(name = "permissionauthor", description = "Author")
+@Getter
+@Setter
+@ReadPermission(expression = "author has user accessible books")
+public class PermissionAuthor {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+    private String name;
+
+    @OneToMany(mappedBy = "author")
+    private List<PermissionAuthorBook> authorBooks;
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/PermissionAuthorBook.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/PermissionAuthorBook.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.models.jpa;
+
+import com.yahoo.elide.annotation.Include;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Model for author book.
+ */
+@Entity
+@Table(name = "permissionauthorbook")
+@Include(name = "permissionauthorBook", description = "Author Book")
+@Getter
+@Setter
+public class PermissionAuthorBook {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "AUTHOR_ID")
+    private PermissionAuthor author;
+
+    @ManyToOne
+    @JoinColumn(name = "BOOK_ID")
+    private PermissionBook book;
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/PermissionBook.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/PermissionBook.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.models.jpa;
+
+import com.yahoo.elide.annotation.Include;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Model for books.
+ */
+@Entity
+@Table(name = "permissionbook")
+@Include(name = "permissionbook", description = "A Book")
+@Getter
+@Setter
+public class PermissionBook {
+    @Id
+    private long id;
+    private String title;
+
+    @OneToMany(mappedBy = "book")
+    private List<PermissionAuthorBook> authorBooks;
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -289,6 +289,7 @@ public class AsyncTest extends IntegrationTest {
                 .body("tags.name", containsInAnyOrder("group", "argument", "metric",
                         "dimension", "column", "table", "asyncQuery",
                         "timeDimensionGrain", "timeDimension", "product", "playerCountry", "version", "playerStats",
-                        "stats", "tableExport", "namespace", "tableSource", "maintainer", "book", "publisher", "person"));
+                        "stats", "tableExport", "namespace", "tableSource", "maintainer", "book", "publisher", "person",
+                        "permissionauthor", "permissionbook", "permissionauthorBook"));
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableAggStoreControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableAggStoreControllerTest.java
@@ -30,6 +30,6 @@ public class DisableAggStoreControllerTest extends ControllerTest {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("tags.name", containsInAnyOrder("group", "asyncQuery", "product", "version", "maintainer", "book",
-                        "publisher", "person"));
+                        "publisher", "person", "permissionauthor", "permissionbook", "permissionauthorBook"));
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableMetaDataStoreControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableMetaDataStoreControllerTest.java
@@ -31,6 +31,7 @@ public class DisableMetaDataStoreControllerTest extends ControllerTest {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("tags.name", containsInAnyOrder("playerCountry", "version",
-                        "asyncQuery", "playerStats", "stats", "product", "group", "maintainer", "book", "publisher", "person"));
+                        "asyncQuery", "playerStats", "stats", "product", "group", "maintainer", "book", "publisher",
+                        "person", "permissionauthor", "permissionbook", "permissionauthorBook"));
     }
 }

--- a/elide-test/src/main/java/com/yahoo/elide/test/jsonapi/JsonApiDSL.java
+++ b/elide-test/src/main/java/com/yahoo/elide/test/jsonapi/JsonApiDSL.java
@@ -190,11 +190,23 @@ public class JsonApiDSL {
      *
      * @param type       the type
      * @param id         the id
-     * @param relationships the attributes
+     * @param relationships the relationships
      * @return the resource
      */
     public static Resource resource(Type type, Id id, Relationships relationships) {
         return new Resource(id, type, null, null, relationships);
+    }
+
+    /**
+     * Resource resource.
+     *
+     * @param type       the type
+     * @param lid        the lid
+     * @param relationships the relationships
+     * @return the resource
+     */
+    public static Resource resource(Type type, Lid lid, Relationships relationships) {
+        return new Resource(lid, type, null, null, relationships);
     }
 
     /**


### PR DESCRIPTION
Resolves #2986

## Description
This defers inline checks in the `ActivePermissionExecutor` when processing relationships.
- Added a `deferInlineChecks` variable in the `RequestScope`
- Modified `ActivePermissionExecutor` to also take into consideration the `deferInlineChecks` variable
- Modified `JsonApiAtomicOperations` and `JsonApiJsonPatch` to set defer inline checks to true when post processing relationships.

## Motivation and Context
Previously it was possible for two separate consecutive updates to succeed but when the same updates were bundled into a atomic operation or json patch request were failing due to permissions checks.

## How Has This Been Tested?
Added the appropriate tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
