### PR TITLE
Add @key support for GraphQL Federation

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -539,7 +539,7 @@ public class GraphQLConversionUtils {
 
 
     private GraphQLOutputType fetchScalarOrObjectOutput(Type<?> conversionClass,
-                                                        DataFetcher fetcher) {
+                                                        DataFetcher<?> fetcher) {
         /* If class is enum, provide enum type */
         if (conversionClass.isEnum()) {
             return classToEnumType(conversionClass);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
@@ -62,7 +62,7 @@ public class GraphQLScalars {
 
     public static GraphQLScalarType GRAPHQL_DEFERRED_ID = GraphQLScalarType.newScalar()
             .name("DeferredID")
-            .description("custom id type")
+            .description("The DeferredID scalar type represents a unique identifier.")
             .coercing(new Coercing() {
                 @Override
                 public Object serialize(Object o) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLSettings.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLSettings.java
@@ -11,6 +11,7 @@ import com.yahoo.elide.core.exceptions.BasicExceptionMappers;
 import com.yahoo.elide.core.exceptions.Slf4jExceptionLogger;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.core.filter.dialect.graphql.FilterDialect;
+import com.yahoo.elide.graphql.federation.FederationVersion;
 
 import lombok.Getter;
 
@@ -26,9 +27,11 @@ public class GraphQLSettings implements Settings {
     @Getter
     public static class Federation {
         private final boolean enabled;
+        private final FederationVersion version;
 
-        public Federation(boolean enabled) {
+        public Federation(boolean enabled, FederationVersion version) {
             this.enabled = enabled;
+            this.version = version;
         }
 
         public static FederationBuilder builder() {
@@ -37,14 +40,24 @@ public class GraphQLSettings implements Settings {
 
         public static class FederationBuilder {
             private boolean enabled = false;
+            private FederationVersion version = FederationVersion.FEDERATION_1_0;
 
             public FederationBuilder enabled(boolean enabled) {
                 this.enabled = enabled;
                 return this;
             }
 
+            public FederationBuilder version(FederationVersion version) {
+                this.version = version;
+                return this;
+            }
+
+            public FederationBuilder version(String version) {
+                return version(FederationVersion.from(version));
+            }
+
             public Federation build() {
-                return new Federation(this.enabled);
+                return new Federation(this.enabled, this.version);
             }
         }
     }
@@ -74,7 +87,8 @@ public class GraphQLSettings implements Settings {
                 .enabled(this.enabled)
                 .path(this.path)
                 .filterDialect(this.filterDialect)
-                .federation(newFederation -> newFederation.enabled(this.getFederation().isEnabled()))
+                .federation(newFederation -> newFederation.enabled(this.getFederation().isEnabled())
+                        .version(this.getFederation().getVersion()))
                 .graphqlExceptionHandler(this.graphqlExceptionHandler);
     }
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/EntitiesDataFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/EntitiesDataFetcher.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.federation;
+
+import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.exceptions.BadRequestException;
+import com.yahoo.elide.core.request.EntityProjection;
+import com.yahoo.elide.graphql.GraphQLRequestScope;
+import com.yahoo.elide.graphql.KeyWord;
+import com.yahoo.elide.graphql.containers.NodeContainer;
+
+import com.apollographql.federation.graphqljava._Entity;
+
+import org.apache.commons.lang3.StringUtils;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.reactivex.Observable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Entities Data Fetcher for Apollo Federation.
+ */
+public class EntitiesDataFetcher implements DataFetcher<List<NodeContainer>> {
+
+    @Override
+    public List<NodeContainer> get(DataFetchingEnvironment environment) throws Exception {
+        List<Map<String, Object>> representations = environment.getArgument(_Entity.argumentName);
+        List<String> ids = representations.stream() // only supports the single id key field
+            .map(representation -> {
+                    String idKey = representation.keySet()
+                            .stream()
+                            .filter(key -> !KeyWord.TYPENAME.getName().equals(key))
+                            .findFirst()
+                            .get();
+                    return (String) representation.get(idKey);
+                })
+            .toList();
+
+        String entityName = StringUtils.uncapitalize(representations.get(0).get(KeyWord.TYPENAME.getName()).toString());
+
+        GraphQLRequestScope requestScope = environment.getLocalContext();
+        EntityProjection projection = requestScope
+                .getProjectionInfo()
+                .getProjection(null, entityName);
+
+        /* fetching a collection */
+        Observable<PersistentResource> records = Optional.of(ids).map((idList) -> {
+            /* handle empty list of ids */
+            if (idList.isEmpty()) {
+                throw new BadRequestException("Empty list passed to ids");
+            }
+
+            return PersistentResource.loadRecords(projection, idList, requestScope);
+        }).orElseGet(() -> PersistentResource.loadRecords(projection, new ArrayList<>(), requestScope));
+
+
+        // Ignore errors as potentially an id on a subgraph no longer exists here
+        Set<PersistentResource> results = records.onExceptionResumeNext(Observable.empty())
+                .toList(LinkedHashSet::new)
+                .blockingGet();
+
+        // Return node containers in order of the ids from the representations
+        return ids.stream().map(id -> {
+            Optional<PersistentResource> result = results.stream().filter(r -> id.equals(r.getId())).findFirst();
+            if (result.isPresent()) {
+                return new NodeContainer(result.get());
+            } else {
+                return null;
+            }
+        }).toList();
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/EntityTypeResolver.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/EntityTypeResolver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.federation;
+
+import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.graphql.GraphQLNameUtils;
+import com.yahoo.elide.graphql.containers.PersistentResourceContainer;
+
+import graphql.TypeResolutionEnvironment;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.TypeResolver;
+
+/**
+ * Entity Type Resolver for Apollo Federation.
+ */
+public class EntityTypeResolver implements TypeResolver {
+
+    private final GraphQLNameUtils nameUtils;
+
+    public EntityTypeResolver(GraphQLNameUtils nameUtils) {
+        this.nameUtils = nameUtils;
+    }
+
+    @Override
+    public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+        final Object src = env.getObject();
+        String objectType;
+        if (src instanceof PersistentResourceContainer nodeContainer) {
+            objectType = nameUtils.toOutputTypeName(nodeContainer.getPersistentResource().getResourceType());
+        } else {
+            objectType = nameUtils.toOutputTypeName(ClassType.of(src.getClass()));
+        }
+        return env.getSchema().getObjectType(objectType);
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/FederationDefinitions.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/FederationDefinitions.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.federation;
+
+import graphql.language.Argument;
+import graphql.language.ArrayValue;
+import graphql.language.Directive;
+import graphql.language.StringValue;
+import graphql.language.Value;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Federation Definitions.
+ */
+public class FederationDefinitions {
+    public static String namespace = "federation__";
+
+    public static String shareableName = "shareable";
+
+    public static String linkName = "link";
+
+    public static String urlArgumentName = "url";
+
+    public static String importArgumentName = "import";
+
+    /**
+     * Returns a link directive.
+     *
+     * @param url the url
+     * @param imports the imports
+     * @return the link directive
+     */
+    public static Directive link(String url, String... imports) {
+        return Directive.newDirective().name(linkName).argument(urlArgument(url))
+                .argument(importArgument(Arrays.stream(imports).toList())).build();
+    }
+
+    /**
+     * Returns a url argument.
+     *
+     * @param url the url
+     * @return the url argument
+     */
+    public static Argument urlArgument(String url) {
+        return Argument.newArgument().name(urlArgumentName).value(StringValue.of(url)).build();
+    }
+
+    /**
+     * Returns a import argument.
+     *
+     * @param imports the imports
+     * @return the imports argument
+     */
+    public static Argument importArgument(List<String> imports) {
+        List<Value> values = new ArrayList<>(imports.size());
+        imports.stream().map(StringValue::of).forEach(values::add);
+        return Argument.newArgument().name(importArgumentName).value(ArrayValue.newArrayValue().values(values).build())
+                .build();
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/FederationSchema.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/FederationSchema.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.federation;
+
+
+import com.apollographql.federation.graphqljava.Federation;
+import com.apollographql.federation.graphqljava.FederationDirectives;
+
+import graphql.language.SchemaExtensionDefinition;
+import graphql.language.StringValue;
+import graphql.schema.GraphQLAppliedDirective;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.TypeDefinitionRegistry;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Federation Schema.
+ */
+public class FederationSchema {
+    private final GraphQLSchema schema;
+    private final FederationVersion version;
+
+    public FederationSchema(GraphQLSchema schema, FederationVersion version) {
+        this.schema = schema;
+        this.version = version;
+    }
+
+    /**
+     * Returns the {@link GraphQLSchema}.
+     *
+     * @return the schema
+     */
+    public GraphQLSchema getSchema() {
+        return this.schema;
+    }
+
+    /**
+     * Returns the federation specification version.
+     *
+     * @return the federation specification version
+     */
+    public FederationVersion getVersion() {
+        return this.version;
+    }
+
+    /**
+     * Returns the federation directive by name which may be namespaced.
+     *
+     * @param name the directive name
+     * @return the directive
+     */
+    public GraphQLDirective getDirective(String name) {
+        GraphQLDirective directive = this.schema.getDirective(name);
+        if (directive == null) {
+            directive = this.schema.getDirective(FederationDefinitions.namespace + name);
+        }
+        return directive;
+    }
+
+    /**
+     * Gets the @key applied directive.
+     *
+     * @param fields the fields
+     * @return the @key applied directive
+     */
+    public GraphQLAppliedDirective key(String fields) {
+        GraphQLDirective key = getDirective(FederationDirectives.keyName);
+        GraphQLArgument argument = key.getArgument(FederationDirectives.fieldsArgumentName);
+        return key.toAppliedDirective().transform(directive -> directive
+                .argument(argument.toAppliedArgument().transform(arg -> arg.valueLiteral(StringValue.of(fields)))));
+    }
+
+    /**
+     * Gets the @shareable applied directive in Federation 2.
+     *
+     * @return the @shareable applied directive if present
+     */
+    public Optional<GraphQLAppliedDirective> shareable() {
+        GraphQLDirective shareable = getDirective(FederationDefinitions.shareableName);
+        if (shareable == null) {
+            return Optional.empty();
+        }
+        return Optional.of(shareable.toAppliedDirective());
+    }
+
+    /**
+     * Returns a mutable @{link FederationSchemaBuilder} for building a
+     * {@link FederationSchema}.
+     *
+     * @return a mutable builder
+     */
+    public static FederationSchemaBuilder builder() {
+        return new FederationSchemaBuilder();
+    }
+
+    /**
+     * The mutable builder for {@link FederationSchema}.
+     */
+    public static class FederationSchemaBuilder {
+        private FederationVersion version = FederationVersion.FEDERATION_1_0;
+        private List<String> imports = new ArrayList<>();
+
+        /**
+         * Sets the federation specification version.
+         *
+         * @param version the version
+         * @return the builder
+         */
+        public FederationSchemaBuilder version(FederationVersion version) {
+            this.version = version;
+            return this;
+        }
+
+        /**
+         * Sets the imports for instance @key or @shareable.
+         *
+         * @param imports the imports
+         * @return the builder
+         */
+        public FederationSchemaBuilder imports(String... imports) {
+            this.imports.addAll(List.of(imports));
+            return this;
+        }
+
+        /**
+         * Builds the {@link FederationSchema}.
+         *
+         * @return the federation schema
+         */
+        public FederationSchema build() {
+            GraphQLSchema schema = getSchema(version, imports.toArray(String[]::new));
+            return new FederationSchema(schema, this.version);
+        }
+    }
+
+    /**
+     * Gets the federation schema given the version and imports.
+     *
+     * @param version the federation specification version
+     * @param imports the imports eg. @key, @shareable
+     * @return the federation schema
+     */
+    public static GraphQLSchema getSchema(FederationVersion version, String... imports) {
+        String specification = toSpecification(version);
+        TypeDefinitionRegistry typeDefinitionRegistry = new TypeDefinitionRegistry();
+        if (specification != null) {
+            typeDefinitionRegistry.add(
+                    SchemaExtensionDefinition.newSchemaExtensionDefinition()
+                            .directive(FederationDefinitions.link(specification, imports)).build());
+        }
+        return Federation.transform(typeDefinitionRegistry).build();
+    }
+
+    /**
+     * Determine the federation specification url from the version.
+     *
+     * @param version the version
+     * @return the federation specification url
+     */
+    public static String toSpecification(FederationVersion version) {
+        switch (version) {
+        case FEDERATION_2_5:
+            return Federation.FEDERATION_SPEC_V2_5;
+        case FEDERATION_2_4:
+            return Federation.FEDERATION_SPEC_V2_4;
+        case FEDERATION_2_3:
+            return Federation.FEDERATION_SPEC_V2_3;
+        case FEDERATION_2_2:
+            return Federation.FEDERATION_SPEC_V2_2;
+        case FEDERATION_2_1:
+            return Federation.FEDERATION_SPEC_V2_1;
+        case FEDERATION_2_0:
+            return Federation.FEDERATION_SPEC_V2_0;
+        case FEDERATION_1_1:
+            return null;
+        case FEDERATION_1_0:
+            return null;
+        }
+        throw new IllegalArgumentException("Unsupported Federation Version " + version);
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/FederationVersion.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/federation/FederationVersion.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.federation;
+
+import java.util.Arrays;
+
+/**
+ * The Federation Specification Version.
+ */
+public enum FederationVersion {
+    FEDERATION_2_5("2.5"),
+    FEDERATION_2_4("2.4"),
+    FEDERATION_2_3("2.3"),
+    FEDERATION_2_2("2.2"),
+    FEDERATION_2_1("2.1"),
+    FEDERATION_2_0("2.0"),
+    FEDERATION_1_1("1.1"),
+    FEDERATION_1_0("1.0");
+
+    private final String value;
+
+    FederationVersion(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public float floatValue() {
+        return Float.valueOf(this.value);
+    }
+
+    public int intValue() {
+        return Integer.valueOf(this.value.replace(".", ""));
+    }
+
+    public static FederationVersion from(String version) {
+        return Arrays.stream(FederationVersion.values()).filter(v -> version.equals(v.getValue())).findFirst()
+                .orElseThrow(() -> {
+                    throw new IllegalArgumentException("Invalid Federation version.");
+                });
+    }
+}

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherFetchTest.java
@@ -6,6 +6,8 @@
 
 package com.yahoo.elide.graphql;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -22,9 +24,6 @@ import java.util.HashMap;
  *   /resources/graphql/{requests,responses}/fetch directory, respectively.
  */
 public class FetcherFetchTest extends PersistentResourceFetcherTest {
-
-    private final String baseUrl = "http://localhost:8080/graphql";
-
     @Test
     public void testMutationInQueryThrowsError() throws Exception {
         String query = "query {\n"
@@ -285,10 +284,89 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
     @Test
     public void testFederationServiceIntrospection() throws Exception {
         String graphQLRequest = "{ _service { sdl }}";
-
         ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
+        assertFalse(response.getBody().contains("errors"));
+    }
 
-        assertTrue(! response.getBody().contains("errors"));
+    @Test
+    public void testFederationHasKeyDirective() throws Exception {
+        String graphQLRequest = "{ _service { sdl }}";
+        ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
+        assertTrue(response.getBody().contains("@key")); // @key directive present
+    }
+
+    @Test
+    public void testFederationQueryEntities() throws Exception {
+        String graphQLRequest = """
+                query {
+                  _entities(representations: [{__typename: "Book", id: "1"}]) {
+                    ... on Book {
+                      title
+                      genre
+                      language
+                    }
+                  }
+                }
+                """;
+        ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
+        String expected = """
+                {"data":{"_entities":[{"title":"Libro Uno","genre":null,"language":null}]}}""";
+        assertEquals(expected, response.getBody());
+    }
+
+    @Test
+    public void testFederationQueryEntitiesMissingShouldReturnNullNotThrow() throws Exception {
+        String graphQLRequest = """
+                query {
+                  _entities(representations: [{__typename: "Book", id: "1"},{__typename: "Book", id: "99"},{__typename: "Book", id: "2"},{__typename: "Book", id: "3"}]) {
+                    ... on Book {
+                      title
+                      genre
+                      language
+                    }
+                  }
+                }
+                """;
+        ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
+        String expected = """
+                {"data":{"_entities":[{"title":"Libro Uno","genre":null,"language":null},null,{"title":"Libro Dos","genre":null,"language":null},{"title":"Doctor Zhivago","genre":null,"language":null}]}}""";
+        assertEquals(expected, response.getBody());
+    }
+
+    @Test
+    public void testFederationQueryEntitiesInvalidSelection() throws Exception {
+        String graphQLRequest = """
+                query {
+                  _entities(representations: [{__typename: "Book", id: "1"}]) {
+                    title
+                    genre
+                    language
+                  }
+                }
+                """;
+        ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
+        String expected = """
+                {"errors":[{"message":"Bad Request Body&#39;Entity selection must be an inline fragment.&#39;","extensions":{"classification":"DataFetchingException"}}]}""";
+        assertEquals(expected, response.getBody());
+    }
+
+    @Test
+    public void testFederationQueryEntitiesInvalidEntity() throws Exception {
+        String graphQLRequest = """
+                query {
+                  _entities(representations: [{__typename: "Book", id: "1"}]) {
+                    ... on InvalidEntity {
+                      title
+                      genre
+                      language
+                    }
+                  }
+                }
+                """;
+        ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
+        String expected = """
+                {"errors":[{"message":"Bad Request Body&#39;Unknown entity {invalidEntity}.&#39;","extensions":{"classification":"DataFetchingException"}}]}""";
+        assertEquals(expected, response.getBody());
     }
 
     @Test
@@ -302,8 +380,7 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
                 + "}";
 
         ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
-
-        assertTrue(! response.getBody().contains("errors"));
+        assertFalse(response.getBody().contains("errors"));
     }
 
     @Test
@@ -319,8 +396,7 @@ public class FetcherFetchTest extends PersistentResourceFetcherTest {
             + "}";
 
         ElideResponse<String> response = runGraphQLRequest(graphQLRequest, new HashMap<>());
-
-        assertTrue(! response.getBody().contains("errors"));
+        assertFalse(response.getBody().contains("errors"));
     }
 
     @Override

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/federation/EntityTypeResolverTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/federation/EntityTypeResolverTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.federation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.core.PersistentResource;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.request.route.Route;
+import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.graphql.GraphQLNameUtils;
+import com.yahoo.elide.graphql.GraphQLRequestScope;
+import com.yahoo.elide.graphql.containers.NodeContainer;
+import com.yahoo.elide.models.Book;
+
+import org.junit.jupiter.api.Test;
+
+import graphql.TypeResolutionEnvironment;
+import graphql.execution.TypeResolutionParameters;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+
+/**
+ * Test for EntityTypeResolver.
+ */
+class EntityTypeResolverTest {
+
+    @Test
+    void getTypeNodeContainer() {
+        EntityDictionary entityDictionary = EntityDictionary.builder().build();
+        entityDictionary.bindEntity(Book.class);
+        GraphQLNameUtils nameUtils = new GraphQLNameUtils(entityDictionary);
+        EntityTypeResolver entityTypeResolver = new EntityTypeResolver(nameUtils);
+        ElideSettings elideSettings = ElideSettings.builder().entityDictionary(entityDictionary).build();
+        Route route = Route.builder().build();
+        PersistentResource<Book> book = new PersistentResource<>(new Book(), "1",
+                GraphQLRequestScope.builder().elideSettings(elideSettings).route(route).build());
+        NodeContainer value = new NodeContainer(book);
+        GraphQLObjectType bookType = GraphQLObjectType.newObject().name(nameUtils.toOutputTypeName(ClassType.of(Book.class))).build();
+        GraphQLSchema schema = mock(GraphQLSchema.class);
+        when(schema.getObjectType(bookType.getName())).thenReturn(bookType);
+        TypeResolutionEnvironment env = TypeResolutionParameters.newParameters().value(value).schema(schema).build();
+        GraphQLObjectType objectType = entityTypeResolver.getType(env);
+        assertEquals(bookType.getName(), objectType.getName());
+    }
+
+    @Test
+    void getType() {
+        EntityDictionary entityDictionary = EntityDictionary.builder().build();
+        entityDictionary.bindEntity(Book.class);
+        GraphQLNameUtils nameUtils = new GraphQLNameUtils(entityDictionary);
+        EntityTypeResolver entityTypeResolver = new EntityTypeResolver(nameUtils);
+        Book value = new Book();
+        GraphQLObjectType bookType = GraphQLObjectType.newObject().name(nameUtils.toOutputTypeName(ClassType.of(Book.class))).build();
+        GraphQLSchema schema = mock(GraphQLSchema.class);
+        when(schema.getObjectType(bookType.getName())).thenReturn(bookType);
+        TypeResolutionEnvironment env = TypeResolutionParameters.newParameters().value(value).schema(schema).build();
+        GraphQLObjectType objectType = entityTypeResolver.getType(env);
+        assertEquals(bookType.getName(), objectType.getName());
+    }
+}

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/federation/FederationSchemaTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/federation/FederationSchemaTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql.federation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import graphql.schema.GraphQLAppliedDirective;
+
+/**
+ * Test for Federation Schema.
+ *
+ */
+class FederationSchemaTest {
+
+    @Test
+    void applyFederation() {
+        for (FederationVersion version : FederationVersion.values()) {
+            assertNotNull(FederationSchema.getSchema(version));
+        }
+    }
+
+    @Test
+    void shareableNotPresentForFederation1() {
+        FederationSchema schema = FederationSchema.builder().version(FederationVersion.FEDERATION_1_1).build();
+        assertFalse(schema.shareable().isPresent());
+    }
+
+    @Test
+    void shareablePresentForFederation2() {
+        FederationSchema schema = FederationSchema.builder().version(FederationVersion.FEDERATION_2_0).build();
+        assertTrue(schema.shareable().isPresent());
+    }
+
+    @Test
+    void importWithNamespace() {
+        GraphQLAppliedDirective directive = FederationSchema.builder().version(FederationVersion.FEDERATION_2_0).build()
+                .key("id");
+        assertTrue(directive.getName().startsWith(FederationDefinitions.namespace));
+    }
+
+    @Test
+    void importWithoutNamespace() {
+        GraphQLAppliedDirective directive = FederationSchema.builder().version(FederationVersion.FEDERATION_2_0)
+                .imports("@key").build().key("id");
+        assertEquals("key", directive.getName());
+    }
+
+    @Test
+    void getSchema() {
+        FederationSchema schema = FederationSchema.builder().version(FederationVersion.FEDERATION_2_0).build();
+        assertNotNull(schema.getSchema());
+    }
+
+    @Test
+    void getVersion() {
+        FederationSchema schema = FederationSchema.builder().version(FederationVersion.FEDERATION_2_3).build();
+        assertEquals(FederationVersion.FEDERATION_2_3, schema.getVersion());
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -889,8 +889,10 @@ public class ElideAutoConfiguration {
                 ObjectProvider<GraphQLSettingsBuilderCustomizer> customizerProviders) {
             return GraphQLSettingsBuilderCustomizers.buildGraphQLSettingsBuilder(entityDictionary,
                     builder -> {
-                        builder.path(settings.getGraphql().getPath()).federation(
-                                federation -> federation.enabled(settings.getGraphql().getFederation().isEnabled()))
+                        builder.path(settings.getGraphql().getPath())
+                                .federation(federation -> federation
+                                        .enabled(settings.getGraphql().getFederation().isEnabled())
+                                        .version(settings.getGraphql().getFederation().getVersion().getValue()))
                                 .graphqlExceptionHandler(graphqlExceptionHandler);
                         customizerProviders.orderedStream().forEach(customizer -> customizer.customize(builder));
                     });

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/GraphQLControllerProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/GraphQLControllerProperties.java
@@ -5,10 +5,13 @@
  */
 package com.yahoo.elide.spring.config;
 
+
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.Arrays;
 
 /**
  * Extra controller properties for the GraphQL endpoint.
@@ -20,9 +23,45 @@ public class GraphQLControllerProperties extends ControllerProperties {
     @Data
     public static class Federation {
         /**
+         * The Federation Specification Version.
+         */
+        public enum Version {
+            FEDERATION_2_5("2.5"),
+            FEDERATION_2_4("2.4"),
+            FEDERATION_2_3("2.3"),
+            FEDERATION_2_2("2.2"),
+            FEDERATION_2_1("2.1"),
+            FEDERATION_2_0("2.0"),
+            FEDERATION_1_1("1.1"),
+            FEDERATION_1_0("1.0");
+
+            private final String value;
+
+            Version(String value) {
+                this.value = value;
+            }
+
+            public String getValue() {
+                return this.value;
+            }
+
+            public static Version from(String version) {
+                return Arrays.stream(Version.values()).filter(v -> version.equals(v.getValue())).findFirst()
+                        .orElseThrow(() -> {
+                            throw new IllegalArgumentException("Invalid Federation version.");
+                        });
+            }
+        }
+
+        /**
          * Turns on/off Apollo federation schema.
          */
         private boolean enabled = false;
+
+        /**
+         * The Federation Specification Version to generate.
+         */
+        private Version version = Version.FEDERATION_1_0;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,8 @@
         <dom4j.version>2.1.4</dom4j.version>
         <embedded-redis.version>0.11.0</embedded-redis.version>
         <encoder.version>1.2.3</encoder.version>
-        <federation-graphql-java-support-api.version>4.1.1</federation-graphql-java-support-api.version>
-        <graphql-java.version>20.2</graphql-java.version>
+        <federation-graphql-java-support-api.version>4.2.0</federation-graphql-java-support-api.version>
+        <graphql-java.version>21.0</graphql-java.version>
         <graal-sdk.version>23.1.0</graal-sdk.version>
         <guava.version>32.1.1-jre</guava.version>
         <handlebars.version>4.3.1</handlebars.version>


### PR DESCRIPTION
Resolves #2638

## Description
This adds support for the `@key` directive for Apollo Federation.

## Motivation and Context
This is required for to resolve from a different subgraph onto the Elide subgraph.

## How Has This Been Tested?
Added the appropriate unit and integration tests.

This was also tested using the following example
- https://github.com/justin-tay/federation-jvm-elide-example
- https://github.com/justin-tay/elide-spring-boot-example/tree/apiversion_elide-7.x

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
