### PR TITLE
Update swagger jersey-hk2 dependency to test

### DIFF
--- a/elide-swagger/pom.xml
+++ b/elide-swagger/pom.xml
@@ -45,12 +45,12 @@
             <version>7.0.0-pr7-SNAPSHOT</version>
         </dependency>
 
+        <!-- Test -->
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
+            <scope>test</scope>
         </dependency>
-
-        <!-- Test -->
         <dependency>
             <groupId>com.yahoo.elide</groupId>
     	    <artifactId>elide-integration-tests</artifactId>


### PR DESCRIPTION
## Description
Updates the `jersey-hk2` dependency on the `elide-swagger` module to the `test` scope to be inline with the other modules.

## Motivation and Context
The `jersey-hk2` dependency isn't required when using Spring but is being pulled in when the `elide-swagger` module is include.

## How Has This Been Tested?
Tested by ensuring existing tests pass and that the dependency is no longer included for the spring boot example application.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
