### PR TITLE
Add route resolvers for API Versioning

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/ApiVersionValidator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/ApiVersionValidator.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+@FunctionalInterface
+/**
+ * Api Version Validator.
+ */
+public interface ApiVersionValidator {
+    boolean isValidApiVersion(String apiVersion);
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/BasicApiVersionValidator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/BasicApiVersionValidator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+/**
+ * BasicApiVersionValidator.
+ */
+public class BasicApiVersionValidator implements ApiVersionValidator {
+
+    @Override
+    public boolean isValidApiVersion(String apiVersion) {
+        return (apiVersion != null
+                && (EntityDictionary.NO_VERSION.equals(apiVersion) || Character.isDigit(apiVersion.charAt(0))));
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/DelegatingRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/DelegatingRouteResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A route resolver that delegates to other implementations.
+ */
+public class DelegatingRouteResolver implements RouteResolver {
+
+    private final List<RouteResolver> routeResolvers;
+
+    public DelegatingRouteResolver(RouteResolver... routeResolver) {
+        this(Arrays.asList(routeResolver));
+    }
+
+    public DelegatingRouteResolver(List<RouteResolver> routeResolvers) {
+        this.routeResolvers = routeResolvers;
+    }
+
+    @Override
+    public Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters) {
+        for (RouteResolver routeResolver : this.routeResolvers) {
+            Route route = routeResolver.resolve(mediaType, baseUrl, path, headers, parameters);
+            if (!NO_VERSION.equals(route.getApiVersion())) {
+                return route;
+            }
+        }
+        return Route.builder().apiVersion(NO_VERSION).baseUrl(baseUrl).path(path).headers(headers)
+                .parameters(parameters).build();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/FlexibleRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/FlexibleRouteResolver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The flexible route resolver allows multiple ways to derive the requested version.
+ *
+ * <li>Header: ApiVersion, Accept-Version
+ * <li>Path: Prefixed with 'v'
+ * <li>Query Parameter: For 'v'
+ * <li>Media Type Profile: After the last /
+ */
+public class FlexibleRouteResolver implements RouteResolver {
+
+    private final DelegatingRouteResolver routeResolver;
+
+    public FlexibleRouteResolver(ApiVersionValidator apiVersionValidator, UriPrefixSupplier uriPrefixSupplier) {
+        this.routeResolver = new DelegatingRouteResolver(new HeaderRouteResolver("Accept-Version", "ApiVersion"),
+                new PathRouteResolver("v", apiVersionValidator), new ParameterRouteResolver("v", apiVersionValidator),
+                new MediaTypeProfileRouteResolver("v", apiVersionValidator, uriPrefixSupplier));
+    }
+
+    @Override
+    public Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters) {
+        return this.routeResolver.resolve(mediaType, baseUrl, path, headers, parameters);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/HeaderRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/HeaderRouteResolver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Resolves a route using a header.
+ */
+public class HeaderRouteResolver implements RouteResolver {
+
+    private final String[] apiVersionHeaderNames;
+
+    public HeaderRouteResolver(String... apiVersionHeaderNames) {
+        this.apiVersionHeaderNames = apiVersionHeaderNames;
+        for (int x = 0; x < apiVersionHeaderNames.length; x++) {
+            this.apiVersionHeaderNames[x] = this.apiVersionHeaderNames[x].toLowerCase(Locale.ENGLISH);
+        }
+    }
+
+    @Override
+    public Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters) {
+        for (String apiVersionHeaderName : this.apiVersionHeaderNames) {
+            if (headers != null && headers.get(apiVersionHeaderName) != null) {
+                String apiVersion = headers.get(apiVersionHeaderName).get(0);
+                if (apiVersion != null) {
+                    return Route.builder().apiVersion(apiVersion).baseUrl(baseUrl).path(path).headers(headers)
+                            .parameters(parameters).build();
+                }
+            }
+        }
+        return Route.builder().apiVersion(NO_VERSION).baseUrl(baseUrl).path(path).headers(headers)
+                .parameters(parameters).build();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/MediaTypeParameterRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/MediaTypeParameterRouteResolver.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Resolves a route using a media type parameter.
+ */
+public class MediaTypeParameterRouteResolver implements RouteResolver {
+
+    private final Function<String, String> resolver;
+
+    /**
+     * Constructor.
+     *
+     * @param resolver the resolver to map the media type parameter value to API Version
+     */
+    public MediaTypeParameterRouteResolver(Function<String, String> resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters) {
+
+        List<String> acceptHeader = headers.get("accept");
+        if (acceptHeader != null) {
+            for (String accept : acceptHeader) {
+                String apiVersion = fromHeader(accept, mediaType);
+                if (apiVersion != null) {
+                    return Route.builder().apiVersion(apiVersion).baseUrl(baseUrl).path(path).headers(headers)
+                            .parameters(parameters).build();
+                }
+            }
+        }
+        return Route.builder().apiVersion(NO_VERSION).baseUrl(baseUrl).path(path).headers(headers)
+                .parameters(parameters).build();
+    }
+
+    /**
+     * Determine if the Accept header value should be supported.
+     *
+     * @param acceptHeaderValue the Accept header value
+     * @param mediaType the media type that should be processed
+     * @return true if it should be processed
+     */
+    protected boolean supports(String acceptHeaderValue, String mediaType) {
+        return true;
+    }
+
+    /**
+     * Determine the API Version from the Accept header value.
+     *
+     * @param acceptHeaderValue the Accept header value
+     * @param mediaType the media type that should be processed
+     * @return the API Version or null
+     */
+    protected String fromHeader(String acceptHeaderValue, String mediaType) {
+        if (supports(acceptHeaderValue, mediaType)) {
+            String[] parameters = acceptHeaderValue.split(";");
+            for (int x = 1; x < parameters.length; x++) {
+                String parameter = parameters[x].trim();
+                String apiVersion = fromMediaTypeParameter(parameter);
+                if (apiVersion != null && !apiVersion.isBlank()) {
+                    return apiVersion;
+                }
+            }
+        }
+        return null;
+    }
+
+    protected String fromMediaTypeParameter(String parameter) {
+        return resolver.apply(parameter);
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/MediaTypeProfileRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/MediaTypeProfileRouteResolver.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Resolves a route using a media type profile.
+ *
+ * <p>This assumes that the profile is in the last path segment.
+ *
+ * <p>For example: application/vnd.api+json; profile="https://example.org/1.0 https://example.org/profile"
+ */
+public class MediaTypeProfileRouteResolver extends MediaTypeParameterRouteResolver {
+    private static final String MEDIA_TYPE_PARAMETER_PROFILE = "profile=";
+    private final String versionPrefix;
+    private final UriPrefixSupplier uriPrefixSupplier;
+    private final ApiVersionValidator apiVersionValidator;
+
+    public MediaTypeProfileRouteResolver(String versionPrefix, ApiVersionValidator apiVersionValidator,
+            UriPrefixSupplier uriPrefixSupplier) {
+        super(null);
+        this.versionPrefix = versionPrefix;
+        this.uriPrefixSupplier = uriPrefixSupplier;
+        this.apiVersionValidator = apiVersionValidator;
+    }
+
+    @Override
+    protected String fromMediaTypeParameter(String parameter) {
+        if (parameter.startsWith(MEDIA_TYPE_PARAMETER_PROFILE)) {
+            Profile profile = parseProfile(parameter.substring(MEDIA_TYPE_PARAMETER_PROFILE.length()));
+            return processProfile(profile);
+        }
+        return NO_VERSION;
+    }
+
+    public String processProfile(Profile profile) {
+        String uriPrefix = this.uriPrefixSupplier.getUriPrefix();
+        for (String value : profile.getValues()) {
+            if (value.startsWith(uriPrefix)) {
+                int start = value.lastIndexOf("/");
+                if (start != -1 && value.length() > start + 1) {
+                    String version = value.substring(start + 1);
+                    if (version.startsWith(this.versionPrefix)) {
+                        version = version.substring(this.versionPrefix.length());
+                        if (apiVersionValidator.isValidApiVersion(version)) {
+                            return version;
+                        }
+                    }
+                }
+            }
+        }
+        return NO_VERSION;
+    }
+
+    /**
+     * The media type profile values.
+     */
+    public static final class Profile {
+        private List<String> values;
+
+        public Profile(List<String> values) {
+            this.values = values;
+        }
+
+        public List<String> getValues() {
+            return this.values;
+        }
+    }
+
+    /**
+     * Parses a space delimited profile parameter into a list.
+     *
+     * <p>"https://example.com/resource-timestamps https://example.com/api/"
+     *
+     * @param parameter the profile parameter value
+     * @return the profile list
+     */
+    public Profile parseProfile(String parameter) {
+        if (parameter.charAt(0) == '"' && parameter.charAt(parameter.length() - 1) == '"') {
+            String list = parameter.substring(1, parameter.length() - 1);
+            String[] items = list.split(" ");
+            List<String> values = new ArrayList<>(items.length);
+            Collections.addAll(values, items);
+            return new Profile(values);
+        } else {
+            return new Profile(Collections.singletonList(parameter));
+        }
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/NullRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/NullRouteResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The no-op route resolver.
+ */
+public class NullRouteResolver implements RouteResolver {
+
+    @Override
+    public Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters) {
+        return Route.builder().apiVersion(EntityDictionary.NO_VERSION).baseUrl(baseUrl).path(path)
+                .headers(headers).parameters(parameters).build();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/ParameterRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/ParameterRouteResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves a route using a parameter.
+ */
+public class ParameterRouteResolver implements RouteResolver {
+
+    private final String apiVersionParameterName;
+    private final ApiVersionValidator apiVersionValidator;
+
+    public ParameterRouteResolver(String apiVersionParameterName, ApiVersionValidator apiVersionValidator) {
+        this.apiVersionParameterName = apiVersionParameterName;
+        this.apiVersionValidator = apiVersionValidator;
+    }
+
+    @Override
+    public Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters) {
+        Map<String, List<String>> result = parameters;
+
+        if (parameters != null && parameters.get(apiVersionParameterName) != null) {
+            String apiVersion = parameters.get(apiVersionParameterName).get(0);
+            if (this.apiVersionValidator.isValidApiVersion(apiVersion)) {
+                result = new LinkedHashMap<>(parameters);
+                result.remove(apiVersionParameterName);
+                return Route.builder().apiVersion(apiVersion).baseUrl(baseUrl).path(path).headers(headers)
+                        .parameters(result).build();
+            }
+        }
+        return Route.builder().apiVersion(NO_VERSION).baseUrl(baseUrl).path(path).headers(headers).parameters(result)
+                .build();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/PathRouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/PathRouteResolver.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves a route using the path.
+ */
+public class PathRouteResolver implements RouteResolver {
+
+    private final String versionPrefix;
+    private final ApiVersionValidator apiVersionValidator;
+
+    public PathRouteResolver(String versionPrefix, ApiVersionValidator apiVersionValidator) {
+        this.versionPrefix = versionPrefix;
+        this.apiVersionValidator = apiVersionValidator;
+    }
+
+    @Override
+    public Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters) {
+        String baseRoute = baseUrl == null ? "" : baseUrl;
+        String route = path;
+        String apiVersion = NO_VERSION;
+
+        String apiVersionString = "";
+        int versionStart = -1;
+        int versionEnd = -1;
+        int pathStart = -1;
+        int pathEnd = -1;
+
+        int find = path.indexOf('/', 0);
+        if (find != -1) {
+            if (find == 0) {
+                // "/.."
+                versionStart = 1;
+                int findEnd = path.indexOf('/', 1);
+                if (findEnd != -1) {
+                    // "/v2/.."
+                    versionEnd = findEnd;
+                    pathStart = findEnd;
+                    pathEnd = path.length();
+                } else {
+                    // "/v2"
+                    versionEnd = path.length();
+                }
+            } else {
+                // "v2/.."
+                versionStart = 0;
+                versionEnd = find;
+                pathStart = find;
+                pathEnd = path.length();
+            }
+        } else {
+            // "v2"
+            versionStart = 0;
+            versionEnd = path.length();
+        }
+
+        if (versionStart != -1 && versionEnd != -1) {
+            apiVersion = path.substring(versionStart, versionEnd);
+            apiVersionString = apiVersion;
+        }
+
+        if (!apiVersion.isEmpty() && !this.versionPrefix.isEmpty()) {
+            if (apiVersion.startsWith(this.versionPrefix)) {
+                apiVersion = apiVersion.substring(this.versionPrefix.length());
+            }
+        }
+
+        if (!apiVersion.isEmpty()) {
+            if (!apiVersionValidator.isValidApiVersion(apiVersion)) { // sanity check version
+                apiVersion = NO_VERSION;
+                pathStart = 0;
+                pathEnd = path.length();
+                apiVersionString = "";
+            }
+        }
+
+        if (pathStart != -1 && pathEnd != -1) {
+            route = path.substring(pathStart, pathEnd);
+        } else {
+            route = "";
+        }
+
+        if (route.length() > 0 && route.charAt(0) == '/') {
+            route = route.substring(1);
+        }
+
+        if (baseRoute.length() > 0 && baseRoute.charAt(baseRoute.length() - 1) == '/') {
+            baseRoute = baseRoute + apiVersionString;
+        } else {
+            baseRoute = baseRoute + "/" + apiVersionString;
+        }
+
+        return Route.builder().apiVersion(apiVersion).baseUrl(baseRoute).path(route).headers(headers)
+                .parameters(parameters).build();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/Route.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/Route.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a route which contains the base url, path, headers, parameters and
+ * api version of the request.
+ * <p>
+ * Use the static factory {@link #builder()} method to prepare an instance.
+ */
+@Data
+@Builder
+public class Route {
+    /**
+     * The baseUrl of the resolved route.
+     */
+    private final String baseUrl;
+
+    /**
+     * The path of the resolved route.
+     */
+    private final String path;
+
+    /**
+     * The API Version of the resolved route.
+     */
+    private final String apiVersion;
+
+    /**
+     * The parameters of the resolved route.
+     */
+    private final Map<String, List<String>> parameters;
+
+    /**
+     * The headers of the resolved route.
+     */
+    private final Map<String, List<String>> headers;
+
+    /**
+     * Returns a builder with the current values.
+     *
+     * @return the builder to mutate
+     */
+    public RouteBuilder mutate() {
+        return builder().baseUrl(this.baseUrl).path(this.path).apiVersion(this.apiVersion).parameters(this.parameters)
+                .headers(this.headers);
+    }
+
+    /**
+     * A mutable builder for creating a {@link Route}.
+     */
+    public static class RouteBuilder {
+        private String baseUrl = "";
+        private String path = "";
+        private String apiVersion = EntityDictionary.NO_VERSION;
+        private Map<String, List<String>> parameters = Collections.emptyMap();
+        private Map<String, List<String>> headers = Collections.emptyMap();
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/RouteResolver.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/RouteResolver.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Strategy for resolving a route.
+ */
+public interface RouteResolver {
+    /**
+     * Resolves a route.
+     *
+     * @param mediaType the acceptable media type for processing
+     * @param baseUrl the base url
+     * @param path the path
+     * @param headers the request headers
+     * @param parameters the request parameters
+     * @return the route information
+     */
+    Route resolve(String mediaType, String baseUrl, String path,
+            Map<String, List<String>> headers, Map<String, List<String>> parameters);
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/route/UriPrefixSupplier.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/route/UriPrefixSupplier.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+@FunctionalInterface
+/**
+ * Used to determine the URI prefix for the MediaType Profile URI.
+ */
+public interface UriPrefixSupplier {
+    String getUriPrefix();
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/BasicApiVersionValidatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/BasicApiVersionValidatorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for BasicApiVersionValidator.
+ */
+class BasicApiVersionValidatorTest {
+
+    @Test
+    void noVersionIsValid() {
+        BasicApiVersionValidator validator = new BasicApiVersionValidator();
+        assertTrue(validator.isValidApiVersion(EntityDictionary.NO_VERSION));
+    }
+
+    @Test
+    void nullVersionIsNotValid() {
+        BasicApiVersionValidator validator = new BasicApiVersionValidator();
+        assertFalse(validator.isValidApiVersion(null));
+    }
+
+    @Test
+    void digitVersionIsValid() {
+        BasicApiVersionValidator validator = new BasicApiVersionValidator();
+        assertTrue(validator.isValidApiVersion("3"));
+    }
+
+    @Test
+    void letterVersionIsNotValid() {
+        BasicApiVersionValidator validator = new BasicApiVersionValidator();
+        assertFalse(validator.isValidApiVersion("a"));
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/DelegatingRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/DelegatingRouteResolverTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for DelegatingRouteResolver.
+ */
+class DelegatingRouteResolverTest {
+
+    @Test
+    void shouldDelegate() {
+        RouteResolver delegate = mock(RouteResolver.class);
+        DelegatingRouteResolver routeResolver = new DelegatingRouteResolver(delegate);
+        when(delegate.resolve("", "", "", null, null)).thenReturn(Route.builder().apiVersion("2").build());
+        Route route = routeResolver.resolve("", "", "", null, null);
+        assertEquals("2", route.getApiVersion());
+    }
+
+    @Test
+    void shouldPassthrough() {
+        RouteResolver delegate = mock(RouteResolver.class);
+        DelegatingRouteResolver routeResolver = new DelegatingRouteResolver(delegate);
+        when(delegate.resolve("", "baseUrl", "", null, null)).thenReturn(Route.builder().apiVersion("").baseUrl("test").build());
+        Route route = routeResolver.resolve("", "baseUrl", "", null, null);
+        assertEquals("baseUrl", route.getBaseUrl());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/FlexibleRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/FlexibleRouteResolverTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Test for FlexibleRouteResolver.
+ */
+class FlexibleRouteResolverTest {
+
+    @Test
+    void parametersApiVersion() {
+        FlexibleRouteResolver resolver = new FlexibleRouteResolver(new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> parameters = Collections
+                .unmodifiableMap(Map.of("v", Arrays.asList("1")));
+        Route route = resolver.resolve("", "", "", Collections.emptyMap(), parameters);
+        assertNotSame(parameters, route.getParameters());
+        assertEquals("1", route.getApiVersion());
+    }
+
+    @Test
+    void pathApiVersion() {
+        FlexibleRouteResolver resolver = new FlexibleRouteResolver(new BasicApiVersionValidator(), () -> "");
+        Route route = resolver.resolve("", "", "/v1/books", Collections.emptyMap(), Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+        assertEquals("/v1", route.getBaseUrl());
+        assertEquals("books", route.getPath());
+    }
+
+    @Test
+    void headerApiVersion() {
+        FlexibleRouteResolver resolver = new FlexibleRouteResolver(new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.putAll(Map.of("ApiVersion", Arrays.asList("1")));
+        Route route = resolver.resolve("", "", "", headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+        assertSame(headers, route.getHeaders());
+    }
+
+    @Test
+    void headerAcceptVersion() {
+        FlexibleRouteResolver resolver = new FlexibleRouteResolver(new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.putAll(Map.of("Accept-Version", Arrays.asList("1")));
+        Route route = resolver.resolve("", "", "", headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+        assertSame(headers, route.getHeaders());
+    }
+
+    @Test
+    void mediaTypeProfileApiVersion() {
+        FlexibleRouteResolver resolver = new FlexibleRouteResolver(new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        String mediaType = """
+                application/vnd.api+json; profile=https://example.com/api/v1
+                """;
+
+        headers.put("Accept", Arrays.asList(mediaType));
+        Route route = resolver.resolve("", "", "", headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/HeaderRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/HeaderRouteResolverTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Test for HeaderRouteResolver.
+ */
+class HeaderRouteResolverTest {
+
+    @Test
+    void headerApiVersion() {
+        HeaderRouteResolver resolver = new HeaderRouteResolver("Accept-Version", "ApiVersion");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.putAll(Map.of("ApiVersion", Arrays.asList("1")));
+        Route route = resolver.resolve(null, null, null, headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+        assertSame(headers, route.getHeaders());
+    }
+
+    @Test
+    void headerNoApiVersion() {
+        HeaderRouteResolver resolver = new HeaderRouteResolver("Accept-Version", "ApiVersion");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.putAll(Map.of("Test", Arrays.asList("1")));
+        Route route = resolver.resolve(null, null, null, headers, Collections.emptyMap());
+        assertEquals(EntityDictionary.NO_VERSION, route.getApiVersion());
+        assertSame(headers, route.getHeaders());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/MediaTypeParameterRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/MediaTypeParameterRouteResolverTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test for MediaTypeParameterRouteResolver.
+ */
+class MediaTypeParameterRouteResolverTest {
+
+    @Test
+    void version() {
+        Map<String, List<String>> headers = Collections
+                .unmodifiableMap(Map.of("accept", Arrays.asList("application/json; v=1")));
+
+        MediaTypeParameterRouteResolver resolver = new MediaTypeParameterRouteResolver(parameter -> {
+            if (parameter.startsWith("v=")) {
+                return parameter.substring("v=".length());
+            }
+            return null;
+        });
+        Route route = resolver.resolve("application/json", null, null, headers, null);
+        assertEquals("1", route.getApiVersion());
+    }
+
+    @Test
+    void noVersion() {
+        Map<String, List<String>> headers = Collections
+                .unmodifiableMap(Map.of("accept", Arrays.asList("application/json")));
+
+        MediaTypeParameterRouteResolver resolver = new MediaTypeParameterRouteResolver(parameter -> {
+            if (parameter.startsWith("v=")) {
+                return parameter.substring("v=".length());
+            }
+            return null;
+        });
+        Route route = resolver.resolve("application/json", null, null, headers, null);
+        assertEquals(EntityDictionary.NO_VERSION, route.getApiVersion());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/MediaTypeProfileRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/MediaTypeProfileRouteResolverTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Tests for MediaTypeProfileRouteResolver.
+ */
+class MediaTypeProfileRouteResolverTest {
+
+    @Test
+    void testSingleShouldFind() {
+        MediaTypeProfileRouteResolver resolver = new MediaTypeProfileRouteResolver("", new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        String mediaType = """
+                application/vnd.api+json; profile=https://example.com/api/1
+                """;
+
+        headers.put("Accept", Collections.singletonList(mediaType));
+        Route route = resolver.resolve("", null, "", headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+    }
+
+    @Test
+    void testShouldFind() {
+        MediaTypeProfileRouteResolver resolver = new MediaTypeProfileRouteResolver("", new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        String mediaType = """
+                application/vnd.api+json; ext="https://jsonapi.org/ext/version"; profile="https://example.com/resource-timestamps https://example.com/api/1"
+                """;
+
+        headers.put("Accept", Collections.singletonList(mediaType));
+        Route route = resolver.resolve("", null, "", headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+    }
+
+    @Test
+    void testShouldNotFind() {
+        MediaTypeProfileRouteResolver resolver = new MediaTypeProfileRouteResolver("", new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        String mediaType = """
+                application/vnd.api+json; ext="https://jsonapi.org/ext/version"; profile="https://example.com/resource-timestamps https://example.com/api/"
+                """;
+
+        headers.put("Accept", Collections.singletonList(mediaType));
+        Route route = resolver.resolve("", null, "", headers, Collections.emptyMap());
+        assertEquals("", route.getApiVersion());
+    }
+
+    @Test
+    void testVersionPrefixShouldFind() {
+        MediaTypeProfileRouteResolver resolver = new MediaTypeProfileRouteResolver("v", new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        String mediaType = """
+                application/vnd.api+json; ext="https://jsonapi.org/ext/version"; profile="https://example.com/resource-timestamps https://example.com/api/v1"
+                """;
+
+        headers.put("Accept", Collections.singletonList(mediaType));
+        Route route = resolver.resolve("", null, "", headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+    }
+
+    @Test
+    void testVersionPrefixShouldNotFind() {
+        MediaTypeProfileRouteResolver resolver = new MediaTypeProfileRouteResolver("v", new BasicApiVersionValidator(), () -> "");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        String mediaType = """
+                application/vnd.api+json; ext="https://jsonapi.org/ext/version"; profile="https://example.com/resource-timestamps https://example.com/api/v"
+                """;
+
+        headers.put("Accept", Collections.singletonList(mediaType));
+        Route route = resolver.resolve("", null, "", headers, Collections.emptyMap());
+        assertEquals("", route.getApiVersion());
+    }
+
+    @Test
+    void testUriPrefixShouldFind() {
+        MediaTypeProfileRouteResolver resolver = new MediaTypeProfileRouteResolver("v", new BasicApiVersionValidator(), () -> "https://example.com/api");
+        Map<String, List<String>> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        String mediaType = """
+                application/vnd.api+json; ext="https://jsonapi.org/ext/version"; profile="https://example.com/resource-timestamps/v2 https://example.com/api/v1"
+                """;
+
+        headers.put("Accept", Collections.singletonList(mediaType));
+        Route route = resolver.resolve("", null, "", headers, Collections.emptyMap());
+        assertEquals("1", route.getApiVersion());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/NullRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/NullRouteResolverTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for NullRouteResolver.
+ */
+class NullRouteResolverTest {
+
+    @Test
+    void shouldPassthrough() {
+        NullRouteResolver routeResolver = new NullRouteResolver();
+        Route route = routeResolver.resolve("", "baseUrl", "path", null, null);
+        assertEquals("baseUrl", route.getBaseUrl());
+        assertEquals("path", route.getPath());
+        assertEquals(EntityDictionary.NO_VERSION, route.getApiVersion());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/ParameterRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/ParameterRouteResolverTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test for ParameterRouteResolver.
+ */
+class ParameterRouteResolverTest {
+
+    @Test
+    void parametersShouldPassThrough() {
+        ParameterRouteResolver resolver = new ParameterRouteResolver("v", new BasicApiVersionValidator());
+        Map<String, List<String>> parameters = Collections
+                .unmodifiableMap(Map.of("Content-Type", Arrays.asList("application/json")));
+        Route route = resolver.resolve(null, null, null, Collections.emptyMap(), parameters);
+        assertSame(parameters, route.getParameters());
+    }
+
+    @Test
+    void parametersRemoveApiVersion() {
+        ParameterRouteResolver resolver = new ParameterRouteResolver("v", new BasicApiVersionValidator());
+        Map<String, List<String>> parameters = Collections
+                .unmodifiableMap(Map.of("Content-Type", Arrays.asList("application/json"), "v", Arrays.asList("1")));
+        Route route = resolver.resolve(null, null, null, Collections.emptyMap(), parameters);
+        assertNotSame(parameters, route.getParameters());
+        assertNull(route.getParameters().get("v"));
+        assertEquals("1", route.getApiVersion());
+    }
+
+    @Test
+    void parametersInvalidApiVersion() {
+        ParameterRouteResolver resolver = new ParameterRouteResolver("v", new BasicApiVersionValidator());
+        Map<String, List<String>> parameters = Collections
+                .unmodifiableMap(Map.of("Content-Type", Arrays.asList("application/json"), "v", Arrays.asList("abc")));
+        Route route = resolver.resolve(null, null, null, Collections.emptyMap(), parameters);
+        assertSame(parameters, route.getParameters());
+        assertNotNull(route.getParameters().get("v"));
+        assertEquals(EntityDictionary.NO_VERSION, route.getApiVersion());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/PathRouteResolverTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/PathRouteResolverTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Collections;
+
+/**
+ * Tests for path route resolver.
+ */
+class PathRouteResolverTest {
+
+    enum Input {
+        VERSION_LEADING_SLASH_BASE("https://elide.io/", "v", "/v1/post", "1", "https://elide.io/v1", "post"),
+        VERSION_LEADING_SLASH_NULL_BASE(null, "v", "/v1/post", "1", "/v1", "post"),
+        VERSION_LEADING_SLASH("", "v", "/v1/post", "1", "/v1", "post"),
+        VERSION_LEADING_SLASH_NO_PATH("", "v", "/v1", "1", "/v1", ""),
+        VERSION_WITHOUT_LEADING_SLASH("", "v", "/v1/post", "1", "/v1", "post"),
+        VERSION_LEADING_SLASH_NO_PREFIX("", "", "1/post", "1", "/1", "post"),
+        VERSION_WIHOUT_LEADING_SLASH_NO_PREFIX("", "", "/1/post", "1", "/1", "post"),
+
+        NO_VERSION_LEADING_SLASH_BASE("https://elide.io/", "v", "/post", "", "https://elide.io/", "post"),
+        NO_VERSION_LEADING_SLASH_NULL_BASE(null, "v", "/post", "", "/", "post"),
+        NO_VERSION_LEADING_SLASH("", "v", "/post", "", "/", "post"),
+        NO_VERSION_LEADING_SLASH_NO_PATH("", "v", "/", "", "/", ""),
+        NO_VERSION_WITHOUT_LEADING_SLASH("", "v", "post", "", "/", "post"),
+        NO_VERSION_LEADING_SLASH_NO_PREFIX("", "", "/post", "", "/", "post"),
+        NO_VERSION_WIHOUT_LEADING_SLASH_NO_PREFIX("", "", "post", "", "/", "post"),
+        NO_VERSION_LEADING_SLASH_NO_PREFIX_NEST("", "", "/post/1/author", "", "/", "post/1/author"),
+        NO_VERSION_WIHOUT_LEADING_SLASH_NO_PREFIX_NEST("", "", "post/1/author", "", "/", "post/1/author");
+
+        String baseUrl;
+        String versionPrefix;
+        String path;
+        String apiVersion;
+        String baseRoute;
+        String route;
+
+        Input(String baseUrl, String versionPrefix, String path, String apiVersion, String baseRoute, String route) {
+            this.baseUrl = baseUrl;
+            this.versionPrefix = versionPrefix;
+            this.path = path;
+            this.apiVersion = apiVersion;
+            this.baseRoute = baseRoute;
+            this.route = route;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(Input.class)
+    void testInputs(Input input) {
+        PathRouteResolver routeResolver = new PathRouteResolver(input.versionPrefix, new BasicApiVersionValidator());
+        Route route = routeResolver.resolve("", input.baseUrl, input.path, Collections.emptyMap(), Collections.emptyMap());
+        assertEquals(input.apiVersion, route.getApiVersion());
+        assertEquals(input.route, route.getPath());
+        assertEquals(input.baseRoute, route.getBaseUrl());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/request/route/RouteTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/request/route/RouteTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.request.route;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test for Route.
+ */
+class RouteTest {
+
+    @Test
+    void mutate() {
+        Map<String, List<String>> headers = Map.of("Content-Type", Arrays.asList("application/json"));
+        Route route = Route.builder().apiVersion("1").headers(headers).build();
+        Route mutated = route.mutate().apiVersion("2").build();
+        assertNotEquals(route.getApiVersion(), mutated.getApiVersion());
+        assertEquals(route.getHeaders(), mutated.getHeaders());
+        assertNotEquals(route, mutated);
+    }
+
+    @Test
+    void parametersShouldNotBeNull() {
+        assertNotNull(Route.builder().build().getParameters());
+    }
+
+    @Test
+    void headersShouldNotBeNull() {
+        assertNotNull(Route.builder().build().getHeaders());
+    }
+
+    @Test
+    void baseUrlShouldNotBeNull() {
+        assertNotNull(Route.builder().build().getBaseUrl());
+    }
+
+    @Test
+    void pathShouldNotBeNull() {
+        assertNotNull(Route.builder().build().getPath());
+    }
+
+    @Test
+    void apiVersionShouldNotBeNull() {
+        assertNotNull(Route.builder().build().getApiVersion());
+    }
+
+    @Test
+    void apiVersionDefaultShouldBeNoVersion() {
+        assertEquals(EntityDictionary.NO_VERSION, Route.builder().build().getApiVersion());
+    }
+
+    @Test
+    void shouldEquals() {
+        assertEquals(Route.builder().build(), Route.builder().build());
+    }
+
+    @Test
+    void hashCodeShouldEquals() {
+        assertEquals(Route.builder().build().hashCode(), Route.builder().build().hashCode());
+    }
+
+    @Test
+    void toStringShouldEquals() {
+        assertEquals(Route.builder().build().toString(), Route.builder().build().toString());
+    }
+
+    @Test
+    void builderToStringShouldEquals() {
+        assertEquals(Route.builder().toString(), Route.builder().toString());
+    }
+}


### PR DESCRIPTION
## Description
Adds the route resolvers for API Versioning

## Motivation and Context
Support other methods for API Versioning

## How Has This Been Tested?
Added unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
