### PR TITLE
Refactor map parameters

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
@@ -15,11 +15,13 @@ import com.yahoo.elide.core.security.User;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -40,7 +42,7 @@ public class JsonApiAsyncQueryOperation extends AsyncQueryOperation {
         String apiVersion = scope.getApiVersion();
         UUID requestUUID = UUID.fromString(queryObj.getRequestId());
         URIBuilder uri = new URIBuilder(queryObj.getQuery());
-        MultivaluedMap<String, String> queryParams = getQueryParams(uri);
+        Map<String, List<String>> queryParams = getQueryParams(uri);
         log.debug("Extracted QueryParams from AsyncQuery Object: {}", queryParams);
 
         //TODO - we need to add the baseUrlEndpoint to the queryObject.
@@ -53,14 +55,15 @@ public class JsonApiAsyncQueryOperation extends AsyncQueryOperation {
 
     /**
      * This method parses the url and gets the query params.
-     * And adds them into a MultivaluedMap to be used by underlying Elide.get method
+     * And adds them into a Map to be used by underlying Elide.get method
      * @param uri URIBuilder instance
-     * @return MultivaluedMap with query parameters
+     * @return Map with query parameters
      */
-    public static MultivaluedMap<String, String> getQueryParams(URIBuilder uri) {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    public static Map<String, List<String>> getQueryParams(URIBuilder uri) {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         for (NameValuePair queryParam : uri.getQueryParams()) {
-            queryParams.add(queryParam.getName(), queryParam.getValue());
+            queryParams.computeIfAbsent(queryParam.getName(), key -> new ArrayList<>())
+                    .add(queryParam.getValue());
         }
         return queryParams;
     }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiTableExportOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiTableExportOperation.java
@@ -20,7 +20,6 @@ import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.EntityProjectionMaker;
 import org.apache.http.client.utils.URIBuilder;
 
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URISyntaxException;
@@ -57,7 +56,7 @@ public class JsonApiTableExportOperation extends TableExportOperation {
             throw new BadRequestException(e.getMessage());
         }
 
-        MultivaluedMap<String, String> queryParams = JsonApiAsyncQueryOperation.getQueryParams(uri);
+        Map<String, List<String>> queryParams = JsonApiAsyncQueryOperation.getQueryParams(uri);
 
         // Call with additionalHeader alone
         if (scope.getRequestHeaders().isEmpty()) {

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncApiDao.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/dao/DefaultAsyncApiDao.java
@@ -19,8 +19,6 @@ import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
 import jakarta.inject.Singleton;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +26,9 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -165,7 +166,7 @@ public class DefaultAsyncApiDao implements AsyncApiDao {
         Object result = null;
         try (DataStoreTransaction tx = dataStore.beginTransaction()) {
             JsonApiDocument jsonApiDoc = new JsonApiDocument();
-            MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+            Map<String, List<String>> queryParams = new LinkedHashMap<>();
             RequestScope scope = new RequestScope("", "query", NO_VERSION, jsonApiDoc,
                     tx, null, queryParams, Collections.emptyMap(), UUID.randomUUID(), elideSettings);
             result = action.execute(tx, scope);

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncApiCancelRunnable.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/thread/AsyncApiCancelRunnable.java
@@ -21,14 +21,14 @@ import com.yahoo.elide.core.filter.predicates.InPredicate;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.google.common.collect.Sets;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -108,7 +108,7 @@ public class AsyncApiCancelRunnable implements Runnable {
                    DataStoreTransaction runningTransaction = transactionRegistry.getRunningTransaction(uuid);
                    if (runningTransaction != null) {
                        JsonApiDocument jsonApiDoc = new JsonApiDocument();
-                       MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+                       Map<String, List<String>> queryParams = new LinkedHashMap<>();
                        RequestScope scope = new RequestScope("", "query", NO_VERSION, jsonApiDoc,
                                runningTransaction, null, queryParams, Collections.emptyMap(),
                                uuid, elide.getElideSettings());

--- a/elide-core/src/main/java/com/yahoo/elide/Elide.java
+++ b/elide-core/src/main/java/com/yahoo/elide/Elide.java
@@ -58,7 +58,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -217,7 +216,7 @@ public class Elide {
      * @param apiVersion the API version
      * @return Elide response object
      */
-    public ElideResponse get(String baseUrlEndPoint, String path, MultivaluedMap<String, String> queryParams,
+    public ElideResponse get(String baseUrlEndPoint, String path, Map<String, List<String>> queryParams,
                              User opaqueUser, String apiVersion) {
         return get(baseUrlEndPoint, path, queryParams, opaqueUser, apiVersion, UUID.randomUUID());
     }
@@ -233,7 +232,7 @@ public class Elide {
      * @param requestId the request ID
      * @return Elide response object
      */
-    public ElideResponse get(String baseUrlEndPoint, String path, MultivaluedMap<String, String> queryParams,
+    public ElideResponse get(String baseUrlEndPoint, String path, Map<String, List<String>> queryParams,
                              User opaqueUser, String apiVersion, UUID requestId) {
         return get(baseUrlEndPoint, path, queryParams, Collections.emptyMap(), opaqueUser, apiVersion, requestId);
     }
@@ -250,7 +249,7 @@ public class Elide {
      * @param requestId the request ID
      * @return Elide response object
      */
-    public ElideResponse get(String baseUrlEndPoint, String path, MultivaluedMap<String, String> queryParams,
+    public ElideResponse get(String baseUrlEndPoint, String path, Map<String, List<String>> queryParams,
                              Map<String, List<String>> requestHeaders, User opaqueUser, String apiVersion,
                              UUID requestId) {
         if (elideSettings.isStrictQueryParams()) {
@@ -299,7 +298,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse post(String baseUrlEndPoint, String path, String jsonApiDocument,
-                              MultivaluedMap<String, String> queryParams,
+                              Map<String, List<String>> queryParams,
                               User opaqueUser, String apiVersion, UUID requestId) {
         return post(baseUrlEndPoint, path, jsonApiDocument, queryParams, Collections.emptyMap(),
                     opaqueUser, apiVersion, requestId);
@@ -319,7 +318,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse post(String baseUrlEndPoint, String path, String jsonApiDocument,
-                              MultivaluedMap<String, String> queryParams, Map<String, List<String>> requestHeaders,
+                              Map<String, List<String>> queryParams, Map<String, List<String>> requestHeaders,
                               User opaqueUser, String apiVersion, UUID requestId) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, requestId, (tx, user) -> {
             JsonApiDocument jsonApiDoc = mapper.readJsonApiDocument(jsonApiDocument);
@@ -366,7 +365,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse patch(String baseUrlEndPoint, String contentType, String accept,
-                               String path, String jsonApiDocument, MultivaluedMap<String, String> queryParams,
+                               String path, String jsonApiDocument, Map<String, List<String>> queryParams,
                                User opaqueUser, String apiVersion, UUID requestId) {
 
         return patch(baseUrlEndPoint, contentType, accept, path, jsonApiDocument, queryParams,
@@ -389,7 +388,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse patch(String baseUrlEndPoint, String contentType, String accept,
-                               String path, String jsonApiDocument, MultivaluedMap<String, String> queryParams,
+                               String path, String jsonApiDocument, Map<String, List<String>> queryParams,
                                Map<String, List<String>> requestHeaders, User opaqueUser,
                                String apiVersion, UUID requestId) {
 
@@ -450,7 +449,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse delete(String baseUrlEndPoint, String path, String jsonApiDocument,
-                                MultivaluedMap<String, String> queryParams,
+                                Map<String, List<String>> queryParams,
                                 User opaqueUser, String apiVersion, UUID requestId) {
         return delete(baseUrlEndPoint, path, jsonApiDocument, queryParams, Collections.emptyMap(),
                       opaqueUser, apiVersion, requestId);
@@ -470,7 +469,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse delete(String baseUrlEndPoint, String path, String jsonApiDocument,
-                                MultivaluedMap<String, String> queryParams,
+                                Map<String, List<String>> queryParams,
                                 Map<String, List<String>> requestHeaders,
                                 User opaqueUser, String apiVersion, UUID requestId) {
         return handleRequest(false, opaqueUser, dataStore::beginTransaction, requestId, (tx, user) -> {
@@ -520,7 +519,7 @@ public class Elide {
      * @return Elide response object
      */
     public ElideResponse operations(String baseUrlEndPoint, String contentType, String accept, String path,
-            String jsonApiDocument, MultivaluedMap<String, String> queryParams, User opaqueUser, String apiVersion,
+            String jsonApiDocument, Map<String, List<String>> queryParams, User opaqueUser, String apiVersion,
             UUID requestId) {
         return operations(baseUrlEndPoint, contentType, accept, path, jsonApiDocument, queryParams, null, opaqueUser,
                 apiVersion, requestId);
@@ -542,7 +541,7 @@ public class Elide {
      * @return
      */
     public ElideResponse operations(String baseUrlEndPoint, String contentType, String accept, String path,
-            String jsonApiDocument, MultivaluedMap<String, String> queryParams,
+            String jsonApiDocument, Map<String, List<String>> queryParams,
             Map<String, List<String>> requestHeaders, User opaqueUser, String apiVersion, UUID requestId) {
 
         Handler<DataStoreTransaction, User, HandlerResult> handler;
@@ -752,7 +751,7 @@ public class Elide {
         }
     }
 
-    private void verifyQueryParams(MultivaluedMap<String, String> queryParams) {
+    private void verifyQueryParams(Map<String, List<String>> queryParams) {
         String undefinedKeys = queryParams.keySet()
                         .stream()
                         .filter(Elide::notAValidKey)

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialect.java
@@ -49,7 +49,6 @@ import cz.jirutka.rsql.parser.ast.Node;
 import cz.jirutka.rsql.parser.ast.OrNode;
 import cz.jirutka.rsql.parser.ast.RSQLOperators;
 import cz.jirutka.rsql.parser.ast.RSQLVisitor;
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.Builder;
 import lombok.NonNull;
 
@@ -60,6 +59,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -148,14 +148,14 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
     }
 
     @Override
-    public FilterExpression parseGlobalExpression(String path, MultivaluedMap<String, String> filterParams,
+    public FilterExpression parseGlobalExpression(String path, Map<String, List<String>> filterParams,
                                                   String apiVersion)
             throws ParseException {
         if (filterParams.size() != 1) {
             throw new ParseException(SINGLE_PARAMETER_ONLY);
         }
 
-        MultivaluedMap.Entry<String, List<String>> entry = CollectionUtils.get(filterParams, 0);
+        Entry<String, List<String>> entry = CollectionUtils.get(filterParams, 0);
         String queryParamName = entry.getKey();
 
         if (!"filter".equals(queryParamName)) {
@@ -190,13 +190,13 @@ public class RSQLFilterDialect implements FilterDialect, SubqueryFilterDialect, 
     }
 
     @Override
-    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams,
+    public Map<String, FilterExpression> parseTypedExpression(String path, Map<String, List<String>> filterParams,
                                                               String apiVersion)
             throws ParseException {
 
         Map<String, FilterExpression> expressionByType = new HashMap<>();
 
-        for (MultivaluedMap.Entry<String, List<String>> entry : filterParams.entrySet()) {
+        for (Entry<String, List<String>> entry : filterParams.entrySet()) {
 
             String paramName = entry.getKey();
             List<String> paramValues = entry.getValue();

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/DefaultFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/DefaultFilterDialect.java
@@ -18,13 +18,12 @@ import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.coerce.CoerceUtil;
 import com.yahoo.elide.jsonapi.parser.JsonApiParser;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,12 +43,12 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
      * @return a list of the predicates from the query params
      * @throws ParseException when a filter parameter cannot be parsed
      */
-    private List<FilterPredicate> extractPredicates(MultivaluedMap<String, String> queryParams,
+    private List<FilterPredicate> extractPredicates(Map<String, List<String>> queryParams,
                                                     String apiVersion) throws ParseException {
         List<FilterPredicate> filterPredicates = new ArrayList<>();
 
         Pattern pattern = Pattern.compile("filter\\[([^\\]]+)\\](\\[([^\\]]+)\\])?");
-        for (MultivaluedMap.Entry<String, List<String>> entry : queryParams.entrySet()) {
+        for (Entry<String, List<String>> entry : queryParams.entrySet()) {
             // Match "filter[<type>.<field>]" OR "filter[<type>.<field>][<operator>]"
 
             String paramName = entry.getKey();
@@ -91,7 +90,7 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
     }
 
     @Override
-    public FilterExpression parseGlobalExpression(String path, MultivaluedMap<String, String> filterParams,
+    public FilterExpression parseGlobalExpression(String path, Map<String, List<String>> filterParams,
                                                   String apiVersion)
             throws ParseException {
         List<FilterPredicate> filterPredicates;
@@ -135,7 +134,7 @@ public class DefaultFilterDialect implements JoinFilterDialect, SubqueryFilterDi
     }
 
     @Override
-    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams,
+    public Map<String, FilterExpression> parseTypedExpression(String path, Map<String, List<String>> filterParams,
                                                               String apiVersion)
             throws ParseException {
         Map<String, FilterExpression> expressionMap = new HashMap<>();

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/JoinFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/JoinFilterDialect.java
@@ -8,7 +8,8 @@ package com.yahoo.elide.core.filter.dialect.jsonapi;
 import com.yahoo.elide.core.filter.dialect.ParseException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 
-import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Parses a filter for one or more entity types that results in a join between them.
@@ -31,6 +32,6 @@ public interface JoinFilterDialect {
      */
     public FilterExpression parseGlobalExpression(
             String path,
-            MultivaluedMap<String, String> filterParams,
+            Map<String, List<String>> filterParams,
             String apiVersion) throws ParseException;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/MultipleFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/MultipleFilterDialect.java
@@ -9,7 +9,6 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.ParseException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,7 +37,7 @@ public class MultipleFilterDialect implements JoinFilterDialect, SubqueryFilterD
 
     @Override
     public FilterExpression parseGlobalExpression(String path,
-                                                  MultivaluedMap<String, String> queryParams,
+                                                  Map<String, List<String>> queryParams,
                                                   String apiVersion) throws ParseException {
         if (joinDialects.isEmpty()) {
             throw new ParseException("Heterogeneous type filtering not supported");
@@ -49,7 +48,7 @@ public class MultipleFilterDialect implements JoinFilterDialect, SubqueryFilterD
 
     @Override
     public Map<String, FilterExpression> parseTypedExpression(String path,
-                                                              MultivaluedMap<String, String> queryParams,
+                                                              Map<String, List<String>> queryParams,
                                                               String apiVersion)
             throws ParseException {
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/SubqueryFilterDialect.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/dialect/jsonapi/SubqueryFilterDialect.java
@@ -8,8 +8,7 @@ package com.yahoo.elide.core.filter.dialect.jsonapi;
 import com.yahoo.elide.core.filter.dialect.ParseException;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,7 +37,7 @@ public interface SubqueryFilterDialect {
      * @return The root of an expression abstract syntax tree parsed from both the path and the query parameters.
      * @throws ParseException if unable to parse
      */
-    public Map<String, FilterExpression> parseTypedExpression(String path, MultivaluedMap<String, String> filterParams,
+    public Map<String, FilterExpression> parseTypedExpression(String path, Map<String, List<String>> filterParams,
                                                               String apiVersion)
             throws ParseException;
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
@@ -13,13 +13,13 @@ import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import com.google.common.collect.ImmutableMap;
 
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -173,7 +173,7 @@ public class PaginationImpl implements Pagination {
      * @throws InvalidValueException invalid query parameter
      */
     public static PaginationImpl parseQueryParams(Type<?> entityClass,
-                                                  final MultivaluedMap<String, String> queryParams,
+                                                  final Map<String, List<String>> queryParams,
                                                   ElideSettings elideSettings)
             throws InvalidValueException {
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
@@ -13,7 +13,6 @@ import com.yahoo.elide.core.request.Sorting;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -24,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Generates a simple wrapper around the sort fields from the JSON-API GET Query.
@@ -162,7 +160,7 @@ public class SortingImpl implements Sorting {
      * @param queryParams The query params on the request.
      * @return The Sorting instance (default or specific).
      */
-    public static Sorting parseQueryParams(final MultivaluedMap<String, String> queryParams,
+    public static Sorting parseQueryParams(final Map<String, List<String>> queryParams,
                                            Type<?> type, EntityDictionary dictionary) {
 
         if (queryParams.isEmpty()) {
@@ -172,7 +170,7 @@ public class SortingImpl implements Sorting {
         List<String> sortRules = queryParams.entrySet().stream()
                 .filter(entry -> entry.getKey().equals("sort"))
                 .map(entry -> entry.getValue().get(0))
-                .collect(Collectors.toList());
+                .toList();
         return parseSortRules(sortRules, type, Collections.emptySet(), dictionary);
     }
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/EntityProjectionMaker.java
@@ -28,12 +28,12 @@ import com.google.common.collect.Sets;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.Builder;
 import lombok.Data;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -59,7 +59,7 @@ public class EntityProjectionMaker
     public static final String INCLUDE = "include";
 
     private EntityDictionary dictionary;
-    private MultivaluedMap<String, String> queryParams;
+    private Map<String, List<String>> queryParams;
     private Map<String, Set<String>> sparseFields;
     private RequestScope scope;
 

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/DocumentProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/DocumentProcessor.java
@@ -9,9 +9,9 @@ import com.yahoo.elide.core.PersistentResource;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 
 /**
  * An interface for building and processing a response document.
@@ -31,7 +31,7 @@ public interface DocumentProcessor {
     void execute(JsonApiDocument jsonApiDocument,
                  RequestScope scope,
                  PersistentResource resource,
-                 MultivaluedMap<String, String> queryParams);
+                 Map<String, List<String>> queryParams);
 
     /**
      * A method for making transformations to the JsonApiDocument.
@@ -44,7 +44,7 @@ public interface DocumentProcessor {
     void execute(JsonApiDocument jsonApiDocument,
                  RequestScope scope,
                  LinkedHashSet<PersistentResource> resources,
-                 MultivaluedMap<String, String> queryParams);
+                 Map<String, List<String>> queryParams);
 
     //TODO Possibly add a something like a 'afterExecute' method to process after the first round of execution
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
@@ -14,12 +14,11 @@ import com.yahoo.elide.jsonapi.EntityProjectionMaker;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.google.common.collect.Lists;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -36,7 +35,7 @@ public class IncludedProcessor implements DocumentProcessor {
      */
     @Override
     public void execute(JsonApiDocument jsonApiDocument, RequestScope scope, PersistentResource resource,
-                        MultivaluedMap<String, String> queryParams) {
+            Map<String, List<String>> queryParams) {
         if (isPresent(queryParams, INCLUDE)) {
             addIncludedResources(jsonApiDocument, resource, queryParams.get(INCLUDE));
         }
@@ -51,7 +50,7 @@ public class IncludedProcessor implements DocumentProcessor {
             JsonApiDocument jsonApiDocument,
             RequestScope scope,
             LinkedHashSet<PersistentResource> resources,
-            MultivaluedMap<String, String> queryParams
+            Map<String, List<String>> queryParams
     ) {
         if (isPresent(queryParams, INCLUDE)) {
 
@@ -112,7 +111,7 @@ public class IncludedProcessor implements DocumentProcessor {
         });
     }
 
-    private static boolean isPresent(MultivaluedMap<String, String> queryParams, String key) {
+    private static boolean isPresent(Map<String, List<String>> queryParams, String key) {
         return queryParams != null && queryParams.get(key) != null;
     }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/PopulateMetaProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/PopulateMetaProcessor.java
@@ -11,10 +11,10 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Meta;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -27,7 +27,7 @@ public class PopulateMetaProcessor implements DocumentProcessor {
             JsonApiDocument jsonApiDocument,
             RequestScope scope,
             PersistentResource persistentResource,
-            MultivaluedMap<String, String> queryParams
+            Map<String, List<String>> queryParams
     ) {
 
         addDocumentMeta(jsonApiDocument, scope);
@@ -55,7 +55,7 @@ public class PopulateMetaProcessor implements DocumentProcessor {
             JsonApiDocument jsonApiDocument,
             RequestScope scope,
             LinkedHashSet<PersistentResource> resources,
-            MultivaluedMap<String, String> queryParams
+            Map<String, List<String>> queryParams
     ) {
         addDocumentMeta(jsonApiDocument, scope);
     }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiAtomicOperationsRequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiAtomicOperationsRequestScope.java
@@ -12,8 +12,6 @@ import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.EntityProjectionMaker;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -43,7 +41,7 @@ public class JsonApiAtomicOperationsRequestScope extends RequestScope {
             DataStoreTransaction transaction,
             User user,
             UUID requestId,
-            MultivaluedMap<String, String> queryParams,
+            Map<String, List<String>> queryParams,
             Map<String, List<String>> requestHeaders,
             ElideSettings elideSettings) {
         super(

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiJsonPatchRequestScope.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/extensions/JsonApiJsonPatchRequestScope.java
@@ -12,8 +12,6 @@ import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.EntityProjectionMaker;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -43,7 +41,7 @@ public class JsonApiJsonPatchRequestScope extends RequestScope {
             DataStoreTransaction transaction,
             User user,
             UUID requestId,
-            MultivaluedMap<String, String> queryParams,
+            Map<String, List<String>> queryParams,
             Map<String, List<String>> requestHeaders,
             ElideSettings elideSettings) {
         super(

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/BaseState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/BaseState.java
@@ -25,8 +25,8 @@ import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 import com.yahoo.elide.jsonapi.models.Resource;
 import org.apache.commons.lang3.tuple.Pair;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -179,7 +179,7 @@ public abstract class BaseState {
     }
 
     protected static JsonApiDocument getResponseBody(PersistentResource resource, RequestScope requestScope) {
-        MultivaluedMap<String, String> queryParams = requestScope.getQueryParams();
+        Map<String, List<String>> queryParams = requestScope.getQueryParams();
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
         //TODO Make this a document processor

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
@@ -34,7 +34,6 @@ import org.apache.commons.collections4.IterableUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import io.reactivex.Observable;
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.ToString;
 
 import java.util.ArrayList;
@@ -71,7 +70,7 @@ public class CollectionTerminalState extends BaseState {
     public Supplier<Pair<Integer, JsonApiDocument>> handleGet(StateContext state) {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
         RequestScope requestScope = state.getRequestScope();
-        MultivaluedMap<String, String> queryParams = requestScope.getQueryParams();
+        Map<String, List<String>> queryParams = requestScope.getQueryParams();
 
         LinkedHashSet<PersistentResource> collection =
                 getResourceCollection(requestScope).toList(LinkedHashSet::new).blockingGet();

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RelationshipTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RelationshipTerminalState.java
@@ -23,10 +23,9 @@ import com.yahoo.elide.jsonapi.models.Resource;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
@@ -55,7 +54,7 @@ public class RelationshipTerminalState extends BaseState {
     public Supplier<Pair<Integer, JsonApiDocument>> handleGet(StateContext state) {
         JsonApiDocument doc = new JsonApiDocument();
         RequestScope requestScope = state.getRequestScope();
-        MultivaluedMap<String, String> queryParams = requestScope.getQueryParams();
+        Map<String, List<String>> queryParams = requestScope.getQueryParams();
 
         Map<String, Relationship> relationships = record.toResource(parentProjection).getRelationships();
         if (relationships != null && relationships.containsKey(relationshipName)) {

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/resources/JsonApiEndpoint.java
@@ -35,8 +35,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
@@ -94,7 +92,6 @@ public class JsonApiEndpoint {
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
@@ -106,11 +103,11 @@ public class JsonApiEndpoint {
         if ("operations".equals(route.getPath())) {
             // Atomic Operations
             return build(elide.operations(route.getBaseUrl(), contentType, accept, route.getPath(), jsonapiDocument,
-                    queryParams, requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
+                    route.getParameters(), requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
         }
 
         return build(elide.post(route.getBaseUrl(), route.getPath(), jsonapiDocument,
-                queryParams, requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
+                route.getParameters(), requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
     }
 
     /**
@@ -129,7 +126,6 @@ public class JsonApiEndpoint {
         @Context UriInfo uriInfo,
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext) {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
@@ -138,8 +134,8 @@ public class JsonApiEndpoint {
         Route route = routeResolver.resolve(JSONAPI_CONTENT_TYPE, baseUrl, pathname, requestHeaders,
                 uriInfo.getQueryParameters());
 
-        return build(elide.get(route.getBaseUrl(), route.getPath(), queryParams,
-                               requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
+        return build(elide.get(route.getBaseUrl(), route.getPath(), route.getParameters(), requestHeaders, user,
+                route.getApiVersion(), UUID.randomUUID()));
     }
 
     /**
@@ -165,7 +161,6 @@ public class JsonApiEndpoint {
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext,
         String jsonapiDocument) {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
@@ -174,8 +169,8 @@ public class JsonApiEndpoint {
         Route route = routeResolver.resolve(JSONAPI_CONTENT_TYPE, baseUrl, pathname, requestHeaders,
                 uriInfo.getQueryParameters());
 
-        return build(elide.patch(route.getBaseUrl(), contentType, accept, route.getPath(), jsonapiDocument, queryParams,
-                requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
+        return build(elide.patch(route.getBaseUrl(), contentType, accept, route.getPath(), jsonapiDocument,
+                route.getParameters(), requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
     }
 
     /**
@@ -197,7 +192,6 @@ public class JsonApiEndpoint {
         @Context HttpHeaders headers,
         @Context SecurityContext securityContext,
         String jsonApiDocument) {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
         User user = new SecurityContextUser(securityContext);
 
@@ -206,8 +200,8 @@ public class JsonApiEndpoint {
         Route route = routeResolver.resolve(JSONAPI_CONTENT_TYPE, baseUrl, pathname, requestHeaders,
                 uriInfo.getQueryParameters());
 
-        return build(elide.delete(route.getBaseUrl(), route.getPath(), jsonApiDocument, queryParams, requestHeaders,
-                                  user, route.getApiVersion(), UUID.randomUUID()));
+        return build(elide.delete(route.getBaseUrl(), route.getPath(), jsonApiDocument, route.getParameters(),
+                requestHeaders, user, route.getApiVersion(), UUID.randomUUID()));
     }
 
     private static Response build(ElideResponse response) {

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -60,7 +60,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToOne;
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import nocreate.NoCreateEntity;
@@ -69,6 +68,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -160,7 +160,7 @@ public class PersistenceResourceTestSetup extends PersistentResource {
         return buildRequestScope(null, tx, user, null);
     }
 
-    protected RequestScope buildRequestScope(String path, DataStoreTransaction tx, User user, MultivaluedMap<String, String> queryParams) {
+    protected RequestScope buildRequestScope(String path, DataStoreTransaction tx, User user, Map<String, List<String>> queryParams) {
         return new RequestScope(null, path, NO_VERSION, null, tx, user, queryParams, null, UUID.randomUUID(), elideSettings);
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -89,8 +89,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 
 import io.reactivex.Observable;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import nocreate.NoCreateEntity;
 
 import java.math.BigDecimal;
@@ -101,6 +99,7 @@ import java.util.Collections;
 import java.util.Currency;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -125,6 +124,10 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
     @BeforeEach
     public void beforeTest() {
         reset(tx);
+    }
+
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
     }
 
     @Test
@@ -1038,8 +1041,8 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
         when(tx.getToManyRelation(eq(tx), any(), any(), any()))
                 .thenReturn(new DataStoreIterableBuilder(Sets.newHashSet(child1)).build());
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[child.name]", "paul john");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[child.name]", "paul john");
         RequestScope goodScope = buildRequestScope("/child", tx, goodUser, queryParams);
 
         PersistentResource<Parent> parentResource = new PersistentResource<>(parent, "1", goodScope);
@@ -2879,9 +2882,9 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
 
     @Test
     public void testFilterExpressionByType() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
@@ -2900,9 +2903,9 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
 
     @Test
     public void testFilterExpressionCollection() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book.authors.name][infix]",
                 "Hemingway"
         );
@@ -2922,9 +2925,9 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
 
     @Test
     public void testSparseFields() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add("fields[author]", "name");
+        add(queryParams, "fields[author]", "name");
 
         RequestScope scope = buildRequestScope("/", mock(DataStoreTransaction.class),
                 new TestUser("1"), queryParams);

--- a/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/RequestScopeTest.java
@@ -18,33 +18,34 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
-public class RequestScopeTest {
+class RequestScopeTest {
     @Test
-    public void testFilterQueryParams() throws Exception {
-        Method method = RequestScope.class.getDeclaredMethod("getFilterParams", MultivaluedMap.class);
+    void testFilterQueryParams() throws Exception {
+        Method method = RequestScope.class.getDeclaredMethod("getFilterParams", Map.class);
         method.setAccessible(true);
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new HashMap<>();
         queryParams.put("foo", Collections.singletonList("bar"));
         queryParams.put("filter", Collections.singletonList("baz"));
         queryParams.put("filter[xyz]", Collections.singletonList("buzz"));
         queryParams.put("bar", Collections.singletonList("foo"));
 
-        MultivaluedMap<String, String> filtered = (MultivaluedMap<String, String>) method.invoke(null, queryParams);
+        Map<String, List<String>> filtered = (Map<String, List<String>>) method.invoke(null, queryParams);
         assertEquals(2, filtered.size());
         assertTrue(filtered.containsKey("filter"));
         assertTrue(filtered.containsKey("filter[xyz]"));
     }
 
     @Test
-    public void testNewObjectsForInheritedTypes() throws Exception {
+    void testNewObjectsForInheritedTypes() throws Exception {
         // NOTE: This tests that inherited types are properly accounted for during a patch extension request.
         //       otherwise it is possible to create an inherited type and when performing introspection on a
         //       superclass we will miss that the object is newly created and then we'll attempt to query

--- a/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/TestRequestScope.java
@@ -15,8 +15,8 @@ import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.links.DefaultJsonApiLinks;
 import com.yahoo.elide.jsonapi.models.JsonApiDocument;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -24,7 +24,7 @@ import java.util.UUID;
  */
 public class TestRequestScope extends RequestScope {
 
-    private MultivaluedMap queryParamOverrides = null;
+    private Map<String, List<String>> queryParamOverrides = null;
 
     public TestRequestScope(String baseURL,
                             DataStoreTransaction transaction,
@@ -44,24 +44,24 @@ public class TestRequestScope extends RequestScope {
         super(null, null, NO_VERSION, new JsonApiDocument(), transaction, user, null, null, UUID.randomUUID(),
                 new ElideSettingsBuilder(null)
                 .withEntityDictionary(dictionary)
-                .build());
+                 .build());
     }
 
     public TestRequestScope(EntityDictionary dictionary,
                             String path,
-                            MultivaluedMap<String, String> queryParams) {
+                            Map<String, List<String>> queryParams) {
         super(null, path, NO_VERSION, new JsonApiDocument(), null, null, queryParams, null, UUID.randomUUID(),
                 new ElideSettingsBuilder(null)
                         .withEntityDictionary(dictionary)
                         .build());
     }
 
-    public void setQueryParams(MultivaluedMap<String, String> queryParams) {
+    public void setQueryParams(Map<String, List<String>> queryParams) {
         this.queryParamOverrides = queryParams;
     }
 
     @Override
-    public MultivaluedMap<String, String> getQueryParams() {
+    public Map<String, List<String>> getQueryParams() {
         if (queryParamOverrides != null) {
             return queryParamOverrides;
         }

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/FilterPredicateTest.java
@@ -24,13 +24,13 @@ import example.Book;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,7 +51,11 @@ public class FilterPredicateTest {
         strategy = new DefaultFilterDialect(entityDictionary);
     }
 
-    private Map<String, Set<FilterPredicate>> parse(MultivaluedMap<String, String> queryParams) {
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
+
+    private Map<String, Set<FilterPredicate>> parse(Map<String, List<String>> queryParams) {
         PredicateExtractionVisitor visitor = new PredicateExtractionVisitor();
 
         Map<String, FilterExpression> expressionMap;
@@ -77,8 +81,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldSingleValue() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title]", "abc");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title]", "abc");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -91,8 +95,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldMultipleValues() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title]", "abc,def");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -105,9 +109,9 @@ public class FilterPredicateTest {
 
     @Test
     void testMultipleFieldMultipleValues() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title]", "abc,def");
-        queryParams.add("filter[book.genre]", "def,jkl");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title]", "abc,def");
+        add(queryParams, "filter[book.genre]", "def,jkl");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -130,8 +134,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithInOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][in]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][in]", "abc,def");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -144,8 +148,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithNotOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][not]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][not]", "abc,def");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -158,8 +162,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithPrefixOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][prefix]", "abc");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][prefix]", "abc");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -172,8 +176,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithPostfixOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][postfix]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][postfix]", "abc,def");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -186,8 +190,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithInfixOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][infix]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][infix]", "abc,def");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -200,8 +204,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithNotPrefixOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][notprefix]", "abc");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][notprefix]", "abc");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -214,8 +218,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithNotPostfixOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][notpostfix]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][notpostfix]", "abc,def");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -228,8 +232,8 @@ public class FilterPredicateTest {
 
     @Test
     void testSingleFieldWithNotInfixOperator() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.title][notinfix]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.title][notinfix]", "abc,def");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -242,16 +246,16 @@ public class FilterPredicateTest {
 
     @Test
     void testMissingType() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[title]", "abc,def");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[title]", "abc,def");
 
         assertThrows(BadRequestException.class, () -> parse(queryParams));
     }
 
     @Test
     void testIntegerFieldType() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.id]", "1");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.id]", "1");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));
@@ -264,8 +268,8 @@ public class FilterPredicateTest {
 
     @Test
     void testComplexAttributeFieldType() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[author.homeAddress.street1]", "foo");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[author.homeAddress.street1]", "foo");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("author"));
@@ -282,8 +286,8 @@ public class FilterPredicateTest {
 
     @Test
     void testMultipleIntegerFieldType() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book.id]", "1,2,3");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book.id]", "1,2,3");
 
         Map<String, Set<FilterPredicate>> predicates = parse(queryParams);
         assertTrue(predicates.containsKey("book"));

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/DefaultFilterDialectTest.java
@@ -17,9 +17,9 @@ import example.Book;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,11 +38,15 @@ public class DefaultFilterDialectTest {
         dialect = new DefaultFilterDialect(dictionary);
     }
 
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
+
     @Test
     public void testGlobalExpressionParsingWithComplexAttribute() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.homeAddress.street1][infix]", "State"
         );
 
@@ -53,14 +57,14 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testGlobalExpressionParsing() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
@@ -75,9 +79,9 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testTypedExpressionParsingWithComplexAttribute() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.homeAddress.street1][infix]",
                 "State"
         );
@@ -93,25 +97,25 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testTypedExpressionParsing() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book.genre]",
                 "scifi"
         );
 
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
@@ -120,15 +124,15 @@ public class DefaultFilterDialectTest {
 
         assertEquals(2, expressionMap.size());
         assertEquals("(book.title IN [foo, bar, baz] AND book.genre IN [scifi])", expressionMap.get("book").toString());
-        assertEquals("(author.books.title IN [foo, bar, baz] AND author.name INFIX [Hemingway])",
+        assertEquals("(author.name INFIX [Hemingway] AND author.books.title IN [foo, bar, baz])",
                 expressionMap.get("author").toString());
     }
 
     @Test
     public void testInvalidType() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[invalid.title][in]",
                 "foo,bar,baz"
         );
@@ -138,9 +142,9 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testInvalidAttribute() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book.invalid][in]",
                 "foo,bar,baz"
         );
@@ -150,10 +154,10 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testInvalidTypeQualifier() throws ParseException {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
         /* This is now OK for global and for subqueries */
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
@@ -166,9 +170,9 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testBetweenOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.id][between]",
                 "10,20"
         );
@@ -181,9 +185,9 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testEmptyOperatorException() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book.authors.name][isempty]",
                 ""
         );
@@ -194,8 +198,8 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testMemberOfOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add(
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams,
                 "filter[book.awards][hasnomember]",
                 "awards1"
         );
@@ -208,9 +212,9 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testMemberOfToManyRelationship() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book.authors.name][hasmember]",
                 "name"
         );
@@ -224,8 +228,8 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testMemberOfOperatorOnNonCollectionAttributeException() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add(
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams,
                 "filter[book.title][hasmember]",
                 "title"
         );
@@ -238,10 +242,10 @@ public class DefaultFilterDialectTest {
 
     @Test
     public void testMemberOfOperatorOnRelationshipException() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
         queryParams.clear();
-        queryParams.add(
+        add(queryParams,
                 "filter[book.authors][hasmember]",
                 "1"
         );

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/MultipleFilterDialectTest.java
@@ -19,17 +19,21 @@ import com.yahoo.elide.core.filter.dialect.jsonapi.SubqueryFilterDialect;
 import com.yahoo.elide.core.filter.expression.FilterExpression;
 import org.junit.jupiter.api.Test;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
  * Tests MultipleFilterDialect
  */
 public class MultipleFilterDialectTest {
+
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
 
     /**
      * Verify that all dialects are iterated over.
@@ -45,14 +49,14 @@ public class MultipleFilterDialectTest {
                 Collections.emptyList()
         );
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
@@ -82,14 +86,14 @@ public class MultipleFilterDialectTest {
                 Arrays.asList(dialect1, dialect2)
         );
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
@@ -116,14 +120,14 @@ public class MultipleFilterDialectTest {
                 Collections.emptyList()
         );
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
@@ -142,14 +146,14 @@ public class MultipleFilterDialectTest {
                 Collections.emptyList()
         );
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
@@ -170,14 +174,14 @@ public class MultipleFilterDialectTest {
                 Collections.emptyList()
         );
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );
@@ -205,14 +209,14 @@ public class MultipleFilterDialectTest {
                 Arrays.asList(dialect1, dialect2)
         );
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.books.title][in]",
                 "foo,bar,baz"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author.name][infix]",
                 "Hemingway"
         );

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectTest.java
@@ -31,12 +31,13 @@ import org.junit.jupiter.api.Test;
 
 import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.ComparisonOperator;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,11 +60,15 @@ public class RSQLFilterDialectTest {
         dialect = RSQLFilterDialect.builder().dictionary(dictionary).build();
     }
 
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
+
     @Test
     public void testTypedExpressionParsingWithComplexAttribute() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author]",
                 "homeAddress.street1==*State*"
         );
@@ -79,14 +84,14 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testTypedExpressionParsing() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book]",
                 "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
         );
 
-        queryParams.add(
+        add(queryParams,
                 "filter[author]",
                 "books.title=in=(foo,bar,baz)"
         );
@@ -107,7 +112,7 @@ public class RSQLFilterDialectTest {
         );
 
         queryParams.clear();
-        queryParams.add(
+        add(queryParams,
                 "filter[author]",
                 "books.title=ini=(foo,bar,baz)"
         );
@@ -123,9 +128,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testGlobalExpressionParsingWithComplexAttribute() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter", "homeAddress.street1==*State*"
         );
 
@@ -136,9 +141,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testGlobalExpressionParsing() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title==*foo*;authors.name=ini=Hemingway"
         );
@@ -153,9 +158,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testEqualOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title==Hemingway"
         );
@@ -167,9 +172,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testNotEqualOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title!=Hemingway"
         );
@@ -181,9 +186,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testInOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=in=Hemingway"
         );
@@ -195,9 +200,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testInInsensitiveOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=ini=Hemingway"
         );
@@ -209,9 +214,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testOutOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=out=Hemingway"
         );
@@ -223,9 +228,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testOutInsensitiveOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=outi=Hemingway"
         );
@@ -237,9 +242,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testNumericComparisonOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "(publishDate=gt=5,publishDate=ge=5,publishDate=lt=10,publishDate=le=10);"
                         + "(publishDate>5,publishDate>=5,publishDate<10,publishDate<=10)"
@@ -259,9 +264,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testBetweenOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "(publishDate=notbetween=(5,10))"
         );
@@ -276,9 +281,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testSubstringOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title==*Hemingway*,title==*Hemingway,title==Hemingway*"
         );
@@ -295,9 +300,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testSubstringCIOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=ini=*Hemingway*,title=ini=*Hemingway,title=ini=Hemingway*"
         );
@@ -314,9 +319,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testExpressionGrouping() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=ini=foo;(title==bar;title==baz)"
         );
@@ -332,9 +337,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testIsnullOperatorBool() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=true"
         );
@@ -346,9 +351,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testIsnullOperatorInt() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=1"
         );
@@ -360,9 +365,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testNotnullOperatorBool() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=false"
         );
@@ -374,9 +379,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testNotnullOperatorInt() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=0"
         );
@@ -404,9 +409,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testFilterOnCustomizedLongIdField() throws ParseException {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "id==1"
         );
@@ -418,9 +423,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testFilterOnCustomizedStringIdField() throws ParseException {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "id==*identifier*"
         );
@@ -432,9 +437,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testInfixFilterOnPrimitiveIdField() throws ParseException {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "id==*1*"
         );
@@ -450,9 +455,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testIsemptyOperatorBool() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isempty=true"
         );
@@ -464,9 +469,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testIsemptyOperatorInt() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "authors=isempty=1"
         );
@@ -478,9 +483,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testNotemptyOperatorBool() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "authors=isempty=false"
         );
@@ -492,9 +497,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testNotemptyOperatorInt() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isempty=0"
         );
@@ -506,9 +511,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testEmptyOperatorException() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "authors.name=isempty=0"
         );
@@ -519,9 +524,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testMemberOfOperatorInt() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "awards=hasmember=title1"
         );
@@ -533,9 +538,9 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testMemberOfToManyRelationship() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "authors.name=hasmember='0'"
         );
@@ -546,10 +551,10 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testMemberOfOperatorOnNonCollectionAttributeException() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
         queryParams.clear();
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=hasmember=title11"
         );
@@ -562,10 +567,10 @@ public class RSQLFilterDialectTest {
 
     @Test
     public void testMemberOfOperatorOnRelationshipException() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
         queryParams.clear();
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "authors=hasmember=1"
         );

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithFIQLCompliantStrategyTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/dialect/RSQLFilterDialectWithFIQLCompliantStrategyTest.java
@@ -15,9 +15,9 @@ import example.Book;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,11 +38,15 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
                 .build();
     }
 
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
+
     @Test
     public void testTypedExpressionParsing() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter[book]",
                 "title==*foo*;title!=bar*;(genre=in=(sci-fi,action),publishDate>123)"
         );
@@ -59,9 +63,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testGlobalExpressionParsing() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title==*foo*;authors.name==Hemingway"
         );
@@ -73,9 +77,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testEqualOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title==Hemingway"
         );
@@ -87,9 +91,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testNotEqualOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title!=Hemingway"
         );
@@ -101,9 +105,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testInOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=in=Hemingway"
         );
@@ -115,9 +119,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testOutOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=out=Hemingway"
         );
@@ -129,9 +133,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testNumericComparisonOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "(publishDate=gt=5,publishDate=ge=5,publishDate=lt=10,publishDate=le=10);"
                         + "(publishDate>5,publishDate>=5,publishDate<10,publishDate<=10)"
@@ -151,9 +155,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testSubstringOperator() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title==*Hemingway*,title==*Hemingway,title==Hemingway*"
         );
@@ -168,9 +172,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testExpressionGrouping() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title==foo;(title==bar;title==baz)"
         );
@@ -182,9 +186,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testIsnullOperatorBool() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=true"
         );
@@ -196,9 +200,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testIsnullOperatorInt() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=1"
         );
@@ -210,9 +214,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testNotnullOperatorBool() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=false"
         );
@@ -224,9 +228,9 @@ public class RSQLFilterDialectWithFIQLCompliantStrategyTest {
 
     @Test
     public void testNotnullOperatorInt() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
-        queryParams.add(
+        add(queryParams,
                 "filter",
                 "title=isnull=0"
         );

--- a/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/lifecycle/LifeCycleTest.java
@@ -59,12 +59,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import jakarta.validation.ConstraintViolationException;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -237,7 +237,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         ElideResponse response = elide.get(baseUrl, "/testModel/1", queryParams, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
@@ -272,7 +272,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         ElideResponse response = elide.get(baseUrl, "/legacyTestModel/1", queryParams, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
@@ -314,8 +314,8 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.putSingle("fields[testModel]", "field");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("fields[testModel]", List.of("field"));
         ElideResponse response = elide.get(baseUrl, "/testModel/1", queryParams, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 
@@ -342,16 +342,16 @@ public class LifeCycleTest {
         DataStore store = mock(DataStore.class);
         Elide elide = getElide(store, dictionary, MOCK_AUDIT_LOGGER);
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.putSingle("fields[testModel]", "field");
-        queryParams.putSingle("?filter", "field"); // Key starts with '?'
-        queryParams.putSingle("Sort", "field"); // Valid Key is sort
-        queryParams.putSingle("INCLUDE", "field"); // Valid Key is include
-        queryParams.putSingle("fields.testModel", "field"); // fields is not followed by [
-        queryParams.putSingle("page.size", "10"); // page is not followed by [
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        queryParams.put("fields[testModel]", List.of("field"));
+        queryParams.put("?filter", List.of("field")); // Key starts with '?'
+        queryParams.put("Sort", List.of("field")); // Valid Key is sort
+        queryParams.put("INCLUDE", List.of("field")); // Valid Key is include
+        queryParams.put("fields.testModel", List.of("field")); // fields is not followed by [
+        queryParams.put("page.size", List.of("10")); // page is not followed by [
         ElideResponse response = elide.get(baseUrl, "/testModel/1", queryParams, null, NO_VERSION);
         assertEquals(HttpStatus.SC_BAD_REQUEST, response.getResponseCode());
-        assertEquals("{\"errors\":[{\"detail\":\"Found undefined keys in request: fields.testModel, ?filter, Sort, page.size, INCLUDE\"}]}",
+        assertEquals("{\"errors\":[{\"detail\":\"Found undefined keys in request: ?filter, Sort, INCLUDE, fields.testModel, page.size\"}]}",
                         response.getBody());
     }
 
@@ -369,7 +369,7 @@ public class LifeCycleTest {
         when(store.beginTransaction()).thenReturn(tx);
         when(tx.loadObject(isA(EntityProjection.class), any(), isA(RequestScope.class))).thenReturn(mockModel);
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         ElideResponse response = elide.get(baseUrl, "/testModel/1/relationships/models", queryParams, null, NO_VERSION);
         assertEquals(HttpStatus.SC_OK, response.getResponseCode());
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/pagination/PaginationImplTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/pagination/PaginationImplTest.java
@@ -16,10 +16,12 @@ import com.yahoo.elide.annotation.Paginate;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.type.ClassType;
-import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
 import org.junit.jupiter.api.Test;
 
-import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tests parsing the page params for json-api pagination.
@@ -29,12 +31,15 @@ public class PaginationImplTest {
             new ElideSettingsBuilder(null)
                     .withEntityDictionary(EntityDictionary.builder().build())
                     .build();
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
 
     @Test
     public void shouldParseQueryParamsForCurrentPageAndPageSize() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[size]", "10");
-        queryParams.add("page[number]", "2");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[size]", "10");
+        add(queryParams, "page[number]", "2");
 
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings);
@@ -46,9 +51,9 @@ public class PaginationImplTest {
 
     @Test
     public void shouldThrowExceptionForNegativePageNumber() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[size]", "10");
-        queryParams.add("page[number]", "-2");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[size]", "10");
+        add(queryParams, "page[number]", "-2");
 
         assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings));
@@ -56,9 +61,9 @@ public class PaginationImplTest {
 
     @Test
     public void shouldThrowExceptionForNegativePageSize() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[size]", "-10");
-        queryParams.add("page[number]", "2");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[size]", "-10");
+        add(queryParams, "page[number]", "2");
 
         assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings));
@@ -66,9 +71,9 @@ public class PaginationImplTest {
 
     @Test
     public void shouldParseQueryParamsForOffsetAndLimit() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[limit]", "10");
-        queryParams.add("page[offset]", "2");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[limit]", "10");
+        add(queryParams, "page[offset]", "2");
 
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings);
@@ -79,7 +84,7 @@ public class PaginationImplTest {
 
     @Test
     public void shouldUseDefaultsWhenMissingCurrentPageAndPageSize() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings);
         assertEquals(PaginationImpl.DEFAULT_OFFSET, pageData.getOffset());
@@ -141,8 +146,8 @@ public class PaginationImplTest {
 
     @Test
     public void neverExceedMaxPageSize() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[size]", "25000");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[size]", "25000");
         assertThrows(InvalidValueException.class,
                 () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                         queryParams, elideSettings));
@@ -150,9 +155,9 @@ public class PaginationImplTest {
 
     @Test
     public void invalidUsageOfPaginationParameters() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[size]", "10");
-        queryParams.add("page[offset]", "100");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[size]", "10");
+        add(queryParams, "page[offset]", "100");
         assertThrows(InvalidValueException.class,
                 () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                         queryParams, elideSettings));
@@ -160,8 +165,8 @@ public class PaginationImplTest {
 
     @Test
     public void pageBasedPaginationWithDefaultSize() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[number]", "2");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[number]", "2");
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImpl.class),
                 queryParams, elideSettings);
         assertEquals(PaginationImpl.DEFAULT_PAGE_LIMIT, pageData.getLimit());
@@ -170,8 +175,8 @@ public class PaginationImplTest {
 
     @Test
     public void shouldThrowExceptionForNonIntPageParamValues() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[size]", "2.5");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[size]", "2.5");
         assertThrows(InvalidValueException.class,
                 () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                         queryParams, elideSettings));
@@ -179,8 +184,8 @@ public class PaginationImplTest {
 
     @Test
     public void shouldThrowExceptionForInvalidPageParams() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[random]", "1");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[random]", "1");
         assertThrows(InvalidValueException.class,
         () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings));
@@ -188,8 +193,8 @@ public class PaginationImplTest {
 
     @Test
     public void shouldSetGenerateTotals() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
-        queryParams.add("page[totals]", null);
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[totals]", null);
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings);
         assertTrue(pageData.returnPageTotals());
@@ -197,7 +202,7 @@ public class PaginationImplTest {
 
     @Test
     public void shouldNotSetGenerateTotals() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings);
         assertFalse(pageData.returnPageTotals());
@@ -206,7 +211,7 @@ public class PaginationImplTest {
 
     @Test
     public void shouldUseDefaultsWhenNoParams() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
 
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
                 queryParams, elideSettings);
@@ -228,7 +233,7 @@ public class PaginationImplTest {
         @Paginate(maxLimit = 100000, defaultLimit = 10)
         class PaginationOverrideTest { }
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedStringMap();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationOverrideTest.class),
                 queryParams,
                 new ElideSettingsBuilder(null)

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/EntityProjectionMakerTest.java
@@ -35,10 +35,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,9 +56,13 @@ public class EntityProjectionMakerTest {
         dictionary.bindEntity(Editor.class);
     }
 
+    static void add(Map<String, List<String>> params, String key, String value) {
+        params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
+
     @Test
     public void testRootCollectionNoQueryParams() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         String path = "/book";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -93,8 +97,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootCollectionSparseFields() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("fields[book]", "title,publishDate,authors");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "fields[book]", "title,publishDate,authors");
         String path = "/book";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -118,7 +122,7 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootEntityNoQueryParams() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         String path = "/book/1";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -152,7 +156,7 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testNestedCollectionNoQueryParams() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         String path = "/author/1/books/3/publisher";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -185,7 +189,7 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testNestedEntityNoQueryParams() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         String path = "/author/1/books/3/publisher/1";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -217,7 +221,7 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRelationshipNoQueryParams() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         String path = "/author/1/relationships/books";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -242,8 +246,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRelationshipWithSingleInclude() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "authors");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "authors");
         String path = "/book/1/relationships/publisher";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -283,8 +287,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootCollectionWithSingleInclude() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "authors");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "authors");
         String path = "/book";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -331,8 +335,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootEntityWithSingleInclude() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "authors");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "authors");
         String path = "/book/1";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -378,9 +382,9 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootCollectionWithNestedInclude() throws Exception {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "books");
-        queryParams.add("include", "books.publisher,books.editor");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "books");
+        add(queryParams, "include", "books.publisher,books.editor");
         String path = "/author";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -441,9 +445,9 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootEntityWithNestedInclude() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "books");
-        queryParams.add("include", "books.publisher,books.editor");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "books");
+        add(queryParams, "include", "books.publisher,books.editor");
         String path = "/author/1";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -503,8 +507,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testNestedEntityWithSingleInclude() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "books");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "books");
         String path = "/author/1/books/3/publisher/1";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -552,8 +556,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testNestedCollectionWithSingleInclude() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "books");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "books");
         String path = "/author/1/books/3/publisher";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -602,12 +606,12 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootEntityWithNestedIncludeAndSparseFields() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "books");
-        queryParams.add("include", "books.publisher,books.editor");
-        queryParams.add("fields[publisher]", "name");
-        queryParams.add("fields[editor]", "fullName");
-        queryParams.add("fields[book]", "publisher,editor,title");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "books");
+        add(queryParams, "include", "books.publisher,books.editor");
+        add(queryParams, "fields[publisher]", "name");
+        add(queryParams, "fields[editor]", "fullName");
+        add(queryParams, "fields[book]", "publisher,editor,title");
         String path = "/author/1";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -646,8 +650,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootCollectionWithGlobalFilter() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter", "genre=='Science Fiction'");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter", "genre=='Science Fiction'");
         String path = "/book";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -686,8 +690,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testNestedCollectionWithTypedFilter() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[publisher]", "name=='Foo'");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[publisher]", "name=='Foo'");
         String path = "/author/1/books/3/publisher";
 
         FilterExpression expression =
@@ -724,11 +728,11 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRelationshipsAndIncludeWithFilterAndSort() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("include", "authors");
-        queryParams.add("filter[author]", "name=='Foo'");
-        queryParams.add("filter[publisher]", "name=='Foo'");
-        queryParams.add("sort", "name");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "include", "authors");
+        add(queryParams, "filter[author]", "name=='Foo'");
+        add(queryParams, "filter[publisher]", "name=='Foo'");
+        add(queryParams, "sort", "name");
         String path = "/book/1/relationships/publisher";
         Sorting sorting = SortingImpl.parseSortRule("name", ClassType.of(Publisher.class), dictionary);
 
@@ -772,8 +776,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testRootCollectionWithTypedFilter() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("filter[book]", "genre=='Science Fiction'");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "filter[book]", "genre=='Science Fiction'");
         String path = "/book";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -812,8 +816,8 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testInvalidSparseFields() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("fields[book]", "publisher,bookTitle,bookName"); // Invalid Fields: bookTitle & bookName
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "fields[book]", "publisher,bookTitle,bookName"); // Invalid Fields: bookTitle & bookName
         String path = "/book";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);
@@ -825,10 +829,10 @@ public class EntityProjectionMakerTest {
 
     @Test
     public void testInvalidSparseFieldsNested() {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
-        queryParams.add("fields[book]", "publisher,title");
-        queryParams.add("fields[publisher]", "name,cost"); // Invalid Fields: cost
-        queryParams.add("include", "publisher");
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "fields[book]", "publisher,title");
+        add(queryParams, "fields[publisher]", "name,cost"); // Invalid Fields: cost
+        add(queryParams, "include", "publisher");
         String path = "/book";
 
         RequestScope scope = new TestRequestScope(dictionary, path, queryParams);

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessorTest.java
@@ -26,14 +26,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class IncludedProcessorTest {
@@ -109,7 +108,7 @@ public class IncludedProcessorTest {
     public void testExecuteSingleRelation() throws Exception {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children"));
         testScope.setQueryParams(queryParams);
         includedProcessor.execute(jsonApiDocument, testScope, parentRecord1, queryParams);
@@ -129,7 +128,7 @@ public class IncludedProcessorTest {
         parents.add(parentRecord1);
         parents.add(parentRecord2);
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children"));
         testScope.setQueryParams(queryParams);
         includedProcessor.execute(jsonApiDocument, testScope, parents, queryParams);
@@ -146,7 +145,7 @@ public class IncludedProcessorTest {
 
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children.friends"));
         testScope.setQueryParams(queryParams);
         includedProcessor.execute(jsonApiDocument, testScope, parentRecord1, queryParams);
@@ -163,7 +162,7 @@ public class IncludedProcessorTest {
     public void testExecuteMultipleRelations() throws Exception {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         queryParams.put(INCLUDE, Arrays.asList("children", "spouses"));
         testScope.setQueryParams(queryParams);
         includedProcessor.execute(jsonApiDocument, testScope, parentRecord1, queryParams);
@@ -180,7 +179,7 @@ public class IncludedProcessorTest {
     public void testExecuteMultipleNestedRelations() throws Exception {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("children.friends"));
         testScope.setQueryParams(queryParams);
         includedProcessor.execute(jsonApiDocument, testScope, parentRecord3, queryParams);
@@ -202,7 +201,7 @@ public class IncludedProcessorTest {
     public void testIncludeForbiddenRelationship() {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         queryParams.put(INCLUDE, Collections.singletonList("relation1"));
         testScope.setQueryParams(queryParams);
         includedProcessor.execute(jsonApiDocument, testScope, funWithPermissionsRecord, queryParams);
@@ -225,7 +224,7 @@ public class IncludedProcessorTest {
     public void testNoQueryIncludeParams() throws Exception {
         JsonApiDocument jsonApiDocument = new JsonApiDocument();
 
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
         queryParams.put("unused", Collections.emptyList());
         testScope.setQueryParams(queryParams);
         includedProcessor.execute(jsonApiDocument, testScope, parentRecord1, queryParams);

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/extensions/JsonApiAtomicOperationsTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/extensions/JsonApiAtomicOperationsTest.java
@@ -32,13 +32,13 @@ import example.Company;
 import example.Person;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.glassfish.jersey.internal.util.collection.ImmutableMultivaluedMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.function.Function;
@@ -64,7 +64,7 @@ public class JsonApiAtomicOperationsTest {
             Function<JsonApiAtomicOperationsRequestScope, Supplier<Pair<Integer, JsonNode>>> callback) {
         try (DataStoreTransaction transaction = this.dataStore.beginTransaction()) {
             JsonApiAtomicOperationsRequestScope scope = new JsonApiAtomicOperationsRequestScope("https://elide.io", "", "", transaction, null,
-                    UUID.randomUUID(), ImmutableMultivaluedMap.empty(), new HashMap<>(), settings);
+                    UUID.randomUUID(), Collections.emptyMap(), new HashMap<>(), settings);
             Supplier<Pair<Integer, JsonNode>> result = callback.apply(scope);
 
             scope.saveOrCreateObjects();

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/QueryLogger.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/QueryLogger.java
@@ -8,8 +8,6 @@ package com.yahoo.elide.datastores.aggregation.core;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.datastores.aggregation.query.Query;
 
-import jakarta.ws.rs.core.MultivaluedMap;
-
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -29,7 +27,7 @@ public interface QueryLogger {
      * @param path The apiQuery endpoint path for the incoming query
      */
     void acceptQuery(UUID queryId, User user, Map<String, String> headers, String apiVer,
-                     MultivaluedMap<String, String> queryParams, String path);
+            Map<String, List<String>> queryParams, String path);
 
     /**
      * Processes and logs all the queries from QueryDetail.

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/Slf4jQueryLogger.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/core/Slf4jQueryLogger.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import jakarta.ws.rs.core.MultivaluedMap;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -48,7 +47,7 @@ public class Slf4jQueryLogger implements QueryLogger {
 
     @Override
     public void acceptQuery(UUID queryId, User user, Map<String, String> headers, String apiVer,
-                            MultivaluedMap<String, String> queryParams, String path) {
+            Map<String, List<String>> queryParams, String path) {
         ObjectNode rootNode = mapper.createObjectNode();
 
         rootNode.put(ID, queryId.toString());

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -36,8 +36,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
@@ -104,13 +102,12 @@ public class GraphQLEndpoint {
             @Context SecurityContext securityContext,
             String graphQLDocument) {
         Map<String, List<String>> requestHeaders = headerProcessor.process(headers.getRequestHeaders());
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>(uriInfo.getQueryParameters());
         User user = new SecurityContextUser(securityContext);
 
         String baseUrl = getBaseUrlEndpoint(uriInfo);
         String pathname = path;
         Route route = routeResolver.resolve(JSONAPI_CONTENT_TYPE, baseUrl, pathname, requestHeaders,
-                queryParams);
+                uriInfo.getQueryParameters());
 
         QueryRunner runner = runners.getOrDefault(route.getApiVersion(), null);
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -34,7 +34,6 @@ import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.core.MultivaluedHashMap;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -65,12 +64,6 @@ public class JsonApiController {
         this.routeResolver = routeResolver;
     }
 
-    private <K, V> MultivaluedHashMap<K, V> convert(MultiValueMap<K, V> springMVMap) {
-        MultivaluedHashMap<K, V> convertedMap = new MultivaluedHashMap<>(springMVMap.size());
-        springMVMap.forEach(convertedMap::put);
-        return convertedMap;
-    }
-
     @GetMapping(value = "/**", produces = JsonApi.MEDIA_TYPE)
     public Callable<ResponseEntity<String>> elideGet(@RequestHeader HttpHeaders requestHeaders,
                                                      @RequestParam MultiValueMap<String, String> allRequestParams,
@@ -86,7 +79,7 @@ public class JsonApiController {
             @Override
             public ResponseEntity<String> call() throws Exception {
                 ElideResponse response = elide.get(route.getBaseUrl(), route.getPath(),
-                        convert(allRequestParams), requestHeadersCleaned,
+                        route.getParameters(), requestHeadersCleaned,
                         user, route.getApiVersion(), UUID.randomUUID());
                 return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
             }
@@ -115,14 +108,14 @@ public class JsonApiController {
                             .operations(route.getBaseUrl(), request.getContentType(), request.getContentType(),
                                     route.getPath(),
                                     body,
-                                    convert(allRequestParams), requestHeadersCleaned, user, route.getApiVersion(),
+                                    route.getParameters(), requestHeadersCleaned, user, route.getApiVersion(),
                                    UUID.randomUUID());
                     return ResponseEntity.status(response.getResponseCode())
                             .contentType(MediaType.valueOf(JsonApi.AtomicOperations.MEDIA_TYPE))
                             .body(response.getBody());
                 } else {
                     ElideResponse response = elide.post(route.getBaseUrl(), route.getPath(), body,
-                            convert(allRequestParams), requestHeadersCleaned, user, route.getApiVersion(),
+                            route.getParameters(), requestHeadersCleaned, user, route.getApiVersion(),
                             UUID.randomUUID());
                     return ResponseEntity.status(response.getResponseCode())
                             .contentType(MediaType.valueOf(JsonApi.MEDIA_TYPE)).body(response.getBody());
@@ -151,7 +144,7 @@ public class JsonApiController {
             @Override
             public ResponseEntity<String> call() throws Exception {
                 ElideResponse response = elide.patch(route.getBaseUrl(), request.getContentType(),
-                        request.getContentType(), route.getPath(), body, convert(allRequestParams),
+                        request.getContentType(), route.getPath(), body, route.getParameters(),
                         requestHeadersCleaned, user, route.getApiVersion(), UUID.randomUUID());
                 return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
             }
@@ -174,7 +167,7 @@ public class JsonApiController {
             @Override
             public ResponseEntity<String> call() throws Exception {
                 ElideResponse response = elide.delete(route.getBaseUrl(), route.getPath(), null,
-                        convert(allRequestParams), requestHeadersCleaned,
+                        route.getParameters(), requestHeadersCleaned,
                         user, route.getApiVersion(), UUID.randomUUID());
                 return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
             }
@@ -199,7 +192,7 @@ public class JsonApiController {
             @Override
             public ResponseEntity<String> call() throws Exception {
                 ElideResponse response = elide
-                        .delete(route.getBaseUrl(), route.getPath(), body, convert(allRequestParams),
+                        .delete(route.getBaseUrl(), route.getPath(), body, route.getParameters(),
                                 requestHeadersCleaned, user, route.getApiVersion(), UUID.randomUUID());
                 return ResponseEntity.status(response.getResponseCode()).body(response.getBody());
             }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderCleansingTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderCleansingTest.java
@@ -37,9 +37,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -107,11 +105,11 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_CREATED);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).post(any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -130,11 +128,11 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_OK);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).get(any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -165,11 +163,11 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).patch(any(), any(), any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -188,7 +186,7 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).delete(
                 any(),
@@ -201,7 +199,7 @@ public class HeaderCleansingTest extends IntegrationTest {
                 any()
         );
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -224,7 +222,7 @@ public class HeaderCleansingTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).delete(
                 any(),
@@ -237,7 +235,7 @@ public class HeaderCleansingTest extends IntegrationTest {
                 any()
         );
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderIdentityTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/HeaderIdentityTest.java
@@ -37,9 +37,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -62,7 +60,7 @@ import java.util.Map;
         }
 )
 @ActiveProfiles("default")
-public class HeaderIdentityTest extends IntegrationTest {
+class HeaderIdentityTest extends IntegrationTest {
     public static final String SORT_PARAM = "sort";
     private String baseUrl;
 
@@ -85,7 +83,7 @@ public class HeaderIdentityTest extends IntegrationTest {
     }
 
     @Test
-    public void jsonVerifyParamsAndHeadersGetTest() {
+    void jsonVerifyParamsAndHeadersGetTest() {
         given()
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
@@ -108,11 +106,11 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_CREATED);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).post(any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -121,7 +119,7 @@ public class HeaderIdentityTest extends IntegrationTest {
     }
 
     @Test
-    public void jsonVerifyParamsAndHeadersPostTest() {
+    void jsonVerifyParamsAndHeadersPostTest() {
         given()
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
@@ -131,11 +129,11 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_OK);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).get(any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -144,7 +142,7 @@ public class HeaderIdentityTest extends IntegrationTest {
     }
 
     @Test
-    public void jsonVerifyParamsAndHeadersPatchTest() {
+    void jsonVerifyParamsAndHeadersPatchTest() {
         given()
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
@@ -166,11 +164,11 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).patch(any(), any(), any(), any(), any(), requestParamsCaptor.capture(), requestHeadersCleanedCaptor.capture(), any(), any(), any());
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -179,7 +177,7 @@ public class HeaderIdentityTest extends IntegrationTest {
     }
 
     @Test
-    public void jsonVerifyParamsAndHeadersDeleteTest() {
+    void jsonVerifyParamsAndHeadersDeleteTest() {
         given()
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
@@ -189,7 +187,7 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).delete(
                 any(),
@@ -202,7 +200,7 @@ public class HeaderIdentityTest extends IntegrationTest {
                 any()
         );
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 
@@ -211,7 +209,7 @@ public class HeaderIdentityTest extends IntegrationTest {
     }
 
     @Test
-    public void jsonVerifyParamsAndHeadersDeleteRelationshipTest() {
+    void jsonVerifyParamsAndHeadersDeleteRelationshipTest() {
         given()
                 .header(HttpHeaders.AUTHORIZATION, "willBeRemoved")
                 .header(HttpHeaders.PROXY_AUTHORIZATION, "willBeRemoved")
@@ -225,7 +223,7 @@ public class HeaderIdentityTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
 
-        ArgumentCaptor<MultivaluedMap<String, String>> requestParamsCaptor = ArgumentCaptor.forClass(MultivaluedMap.class);
+        ArgumentCaptor<Map<String, List<String>>> requestParamsCaptor = ArgumentCaptor.forClass(Map.class);
         ArgumentCaptor<Map<String, List<String>>> requestHeadersCleanedCaptor = ArgumentCaptor.forClass(Map.class);
         verify(elide.getElide()).delete(
                 any(),
@@ -238,7 +236,7 @@ public class HeaderIdentityTest extends IntegrationTest {
                 any()
         );
 
-        MultivaluedHashMap<String, String> expectedRequestParams = new MultivaluedHashMap<>();
+        Map<String, List<String>> expectedRequestParams = new HashMap<>();
         expectedRequestParams.put(SORT_PARAM, ImmutableList.of("name", "description"));
         assertEquals(expectedRequestParams, requestParamsCaptor.getValue());
 

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
@@ -106,9 +106,8 @@ public class ApiDocsEndpoint {
             @Context UriInfo uriInfo,
             @Context HttpHeaders headers
             ) {
-        Map<String, List<String>> queryParams = new HashMap<>(uriInfo.getQueryParameters());
         Route route = routeResolver.resolve(MediaType.APPLICATION_JSON, "", path, headers.getRequestHeaders(),
-                queryParams);
+                uriInfo.getQueryParameters());
         String name = route.getPath();
         if (name.startsWith("/")) {
             name = name.substring(1);
@@ -128,9 +127,8 @@ public class ApiDocsEndpoint {
             @Context UriInfo uriInfo,
             @Context HttpHeaders headers
     ) {
-        Map<String, List<String>> queryParams = new HashMap<>(uriInfo.getQueryParameters());
         Route route = routeResolver.resolve(MediaType.APPLICATION_YAML, "", path, headers.getRequestHeaders(),
-                queryParams);
+                uriInfo.getQueryParameters());
         String name = route.getPath();
         if (name.startsWith("/")) {
             name = name.substring(1);


### PR DESCRIPTION
## Description
This refactors the JAX-RS `MultivaluedMap` to the standard `Map`

After this is 
- Refactor request scope
- Refactor JSON API
- Refactor settings and config
- Add api version handling for graphql subscriptions

## Motivation and Context
This makes the code more consistent and reduces the dependency on JAX-RS.

## How Has This Been Tested?
Existing tests continue to pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
