### PR TITLE
Add generic, json api and graphql errors

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/ElideError.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideError.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide;
+
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Represents an error that can later be mapped to the more specific
+ * JsonApiError or GraphQLError.
+ *
+ * @see ElideErrors
+ */
+@Getter
+public class ElideError {
+    /**
+     * The error message. For JSON-API this will be mapped to the details member and
+     * for GraphQL this will be mapped to the message member.
+     */
+    private final String message;
+
+    /**
+     * Additional attributes about the error. For JSON-API this will be mapped to the
+     * meta member and for GraphQL this will be mapped to the extensions member.
+     */
+    private final Map<String, Object> attributes;
+
+    public ElideError(String message, Map<String, Object> attributes) {
+        this.message = message;
+        this.attributes = attributes;
+    }
+
+    /**
+     * Returns a mutable {@link ElideErrorBuilder} for building {@link ElideError}.
+     *
+     * @return the builder
+     */
+    public static ElideErrorBuilder builder() {
+        return new ElideErrorBuilder();
+    }
+
+    /**
+     * A mutable builder for building {@link ElideError}.
+     */
+    public static class ElideErrorBuilder {
+        private String message;
+        private Map<String, Object> attributes = new LinkedHashMap<>();
+
+        /**
+         * Sets the message of the error.
+         * <p>
+         * For JSON-API this will be mapped to the details member and for GraphQL this
+         * will be mapped to the message member.
+         *
+         * @param message the message
+         * @return the builder
+         */
+        public ElideErrorBuilder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        /**
+         * Sets the attributes.
+         *
+         * @param attributes the attributes to set
+         * @return the builder
+         */
+        public ElideErrorBuilder attributes(Map<String, Object> attributes) {
+            this.attributes = attributes;
+            return this;
+        }
+
+        /**
+         * Customize the attributes.
+         *
+         * @param attributes the customizer
+         * @return the builder
+         */
+        public ElideErrorBuilder attributes(Consumer<Map<String, Object>> attributes) {
+            attributes.accept(this.attributes);
+            return this;
+        }
+
+        /**
+         * Sets the attribute.
+         *
+         * @param key the key
+         * @param value the value
+         * @return the builder
+         */
+        public ElideErrorBuilder attribute(String key, Object value) {
+            this.attributes.put(key, value);
+            return this;
+        }
+
+        /**
+         * Builds the {@link ElideError}.
+         *
+         * @return the ElideError
+         */
+        public ElideError build() {
+            return new ElideError(this.message, this.attributes);
+        }
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/ElideErrors.java
+++ b/elide-core/src/main/java/com/yahoo/elide/ElideErrors.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Stores the list of errors.
+ * <p>
+ * Builder example:
+ * <pre><code>
+ * ElideErrors.builder()
+ *     .error(error -> error.message(message).attribute("code", "INTERNAL_SERVER_ERROR"))
+ *     .build();
+ * </code></pre>
+ *
+ * @see ElideError
+ */
+@Getter
+public class ElideErrors {
+    private final List<ElideError> errors;
+
+    public ElideErrors(List<ElideError> errors) {
+        this.errors = errors;
+    }
+
+    public static ElideErrorsBuilder builder() {
+        return new ElideErrorsBuilder();
+    }
+
+    public static class ElideErrorsBuilder {
+        private List<ElideError> errors = new ArrayList<>();
+
+        public ElideErrorsBuilder error(Consumer<ElideError.ElideErrorBuilder> error) {
+            ElideError.ElideErrorBuilder builder = ElideError.builder();
+            error.accept(builder);
+            return error(builder.build());
+        }
+
+        public ElideErrorsBuilder error(ElideError error) {
+            this.errors.add(error);
+            return this;
+        }
+
+        public ElideErrors build() {
+            return new ElideErrors(this.errors);
+        }
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiError.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiError.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.jsonapi.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Represents a JSON API Error Object.
+ */
+@Builder
+@Getter
+@JsonInclude(Include.NON_NULL)
+@JsonPropertyOrder({"id", "links", "status", "code", "source", "title", "detail", "meta"})
+public class JsonApiError {
+    @Builder
+    @Getter
+    @JsonInclude(Include.NON_NULL)
+    @JsonPropertyOrder({"about", "type"})
+    public static class Links {
+        private final String about;
+        private final String type;
+
+        @JsonCreator
+        public Links(@JsonProperty("about") String about, @JsonProperty("type") String type) {
+            this.about = about;
+            this.type = type;
+        }
+    }
+
+    @Builder
+    @Getter
+    @JsonInclude(Include.NON_NULL)
+    @JsonPropertyOrder({"pointer", "parameter", "header"})
+    public static class Source {
+        private final String pointer;
+        private final String parameter;
+        private final String header;
+
+        @JsonCreator
+        public Source(@JsonProperty("pointer") String pointer, @JsonProperty("parameter") String parameter,
+                @JsonProperty("header") String header) {
+            this.pointer = pointer;
+            this.parameter = parameter;
+            this.header = header;
+        }
+    }
+
+    private final String id;
+    private final Links links;
+    private final String status;
+    private final String code;
+    private final Source source;
+    private final String title;
+    private final String detail;
+    private final Object meta;
+
+    @JsonCreator
+    public JsonApiError(@JsonProperty("id") String id, @JsonProperty("links") Links links,
+            @JsonProperty("status") String status, @JsonProperty("code") String code,
+            @JsonProperty("source") Source source, @JsonProperty("title") String title,
+            @JsonProperty("detail") String detail, @JsonProperty("meta") Object meta) {
+        this.id = id;
+        this.links = links;
+        this.status = status;
+        this.code = code;
+        this.source = source;
+        this.title = title;
+        this.detail = detail;
+        this.meta = meta;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getMeta() {
+        return (T) this.meta;
+    }
+
+    /**
+     * A mutable builder for building {@link JsonApiError}.
+     */
+    public static class JsonApiErrorBuilder {
+        /**
+         * Sets the {@link Links}.
+         *
+         * @param links the links
+         * @return the builder
+         */
+        public JsonApiErrorBuilder links(Links links) {
+            this.links = links;
+            return this;
+        }
+
+        /**
+         * Customize the {@link Links}.
+         *
+         * @param links the customizer
+         * @return the builder
+         */
+        public JsonApiErrorBuilder links(Consumer<Links.LinksBuilder> links) {
+            Links.LinksBuilder builder = new Links.LinksBuilder();
+            links.accept(builder);
+            this.links = builder.build();
+            return this;
+        }
+
+        /**
+         * Sets the {@link Source}.
+         *
+         * @param source the source
+         * @return the builder
+         */
+        public JsonApiErrorBuilder source(Source source) {
+            this.source = source;
+            return this;
+        }
+
+        /**
+         * Customize the {@link Source}.
+         *
+         * @param source the customizer
+         * @return the builder
+         */
+        public JsonApiErrorBuilder source(Consumer<Source.SourceBuilder> source) {
+            Source.SourceBuilder builder = new Source.SourceBuilder();
+            source.accept(builder);
+            this.source = builder.build();
+            return this;
+        }
+
+        /**
+         * Customize the meta.
+         *
+         * @param meta the customizer
+         * @return the builder
+         */
+        public JsonApiErrorBuilder meta(Consumer<Map<String, Object>> meta) {
+            Map<String, Object> builder = new LinkedHashMap<>();
+            meta.accept(builder);
+            return meta(builder);
+        }
+
+        /**
+         * Sets the meta.
+         *
+         * @param meta the meta
+         * @return the builder
+         */
+        public <M> JsonApiErrorBuilder meta(M meta) {
+            this.meta = meta;
+            return this;
+        }
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiErrors.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/models/JsonApiErrors.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.jsonapi.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Error Objects, see http://jsonapi.org/format/#error-objects. <br><br>
+ * Builder example: <br>
+ * <pre><code>
+ * ErrorObjects errors = ErrorObjects.builder()
+ *         .error(error -> error.status("403").source(source -> source.pointer("/data/attributes/secretPowers"))
+ *                 .detail("Editing secret powers is not authorized on Sundays."))
+ *         .error(error -> error.status("422").source(source -> source.pointer("/data/attributes/volume"))
+ *                 .detail("Volume does not, in fact, go to 11."))
+ *         .error(error -> error.status("500").source(source -> source.pointer("/data/attributes/reputation"))
+ *                 .title("The backend responded with an error")
+ *                 .detail("Reputation service not responding after three requests."))
+ *         .build();
+ * </code></pre>
+ */
+public class JsonApiErrors {
+    @Getter
+    private final List<JsonApiError> errors;
+
+    @JsonCreator
+    public JsonApiErrors(@JsonProperty("errors") List<JsonApiError> errors) {
+        this.errors = Objects.requireNonNull(errors, "errors must not be null");
+    }
+
+    /**
+     * Returns a mutable builder for {@link JsonApiErrors}.
+     *
+     * @return the mutable builder
+     */
+    public static JsonApiErrorsBuilder builder() {
+        return new JsonApiErrorsBuilder();
+    }
+
+    /**
+     * The mutable builder for {@link JsonApiErrors}.
+     */
+    public static class JsonApiErrorsBuilder {
+        private List<JsonApiError> errors = new ArrayList<>();
+
+        public JsonApiErrorsBuilder error(JsonApiError error) {
+            this.errors.add(error);
+            return this;
+        }
+
+        public JsonApiErrorsBuilder error(Consumer<JsonApiError.JsonApiErrorBuilder> error) {
+            JsonApiError.JsonApiErrorBuilder builder = JsonApiError.builder();
+            error.accept(builder);
+            return error(builder.build());
+        }
+
+        public JsonApiErrorsBuilder errors(List<JsonApiError> errors) {
+            this.errors = errors;
+            return this;
+        }
+
+        public JsonApiErrorsBuilder errors(Consumer<List<JsonApiError>> errors) {
+            errors.accept(this.errors);
+            return this;
+        }
+
+        public JsonApiErrors build() {
+            if (this.errors.isEmpty()) {
+                throw new IllegalArgumentException("At least one error is required");
+            }
+            return new JsonApiErrors(this.errors);
+        }
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/ElideErrorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/ElideErrorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/**
+ * Test for ElideError.
+ */
+class ElideErrorTest {
+
+    @Test
+    void attributesCustomizer() {
+        ElideError error = ElideError.builder().attributes(attributes -> attributes.put("key", "value")).build();
+        assertEquals("value", error.getAttributes().get("key"));
+    }
+
+    @Test
+    void attributes() {
+        ElideError error = ElideError.builder().attributes(Map.of("key", "value")).build();
+        assertEquals("value", error.getAttributes().get("key"));
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/models/JsonApiErrorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/models/JsonApiErrorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.jsonapi.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Test for JsonApiError.
+ */
+class JsonApiErrorTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void getMeta() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder()
+                .meta(meta -> meta.put("property", "property"))
+                .build();
+        Map<String, Object> meta = error.getMeta();
+        assertEquals("property", meta.get("property"));
+    }
+
+    @Test
+    void meta() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder()
+                .meta(Map.of("property1", "value1"))
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"meta":{"property1":"value1"}}""";
+        assertEquals(expected, actual);
+    }
+
+
+    @Test
+    void links() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder()
+                .links(links -> links.about("https://about").type("https://type"))
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"links":{"about":"https://about","type":"https://type"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void linksObject() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder()
+                .links(JsonApiError.Links.builder().about("https://about").type("https://type").build())
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"links":{"about":"https://about","type":"https://type"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void source() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder()
+                .source(source -> source.header("header").parameter("parameter").pointer("/data/attributes/title"))
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"source":{"pointer":"/data/attributes/title","parameter":"parameter","header":"header"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void sourceObject() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder()
+                .source(JsonApiError.Source.builder().header("header").parameter("parameter")
+                        .pointer("/data/attributes/title").build())
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"source":{"pointer":"/data/attributes/title","parameter":"parameter","header":"header"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Getter
+    public static class MetaObject {
+        String property = "value";
+    }
+
+    @Test
+    void metaObject() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder()
+                .meta(new MetaObject())
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"meta":{"property":"value"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void builderToStringEquals() {
+        assertEquals(JsonApiError.builder().toString(), JsonApiError.builder().toString());
+    }
+
+    @Test
+    void builderToStringNotEquals() {
+        assertNotEquals(JsonApiError.builder().toString(), JsonApiError.builder().detail("detail").toString());
+    }
+
+    @Test
+    void linksBuilderToStringEquals() {
+        assertEquals(JsonApiError.Links.builder().toString(), JsonApiError.Links.builder().toString());
+    }
+
+    @Test
+    void linksBuilderToStringNotEquals() {
+        assertNotEquals(JsonApiError.Links.builder().toString(), JsonApiError.Links.builder().type("type").toString());
+    }
+
+    @Test
+    void sourceBuilderToStringEquals() {
+        assertEquals(JsonApiError.Source.builder().toString(), JsonApiError.Source.builder().toString());
+    }
+
+    @Test
+    void sourceBuilderToStringNotEquals() {
+        assertNotEquals(JsonApiError.Source.builder().toString(),
+                JsonApiError.Source.builder().header("header").toString());
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/models/JsonApiErrorsTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/models/JsonApiErrorsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.jsonapi.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+/**
+ * Test for JsonApiErrors.
+ */
+class JsonApiErrorsTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void basicErrorObject() throws JsonProcessingException {
+        JsonApiErrors errors = JsonApiErrors.builder()
+                .error(error -> error.status("422").source(source -> source.pointer("/data/attributes/firstName"))
+                        .title("Invalid Attribute").detail("First name must contain at least two characters."))
+                .build();
+        String actual = objectMapper.writeValueAsString(errors);
+        String expected = """
+                {"errors":[{"status":"422","source":{"pointer":"/data/attributes/firstName"},"title":"Invalid Attribute","detail":"First name must contain at least two characters."}]}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void multipleErrors() throws JsonProcessingException {
+        JsonApiErrors errors = JsonApiErrors.builder()
+                .error(error -> error.status("403").source(source -> source.pointer("/data/attributes/secretPowers"))
+                        .detail("Editing secret powers is not authorized on Sundays."))
+                .error(error -> error.status("422").source(source -> source.pointer("/data/attributes/volume"))
+                        .detail("Volume does not, in fact, go to 11."))
+                .error(error -> error.status("500").source(source -> source.pointer("/data/attributes/reputation"))
+                        .title("The backend responded with an error")
+                        .detail("Reputation service not responding after three requests."))
+                .build();
+        String actual = objectMapper.writeValueAsString(errors);
+        String expected = """
+                {"errors":[{"status":"403","source":{"pointer":"/data/attributes/secretPowers"},"detail":"Editing secret powers is not authorized on Sundays."},{"status":"422","source":{"pointer":"/data/attributes/volume"},"detail":"Volume does not, in fact, go to 11."},{"status":"500","source":{"pointer":"/data/attributes/reputation"},"title":"The backend responded with an error","detail":"Reputation service not responding after three requests."}]}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void meta() throws JsonProcessingException {
+        JsonApiErrors errors = JsonApiErrors.builder()
+                .error(error -> error.status("422").meta(meta -> meta.put("property", "property")))
+                .build();
+        String actual = objectMapper.writeValueAsString(errors);
+        String expected = """
+                {"errors":[{"status":"422","meta":{"property":"property"}}]}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void emptyShouldThrow() {
+        JsonApiErrors.JsonApiErrorsBuilder builder = JsonApiErrors.builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.build());
+    }
+
+    @Test
+    void errorsConsumer() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder().detail("First name must contain at least two characters.").build();
+        JsonApiErrors errorObjects = JsonApiErrors.builder().errors(errors -> errors.add(error)).build();
+        String actual = objectMapper.writeValueAsString(errorObjects);
+        String expected = """
+                {"errors":[{"detail":"First name must contain at least two characters."}]}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void errors() throws JsonProcessingException {
+        JsonApiError error = JsonApiError.builder().detail("First name must contain at least two characters.").build();
+        JsonApiErrors errorObjects = JsonApiErrors.builder().errors(Collections.singletonList(error)).build();
+        String actual = objectMapper.writeValueAsString(errorObjects);
+        String expected = """
+                {"errors":[{"detail":"First name must contain at least two characters."}]}""";
+        assertEquals(expected, actual);
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/models/GraphQLError.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/models/GraphQLError.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.models;
+
+import static graphql.Assert.assertNotNull;
+
+import com.yahoo.elide.graphql.GraphQLErrorSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import graphql.ErrorClassification;
+import graphql.language.SourceLocation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * GraphQL Error.
+ */
+public class GraphQLError {
+    private GraphQLError() {
+    }
+
+    public static GraphQLErrorBuilder builder() {
+        return new GraphQLErrorBuilder();
+    }
+
+    public static class GraphQLErrorBuilder extends graphql.GraphqlErrorBuilder<GraphQLErrorBuilder> {
+        private Map<String, Object> extensions = new LinkedHashMap<>();
+        private List<SourceLocation> locations = null;
+
+        public GraphQLErrorBuilder path(Object ... path) {
+            return path(Arrays.asList(path));
+        }
+
+        public GraphQLErrorBuilder location(Consumer<SourceLocationBuilder> location) {
+            SourceLocationBuilder builder = new SourceLocationBuilder();
+            location.accept(builder);
+            if (getLocations() == null) {
+                this.locations = new ArrayList<>();
+            }
+            return location(builder.build());
+        }
+
+        public GraphQLErrorBuilder locations(Consumer<List<SourceLocation>> locations) {
+            if (getLocations() == null) {
+                this.locations = new ArrayList<>();
+            }
+            locations.accept(getLocations());
+            return this;
+        }
+
+        public GraphQLErrorBuilder extension(String key, Object value) {
+            this.extensions.put(key, value);
+            return super.extensions(this.extensions);
+        }
+
+        public GraphQLErrorBuilder extensions(Consumer<Map<String, Object>> extensions) {
+            extensions.accept(this.extensions);
+            return super.extensions(this.extensions);
+        }
+
+        @Override
+        public GraphQLErrorBuilder extensions(Map<String, Object> extensions) {
+            this.extensions = extensions;
+            return super.extensions(this.extensions);
+        }
+
+        @Override
+        public GraphQLErrorBuilder locations(List<SourceLocation> locations) {
+            if (getLocations() == null) {
+                this.locations = new ArrayList<>();
+            }
+            this.locations.addAll(locations);
+            return this;
+        }
+
+        @Override
+        public GraphQLErrorBuilder location(SourceLocation location) {
+            if (getLocations() == null) {
+                this.locations = new ArrayList<>();
+            }
+            this.locations.add(location);
+            return this;
+        }
+
+        @Override
+        public List<SourceLocation> getLocations() {
+            return this.locations;
+        }
+
+        @Override
+        public graphql.GraphQLError build() {
+            assertNotNull(getMessage(), () -> "You must provide error message");
+            return new BasicGraphQLError(getMessage(), locations, getErrorType(), getPath(),
+                    extensions.isEmpty() ? null : extensions);
+        }
+
+        @JsonSerialize(using = GraphQLErrorSerializer.class)
+        private static class BasicGraphQLError implements graphql.GraphQLError {
+            private static final long serialVersionUID = 1L;
+            private final String message;
+            private final List<SourceLocation> locations;
+            private final ErrorClassification errorType;
+            private final List<Object> path;
+            private final Map<String, Object> extensions;
+
+            public BasicGraphQLError(String message, List<SourceLocation> locations, ErrorClassification errorType,
+                    List<Object> path, Map<String, Object> extensions) {
+                this.message = message;
+                this.locations = locations;
+                this.errorType = errorType;
+                this.path = path;
+                this.extensions = extensions;
+            }
+
+            @Override
+            public String getMessage() {
+                return message;
+            }
+
+            @Override
+            public List<SourceLocation> getLocations() {
+                return locations;
+            }
+
+            @Override
+            public ErrorClassification getErrorType() {
+                return errorType;
+            }
+
+            @Override
+            public List<Object> getPath() {
+                return path;
+            }
+
+            @Override
+            public Map<String, Object> getExtensions() {
+                return extensions;
+            }
+
+            @Override
+            public String toString() {
+                return message;
+            }
+        }
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/models/GraphQLErrors.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/models/GraphQLErrors.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * GraphQLErrors.
+ *
+ * @see <a href="https://spec.graphql.org/October2021/#sec-Errors">Errors</a>
+ */
+public class GraphQLErrors {
+    @Getter
+    private final List<graphql.GraphQLError> errors;
+
+    @JsonCreator
+    public GraphQLErrors(@JsonProperty("errors") List<graphql.GraphQLError> errors) {
+        this.errors = Objects.requireNonNull(errors, "errors must not be null");
+    }
+
+    /**
+     * Returns a mutable builder for {@link GraphQLErrors}.
+     *
+     * @return
+     */
+    public static GraphQLErrorsBuilder builder() {
+        return new GraphQLErrorsBuilder();
+    }
+
+    /**
+     * The mutable builder for {@link GraphQLErrors}.
+     */
+    public static class GraphQLErrorsBuilder {
+        private List<graphql.GraphQLError> errors = new ArrayList<>();
+
+        public GraphQLErrorsBuilder error(graphql.GraphQLError ... error) {
+            this.errors.addAll(Arrays.asList(error));
+            return this;
+        }
+
+        public GraphQLErrorsBuilder error(Consumer<GraphQLError.GraphQLErrorBuilder> error) {
+            GraphQLError.GraphQLErrorBuilder builder = GraphQLError.builder();
+            error.accept(builder);
+            return error(builder.build());
+        }
+
+        public GraphQLErrorsBuilder errors(List<graphql.GraphQLError> errors) {
+            this.errors = errors;
+            return this;
+        }
+
+        public GraphQLErrorsBuilder errors(Consumer<List<graphql.GraphQLError>> errors) {
+            errors.accept(this.errors);
+            return this;
+        }
+
+        public GraphQLErrors build() {
+            if (this.errors.isEmpty()) {
+                throw new IllegalArgumentException("At least one error is required");
+            }
+            return new GraphQLErrors(this.errors);
+        }
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/models/SourceLocationBuilder.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/models/SourceLocationBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.models;
+
+import graphql.AssertException;
+import graphql.language.SourceLocation;
+
+/**
+ * SourceLocationBuilder.
+ */
+public class SourceLocationBuilder {
+    private Integer line = null;
+    private Integer column = null;
+
+    public SourceLocationBuilder line(Integer line) {
+        this.line = line;
+        return this;
+    }
+
+    public SourceLocationBuilder column(Integer column) {
+        this.column = column;
+        return this;
+    }
+
+    public SourceLocation build() {
+        if (this.line == null || this.column == null) {
+            throw new AssertException("Line and column must be set.");
+        }
+        return new SourceLocation(this.line, this.column);
+    }
+}

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/models/GraphQLErrorTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/models/GraphQLErrorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import graphql.language.SourceLocation;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Test for ExtendedGraphqlErrorBuilder.
+ */
+class GraphQLErrorTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void extensionsConsumer() throws JsonProcessingException {
+        graphql.GraphQLError error = GraphQLError.builder()
+                .message("Name for character with ID 1002 could not be fetched.").extensions(extensions -> {
+                    extensions.put("code", "CAN_NOT_FETCH_BY_ID");
+                    extensions.put("timestamp", "Fri Feb 9 14:33:09 UTC 2018");
+                }).build();
+
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"message":"Name for character with ID 1002 could not be fetched.","extensions":{"code":"CAN_NOT_FETCH_BY_ID","timestamp":"Fri Feb 9 14:33:09 UTC 2018","classification":"DataFetchingException"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void extensions() throws JsonProcessingException {
+        graphql.GraphQLError error = GraphQLError.builder()
+                .message("Name for character with ID 1002 could not be fetched.")
+                .extensions(Map.of("code", "CAN_NOT_FETCH_BY_ID")).build();
+
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"message":"Name for character with ID 1002 could not be fetched.","extensions":{"code":"CAN_NOT_FETCH_BY_ID","classification":"DataFetchingException"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void locationsConsumer() throws JsonProcessingException {
+        SourceLocation location = new SourceLocationBuilder().line(6).column(7).build();
+        graphql.GraphQLError error = GraphQLError.builder()
+                .message("Name for character with ID 1002 could not be fetched.")
+                .locations(locations -> locations.add(location)).build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"message":"Name for character with ID 1002 could not be fetched.","locations":[{"line":6,"column":7}],"extensions":{"classification":"DataFetchingException"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void locationsConsumerMultiple() throws JsonProcessingException {
+        graphql.GraphQLError error = GraphQLError.builder()
+                .message("Name for character with ID 1002 could not be fetched.")
+                .location(location -> location.line(1).column(2)).location(location -> location.line(3).column(4))
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"message":"Name for character with ID 1002 could not be fetched.","locations":[{"line":1,"column":2},{"line":3,"column":4}],"extensions":{"classification":"DataFetchingException"}}""";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void locations() throws JsonProcessingException {
+        SourceLocation location = new SourceLocationBuilder().line(6).column(7).build();
+        graphql.GraphQLError error = GraphQLError.builder()
+                .message("Name for character with ID 1002 could not be fetched.").locations(Arrays.asList(location))
+                .build();
+        String actual = objectMapper.writeValueAsString(error);
+        String expected = """
+                {"message":"Name for character with ID 1002 could not be fetched.","locations":[{"line":6,"column":7}],"extensions":{"classification":"DataFetchingException"}}""";
+        assertEquals(expected, actual);
+    }
+}

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/models/GraphQLErrorsTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/models/GraphQLErrorsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for GraphqlErrors.
+ */
+class GraphQLErrorsTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void basicErrorResult() throws JsonProcessingException {
+        GraphQLErrors errors = GraphQLErrors.builder()
+                .error(error -> error.message("Name for character with ID 1002 could not be fetched.")
+                        .location(location -> location.line(6).column(7)).path("hero", "heroFriends", 1, "name")
+                        .extension("code", "CAN_NOT_FETCH_BY_ID").extension("timestamp", "Fri Feb 9 14:33:09 UTC 2018"))
+                .build();
+        String actual = objectMapper.writeValueAsString(errors);
+        String expected = """
+                {"errors":[{"message":"Name for character with ID 1002 could not be fetched.","locations":[{"line":6,"column":7}],"path":["hero","heroFriends",1,"name"],"extensions":{"code":"CAN_NOT_FETCH_BY_ID","timestamp":"Fri Feb 9 14:33:09 UTC 2018","classification":"DataFetchingException"}}]}""";
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
## Description
This separates the error message concerns for JSON API and GraphQL as their error message formats are different.

This particular PR only adds the error classes, a generic `ElideError` class that is intended to be mapped to the specialized `JsonApiError` or `GraphQLError` using a mapper class. This PR doesn't yet add or refactor the error mappers or exception handling mechanism.

The subsequent PRs after this are
- Add error mappers and refactor serializers
- Refactor response and exception handling

## Motivation and Context
The existing `ErrorObjects` class somewhat follows the JSON API error format, but allows arbitrary attributes leading it to be used in different ways for JSON API and GraphQL which tends to make it generate error messages that do not conform to either specification.

For JSON API attributes that are not defined by the specification should be in the [`meta`](https://jsonapi.org/format/#error-objects) member while for GraphQL this should be in the [`extensions`](https://spec.graphql.org/October2021/#example-8b658) member.

## How Has This Been Tested?
Added the appropriate unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
