### PR TITLE
Bump hibernate.version from 6.2.7.Final to 6.3.1.Final

### DIFF
--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/filter/FilterTranslator.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/filter/FilterTranslator.java
@@ -102,73 +102,85 @@ public class FilterTranslator implements FilterOperation<String> {
         GLOBAL_OPERATOR_GENERATORS.put(PREFIX, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.NONE,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(NOT_PREFIX, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.NONE,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(PREFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.LOWER,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(NOT_PREFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT(%s, '%%')",
                 CaseAwareJPQLGenerator.Case.LOWER,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(POSTFIX, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.NONE,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(NOT_POSTFIX, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.NONE,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(POSTFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.LOWER,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(NOT_POSTFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', %s)",
                 CaseAwareJPQLGenerator.Case.LOWER,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(INFIX, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.NONE,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(NOT_INFIX, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.NONE,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(INFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.LOWER,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(NOT_INFIX_CASE_INSENSITIVE, new CaseAwareJPQLGenerator(
                 "%s NOT LIKE CONCAT('%%', CONCAT(%s, '%%'))",
                 CaseAwareJPQLGenerator.Case.LOWER,
-                CaseAwareJPQLGenerator.ArgumentCount.ONE)
+                CaseAwareJPQLGenerator.ArgumentCount.ONE,
+                true)
         );
 
         GLOBAL_OPERATOR_GENERATORS.put(LT, (predicate, aliasGenerator) -> {

--- a/elide-datastore/elide-datastore-search/pom.xml
+++ b/elide-datastore/elide-datastore-search/pom.xml
@@ -48,13 +48,6 @@
             <artifactId>jakarta.persistence-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        
-        <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-core</artifactId>
-            <!-- This override is for hibernate-search-mapper-orm-orm6 6.1 fails with 6.2.2.Final -->
-            <version>6.2.7.Final</version>
-        </dependency> 
 
         <dependency>
             <groupId>org.hibernate.search</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <graal-sdk.version>23.1.0</graal-sdk.version>
         <guava.version>32.1.1-jre</guava.version>
         <handlebars.version>4.3.1</handlebars.version>
-        <hibernate.version>6.2.7.Final</hibernate.version>
+        <hibernate.version>6.3.1.Final</hibernate.version>
         <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
         <hibernate-search.version>6.2.1.Final</hibernate-search.version>
         <hjson.version>3.0.1</hjson.version>


### PR DESCRIPTION
## Description
Uses the `CONCAT` function to make the field a string for the `LIKE` operators.

## Motivation and Context
Hibernate now checks that the operand to the `LIKE` operator must be a string.

- https://github.com/hibernate/hibernate-orm/commit/935ac494dd19fc84672f64f5bd40b2b9ed7c76c3
- https://github.com/hibernate/hibernate-orm/blob/75f173a4a056c3091772079a0f95aa57ab71dad6/hibernate-core/src/main/java/org/hibernate/query/sqm/tree/predicate/SqmLikePredicate.java#L61-L62

## How Has This Been Tested?
Existing tests continue to pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
