### PR TITLE
Add api version handling to controllers

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
@@ -39,7 +39,8 @@ public class GraphQLAsyncQueryOperation extends AsyncQueryOperation {
         }
         UUID requestUUID = UUID.fromString(queryObj.getRequestId());
         //TODO - we need to add the baseUrlEndpoint to the queryObject.
-        ElideResponse response = runner.run("", queryObj.getQuery(), user, requestUUID, scope.getRequestHeaders());
+        ElideResponse response = runner.run(scope.getBaseUrlEndPoint(), queryObj.getQuery(), user, requestUUID,
+                scope.getRequestHeaders());
         log.debug("GRAPHQL_V1_0 getResponseCode: {}, GRAPHQL_V1_0 getBody: {}",
                 response.getResponseCode(), response.getBody());
         return response;

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
@@ -38,7 +38,6 @@ public class GraphQLAsyncQueryOperation extends AsyncQueryOperation {
             throw new InvalidOperationException("Invalid API Version");
         }
         UUID requestUUID = UUID.fromString(queryObj.getRequestId());
-        //TODO - we need to add the baseUrlEndpoint to the queryObject.
         ElideResponse response = runner.run(scope.getBaseUrlEndPoint(), queryObj.getQuery(), user, requestUUID,
                 scope.getRequestHeaders());
         log.debug("GRAPHQL_V1_0 getResponseCode: {}, GRAPHQL_V1_0 getBody: {}",

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
@@ -44,8 +44,8 @@ public class JsonApiAsyncQueryOperation extends AsyncQueryOperation {
         log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
 
         //TODO - we need to add the baseUrlEndpoint to the queryObject.
-        ElideResponse response = elide.get("", getPath(uri), queryParams, scope.getRequestHeaders(), user, apiVersion,
-                requestUUID);
+        ElideResponse response = elide.get(scope.getBaseUrlEndPoint(), getPath(uri), queryParams,
+                scope.getRequestHeaders(), user, apiVersion, requestUUID);
         log.debug("JSONAPI_V1_0 getResponseCode: {}, JSONAPI_V1_0 getBody: {}",
                 response.getResponseCode(), response.getBody());
         return response;

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/TableExportOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/TableExportOperation.java
@@ -165,6 +165,14 @@ public abstract class TableExportOperation implements Callable<AsyncApiResult> {
     public String generateDownloadURL(TableExport exportObj, RequestScope scope) {
         String downloadPath =  scope.getElideSettings().getExportApiPath();
         String baseURL = scope.getBaseUrlEndPoint();
+        String jsonApiPath = scope.getElideSettings().getJsonApiPath();
+        if (jsonApiPath != null && baseURL.endsWith(jsonApiPath)) {
+            baseURL = baseURL.substring(0, baseURL.length() - jsonApiPath.length());
+        }
+        String graphqlApiPath = scope.getElideSettings().getGraphQLApiPath();
+        if (graphqlApiPath != null && baseURL.endsWith(graphqlApiPath)) {
+            baseURL = baseURL.substring(0, baseURL.length() - graphqlApiPath.length());
+        }
         String extension = this.engine.isExtensionEnabled()
                 ? exportObj.getResultType().getFileExtensionType().getExtension()
                 : FileExtensionType.NONE.getExtension();

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/links/DefaultJsonApiLinks.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/links/DefaultJsonApiLinks.java
@@ -52,16 +52,10 @@ public class DefaultJsonApiLinks implements JsonApiLinks {
     protected String getResourceUrl(PersistentResource resource) {
         StringBuilder result = new StringBuilder();
 
-        if (StringUtils.isEmpty(baseUrl)) {
-            if (resource.getRequestScope().getBaseUrlEndPoint() != null) {
-                result.append(resource.getRequestScope().getBaseUrlEndPoint());
-                String jsonApiPath = resource.getRequestScope().getElideSettings().getJsonApiPath();
-                if (StringUtils.isNotEmpty(jsonApiPath)) {
-                    result.append(jsonApiPath);
-                }
-                result.append("/");
-            }
-        } else {
+        if (resource.getRequestScope().getBaseUrlEndPoint() != null) {
+            result.append(resource.getRequestScope().getBaseUrlEndPoint());
+            result.append("/");
+        } else if (!StringUtils.isEmpty(baseUrl)) {
             result.append(baseUrl);
         }
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
@@ -244,11 +244,6 @@ public class JsonApiEndpoint {
         if (path.endsWith("/")) {
             path = path.substring(0, path.length() - 1);
         }
-
-        if (uriInfo.getRequestUri().getPath().contains("/tableExport")) {
-            return baseUrl;
-        }
-
         return baseUrl + path;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
@@ -35,6 +35,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
@@ -91,7 +92,7 @@ public class JsonApiEndpoint {
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
-        MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
@@ -120,7 +121,7 @@ public class JsonApiEndpoint {
         @Context UriInfo uriInfo,
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext) {
-        MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
@@ -156,7 +157,7 @@ public class JsonApiEndpoint {
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
-        MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
@@ -188,7 +189,7 @@ public class JsonApiEndpoint {
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
-        MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -49,7 +49,7 @@ import java.util.Map;
 public class JsonApiTest {
     private JsonApiMapper mapper;
     private User user = new TestUser("0");
-    private static String BASE_URL = "http://localhost:8080";
+    private static String BASE_URL = "http://localhost:8080/json";
 
     private EntityDictionary dictionary;
     private DataStoreTransaction tx = mock(DataStoreTransaction.class, Answers.CALLS_REAL_METHODS);

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/metadata/MetaDataStore.java
@@ -244,6 +244,7 @@ public class MetaDataStore implements DataStore {
             metadataModelClasses.forEach(
                 cls -> dictionary.bindEntity(cls, IS_FIELD_HIDDEN)
             );
+            this.metadataDictionary.getApiVersions().forEach(dictionary.getApiVersions()::add);
         }
     }
 

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
@@ -112,6 +112,7 @@ public final class MultiplexManager implements DataStore {
 
                 // bind to multiplex dictionary
                 dictionary.bindEntity(binding);
+                subordinateDictionary.getApiVersions().forEach(dictionary.getApiVersions()::add);
             }
 
             for (Map.Entry<Type<?>, Function<RequestScope, PermissionExecutor>> entry

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -36,6 +36,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
@@ -102,12 +104,13 @@ public class GraphQLEndpoint {
             @Context SecurityContext securityContext,
             String graphQLDocument) {
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         User user = new SecurityContextUser(securityContext);
 
         String baseUrl = getBaseUrlEndpoint(uriInfo);
         String pathname = path;
         Route route = routeResolver.resolve(JSONAPI_CONTENT_TYPE, baseUrl, pathname, requestHeaders,
-                uriInfo.getQueryParameters());
+                queryParams);
 
         QueryRunner runner = runners.getOrDefault(route.getApiVersion(), null);
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -124,6 +124,7 @@ public class GraphQLEndpointTest {
         Mockito.when(user2.getUserPrincipal()).thenReturn(new User().withName("2"));
         Mockito.when(user3.getUserPrincipal()).thenReturn(new User().withName("3"));
         Mockito.when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost:8080/graphql"));
+        Mockito.when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
         Mockito.when(requestHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
     }
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -147,7 +147,7 @@ public class GraphQLEndpointTest {
                 );
 
         elide.doScans();
-        endpoint = new GraphQLEndpoint(elide, Optional.of(dataFetcherExceptionHandler));
+        endpoint = new GraphQLEndpoint(elide, Optional.of(dataFetcherExceptionHandler), Optional.empty());
 
         DataStoreTransaction tx = inMemoryStore.beginTransaction();
 
@@ -234,7 +234,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -287,7 +287,7 @@ public class GraphQLEndpointTest {
 
         Map<String, String> variables = new HashMap<>();
         variables.put("bookId", "1");
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest, variables));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest, variables));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -315,7 +315,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -335,7 +335,7 @@ public class GraphQLEndpointTest {
         //Empty response because the collection is skipped because of failed user check.
         String expected = "{\"data\":{\"book\":{\"edges\":[]}}}";
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -360,7 +360,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
         verify(elide).mapError(any());
     }
@@ -387,7 +387,7 @@ public class GraphQLEndpointTest {
            )
         ).toQuery();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
         JsonNode node = extract200Response(response);
         Iterator<JsonNode> errors = node.get("errors").elements();
         assertTrue(errors.hasNext());
@@ -421,7 +421,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
         verify(dataFetcherExceptionHandler).handleException(any());
 
@@ -449,7 +449,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post("", uriInfo, requestHeaders, user2, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -493,7 +493,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
 
         assertHasErrors(response);
 
@@ -540,7 +540,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -585,7 +585,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         String expectedLog = "On Title Update Pre Security\nOn Title Update Pre Commit\nOn Title Update Post Commit\n";
@@ -618,7 +618,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
 
         verify(audit, Mockito.times(1)).log(Mockito.any());
         verify(audit, Mockito.times(1)).commit();
@@ -667,7 +667,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
 
         graphQLRequest = document(
@@ -720,7 +720,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -749,7 +749,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user3, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user3, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
         verify(elide).mapError(any());
     }
@@ -804,7 +804,7 @@ public class GraphQLEndpointTest {
                 )
         ).toResponse();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, expected);
     }
 
@@ -829,7 +829,7 @@ public class GraphQLEndpointTest {
                 )
         ).toQuery();
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assertHasErrors(response);
         verify(elide).mapError(any());
     }
@@ -907,7 +907,7 @@ public class GraphQLEndpointTest {
         ).toResponse();
 
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -973,7 +973,7 @@ public class GraphQLEndpointTest {
         ).toResponse();
 
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
         assert200EqualBody(response, graphQLResponse);
     }
 
@@ -1057,7 +1057,7 @@ public class GraphQLEndpointTest {
         variables.put("author1", "1");
         variables.put("author2", "2");
 
-        Response response = endpoint.post(uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest, variables));
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest, variables));
         assert200EqualBody(response, graphQLResponse);
     }
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -108,6 +108,7 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                         .withEntityDictionary(dictionary)
                         .withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", Calendar.getInstance().getTimeZone())
                         .withExportApiPath("/export")
+                        .withGraphQLApiPath("/graphQL")
                         .build());
                 bind(elide).to(Elide.class).named("elide");
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/DefaultElideGroupedOpenApiCustomizer.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/DefaultElideGroupedOpenApiCustomizer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.api;
+
+import com.yahoo.elide.RefreshableElide;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.spring.config.ElideConfigProperties;
+import com.yahoo.elide.swagger.OpenApiBuilder;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+
+import io.swagger.v3.oas.models.OpenAPI;
+
+/**
+ * Default implementation for Elide OpenApiCustomizer to apply to the
+ * GroupedOpenApi to contribute to SpringDoc.
+ */
+public class DefaultElideGroupedOpenApiCustomizer implements ElideGroupedOpenApiCustomizer {
+
+    private final RefreshableElide elide;
+    private final ElideConfigProperties settings;
+    private final PathMatcher pathMatcher;
+
+    public DefaultElideGroupedOpenApiCustomizer(RefreshableElide elide, ElideConfigProperties settings,
+            PathMatcher pathMatcher) {
+        this.elide = elide;
+        this.settings = settings;
+        this.pathMatcher = pathMatcher;
+    }
+
+    public DefaultElideGroupedOpenApiCustomizer(RefreshableElide elide, ElideConfigProperties settings) {
+        this(elide, settings, new AntPathMatcher());
+    }
+
+    @Override
+    public void customize(GroupedOpenApi groupedOpenApi) {
+        groupedOpenApi.getOpenApiCustomizers().add(0, new ElideOpenApiCustomizer() {
+            @Override
+            public void customise(OpenAPI openApi) {
+                OpenApis.removePathsByTags(openApi, "graphql-controller", "api-docs-controller", "json-api-controller");
+            }
+        });
+        for (String apiVersion : this.elide.getElide().getElideSettings().getDictionary().getApiVersions()) {
+            String path = this.elide.getElide().getElideSettings().getJsonApiPath();
+            if (this.settings.getApiVersioningStrategy().getPath().isEnabled()) {
+                if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                    if (!path.endsWith("/")) {
+                        path = path + "/";
+                    }
+                    path = path + this.settings.getApiVersioningStrategy().getPath().getVersionPrefix() + apiVersion;
+                }
+            } else if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                // Regardless of the api versioning strategy the NO_VERSION one needs to be
+                // applied so other versions shall be skipped
+                continue;
+            }
+
+            if (match(groupedOpenApi, path)) {
+                String basePath = path;
+                groupedOpenApi.getOpenApiCustomizers().add(0, new ElideOpenApiCustomizer() {
+                    @Override
+                    public void customise(OpenAPI openApi) {
+                        OpenApiBuilder builder = new OpenApiBuilder(elide.getElide().getElideSettings().getDictionary())
+                                .apiVersion(apiVersion).basePath(basePath);
+                        builder.applyTo(openApi);
+                    }
+                });
+            }
+        }
+    }
+
+    protected boolean match(GroupedOpenApi groupedOpenApi, String path) {
+        // Check if the path matches
+        boolean matches = false;
+        if (groupedOpenApi.getPathsToMatch() != null) {
+            for (String pathToMatch : groupedOpenApi.getPathsToMatch()) {
+                if (pathMatcher.match(pathToMatch, path)) {
+                    matches = true;
+                    break;
+                }
+            }
+        }
+        if (matches && groupedOpenApi.getPathsToExclude() != null) {
+            for (String pathToExclude : groupedOpenApi.getPathsToExclude()) {
+                if (pathMatcher.match(pathToExclude, path)) {
+                    matches = false;
+                    break;
+                }
+            }
+        }
+        return matches;
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/DefaultElideOpenApiCustomizer.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/DefaultElideOpenApiCustomizer.java
@@ -6,14 +6,11 @@
 package com.yahoo.elide.spring.api;
 
 import com.yahoo.elide.RefreshableElide;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.spring.config.ElideConfigProperties;
 import com.yahoo.elide.swagger.OpenApiBuilder;
 
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Paths;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Default implementation for Elide OpenApiCustomizer to contribute to SpringDoc.
@@ -21,19 +18,34 @@ import java.util.Set;
 public class DefaultElideOpenApiCustomizer implements ElideOpenApiCustomizer {
 
     private final RefreshableElide elide;
-    private final String apiVersion;
+    private final ElideConfigProperties settings;
 
-    public DefaultElideOpenApiCustomizer(RefreshableElide elide, String apiVersion) {
+    public DefaultElideOpenApiCustomizer(RefreshableElide elide, ElideConfigProperties settings) {
         this.elide = elide;
-        this.apiVersion = apiVersion;
+        this.settings = settings;
     }
 
     @Override
     public void customise(OpenAPI openApi) {
         removePaths(openApi);
-        new OpenApiBuilder(this.elide.getElide().getElideSettings().getDictionary())
-                .apiVersion(this.apiVersion)
-                .basePath(this.elide.getElide().getElideSettings().getJsonApiPath()).applyTo(openApi);
+        for (String apiVersion : this.elide.getElide().getElideSettings().getDictionary().getApiVersions()) {
+            OpenApiBuilder builder = new OpenApiBuilder(this.elide.getElide().getElideSettings().getDictionary())
+                    .apiVersion(apiVersion).basePath(this.elide.getElide().getElideSettings().getJsonApiPath());
+            if (this.settings.getApiVersioningStrategy().getPath().isEnabled()) {
+                if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                    String path = this.elide.getElide().getElideSettings().getJsonApiPath();
+                    if (!path.endsWith("/")) {
+                        path = path + "/";
+                    }
+                    path = path + this.settings.getApiVersioningStrategy().getPath().getVersionPrefix() + apiVersion;
+                    builder.basePath(path);
+                }
+            } else if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                // Regardless of the api versioning strategy the NO_VERSION one needs to be
+                // applied so other versions shall be skipped
+            }
+            builder.applyTo(openApi);
+        }
     }
 
     /**
@@ -42,34 +54,6 @@ public class DefaultElideOpenApiCustomizer implements ElideOpenApiCustomizer {
      * @param openApi the document to remove paths from
      */
     protected void removePaths(OpenAPI openApi) {
-        removePathsByTags(openApi, "graphql-controller", "api-docs-controller", "json-api-controller");
-    }
-
-    public static void removePathsByTags(OpenAPI openApi, String... tagsToRemove) {
-        Set<String> tags = new HashSet<>();
-        Collections.addAll(tags, tagsToRemove);
-        removePathsByTags(openApi, tags);
-    }
-
-    public static void removePathsByTags(OpenAPI openApi, Set<String> tagsToRemove) {
-        Set<String> pathsToRemove = new HashSet<>();
-        Paths paths = openApi.getPaths();
-        if (paths != null) {
-            openApi.getPaths().forEach((path, pathItem) -> {
-                Set<String> tags = new HashSet<>();
-                if (pathItem.getGet() != null) {
-                    tags.addAll(pathItem.getGet().getTags());
-                } else if (pathItem.getPost() != null) {
-                    tags.addAll(pathItem.getPost().getTags());
-                }
-                for (String tagToRemove : tagsToRemove) {
-                    if (tags.contains(tagToRemove)) {
-                        pathsToRemove.add(path);
-                        break;
-                    }
-                }
-            });
-        }
-        pathsToRemove.forEach(key -> openApi.getPaths().remove(key));
+        OpenApis.removePathsByTags(openApi, "graphql-controller", "api-docs-controller", "json-api-controller");
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/ElideGroupedOpenApiCustomizer.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/ElideGroupedOpenApiCustomizer.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.api;
+
+import org.springdoc.core.models.GroupedOpenApi;
+
+/**
+ * Customize the GroupedOpenApi.
+ */
+public interface ElideGroupedOpenApiCustomizer {
+    void customize(GroupedOpenApi groupedOpenApi);
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/OpenApis.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/OpenApis.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.api;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility methods for processing OpenAPI.
+ */
+public class OpenApis {
+    private OpenApis() {
+    }
+
+    public static void removePathsByTags(OpenAPI openApi, String... tagsToRemove) {
+        Set<String> tags = new HashSet<>();
+        Collections.addAll(tags, tagsToRemove);
+        removePathsByTags(openApi, tags);
+    }
+
+    public static void removePathsByTags(OpenAPI openApi, Set<String> tagsToRemove) {
+        Set<String> pathsToRemove = new HashSet<>();
+        Paths paths = openApi.getPaths();
+        if (paths != null) {
+            openApi.getPaths().forEach((path, pathItem) -> {
+                Set<String> tags = new HashSet<>();
+                if (pathItem.getGet() != null) {
+                    tags.addAll(pathItem.getGet().getTags());
+                } else if (pathItem.getPost() != null) {
+                    tags.addAll(pathItem.getPost().getTags());
+                }
+                for (String tagToRemove : tagsToRemove) {
+                    if (tags.contains(tagToRemove)) {
+                        pathsToRemove.add(path);
+                        break;
+                    }
+                }
+            });
+        }
+        pathsToRemove.forEach(key -> openApi.getPaths().remove(key));
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ApiVersioningStrategyProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ApiVersioningStrategyProperties.java
@@ -33,7 +33,7 @@ public class ApiVersioningStrategyProperties {
     @Data
     public static class MediaTypeProfile {
         private boolean enabled = false;
-        private String versionPrefix = "";
+        private String versionPrefix = "v";
         private String uriPrefix = "";
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ApiVersioningStrategyProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ApiVersioningStrategyProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.config;
+
+import lombok.Data;
+
+/**
+ * Properties to configure the API Versioning Strategy.
+ */
+@Data
+public class ApiVersioningStrategyProperties {
+    @Data
+    public static class Path {
+        private boolean enabled = true;
+        private String versionPrefix = "v";
+    }
+
+    @Data
+    public static class Header {
+        private boolean enabled = false;
+        private String[] headerName = new String[] { "Accept-Version" };
+    }
+
+    @Data
+    public static class Parameter {
+        private boolean enabled = false;
+        private String parameterName = "v";
+    }
+
+    @Data
+    public static class MediaTypeProfile {
+        private boolean enabled = false;
+        private String versionPrefix = "";
+        private String uriPrefix = "";
+    }
+
+    private Path path = new Path();
+    private Header header = new Header();
+    private Parameter parameter = new Parameter();
+    private MediaTypeProfile mediaTypeProfile = new MediaTypeProfile();
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -723,8 +723,9 @@ public class ElideAutoConfiguration {
             @Bean
             @RefreshScope
             @ConditionalOnMissingBean(name = "apiDocsController")
-            public ApiDocsController apiDocsController(ApiDocsController.ApiDocsRegistrations docs) {
-                return new ApiDocsController(docs);
+            public ApiDocsController apiDocsController(ApiDocsController.ApiDocsRegistrations docs,
+                    RouteResolver routeResolver, ElideConfigProperties elideConfigProperties) {
+                return new ApiDocsController(docs, routeResolver, elideConfigProperties);
             }
 
             @Bean
@@ -810,8 +811,9 @@ public class ElideAutoConfiguration {
 
             @Bean
             @ConditionalOnMissingBean(name = "apiDocsController")
-            public ApiDocsController apiDocsController(ApiDocsController.ApiDocsRegistrations docs) {
-                return new ApiDocsController(docs);
+            public ApiDocsController apiDocsController(ApiDocsController.ApiDocsRegistrations docs,
+                    RouteResolver routeResolver, ElideConfigProperties elideConfigProperties) {
+                return new ApiDocsController(docs, routeResolver, elideConfigProperties);
             }
 
             @Bean

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -61,7 +61,9 @@ import com.yahoo.elide.modelconfig.store.ConfigDataStore;
 import com.yahoo.elide.modelconfig.store.models.ConfigChecks;
 import com.yahoo.elide.modelconfig.validator.DynamicConfigValidator;
 import com.yahoo.elide.spring.api.BasicOpenApiDocumentCustomizer;
+import com.yahoo.elide.spring.api.DefaultElideGroupedOpenApiCustomizer;
 import com.yahoo.elide.spring.api.DefaultElideOpenApiCustomizer;
+import com.yahoo.elide.spring.api.ElideGroupedOpenApiCustomizer;
 import com.yahoo.elide.spring.api.ElideOpenApiCustomizer;
 import com.yahoo.elide.spring.api.OpenApiDocumentCustomizer;
 import com.yahoo.elide.spring.controllers.ApiDocsController;
@@ -83,6 +85,7 @@ import com.yahoo.elide.utils.HeaderUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -92,6 +95,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ApplicationContext;
@@ -111,6 +115,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.extern.slf4j.Slf4j;
@@ -694,8 +700,27 @@ public class ElideAutoConfiguration {
         @Bean
         @ConditionalOnMissingBean
         @Scope(SCOPE_PROTOTYPE)
-        public ElideOpenApiCustomizer elideOpenApiCustomizer(RefreshableElide elide) {
-            return new DefaultElideOpenApiCustomizer(elide, EntityDictionary.NO_VERSION);
+        public ElideOpenApiCustomizer elideOpenApiCustomizer(RefreshableElide elide, ElideConfigProperties properties) {
+            return new DefaultElideOpenApiCustomizer(elide, properties);
+        }
+
+        @Bean
+        @Scope(SCOPE_PROTOTYPE)
+        public ElideGroupedOpenApiCustomizer elideGroupedOpenApiCustomizer(RefreshableElide elide,
+                ElideConfigProperties properties) {
+            return new DefaultElideGroupedOpenApiCustomizer(elide, properties);
+        }
+
+        @Configuration
+        public static class ElideGroupedOpenApiConfiguration {
+            public ElideGroupedOpenApiConfiguration(Optional<List<GroupedOpenApi>> optionalGroupedOpenApis,
+                    ObjectProvider<ElideGroupedOpenApiCustomizer> customizerProvider) {
+                optionalGroupedOpenApis.ifPresent(groupedOpenApis -> {
+                    for (GroupedOpenApi groupedOpenApi : groupedOpenApis) {
+                        customizerProvider.orderedStream().forEach(customizer -> customizer.customize(groupedOpenApi));
+                    }
+                });
+            }
         }
     }
 
@@ -750,8 +775,10 @@ public class ElideAutoConfiguration {
             @RefreshScope
             @ConditionalOnMissingBean
             public ApiDocsController.ApiDocsRegistrations apiDocsRegistrations(RefreshableElide elide,
-                    ElideConfigProperties settings, OpenApiDocumentCustomizer customizer) {
-                return buildApiDocsRegistrations(elide, settings, customizer);
+                    ElideConfigProperties settings, ServerProperties serverProperties,
+                    OpenApiDocumentCustomizer customizer) {
+                return buildApiDocsRegistrations(elide, settings, serverProperties.getServlet().getContextPath(),
+                        customizer);
             }
 
             @Bean
@@ -839,8 +866,10 @@ public class ElideAutoConfiguration {
             @Bean
             @ConditionalOnMissingBean
             public ApiDocsController.ApiDocsRegistrations apiDocsRegistrations(RefreshableElide elide,
-                    ElideConfigProperties settings, OpenApiDocumentCustomizer customizer) {
-                return buildApiDocsRegistrations(elide, settings, customizer);
+                    ElideConfigProperties settings, ServerProperties serverProperties,
+                    OpenApiDocumentCustomizer customizer) {
+                return buildApiDocsRegistrations(elide, settings, serverProperties.getServlet().getContextPath(),
+                        customizer);
             }
 
             @Bean
@@ -928,8 +957,8 @@ public class ElideAutoConfiguration {
     }
 
     public static ApiDocsController.ApiDocsRegistrations buildApiDocsRegistrations(RefreshableElide elide,
-            ElideConfigProperties settings, OpenApiDocumentCustomizer customizer) {
-        String jsonApiPath = settings.getJsonApi() != null ? settings.getJsonApi().getPath() : null;
+            ElideConfigProperties settings, String contextPath, OpenApiDocumentCustomizer customizer) {
+        String jsonApiPath = settings.getJsonApi() != null ? settings.getJsonApi().getPath() : "";
 
         EntityDictionary dictionary = elide.getElide().getElideSettings().getDictionary();
 
@@ -938,9 +967,30 @@ public class ElideAutoConfiguration {
             Supplier<OpenAPI> document = () -> {
                 OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(apiVersion)
                         .supportLegacyFilterDialect(false);
+                if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                    if (settings.getApiVersioningStrategy().getPath().isEnabled()) {
+                        // Path needs to be set
+                        builder.basePath(
+                                "/" + settings.getApiVersioningStrategy().getPath().getVersionPrefix() + apiVersion);
+                    } else if (settings.getApiVersioningStrategy().getHeader().isEnabled()) {
+                        // Header needs to be set
+                        builder.globalParameter(new Parameter().in("header")
+                                .name(settings.getApiVersioningStrategy().getHeader().getHeaderName()[0]).required(true)
+                                .schema(new StringSchema().addEnumItem(apiVersion)));
+                    } else if (settings.getApiVersioningStrategy().getParameter().isEnabled()) {
+                        // Header needs to be set
+                        builder.globalParameter(new Parameter().in("query")
+                                .name(settings.getApiVersioningStrategy().getParameter().getParameterName())
+                                .required(true).schema(new StringSchema().addEnumItem(apiVersion)));
+                    }
+                }
+                String url = contextPath != null ? contextPath : "";
+                url = url + jsonApiPath;
+                if (url.isBlank()) {
+                    url = "/";
+                }
                 OpenAPI openApi = builder.build();
-                openApi.addServersItem(new Server().url(jsonApiPath));
-                customizer.customize(openApi);
+                openApi.addServersItem(new Server().url(url));
                 if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
                     Info info = openApi.getInfo();
                     if (info == null) {
@@ -949,10 +999,12 @@ public class ElideAutoConfiguration {
                     }
                     info.setVersion(apiVersion);
                 }
+                customizer.customize(openApi);
                 return openApi;
             };
             registrations.add(new ApiDocsRegistration("", SingletonSupplier.of(document),
-                    settings.getApiDocs().getVersion().getValue(), apiVersion));        });
+                    settings.getApiDocs().getVersion().getValue(), apiVersion));
+        });
         return new ApiDocsController.ApiDocsRegistrations(registrations);
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideConfigProperties.java
@@ -54,6 +54,12 @@ public class ElideConfigProperties {
     private JpaStoreProperties jpaStore = new JpaStoreProperties();
 
     /**
+     * Settings for the API Versioning Strategy.
+     */
+    @NestedConfigurationProperty
+    private ApiVersioningStrategyProperties apiVersioningStrategy = new ApiVersioningStrategyProperties();
+
+    /**
      * Default pagination size for collections if the client doesn't paginate.
      */
     private int pageSize = 500;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ApiDocsController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ApiDocsController.java
@@ -203,15 +203,25 @@ public class ApiDocsController {
         }
     }
 
+    /**
+     * Determines the base url for the api docs controller. eg. http://www.example.org/api-docs.
+     *
+     * @param prefix the api docs path eg. /api-docs
+     * @return the base url for api docs
+     */
     protected String getBaseUrl(String prefix) {
+        // The base url of the application eg. http://www.example.org
         String baseUrl = elideConfigProperties.getBaseUrl();
 
         if (StringUtils.isEmpty(baseUrl)) {
+            // If not specified get from the current context path
+            // Ie. including server.servlet.context-path
             baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
         }
 
         if (prefix.length() > 1) {
             if (baseUrl.endsWith("/")) {
+                // Remove trailing / from application base url before appending
                 baseUrl = baseUrl.substring(0, baseUrl.length() - 1) + prefix;
             } else {
                 baseUrl = baseUrl + prefix;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -7,7 +7,6 @@ package com.yahoo.elide.spring.controllers;
 
 import static com.yahoo.elide.graphql.QueryRunner.buildErrorResponse;
 
-import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.request.route.Route;
@@ -91,7 +90,7 @@ public class GraphqlController {
                                                  Authentication principal) {
         final User user = new AuthenticationUser(principal);
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
-        final String prefix = settings.getJsonApi().getPath();
+        final String prefix = settings.getGraphql().getPath();
         final String baseUrl = getBaseUrl(prefix);
         final String pathname = getPath(request, prefix);
         Route route = routeResolver.resolve(JSON_CONTENT_TYPE, baseUrl, pathname, requestHeaders, allRequestParams);
@@ -106,7 +105,6 @@ public class GraphqlController {
                 if (runner == null) {
                     response = buildErrorResponse(mapper, new InvalidOperationException("Invalid API Version"), false);
                 } else {
-                    Elide elide = runner.getElide();
                     response = runner.run(route.getBaseUrl(), graphQLDocument, user, UUID.randomUUID(),
                             requestHeadersCleaned);
                 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -10,6 +10,8 @@ import static com.yahoo.elide.graphql.QueryRunner.buildErrorResponse;
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideResponse;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
+import com.yahoo.elide.core.request.route.Route;
+import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.graphql.QueryRunners;
@@ -17,17 +19,24 @@ import com.yahoo.elide.jsonapi.JsonApiMapper;
 import com.yahoo.elide.spring.config.ElideConfigProperties;
 import com.yahoo.elide.spring.security.AuthenticationUser;
 import com.yahoo.elide.utils.HeaderUtils;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+
 
 /**
  * Spring rest controller for Elide GraphQL.
@@ -48,6 +58,7 @@ public class GraphqlController {
     private final QueryRunners runners;
     private final ObjectMapper mapper;
     private final HeaderUtils.HeaderProcessor headerProcessor;
+    private final RouteResolver routeResolver;
 
     private static final String JSON_CONTENT_TYPE = "application/json";
 
@@ -55,12 +66,14 @@ public class GraphqlController {
             QueryRunners runners,
             JsonApiMapper jsonApiMapper,
             HeaderUtils.HeaderProcessor headerProcessor,
-            ElideConfigProperties settings) {
+            ElideConfigProperties settings,
+            RouteResolver routeResolver) {
         log.debug("Started ~~");
         this.runners = runners;
         this.settings = settings;
         this.headerProcessor = headerProcessor;
         this.mapper = jsonApiMapper.getObjectMapper();
+        this.routeResolver = routeResolver;
     }
 
     /**
@@ -73,12 +86,17 @@ public class GraphqlController {
      */
     @PostMapping(value = {"/**", ""}, consumes = JSON_CONTENT_TYPE, produces = JSON_CONTENT_TYPE)
     public Callable<ResponseEntity<String>> post(@RequestHeader HttpHeaders requestHeaders,
-                                                 @RequestBody String graphQLDocument, Authentication principal) {
+                                                 @RequestParam MultiValueMap<String, String> allRequestParams,
+                                                 @RequestBody String graphQLDocument, HttpServletRequest request,
+                                                 Authentication principal) {
         final User user = new AuthenticationUser(principal);
-        final String apiVersion = HeaderUtils.resolveApiVersion(requestHeaders);
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
-        final QueryRunner runner = runners.getRunner(apiVersion);
-        final String baseUrl = getBaseUrlEndpoint();
+        final String prefix = settings.getJsonApi().getPath();
+        final String baseUrl = getBaseUrl(prefix);
+        final String pathname = getPath(request, prefix);
+        Route route = routeResolver.resolve(JSON_CONTENT_TYPE, baseUrl, pathname, requestHeaders, allRequestParams);
+
+        final QueryRunner runner = runners.getRunner(route.getApiVersion());
 
         return new Callable<ResponseEntity<String>>() {
             @Override
@@ -89,7 +107,8 @@ public class GraphqlController {
                     response = buildErrorResponse(mapper, new InvalidOperationException("Invalid API Version"), false);
                 } else {
                     Elide elide = runner.getElide();
-                    response = runner.run(baseUrl, graphQLDocument, user, UUID.randomUUID(), requestHeadersCleaned);
+                    response = runner.run(route.getBaseUrl(), graphQLDocument, user, UUID.randomUUID(),
+                            requestHeadersCleaned);
                 }
 
                 return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
@@ -97,12 +116,28 @@ public class GraphqlController {
         };
     }
 
-    protected String getBaseUrlEndpoint() {
-        String baseUrl = settings.getBaseUrl();
+    private String getPath(HttpServletRequest request, String prefix) {
+        String pathname = (String) request
+                .getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+
+        return pathname.replaceFirst(prefix, "");
+    }
+
+    protected String getBaseUrl(String prefix) {
+        String baseUrl = this.settings.getBaseUrl();
 
         if (StringUtils.isEmpty(baseUrl)) {
             baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
         }
+
+        if (prefix.length() > 1) {
+            if (baseUrl.endsWith("/")) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - 1) + prefix;
+            } else {
+                baseUrl = baseUrl + prefix;
+            }
+        }
+
         return baseUrl;
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -97,11 +97,8 @@ public class JsonApiController {
                                                       HttpServletRequest request, Authentication authentication) {
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         String prefix = settings.getJsonApi().getPath();
-        final String pathname = getPath(request, prefix);
-        if (request.getRequestURI().startsWith(prefix + "/tableExport")) {
-            prefix = "";
-        }
         final String baseUrl = getBaseUrl(prefix);
+        final String pathname = getPath(request, prefix);
         Route route = routeResolver.resolve(JSON_API_CONTENT_TYPE, baseUrl, pathname, requestHeaders, allRequestParams);
         final User user = new AuthenticationUser(authentication);
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTest.java
@@ -16,7 +16,9 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.annotation.UserConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -35,7 +37,8 @@ class ElideAutoConfigurationTest {
     private static final String SCOPE_REFRESH = "refresh";
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(ElideAutoConfiguration.class, DataSourceAutoConfiguration.class,
-                    HibernateJpaAutoConfiguration.class, TransactionAutoConfiguration.class, RefreshAutoConfiguration.class));
+                    HibernateJpaAutoConfiguration.class, TransactionAutoConfiguration.class,
+                    RefreshAutoConfiguration.class, ServerConfiguration.class));
 
     @Test
     void nonRefreshable() {
@@ -128,6 +131,11 @@ class ElideAutoConfigurationTest {
         public UserJsonApiController jsonApiController() {
             return new UserJsonApiController();
         }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(ServerProperties.class)
+    public static class ServerConfiguration {
     }
 
     enum OverrideControllerInput {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreTest.java
@@ -23,8 +23,8 @@ import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 import com.yahoo.elide.core.exceptions.HttpStatus;
+import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.modelconfig.store.models.ConfigFile.ConfigFileType;
-import com.yahoo.elide.spring.controllers.JsonApiController;
 import com.yahoo.elide.test.graphql.GraphQLDSL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -432,7 +432,7 @@ public class ConfigStoreTest {
                 + "}";
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -506,7 +506,7 @@ public class ConfigStoreTest {
                 + "}";
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -525,7 +525,7 @@ public class ConfigStoreTest {
                 .statusCode(HttpStatus.SC_CREATED);
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -575,7 +575,7 @@ public class ConfigStoreTest {
                 + "}";
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -620,7 +620,7 @@ public class ConfigStoreTest {
                 + "}";
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -639,7 +639,7 @@ public class ConfigStoreTest {
                 .statusCode(HttpStatus.SC_CREATED);
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -667,7 +667,7 @@ public class ConfigStoreTest {
         String hjson = "#!/bin/sh ...";
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -712,7 +712,7 @@ public class ConfigStoreTest {
                 + "}";
 
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -158,6 +158,29 @@ public class ControllerTest extends IntegrationTest {
     }
 
     @Test
+    public void versionedJsonApiGetPathTest() {
+        given()
+                .when()
+                .get("/json/v1.0/group")
+                .then()
+                .body(equalTo(
+                        data(
+                                resource(
+                                        type("group"),
+                                        id("com.example.repository"),
+                                        attributes(
+                                                attr("title", "Example Repository")
+                                        ),
+                                        links(
+                                                attr("self", baseUrl + "v1.0/group/com.example.repository")
+                                        )
+                                )
+                        ).toJSON())
+                )
+                .statusCode(HttpStatus.SC_OK);
+    }
+
+    @Test
     public void jsonApiPatchTest() {
         given()
                 .contentType(JsonApiController.JSON_API_CONTENT_TYPE)

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.yahoo.elide.core.exceptions.HttpStatus;
-import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.test.graphql.GraphQLDSL;
 import com.yahoo.elide.test.jsonapi.elements.AtomicOperationCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -183,7 +183,7 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiPatchTest() {
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -237,7 +237,7 @@ public class ControllerTest extends IntegrationTest {
     public void jsonApiPostLidTest() {
         String personId = "1";
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -293,7 +293,7 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonForbiddenApiPatchTest() {
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -315,8 +315,8 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiPatchExtensionTest() {
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_PATCH_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_PATCH_CONTENT_TYPE)
+                .contentType(JsonApi.JsonPatch.MEDIA_TYPE)
+                .accept(JsonApi.JsonPatch.MEDIA_TYPE)
                 .body(
                         patchSet(
                                 patchOperation(add, "/group",
@@ -359,8 +359,8 @@ public class ControllerTest extends IntegrationTest {
         assertEquals(expected, result);
 
         ExtractableResponse<Response> deleteResponse = given()
-                .contentType(JsonApiController.JSON_API_PATCH_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_PATCH_CONTENT_TYPE)
+                .contentType(JsonApi.JsonPatch.MEDIA_TYPE)
+                .accept(JsonApi.JsonPatch.MEDIA_TYPE)
                 .body(
                         patchSet(
                                 patchOperation(remove, "/group",
@@ -391,8 +391,8 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiAtomicOperationsExtensionTest() {
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.add, "/group",
@@ -454,8 +454,8 @@ public class ControllerTest extends IntegrationTest {
         assertEquals(expected, result);
 
         ExtractableResponse<Response> deleteResponse = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.remove,
@@ -487,8 +487,8 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiAtomicOperationsExtensionPathInferTest() {
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.add,
@@ -531,8 +531,8 @@ public class ControllerTest extends IntegrationTest {
         assertEquals(expected, result);
 
         ExtractableResponse<Response> deleteResponse = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.remove,
@@ -563,8 +563,8 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiAtomicOperationsExtensionLidTest() {
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.add,
@@ -630,8 +630,8 @@ public class ControllerTest extends IntegrationTest {
         String publisherId = response.path("'atomic:results'[2].data.id");
 
         ExtractableResponse<Response> deleteResponse = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.remove,
@@ -669,8 +669,8 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiAtomicOperationsExtensionRelationshipTest() {
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.add,
@@ -720,8 +720,8 @@ public class ControllerTest extends IntegrationTest {
         assertEquals(expected, result);
 
         ExtractableResponse<Response> deleteResponse = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.remove,
@@ -764,8 +764,8 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiAtomicOperationsExtensionMissingRefTypeTest() {
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.add,
@@ -790,8 +790,8 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiAtomicOperationsExtensionMissingRefAndHrefTest() {
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(
                         atomicOperations(
                                 atomicOperation(AtomicOperationCode.add,
@@ -828,8 +828,8 @@ public class ControllerTest extends IntegrationTest {
                             """;
 
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(body)
                 .when()
                 .post("/json/operations")
@@ -859,8 +859,8 @@ public class ControllerTest extends IntegrationTest {
                       """;
 
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(body)
                 .when()
                 .post("/json/operations")
@@ -881,8 +881,8 @@ public class ControllerTest extends IntegrationTest {
                       """;
 
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(body)
                 .when()
                 .post("/json/operations")
@@ -899,8 +899,8 @@ public class ControllerTest extends IntegrationTest {
         String body = """
                 {"<script src=''></script>"}""";
         ExtractableResponse<Response> response = given()
-                .contentType(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
-                .accept(JsonApiController.JSON_API_ATOMIC_OPERATIONS_CONTENT_TYPE)
+                .contentType(JsonApi.AtomicOperations.MEDIA_TYPE)
+                .accept(JsonApi.AtomicOperations.MEDIA_TYPE)
                 .body(body)
                 .when()
                 .post("/json/operations")
@@ -915,7 +915,7 @@ public class ControllerTest extends IntegrationTest {
     @Test
     public void jsonApiPostTest() {
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -972,7 +972,7 @@ public class ControllerTest extends IntegrationTest {
         when()
                 .delete("/json/group/doestnotexist")
                 .then()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .statusCode(HttpStatus.SC_NOT_FOUND);
     }
 
@@ -983,7 +983,7 @@ public class ControllerTest extends IntegrationTest {
     })
     public void jsonApiDeleteRelationshipTest() {
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(datum(
                         linkage(type("product"), id("foo"))
                 ))

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableVerboseErrorsTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableVerboseErrorsTest.java
@@ -15,7 +15,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import com.yahoo.elide.core.exceptions.HttpStatus;
-import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.yahoo.elide.jsonapi.JsonApi;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 
@@ -32,7 +32,7 @@ public class DisableVerboseErrorsTest extends IntegrationTest {
     @Test
     public void verboseErrorsEnabledTest() {
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/EnableVerboseErrorsTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/EnableVerboseErrorsTest.java
@@ -15,7 +15,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 import com.yahoo.elide.core.exceptions.HttpStatus;
-import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.yahoo.elide.jsonapi.JsonApi;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 
@@ -32,7 +32,7 @@ public class EnableVerboseErrorsTest extends IntegrationTest {
     @Test
     public void verboseErrorsEnabledTest() {
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderCleansingTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderCleansingTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 
 import com.yahoo.elide.RefreshableElide;
 import com.yahoo.elide.core.exceptions.HttpStatus;
-import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.yahoo.elide.jsonapi.JsonApi;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +90,7 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.ACCEPT_LANGUAGE, "en-US")
                 .queryParam(SORT_PARAM, "name", "description")
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -148,7 +148,7 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
                 .queryParam(SORT_PARAM, "name", "description")
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -215,7 +215,7 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
                 .queryParam(SORT_PARAM, "name", "description")
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(datum(
                         linkage(type("product"), id("foo"))
                 ))

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderIdentityTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderIdentityTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 
 import com.yahoo.elide.RefreshableElide;
 import com.yahoo.elide.core.exceptions.HttpStatus;
-import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.yahoo.elide.jsonapi.JsonApi;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -91,7 +91,7 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.ACCEPT_LANGUAGE, "en-US")
                 .queryParam(SORT_PARAM, "name", "description")
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -149,7 +149,7 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
                 .queryParam(SORT_PARAM, "name", "description")
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         datum(
                                 resource(
@@ -216,7 +216,7 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
                 .queryParam(SORT_PARAM, "name", "description")
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(datum(
                         linkage(type("product"), id("foo"))
                 ))

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/SubscriptionTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/SubscriptionTest.java
@@ -17,7 +17,7 @@ import static io.restassured.RestAssured.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketTestClient;
-import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.yahoo.elide.jsonapi.JsonApi;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +44,7 @@ public class SubscriptionTest extends IntegrationTest {
             client.waitOnSubscribe(10);
 
             given()
-                    .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                    .contentType(JsonApi.MEDIA_TYPE)
                     .body(
                             datum(
                                     resource(

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/Update200StatusTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/Update200StatusTest.java
@@ -8,7 +8,7 @@ package example.tests;
 import static io.restassured.RestAssured.given;
 
 import com.yahoo.elide.core.exceptions.HttpStatus;
-import com.yahoo.elide.spring.controllers.JsonApiController;
+import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.test.jsonapi.JsonApiDSL;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,7 +40,7 @@ public class Update200StatusTest extends IntegrationTest {
     @Test
     public void jsonApiPatchTest() {
         given()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .body(
                         JsonApiDSL.datum(
                                 JsonApiDSL.resource(
@@ -55,7 +55,7 @@ public class Update200StatusTest extends IntegrationTest {
                 .when()
                 .patch("/json/group/com.example.repository")
                 .then()
-                .contentType(JsonApiController.JSON_API_CONTENT_TYPE)
+                .contentType(JsonApi.MEDIA_TYPE)
                 .statusCode(HttpStatus.SC_OK);
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/application.yaml
@@ -16,6 +16,11 @@ elide:
   api-docs:
     path: /doc
     enabled: true
+  api-versioning-strategy:
+    header:
+      enabled: true
+      header-name:
+      - ApiVersion
   async:
     enabled: true
     thread-pool-size: 7

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -32,6 +32,7 @@ import com.yahoo.elide.core.TransactionRegistry;
 import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
+import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.utils.ClassScanner;
 import com.yahoo.elide.datastores.aggregation.AggregationDataStore;
@@ -233,6 +234,9 @@ public class ElideResourceConfig extends ResourceConfig {
                         asyncProperties.enabled())).to(Set.class).named("elideAllModels");
                 bind(settings.getDataFetcherExceptionHandler()).to(DataFetcherExceptionHandler.class)
                         .named("dataFetcherExceptionHandler");
+                if (settings.getRouteResolver() != null) {
+                    bind(settings.getRouteResolver()).to(RouteResolver.class).named("routeResolver");
+                }
             }
         });
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -168,8 +168,8 @@ public interface ElideStandaloneSettings {
                 .withJoinFilterDialect(RSQLFilterDialect.builder().dictionary(dictionary).build())
                 .withSubqueryFilterDialect(RSQLFilterDialect.builder().dictionary(dictionary).build())
                 .withBaseUrl(getBaseUrl())
-                .withJsonApiPath(getJsonApiPathSpec().replaceAll("/\\*", ""))
-                .withGraphQLApiPath(getGraphQLApiPathSpec().replaceAll("/\\*", ""))
+                .withJsonApiPath(getJsonApiPathSpec().replace("/*", ""))
+                .withGraphQLApiPath(getGraphQLApiPathSpec().replace("/*", ""))
                 .withJsonApiMapper(mapper)
                 .withAuditLogger(getAuditLogger());
 
@@ -216,21 +216,21 @@ public interface ElideStandaloneSettings {
     /**
      * API root path specification for JSON-API. Namely, this is the mount point of your API.
      * By default it will look something like:
-     *   <strong>yourcompany.com/api/v1/YOUR_ENTITY</strong>
+     *   <strong>yourcompany.com/api/YOUR_ENTITY</strong>
      *
-     * @return Default: /api/v1/*
+     * @return Default: /api/*
      */
     default String getJsonApiPathSpec() {
-        return "/api/v1/*";
+        return "/api/*";
     }
 
     /**
      * API root path specification for the GraphQL endpoint. Namely, this is the root uri for GraphQL.
      *
-     * @return Default: /graphql/api/v1
+     * @return Default: /graphql/api
      */
     default String getGraphQLApiPathSpec() {
-        return "/graphql/api/v1/*";
+        return "/graphql/api/*";
     }
 
     /**
@@ -361,9 +361,13 @@ public interface ElideStandaloneSettings {
                     .title(getApiTitle())
                     .version(apiVersion);
             OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(apiVersion);
+            if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                // Path needs to be set
+                builder.basePath("/" + "v" + apiVersion);
+            }
             String moduleBasePath = getJsonApiPathSpec().replace("/*", "");
             OpenAPI openApi = builder.build().info(info).addServersItem(new Server().url(moduleBasePath));
-            docs.add(new ApiDocsEndpoint.ApiDocsRegistration("test", () -> openApi, getOpenApiVersion().getValue(),
+            docs.add(new ApiDocsEndpoint.ApiDocsRegistration("", () -> openApi, getOpenApiVersion().getValue(),
                     apiVersion));
         });
 

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.dictionary.Injector;
 import com.yahoo.elide.core.exceptions.ErrorMapper;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.prefab.Role;
 import com.yahoo.elide.core.type.ClassType;
@@ -648,5 +649,14 @@ public interface ElideStandaloneSettings {
      */
     default DataFetcherExceptionHandler getDataFetcherExceptionHandler() {
         return new SimpleDataFetcherExceptionHandler();
+    }
+
+    /**
+     * Gets the route resolver to determine the API version.
+     *
+     * @return the route resolver
+     */
+    default RouteResolver getRouteResolver() {
+        return null;
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
@@ -153,7 +153,7 @@ public class ElideStandaloneConfigStoreTest {
     @Test
     public void testEmptyConfiguration() {
         when()
-                .get("/api/v1/config?fields[config]=path,type")
+                .get("/api/config?fields[config]=path,type")
                 .then()
                 .body(equalTo("{\"data\":[]}"))
                 .statusCode(HttpStatus.SC_OK);
@@ -181,7 +181,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo("{\"errors\":[{\"message\":\"Null or empty file content for models/tables/table1.hjson\"}]}"))
                 .log().all()
@@ -196,7 +196,7 @@ public class ElideStandaloneConfigStoreTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .body(query)
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo(
                         GraphQLDSL.document(
@@ -238,7 +238,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
                 .statusCode(200);
@@ -274,7 +274,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo(
                         GraphQLDSL.document(
@@ -315,7 +315,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
                 .statusCode(200);
@@ -366,7 +366,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo(
                         GraphQLDSL.document(
@@ -400,7 +400,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo(
                         GraphQLDSL.document(
@@ -437,7 +437,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
                 .statusCode(200);
@@ -456,7 +456,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 ).toQuery() + "\" }")
                 .when()
-                .post("/graphql/api/v1")
+                .post("/graphql/api")
                 .then()
                 .body(equalTo("{\"data\":{\"config\":{\"edges\":[]}}}"))
                 .statusCode(200);
@@ -501,12 +501,12 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 )
                 .when()
-                .post("/api/v1/config")
+                .post("/api/config")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED);
 
         when()
-                .get("/api/v1/config?fields[config]=content")
+                .get("/api/config?fields[config]=content")
                 .then()
                 .body(equalTo(data(
                         resource(
@@ -516,25 +516,25 @@ public class ElideStandaloneConfigStoreTest {
                                         attr("content", hjson)
                                 ),
                                 links(
-                                        attr("self", "https://elide.io/api/v1/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
+                                        attr("self", "https://elide.io/api/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
                                 )
                         )
                 ).toJSON()))
                 .statusCode(HttpStatus.SC_OK);
 
         when()
-                .delete("/api/v1/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
+                .delete("/api/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
         when()
-                .get("/api/v1/config?fields[config]=path,type")
+                .get("/api/config?fields[config]=path,type")
                 .then()
                 .body(equalTo("{\"data\":[]}"))
                 .statusCode(HttpStatus.SC_OK);
 
         when()
-                .get("/api/v1/json/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
+                .get("/api/json/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
                 .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND);
     }
@@ -578,7 +578,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 )
                 .when()
-                .post("/api/v1/config")
+                .post("/api/config")
                 .then()
                 .body(equalTo("{\"errors\":[{\"detail\":\"Failed to verify column arguments for column: measure in table: Test. Argument &#39;missing&#39; is not defined but found &#39;{{$$column.args.missing}}&#39;.\"}]}"))
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
@@ -603,7 +603,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 )
                 .when()
-                .post("/api/v1/config")
+                .post("/api/config")
                 .then()
                 .body(equalTo("{\"errors\":[{\"detail\":\"Unrecognized File: foo\"}]}"))
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
@@ -648,7 +648,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 )
                 .when()
-                .post("/api/v1/config")
+                .post("/api/config")
                 .then()
                 .body(equalTo("{\"errors\":[{\"detail\":\"Parent directory traversal not allowed: ../../../../../tmp/models/tables/table1.hjson\"}]}"))
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
@@ -693,7 +693,7 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 )
                 .when()
-                .post("/api/v1/config")
+                .post("/api/config")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED);
 
@@ -713,12 +713,12 @@ public class ElideStandaloneConfigStoreTest {
                         )
                 )
                 .when()
-                .patch("/api/v1/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
+                .patch("/api/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
                 .then()
                 .statusCode(HttpStatus.SC_FORBIDDEN);
 
         when()
-                .delete("/api/v1/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
+                .delete("/api/config/bW9kZWxzL3RhYmxlcy90YWJsZTEuaGpzb24=")
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
     }

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -66,7 +66,7 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
         given()
                 .accept(ContentType.JSON)
                 .when()
-                .get("/api-docs/doc/test")
+                .get("/api-docs")
                 .then()
                 .statusCode(200)
                 .body("tags.name", containsInAnyOrder("post", "asyncQuery"));
@@ -90,7 +90,7 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
                         )
                     )
                 )
-                .post("/api/v1/post")
+                .post("/api/post")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED);
     }
@@ -100,7 +100,7 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
     public void metaDataTest() {
         given()
                 .accept("application/vnd.api+json")
-                .get("/api/v1/namespace/default") //"default" namespace added by Agg Store.
+                .get("/api/namespace/default") //"default" namespace added by Agg Store.
                 .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND); // Metadatastore is disabled, so not found.
     }

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
@@ -63,7 +63,7 @@ public class ElideStandaloneDisableMetaDataStoreTest extends ElideStandaloneTest
         given()
                 .accept(ContentType.JSON)
                 .when()
-                .get("/api-docs/doc/test")
+                .get("/api-docs")
                 .then()
                 .statusCode(200)
                 .body("tags.name", containsInAnyOrder("post", "asyncQuery", "postView"));
@@ -74,7 +74,7 @@ public class ElideStandaloneDisableMetaDataStoreTest extends ElideStandaloneTest
     public void metaDataTest() {
         given()
                 .accept("application/vnd.api+json")
-                .get("/api/v1/namespace/default") //"default" namespace added by Agg Store.
+                .get("/api/namespace/default") //"default" namespace added by Agg Store.
                 .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND); // Metadatastore is disabled, so not found.
     }

--- a/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
@@ -151,7 +151,7 @@ public class ElideStandaloneExportTest {
                 )
             )
         )
-        .post("/api/v1/post")
+        .post("/api/post")
         .then()
 
         .statusCode(HttpStatus.SC_CREATED);
@@ -174,7 +174,7 @@ public class ElideStandaloneExportTest {
                                 )
                         ).toJSON())
                 .when()
-                .post("/api/v1/tableExport")
+                .post("/api/tableExport")
                 .then()
                 .statusCode(org.apache.http.HttpStatus.SC_CREATED);
 
@@ -183,7 +183,7 @@ public class ElideStandaloneExportTest {
             Thread.sleep(10);
             Response response = given()
                     .accept("application/vnd.api+json")
-                    .get("/api/v1/tableExport/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d");
+                    .get("/api/tableExport/ba31ca4e-ed8f-4be0-a0f3-12088fa9265d");
             String outputResponse = response.jsonPath().getString("data.attributes.status");
              //If Async Query is created and completed then validate results
             if (outputResponse.equals("COMPLETE")) {
@@ -207,7 +207,7 @@ public class ElideStandaloneExportTest {
                                 + "{ edges { node { id queryType status resultType result "
                                 + "{ url httpStatus recordCount } } } } }\","
                                 + "\"variables\":null }")
-                        .post("/graphql/api/v1")
+                        .post("/graphql/api")
                         .asString();
                 String expectedResponse = "{\"data\":{\"tableExport\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9265d\","
                         + "\"queryType\":\"GRAPHQL_V1_0\",\"status\":\"COMPLETE\",\"resultType\":\"CSV\","
@@ -229,7 +229,7 @@ public class ElideStandaloneExportTest {
         given()
                .accept(ContentType.JSON)
                .when()
-               .get("/api-docs/doc/test")
+               .get("/api-docs")
                 .then()
                 .statusCode(200)
                 .body("tags.name", containsInAnyOrder("post", "argument", "metric",

--- a/elide-standalone/src/test/java/example/ElideStandaloneSubscriptionTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneSubscriptionTest.java
@@ -116,7 +116,7 @@ public class ElideStandaloneSubscriptionTest extends ElideStandaloneTest {
                                     )
                             )
                     )
-                    .post("/api/v1/post")
+                    .post("/api/post")
                     .then()
                     .statusCode(HttpStatus.SC_CREATED);
 

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -111,7 +111,7 @@ public class ElideStandaloneTest {
         given()
             .contentType(JSONAPI_CONTENT_TYPE)
             .accept(JSONAPI_CONTENT_TYPE)
-            .delete("/api/v1/post/1")
+            .delete("/api/post/1")
             .then()
             .statusCode(HttpStatus.SC_NO_CONTENT);
     }
@@ -134,13 +134,13 @@ public class ElideStandaloneTest {
                             )
                     )
             )
-            .post("/api/v1/operations")
+            .post("/api/operations")
             .then()
             .statusCode(HttpStatus.SC_OK);
 
         given()
             .when()
-            .get("/api/v1/post/10")
+            .get("/api/post/10")
             .then()
             .statusCode(200)
             .body(equalTo(
@@ -154,7 +154,7 @@ public class ElideStandaloneTest {
                                             attr("date", null)
                                     ),
                                     links(
-                                            attr("self", "https://elide.io/api/v1/post/10")
+                                            attr("self", "https://elide.io/api/post/10")
                                     )
                             )
                     ).toJSON()
@@ -170,7 +170,7 @@ public class ElideStandaloneTest {
                                 ref(type("post"), id("10")))
                         )
                 )
-            .post("/api/v1/operations")
+            .post("/api/operations")
             .then()
             .statusCode(HttpStatus.SC_OK);
     }

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -82,14 +82,14 @@ public class ElideStandaloneTest {
                     )
                 )
             )
-            .post("/api/v1/post")
+            .post("/api/post")
             .then()
             .statusCode(HttpStatus.SC_CREATED);
 
         // Test the Dynamic Generated Analytical Model is accessible
         given()
             .when()
-            .get("/api/v1/postView")
+            .get("/api/postView")
             .then()
             .statusCode(200)
             .body(equalTo(
@@ -101,7 +101,7 @@ public class ElideStandaloneTest {
                                             attr("content", "This is my first post. woot.")
                                     ),
                                     links(
-                                            attr("self", "https://elide.io/api/v1/postView/0")
+                                            attr("self", "https://elide.io/api/postView/0")
                                     )
                             )
                     ).toJSON()
@@ -193,7 +193,7 @@ public class ElideStandaloneTest {
                                 )
                         )
                 )
-                .post("/api/v1/post")
+                .post("/api/post")
                 .then()
                 .statusCode(HttpStatus.SC_CREATED);
     }
@@ -216,7 +216,7 @@ public class ElideStandaloneTest {
                     )
                 )
             )
-            .post("/api/v1/post")
+            .post("/api/post")
             .then()
             .statusCode(HttpStatus.SC_FORBIDDEN);
     }
@@ -244,7 +244,7 @@ public class ElideStandaloneTest {
     public void testApiDocsEndpoint() throws Exception {
         given()
                 .when()
-                .get("/api-docs/doc/test")
+                .get("/api-docs")
                 .then()
                 .statusCode(200);
     }
@@ -254,7 +254,7 @@ public class ElideStandaloneTest {
         given()
                 .accept(ContentType.JSON)
                 .when()
-                .get("/api-docs/doc/test")
+                .get("/api-docs")
                 .then()
                 .statusCode(200)
                 .body("tags.name", containsInAnyOrder("post", "argument", "metric",
@@ -267,7 +267,7 @@ public class ElideStandaloneTest {
         ExtractableResponse<Response> v0 = given()
                 .accept(ContentType.JSON)
                 .when()
-                .get("/api-docs/doc/test")
+                .get("/api-docs")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract();
@@ -276,7 +276,7 @@ public class ElideStandaloneTest {
                 .accept(ContentType.JSON)
                 .header("ApiVersion", "1.0")
                 .when()
-                .get("/api-docs/doc/test")
+                .get("/api-docs")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract();
@@ -311,14 +311,14 @@ public class ElideStandaloneTest {
                                 )
                         ).toJSON())
                 .when()
-                .post("/api/v1/asyncQuery").asString();
+                .post("/api/asyncQuery").asString();
 
         int i = 0;
         while (i < 1000) {
             Thread.sleep(10);
             Response response = given()
                     .accept("application/vnd.api+json")
-                    .get("/api/v1/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9263d");
+                    .get("/api/asyncQuery/ba31ca4e-ed8f-4be0-a0f3-12088fa9263d");
 
             String outputResponse = response.jsonPath().getString("data.attributes.status");
 
@@ -345,7 +345,7 @@ public class ElideStandaloneTest {
                                         attr("date", "2019-01-01T00:00Z")
                                     ),
                                     links(
-                                        attr("self", "https://elide.io/api/v1/post/2")
+                                        attr("self", "https://elide.io/api/post/2")
                                     )
                                 )
                             ).toJSON()
@@ -359,10 +359,10 @@ public class ElideStandaloneTest {
                                 + "{ edges { node { id queryType status result "
                                 + "{ responseBody httpStatus  contentLength } } } } }\","
                                 + "\"variables\":null}")
-                        .post("/graphql/api/v1/")
+                        .post("/graphql/api/")
                         .asString();
 
-                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"post\\\",\\\"id\\\":\\\"2\\\",\\\"attributes\\\":{\\\"abusiveContent\\\":false,\\\"content\\\":\\\"This is my first post. woot.\\\",\\\"date\\\":\\\"2019-01-01T00:00Z\\\"},\\\"links\\\":{\\\"self\\\":\\\"https://elide.io/api/v1/post/2\\\"}}]}\",\"httpStatus\":200,\"contentLength\":191}}}]}}}";
+                String expectedResponse = "{\"data\":{\"asyncQuery\":{\"edges\":[{\"node\":{\"id\":\"ba31ca4e-ed8f-4be0-a0f3-12088fa9263d\",\"queryType\":\"JSONAPI_V1_0\",\"status\":\"COMPLETE\",\"result\":{\"responseBody\":\"{\\\"data\\\":[{\\\"type\\\":\\\"post\\\",\\\"id\\\":\\\"2\\\",\\\"attributes\\\":{\\\"abusiveContent\\\":false,\\\"content\\\":\\\"This is my first post. woot.\\\",\\\"date\\\":\\\"2019-01-01T00:00Z\\\"},\\\"links\\\":{\\\"self\\\":\\\"https://elide.io/api/post/2\\\"}}]}\",\"httpStatus\":200,\"contentLength\":188}}}]}}}";
                 assertEquals(expectedResponse, responseGraphQL);
                 break;
             }
@@ -394,7 +394,7 @@ public class ElideStandaloneTest {
     public void metaDataTest() {
         given()
                 .accept("application/vnd.api+json")
-                .get("/api/v1/namespace/default") //"default" namespace added by Agg Store
+                .get("/api/namespace/default") //"default" namespace added by Agg Store
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("data.attributes.name", equalTo("default"))
@@ -418,7 +418,7 @@ public class ElideStandaloneTest {
                                 )
                         )
                 )
-                .post("/api/v1/post")
+                .post("/api/post")
                 .then()
                 .body("errors.detail[0]", equalTo("Invalid value: Invalid\nDate strings must be formatted as yyyy-MM-dd&#39;T&#39;HH:mm&#39;Z&#39;"))
                 .statusCode(HttpStatus.SC_BAD_REQUEST);

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/converter/JsonApiModelResolver.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/converter/JsonApiModelResolver.java
@@ -116,7 +116,9 @@ public class JsonApiModelResolver extends ModelResolver {
                     context, next, requiredAttributes);
             entitySchema.addAttribute(attributeName, attribute);
         }
-        entitySchema.getAttributes().required(requiredAttributes);
+        if (!requiredAttributes.isEmpty()) {
+            entitySchema.getAttributes().required(requiredAttributes);
+        }
     }
 
     private void populateRelationships(final Resource entitySchema, final Type<?> clazzType) {
@@ -133,7 +135,33 @@ public class JsonApiModelResolver extends ModelResolver {
                 entitySchema.addRelationship(relationshipName, relationship);
             }
         }
-        entitySchema.getRelationships().required(requiredRelationships);
+        if (!requiredRelationships.isEmpty()) {
+            entitySchema.getRelationships().required(requiredRelationships);
+        }
+
+        entitySchema.name(getSchemaName(clazzType));
+
+        Include include = getInclude(clazzType);
+        if (include != null) {
+            if (!StringUtils.isBlank(include.friendlyName())) {
+                entitySchema.setTitle(include.friendlyName());
+            }
+        }
+        io.swagger.v3.oas.annotations.media.Schema schema = getSchema(clazzType);
+        if (schema != null) {
+            if (!StringUtils.isBlank(schema.title())) {
+                entitySchema.setTitle(schema.title());
+            }
+        }
+    }
+
+    protected String getSchemaName(Type<?> type) {
+        String schemaName = dictionary.getJsonAliasFor(type);
+        String apiVersion = EntityDictionary.getModelVersion(type);
+        if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+            schemaName = "v" + apiVersion + "_" + schemaName;
+        }
+        return schemaName;
     }
 
     @SuppressWarnings("rawtypes")

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
@@ -29,7 +29,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import lombok.AllArgsConstructor;
@@ -107,7 +106,7 @@ public class ApiDocsEndpoint {
             @Context UriInfo uriInfo,
             @Context HttpHeaders headers
             ) {
-        MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+        Map<String, List<String>> queryParams = new HashMap<>(uriInfo.getQueryParameters());
         Route route = routeResolver.resolve(MediaType.APPLICATION_JSON, "", path, headers.getRequestHeaders(),
                 queryParams);
         String name = route.getPath();
@@ -129,7 +128,7 @@ public class ApiDocsEndpoint {
             @Context UriInfo uriInfo,
             @Context HttpHeaders headers
     ) {
-        MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+        Map<String, List<String>> queryParams = new HashMap<>(uriInfo.getQueryParameters());
         Route route = routeResolver.resolve(MediaType.APPLICATION_YAML, "", path, headers.getRequestHeaders(),
                 queryParams);
         String name = route.getPath();

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
  * A convenience endpoint to expose a openapi document.
  */
 
-@Path("/doc")
+@Path("/")
 public class ApiDocsEndpoint {
     //Maps api version & path to a openapi document.
     protected Map<Pair<String, String>, OpenApiDocument> documents;

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
@@ -5,7 +5,6 @@
  */
 package com.yahoo.elide.swagger;
 
-import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.core.dictionary.EntityDictionary.NO_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,6 +26,7 @@ import com.yahoo.elide.core.type.Package;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.coerce.converters.EpochToDateConverter;
 import com.yahoo.elide.core.utils.coerce.converters.TimeZoneSerde;
+import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.swagger.models.media.Data;
 import com.yahoo.elide.swagger.models.media.Datum;
 import com.yahoo.elide.swagger.models.media.Relationship;
@@ -36,6 +36,8 @@ import example.models.Author;
 import example.models.Book;
 import example.models.Product;
 import example.models.Publisher;
+import example.models.v2.BookV2;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -94,6 +96,39 @@ class OpenApiBuilderTest {
 
         OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(info.getVersion());
         openApi = builder.build().info(info);
+    }
+
+    @Test
+    void testApiVersion() {
+        String tag = "v2/book";
+        EntityDictionary dictionary = EntityDictionary.builder().build();
+        dictionary.bindEntity(BookV2.class);
+        OpenAPI openApi = new OpenApiBuilder(dictionary).apiVersion("2").build();
+        assertEquals(tag, openApi.getTags().get(0).getName());
+        Schema<?> schema = openApi.getComponents().getSchemas().get("v2_book");
+        assertNotNull(schema);
+        openApi.getPaths().forEach((path, pathItem) -> {
+          Operation get = pathItem.getGet();
+          if (get != null) {
+              get.getTags().contains(tag);
+          }
+          Operation post = pathItem.getPost();
+          if (post != null) {
+              post.getTags().contains(tag);
+          }
+          Operation patch = pathItem.getPatch();
+          if (patch != null) {
+              patch.getTags().contains(tag);
+          }
+          Operation delete = pathItem.getDelete();
+          if (delete != null) {
+              delete.getTags().contains(tag);
+          }
+          Operation put = pathItem.getPut();
+          if (put != null) {
+              put.getTags().contains(tag);
+          }
+        });
     }
 
     @Test
@@ -953,7 +988,7 @@ class OpenApiBuilderTest {
      * @param refTypeName The model name
      */
     private void verifyData(Content content, String refTypeName) {
-        verifyData(content.get(JSONAPI_CONTENT_TYPE).getSchema(), refTypeName);
+        verifyData(content.get(JsonApi.MEDIA_TYPE).getSchema(), refTypeName);
     }
 
     /**
@@ -978,7 +1013,7 @@ class OpenApiBuilderTest {
      * @param included Whether or not the datum should have an 'included' section.
      */
     private void verifyDatum(Content content, String refTypeName, boolean included) {
-        verifyDatum(content.get(JSONAPI_CONTENT_TYPE).getSchema(), refTypeName, included);
+        verifyDatum(content.get(JsonApi.MEDIA_TYPE).getSchema(), refTypeName, included);
     }
 
     /**
@@ -1006,7 +1041,7 @@ class OpenApiBuilderTest {
      * @param refTypeName The type field to match against
      */
     private void verifyDataRelationship(Content content, String refTypeName) {
-        verifyDataRelationship(content.get(JSONAPI_CONTENT_TYPE).getSchema(), refTypeName);
+        verifyDataRelationship(content.get(JsonApi.MEDIA_TYPE).getSchema(), refTypeName);
     }
 
     /**

--- a/elide-swagger/src/test/java/example/models/v2/BookV2.java
+++ b/elide-swagger/src/test/java/example/models/v2/BookV2.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.models.v2;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
+
+import example.models.Author;
+import example.models.Publisher;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.AccessMode;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.Date;
+import java.util.Set;
+
+@Entity
+@Include(name = "book", friendlyName = "Book")
+@ReadPermission(expression = "Principal is author OR Principal is publisher")
+@CreatePermission(expression = "Principal is author")
+@DeletePermission(expression = "Prefab.Role.None")
+@Schema(title = "Override Include Title", description = "A book")
+public class BookV2 {
+    @OneToMany
+    @Size(max = 10)
+    @UpdatePermission(expression = "Principal is author")
+    @Schema(description = "Writers", requiredMode = RequiredMode.REQUIRED, accessMode = AccessMode.READ_ONLY,
+        example = "[\"author1\", \"author2\", \"author3\"]")
+    public Set<Author> getAuthors() {
+        return null;
+    }
+
+    @OneToOne
+    @UpdatePermission(expression = "Principal is publisher")
+    public Publisher getPublisher() {
+        return null;
+    }
+
+    @NotNull
+    @Schema(requiredMode = RequiredMode.REQUIRED)
+    public String title;
+
+    @Schema(description = "Year published", example = "1999", accessMode = AccessMode.READ_ONLY)
+    public String year;
+
+    public Date publishedOn;
+}

--- a/elide-swagger/src/test/java/example/models/v2/package-info.java
+++ b/elide-swagger/src/test/java/example/models/v2/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+/**
+ * Models Package V2.
+ */
+@ApiVersion(version = "2")
+package example.models.v2;
+
+import com.yahoo.elide.annotation.ApiVersion;


### PR DESCRIPTION
It was a bit difficult to have the settings changes as the next PR so I will be having this one first.

Tentatively I'll split the next few as the following
- Refactor map parameters
- Refactor request scope
- Refactor JSON API
- Refactor settings and config
- Add api version handling for graphql subscriptions

## Description
Adds api version handling to the json api and graphql controllers.

## How Has This Been Tested?
Added the appropriate unit and integration tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
