### PR TITLE
Fix SubscriptionWebSocket for war deployments

### DIFF
--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionWebSocketTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionWebSocketTest.java
@@ -56,6 +56,7 @@ import graphql.GraphQLError;
 import graphql.execution.DataFetcherExceptionHandler;
 import graphql.execution.SimpleDataFetcherExceptionHandler;
 import jakarta.websocket.CloseReason;
+import jakarta.websocket.EndpointConfig;
 import jakarta.websocket.RemoteEndpoint;
 import jakarta.websocket.Session;
 import lombok.extern.slf4j.Slf4j;
@@ -83,6 +84,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
     protected Elide elide;
     protected ExecutorService executorService = MoreExecutors.newDirectExecutorService();
     protected DataFetcherExceptionHandler dataFetcherExceptionHandler = spy(new SimpleDataFetcherExceptionHandler());
+    protected EndpointConfig endpointConfig;
 
     public SubscriptionWebSocketTest() {
         RSQLFilterDialect filterDialect = RSQLFilterDialect.builder().dictionary(dictionary).build();
@@ -143,12 +145,12 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .elide(elide).build();
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
         ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
 
-        endpoint.onClose(session);
+        endpoint.onClose(session, null);
 
         verify(remote, times(1)).sendText(message.capture());
         assertEquals("{\"type\":\"connection_ack\"}", message.getAllValues().get(0));
@@ -165,7 +167,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .elide(elide).build();
 
         String invalid = "{ \"id\": 123 }";
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, invalid);
 
         verify(remote, never()).sendText(any());
@@ -182,7 +184,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .elide(elide).build();
 
         String invalid = "{ \"type\": \"foo\", \"id\": 123 }";
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, invalid);
 
         verify(remote, never()).sendText(any());
@@ -201,7 +203,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
         //Missing payload field
         String invalid = "{ \"type\": \"subscribe\"}";
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
         endpoint.onMessage(session, invalid);
 
@@ -221,7 +223,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .executorService(executorService)
                 .connectionTimeout(Duration.ZERO).elide(elide).build();
 
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
 
         ArgumentCaptor<CloseReason> closeReason = ArgumentCaptor.forClass(CloseReason.class);
         verify(session, timeout(1000).times(1)).close(closeReason.capture());
@@ -235,7 +237,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .elide(elide).build();
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
@@ -255,7 +257,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .executorService(executorService)
                 .elide(elide).build();
 
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
 
         Subscribe subscribe = Subscribe.builder()
                 .id("1")
@@ -280,7 +282,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .elide(elide).build();
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
         Subscribe subscribe = Subscribe.builder()
@@ -330,7 +332,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .thenReturn(new DataStoreIterableBuilder(List.of(book1, book2)).build());
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
         Subscribe subscribe = Subscribe.builder()
@@ -365,7 +367,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
         when(dataStoreTransaction.loadObjects(any(), any())).thenThrow(new BadRequestException("Bad Request"));
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
         Subscribe subscribe = Subscribe.builder()
@@ -406,7 +408,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .thenReturn(new DataStoreIterableBuilder(List.of(book1, book2)).build());
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
         Subscribe subscribe = Subscribe.builder()
@@ -453,7 +455,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                         + "}";
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
         Subscribe subscribe = Subscribe.builder()
@@ -483,7 +485,7 @@ public class SubscriptionWebSocketTest extends GraphQLTest {
                 .elide(elide).build();
 
         ConnectionInit init = new ConnectionInit();
-        endpoint.onOpen(session);
+        endpoint.onOpen(session, endpointConfig);
         endpoint.onMessage(session, mapper.writeValueAsString(init));
 
         Subscribe subscribe = Subscribe.builder()

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
@@ -44,6 +44,7 @@ public class ElideSubscriptionConfiguration {
     ) {
         return ServerEndpointConfig.Builder
                 .create(SubscriptionWebSocket.class, config.getGraphql().getSubscription().getPath())
+                .subprotocols(SubscriptionWebSocket.SUPPORTED_WEBSOCKET_SUBPROTOCOLS)
                 .configurator(SubscriptionWebSocketConfigurator.builder()
                         .baseUrl(config.getGraphql().getSubscription().getPath())
                         .sendPingOnSubscribe(config.getGraphql().getSubscription().isSendPingOnSubscribe())

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
@@ -150,6 +150,7 @@ public interface ElideStandaloneSubscriptionSettings {
     ) {
         return ServerEndpointConfig.Builder
                 .create(SubscriptionWebSocket.class, getPath())
+                .subprotocols(SubscriptionWebSocket.SUPPORTED_WEBSOCKET_SUBPROTOCOLS)
                 .configurator(SubscriptionWebSocketConfigurator.builder()
                         .baseUrl(getPath())
                         .sendPingOnSubscribe(shouldSendPingOnSubscribe())


### PR DESCRIPTION
When the `elide-graphql` library is deployed as part of a war a `jakarta.servlet.ServletException` is thrown as the `SubscriptionWebSocket` is annotated with `@ServerEndpoint`  and classes with that annotation needs to have a no-arg public constructor according to the spec.

## Description
This converts the `SubscriptionWebSocket` from the annotation based model using `@ServerEndpoint` to the programmatic API based model extending `Endpoint`. The existing mechanism of registering the web socket already is following the programmatic API based model.

## Motivation and Context
When deployed as part of a war on Jetty the following is thrown.


```
jakarta.servlet.ServletException: jakarta.websocket.DeploymentException: Cannot access default constructor for the class: com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket
        at org.eclipse.jetty.websocket.jakarta.server.config.JakartaWebSocketServletContainerInitializer.onStartup(JakartaWebSocketServletContainerInitializer.java:259)
        at org.eclipse.jetty.servlet.ServletContainerInitializerHolder.doStart(ServletContainerInitializerHolder.java:148)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:171)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114)
        at org.eclipse.jetty.servlet.ServletContextHandler$ServletContainerInitializerStarter.doStart(ServletContextHandler.java:1660)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93)
        at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:369)
        at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1305)
        at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:902)
        at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:306)
        at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:533)
```

## How Has This Been Tested?
Existing tests continue to pass. Have also manually tested that the Spring Boot and Standalone examples continue to work as well as when deployed as a war on Jetty.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
