### PR TITLE
Bump jakarta.websocket-api from 2.0.0 to 2.1.1

### DIFF
--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -73,6 +73,10 @@
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+        </dependency>
 
         <!-- Subscription serialization -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
         <jakarta-persistence.version>3.1.0</jakarta-persistence.version>
         <jakarta-transaction.version>2.0.1</jakarta-transaction.version>
-        <jakarta-websocket.version>2.0.0</jakarta-websocket.version>
+        <jakarta-websocket.version>2.1.1</jakarta-websocket.version>
         <jakarta-ws-rs.version>3.1.0</jakarta-ws-rs.version>
         <jakarta-validation.version>3.0.2</jakarta-validation.version>
         <javaassist.version>3.29.2-GA</javaassist.version>
@@ -294,6 +294,11 @@
             <dependency>
                 <groupId>jakarta.websocket</groupId>
                 <artifactId>jakarta.websocket-api</artifactId>
+                <version>${jakarta-websocket.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-client-api</artifactId>
                 <version>${jakarta-websocket.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Description

[Jakarta WebSocket 2.1](https://jakarta.ee/specifications/websocket/2.1/) has removed the copy of the jakarta.websocket.* classes from the jakarta.websocket-api jar and replaced the copy with a dependency on the jakarta.websocket-client-api jar.

This adds the jakarta.websocket-client-api dependency where needed.

## How Has This Been Tested?
Existing tests continue to pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
