### PR TITLE
Upgrade to httpclient5

### DIFF
--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -58,8 +58,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
@@ -13,8 +13,8 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.request.route.Route;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.JsonApi;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.net.URIBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -46,7 +46,6 @@ public class JsonApiAsyncQueryOperation extends AsyncQueryOperation {
         Map<String, List<String>> queryParams = getQueryParams(uri);
         log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
 
-        //TODO - we need to add the baseUrlEndpoint to the queryObject.
         Route route = Route.builder().baseUrl(scope.getRoute().getBaseUrl()).path(getPath(uri)).parameters(queryParams)
                 .headers(scope.getRoute().getHeaders()).apiVersion(apiVersion).build();
         ElideResponse<String> response = jsonApi.get(route, user, requestUUID);

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiTableExportOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiTableExportOperation.java
@@ -21,7 +21,7 @@ import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.EntityProjectionMaker;
 import com.yahoo.elide.jsonapi.JsonApiRequestScope;
 
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.hc.core5.net.URIBuilder;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncExecutorServiceTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/AsyncExecutorServiceTest.java
@@ -35,7 +35,7 @@ import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.utils.DefaultClassScanner;
 import com.yahoo.elide.jsonapi.JsonApiSettings;
 
-import org.apache.http.NoHttpResponseException;
+import org.apache.hc.core5.http.NoHttpResponseException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.2.1.Final</hibernate-search.version>
         <hjson.version>3.0.1</hjson.version>
-        <httpclient.version>4.5.14</httpclient.version>
+        <httpclient5.version>5.2.1</httpclient5.version>
         <gson.version>2.10.1</gson.version>
         <h2.version>2.2.224</h2.version>
         <hikaricp.version>5.0.1</hikaricp.version>
@@ -148,6 +148,7 @@
         <system-lambda.version>1.2.1</system-lambda.version>
         <tomcat.version>10.1.13</tomcat.version>
         <mockito.version>5.6.0</mockito.version>
+
 
         <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
@@ -426,7 +427,7 @@
                 <groupId>org.owasp.encoder</groupId>
                 <artifactId>encoder</artifactId>
                 <version>${encoder.version}</version>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>org.fusesource.jansi</groupId>
                 <artifactId>jansi</artifactId>
@@ -462,9 +463,9 @@
                 <version>${handlebars.version}</version>
             </dependency>
             <dependency>
-               <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>${httpclient.version}</version>
+               <groupId>org.apache.httpcomponents.client5</groupId>
+                <artifactId>httpclient5</artifactId>
+                <version>${httpclient5.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.opendevl</groupId>
@@ -492,12 +493,12 @@
                 <groupId>org.skyscreamer</groupId>
                 <artifactId>jsonassert</artifactId>
                 <version>${jsonassert.version}</version>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-lambda</artifactId>
                 <version>${system-lambda.version}</version>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>


### PR DESCRIPTION
## Description
Upgrade from httpclient4 to httpclient5.

## Motivation and Context
Reduce the total number of dependencies as there is a pre-existing transitive dependency on httpclient5 from elide-datastore-aggregation due to calcite.

## How Has This Been Tested?
Pre-existing tests continue to pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
