### PR TITLE
Bump hjson.version from 3.0.0 to 3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <hibernate.version>6.2.7.Final</hibernate.version>
         <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.2.0.Final</hibernate-search.version>
-        <hjson.version>3.0.0</hjson.version>
+        <hjson.version>3.0.1</hjson.version>
         <httpclient.version>4.5.14</httpclient.version>
         <gson.version>2.10.1</gson.version>
         <h2.version>2.2.220</h2.version>


### PR DESCRIPTION
Resolves #3032

## Motivation and Context
Resolves case where dependency check will flag out the dependency.

## How Has This Been Tested?
Existing tests pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
