### PR TITLE
Use JSONAssert to compare JSON strings

### DIFF
--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -158,6 +158,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/JsonApiTest.java
@@ -8,6 +8,7 @@ package com.yahoo.elide.jsonapi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -52,9 +53,11 @@ import example.Child;
 import example.Parent;
 
 import org.apache.commons.collections4.IterableUtils;
+import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -236,7 +239,11 @@ public class JsonApiTest {
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(data, jsonApiDocument.getData());
 
-        assertEquals(expected, doc);
+        try {
+            JSONAssert.assertEquals(expected, doc, true);
+        } catch (JSONException e) {
+            fail(e);
+        }
         checkEquality(jsonApiDocument);
     }
 
@@ -332,7 +339,11 @@ public class JsonApiTest {
         String doc = mapper.writeJsonApiDocument(jsonApiDocument);
         assertEquals(data, jsonApiDocument.getData());
 
-        assertEquals(expected, doc);
+        try {
+            JSONAssert.assertEquals(expected, doc, true);
+        } catch (JSONException e) {
+            fail(e);
+        }
         checkEquality(jsonApiDocument);
     }
 


### PR DESCRIPTION
## Description
There are some tests in `JsonApiTest` class which compare json strings and unintentionally check for the order of json elements as well. Converting a JSON to a string may return different orderings for the key-value pairs. Instead a better technique is to use Skyscreamer's [JSONAssert](https://github.com/skyscreamer/JSONassert)

## Motivation and Context
There are flaky tests detected in JsonApiTest.java with the help of [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool -
- `writeListIncluded`
- `writeSingleIncluded`

These tests may sometimes fail even though the code under test may be working as expected.

## How Has This Been Tested?
Setup the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool and run
```
mvn -pl elide-core edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex  -Dtest=com.yahoo.elide.jsonapi.JsonApiTest
```
**Error Message**
I am including one of the test error messages for reference
```
[INFO] Running com.yahoo.elide.jsonapi.JsonApiTest
[ERROR] Tests run: 20, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.496 s <<< FAILURE! - in com.yahoo.elide.jsonapi.JsonApiTest
[ERROR] com.yahoo.elide.jsonapi.JsonApiTest.writeListIncluded  Time elapsed: 0.049 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"data":[{"type":"parent","id":"123","attributes":{"firstName":"bob"},"relationships":{"children":{"links":{"self":"http://localhost:8080/json/parent/123/relationships/children","related":"http://localhost:8080/json/parent/123/children"},"data":[{"type":"child","id":"2"}]},"spouses":{"links":{"self":"http://localhost:8080/json/parent/123/relationships/spouses","related":"http://localhost:8080/json/parent/123/spouses"},"data":[]}},"links":{"self":"http://localhost:8080/json/parent/123"}}],"included":[{"type":"child","id":"2","attributes":{"name":null},"relationships":{"friends":{"links":{"self":"http://localhost:8080/json/parent/123/children/2/relationships/friends","related":"http://localhost:8080/json/parent/123/children/2/friends"},"data":[]},"parents":{"links":{"self":"http://localhost:8080/json/parent/123/children/2/relationships/parents","related":"http://localhost:8080/json/parent/123/children/2/parents"},"data":[{"type":"parent","id":"123"}]}},"links":{"self":"http://localhost:8080/json/parent/123/children/2"}}]}> but was: <{"included":[{"type":"child","id":"2","attributes":{"name":null},"relationships":{"friends":{"links":{"self":"http://localhost:8080/json/parent/123/children/2/relationships/friends","related":"http://localhost:8080/json/parent/123/children/2/friends"},"data":[]},"parents":{"links":{"self":"http://localhost:8080/json/parent/123/children/2/relationships/parents","related":"http://localhost:8080/json/parent/123/children/2/parents"},"data":[{"type":"parent","id":"123"}]}},"links":{"self":"http://localhost:8080/json/parent/123/children/2"}}],"data":[{"type":"parent","id":"123","attributes":{"firstName":"bob"},"relationships":{"children":{"links":{"self":"http://localhost:8080/json/parent/123/relationships/children","related":"http://localhost:8080/json/parent/123/children"},"data":[{"type":"child","id":"2"}]},"spouses":{"links":{"self":"http://localhost:8080/json/parent/123/relationships/spouses","related":"http://localhost:8080/json/parent/123/spouses"},"data":[]}},"links":{"self":"http://localhost:8080/json/parent/123"}}]}>

```


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
