### PR TITLE
Support api versioning for subscriptions

### DIFF
--- a/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/websocket/SubscriptionWebSocketConfiguratorBuilderCustomizer.java
+++ b/elide-datastore/elide-datastore-jms/src/main/java/com/yahoo/elide/datastores/jms/websocket/SubscriptionWebSocketConfiguratorBuilderCustomizer.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jms.websocket;
+
+import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfigurator.SubscriptionWebSocketConfiguratorBuilder;
+
+/**
+ * Used to customize the mutable {@link SubscriptionWebSocketConfiguratorBuilder}.
+ */
+public interface SubscriptionWebSocketConfiguratorBuilderCustomizer {
+    public void customize(SubscriptionWebSocketConfiguratorBuilder builder);
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLEndpoint.java
@@ -17,7 +17,6 @@ import com.yahoo.elide.core.request.route.NullRouteResolver;
 import com.yahoo.elide.core.request.route.Route;
 import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.core.security.User;
-import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.jsonapi.resources.SecurityContextUser;
 import com.yahoo.elide.utils.HeaderProcessor;
 import com.yahoo.elide.utils.ResourceUtils;
@@ -106,7 +105,7 @@ public class GraphQLEndpoint {
 
         String baseUrl = getBaseUrlEndpoint(uriInfo);
         String pathname = path;
-        Route route = routeResolver.resolve(JsonApi.MEDIA_TYPE, baseUrl, pathname, requestHeaders,
+        Route route = routeResolver.resolve(MediaType.APPLICATION_JSON, baseUrl, pathname, requestHeaders,
                 uriInfo.getQueryParameters());
 
         QueryRunner runner = runners.getOrDefault(route.getApiVersion(), null);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilder.java
@@ -54,7 +54,7 @@ public class SubscriptionModelBuilder {
     private GraphQLConversionUtils generator;   //Converts attributes (non Elide models) to GraphQL types.
     private GraphQLNameUtils nameUtils;         //Generates type names
     private EntityDictionary entityDictionary;  //Client provided model dictionary
-    private DataFetcher dataFetcher;        //Client provided data fetcher
+    private DataFetcher<?> dataFetcher;        //Client provided data fetcher
     private GraphQLArgument filterArgument;
     private Set<Type<?>> excludedEntities;  //Client controlled models to skip.
     private Set<Type<?>> relationshipTypes; //Keeps track of which relationship models need to be built.
@@ -69,7 +69,7 @@ public class SubscriptionModelBuilder {
      */
     public SubscriptionModelBuilder(EntityDictionary entityDictionary,
                         NonEntityDictionary nonEntityDictionary,
-                        DataFetcher dataFetcher, String apiVersion) {
+                        DataFetcher<?> dataFetcher, String apiVersion) {
         this.generator = new GraphQLConversionUtils(entityDictionary, nonEntityDictionary);
         this.entityDictionary = entityDictionary;
         this.nameUtils = new GraphQLNameUtils(entityDictionary);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/ConnectionInfo.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/ConnectionInfo.java
@@ -6,13 +6,11 @@
 
 package com.yahoo.elide.graphql.subscriptions.websocket;
 
+import com.yahoo.elide.core.request.route.Route;
 import com.yahoo.elide.core.security.User;
 
 import lombok.Builder;
 import lombok.Value;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Information about the sessions/connection passed to the request handler.
@@ -26,21 +24,11 @@ public class ConnectionInfo {
      */
     private User user;
 
-
     /**
-     * Return the URL path for this request.
-     * @return URL path.
+     * Returns the {@link Route} of the request which contains the base url, path,
+     * headers, parameters and api version of the request.
+     *
+     * @return the route of the request
      */
-    private String baseUrl;
-
-    /**
-     * Get a map of parameters for the session.
-     * @return map of parameters.
-     */
-    private Map<String, List<String>> parameters;
-
-    /**
-     * Gets the API version associated with this websocket.
-     */
-    private String apiVersion;
+    private Route route;
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/RequestHandler.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/RequestHandler.java
@@ -154,17 +154,12 @@ public class RequestHandler implements Closeable {
         elide.getTransactionRegistry().addRunningTransaction(requestID, transaction);
 
         ElideSettings settings = elide.getElideSettings();
+        Route route = connectionInfo.getRoute();
 
         GraphQLProjectionInfo projectionInfo =
             new SubscriptionEntityProjectionMaker(settings,
                                 subscribeRequest.getPayload().getVariables(),
-                                connectionInfo.getApiVersion()).make(subscribeRequest.getPayload().getQuery());
-
-        Route route = Route.builder()
-                .baseUrl(connectionInfo.getBaseUrl())
-                .apiVersion(connectionInfo.getApiVersion())
-                .parameters(connectionInfo.getParameters())
-                .build();
+                                route.getApiVersion()).make(subscribeRequest.getPayload().getQuery());
 
         GraphQLRequestScope requestScope = GraphQLRequestScope.builder()
                 .route(route)

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
@@ -7,17 +7,24 @@ package com.yahoo.elide.spring.config;
 
 import static com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket.DEFAULT_USER_FACTORY;
 
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+
 import com.yahoo.elide.core.audit.Slf4jLogger;
+import com.yahoo.elide.core.dictionary.Injector;
 import com.yahoo.elide.core.exceptions.ErrorMapper;
+import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfigurator;
+import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfigurator.SubscriptionWebSocketConfiguratorBuilder;
+import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfiguratorBuilderCustomizer;
 import com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 import graphql.execution.DataFetcherExceptionHandler;
@@ -32,39 +39,86 @@ import jakarta.websocket.server.ServerEndpointConfig;
 @ConditionalOnProperty(name = "elide.graphql.enabled", havingValue = "true")
 @EnableConfigurationProperties(ElideConfigProperties.class)
 public class ElideSubscriptionConfiguration {
+    /**
+     * Exposes a subscription {@link ServerEndpointConfig} that doesn't accept a
+     * path parameter for api versioning.
+     *
+     * @param config  the config
+     * @param builder the builder
+     * @return the config
+     */
     @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnExpression("${elide.graphql.subscription.enabled:false}")
-    ServerEndpointConfig serverEndpointConfig(
-            ElideConfigProperties config,
-            SubscriptionWebSocket.UserFactory userFactory,
-            ConnectionFactory connectionFactory,
-            ErrorMapper errorMapper,
-            DataFetcherExceptionHandler dataFetcherExceptionHandler
-    ) {
+    @ConditionalOnProperty(name = "elide.graphql.subscription.enabled", havingValue = "true")
+    ServerEndpointConfig serverEndpointConfig(ElideConfigProperties config,
+            SubscriptionWebSocketConfiguratorBuilder builder) {
+        String path = config.getGraphql().getSubscription().getPath();
         return ServerEndpointConfig.Builder
-                .create(SubscriptionWebSocket.class, config.getGraphql().getSubscription().getPath())
+                .create(SubscriptionWebSocket.class, path)
                 .subprotocols(SubscriptionWebSocket.SUPPORTED_WEBSOCKET_SUBPROTOCOLS)
-                .configurator(SubscriptionWebSocketConfigurator.builder()
-                        .baseUrl(config.getGraphql().getSubscription().getPath())
-                        .sendPingOnSubscribe(config.getGraphql().getSubscription().isSendPingOnSubscribe())
-                        .connectionTimeout(config.getGraphql().getSubscription().getConnectionTimeout())
-                        .maxSubscriptions(config.getGraphql().getSubscription().maxSubscriptions)
-                        .maxMessageSize(config.getGraphql().getSubscription().maxMessageSize)
-                        .maxIdleTimeout(config.getGraphql().getSubscription().getIdleTimeout())
-                        .connectionFactory(connectionFactory)
-                        .userFactory(userFactory)
-                        .auditLogger(new Slf4jLogger())
-                        .verboseErrors(config.isVerboseErrors())
-                        .errorMapper(errorMapper)
-                        .dataFetcherExceptionHandler(dataFetcherExceptionHandler)
-                        .build())
+                .configurator(builder.build())
+                .build();
+    }
+
+    /**
+     * Exposes a subscription {@link ServerEndpointConfig} that accepts a path
+     * parameter for api versioning.
+     *
+     * @param config  the config
+     * @param builder the builder
+     * @return the config
+     */
+    @Bean
+    @ConditionalOnProperty(name = "elide.graphql.subscription.enabled", havingValue = "true")
+    ServerEndpointConfig serverEndpointConfigPath(ElideConfigProperties config,
+            SubscriptionWebSocketConfiguratorBuilder builder) {
+        String path = config.getGraphql().getSubscription().getPath();
+        if (!path.endsWith("/")) {
+            path = path + "/";
+        }
+        path = path + "{path}";
+        return ServerEndpointConfig.Builder
+                .create(SubscriptionWebSocket.class, path)
+                .subprotocols(SubscriptionWebSocket.SUPPORTED_WEBSOCKET_SUBPROTOCOLS)
+                .configurator(builder.build())
                 .build();
     }
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnExpression("${elide.graphql.subscription.enabled:false}")
+    @ConditionalOnProperty(name = "elide.graphql.subscription.enabled", havingValue = "true")
+    @Scope(SCOPE_PROTOTYPE)
+    SubscriptionWebSocketConfiguratorBuilder subscriptionWebSocketConfiguratorBuilder(
+            ElideConfigProperties config,
+            SubscriptionWebSocket.UserFactory userFactory,
+            ConnectionFactory connectionFactory,
+            ErrorMapper errorMapper,
+            DataFetcherExceptionHandler dataFetcherExceptionHandler,
+            RouteResolver routeResolver,
+            ObjectProvider<SubscriptionWebSocketConfiguratorBuilderCustomizer> customizers,
+            Injector injector
+            ) {
+        SubscriptionWebSocketConfiguratorBuilder builder = SubscriptionWebSocketConfigurator.builder()
+                .baseUrl(config.getGraphql().getSubscription().getPath())
+                .sendPingOnSubscribe(config.getGraphql().getSubscription().isSendPingOnSubscribe())
+                .connectionTimeout(config.getGraphql().getSubscription().getConnectionTimeout())
+                .maxSubscriptions(config.getGraphql().getSubscription().maxSubscriptions)
+                .maxMessageSize(config.getGraphql().getSubscription().maxMessageSize)
+                .maxIdleTimeout(config.getGraphql().getSubscription().getIdleTimeout())
+                .connectionFactory(connectionFactory)
+                .userFactory(userFactory)
+                .auditLogger(new Slf4jLogger())
+                .verboseErrors(config.isVerboseErrors())
+                .errorMapper(errorMapper)
+                .dataFetcherExceptionHandler(dataFetcherExceptionHandler)
+                .routeResolver(routeResolver)
+                .injector(injector);
+        customizers.orderedStream().forEach(customizer -> customizer.customize(builder));
+        return builder;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "elide.graphql.subscription.enabled", havingValue = "true")
     ServerEndpointExporter serverEndpointExporter() {
         ServerEndpointExporter exporter = new ServerEndpointExporter();
         return exporter;
@@ -72,7 +126,7 @@ public class ElideSubscriptionConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnExpression("${elide.graphql.subscription.enabled:false}")
+    @ConditionalOnProperty(name = "elide.graphql.subscription.enabled", havingValue = "true")
     SubscriptionWebSocket.UserFactory userFactory() {
         return DEFAULT_USER_FACTORY;
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideSubscriptionConfigurationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideSubscriptionConfigurationTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
@@ -23,6 +24,8 @@ import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.websocket.server.ServerEndpointConfig;
+
+import java.util.List;
 
 /**
  * Test for ElideSubscriptionConfiguration.
@@ -50,9 +53,11 @@ class ElideSubscriptionConfigurationTest {
     void configured() {
         contextRunner.withPropertyValues("elide.graphql.subscription.enabled=true", "elide.graphql.enabled=true")
                 .withUserConfiguration(JmsConfiguration.class).run(context -> {
-                    ServerEndpointConfig config = context
-                            .getBean(ServerEndpointConfig.class);
-                    assertThat(config).isNotNull();
+                    ObjectProvider<ServerEndpointConfig> provider = context
+                            .getBeanProvider(ServerEndpointConfig.class);
+                    // 2 configurations to handle path api versioning strategy
+                    List<ServerEndpointConfig> config = provider.orderedStream().toList();
+                    assertThat(config).hasSize(2);
                 });
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/v2/ArtifactGroupV2.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/v2/ArtifactGroupV2.java
@@ -7,6 +7,8 @@
 package example.models.jpa.v2;
 
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.graphql.subscriptions.annotations.Subscription;
+import com.yahoo.elide.graphql.subscriptions.annotations.SubscriptionField;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,11 +19,15 @@ import lombok.Data;
 @Include(name = "group")
 @Entity
 @Data
+@Subscription
 @Table(name = "ArtifactGroup")
 public class ArtifactGroupV2 {
     @Id
     private String name = "";
 
+    @SubscriptionField
     @Column(name = "commonName")
     private String title = "";
+
+    private boolean deprecated = false;
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -146,6 +146,7 @@ public class ControllerTest extends IntegrationTest {
                                         type("group"),
                                         id("com.example.repository"),
                                         attributes(
+                                                attr("deprecated", false),
                                                 attr("title", "Example Repository")
                                         ),
                                         links(
@@ -169,6 +170,7 @@ public class ControllerTest extends IntegrationTest {
                                         type("group"),
                                         id("com.example.repository"),
                                         attributes(
+                                                attr("deprecated", false),
                                                 attr("title", "Example Repository")
                                         ),
                                         links(

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/ElideStandalone.java
@@ -116,9 +116,11 @@ public class ElideStandalone {
         if (elideStandaloneSettings.enableGraphQL() && subscriptionSettings.enabled()) {
             // GraphQL subscription endpoint
             JakartaWebSocketServletContainerInitializer.configure(context, (servletContext, serverContainer) -> {
-                        serverContainer.addEndpoint(subscriptionSettings.serverEndpointConfig(elideStandaloneSettings));
+                serverContainer.addEndpoint(subscriptionSettings.serverEndpointConfig(elideStandaloneSettings, false));
             });
-
+            JakartaWebSocketServletContainerInitializer.configure(context, (servletContext, serverContainer) -> {
+                serverContainer.addEndpoint(subscriptionSettings.serverEndpointConfig(elideStandaloneSettings, true));
+            });
         }
 
         if (elideStandaloneSettings.getAsyncProperties().enableExport()) {

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSubscriptionSettings.java
@@ -146,10 +146,17 @@ public interface ElideStandaloneSubscriptionSettings {
      * @return Web socket configuration.
      */
     default ServerEndpointConfig serverEndpointConfig(
-            ElideStandaloneSettings settings
+            ElideStandaloneSettings settings, boolean pathParameter
     ) {
+        String path = getPath();
+        if (pathParameter) {
+            if (!path.endsWith("/")) {
+                path = path + "/";
+            }
+            path += "{path}";
+        }
         return ServerEndpointConfig.Builder
-                .create(SubscriptionWebSocket.class, getPath())
+                .create(SubscriptionWebSocket.class, path)
                 .subprotocols(SubscriptionWebSocket.SUPPORTED_WEBSOCKET_SUBPROTOCOLS)
                 .configurator(SubscriptionWebSocketConfigurator.builder()
                         .baseUrl(getPath())

--- a/elide-standalone/src/test/java/example/models/v2/PostV2.java
+++ b/elide-standalone/src/test/java/example/models/v2/PostV2.java
@@ -9,6 +9,9 @@ package example.models.v2;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
+import com.yahoo.elide.graphql.subscriptions.annotations.Subscription;
+import com.yahoo.elide.graphql.subscriptions.annotations.SubscriptionField;
+
 import example.checks.AdminCheck;
 
 import jakarta.persistence.Column;
@@ -25,11 +28,13 @@ import java.util.Date;
 @Include(name = "post")
 @Data
 @Table(name = "Post")
+@Subscription
 public class PostV2 {
     @Id
     private long id;
 
     @Column(nullable = false, name = "content")
+    @SubscriptionField
     private String text;
 
     @Temporal(TemporalType.TIMESTAMP)


### PR DESCRIPTION
## Description
Adds support for GraphQL subscriptions to handle API versioning.

## Motivation and Context
GraphQL subscriptions couldn't easily handle API versioning.

## How Has This Been Tested?
Added the appropriated tests and manually with modified example applications.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
