### PR TITLE
Bump Quarkus Version, Small cleanup

### DIFF
--- a/elide-quarkus/deployment/src/main/java/com/yahoo/elide/extension/deployment/ElideExtensionProcessor.java
+++ b/elide-quarkus/deployment/src/main/java/com/yahoo/elide/extension/deployment/ElideExtensionProcessor.java
@@ -61,7 +61,7 @@ import java.util.List;
 class ElideExtensionProcessor {
     private static final Logger LOG = Logger.getLogger(ElideExtensionProcessor.class.getName());
 
-    private static final String FEATURE = "elide-extension";
+    private static final String FEATURE = "elide";
 
     @BuildStep
     FeatureBuildItem feature() {

--- a/elide-quarkus/deployment/src/main/java/com/yahoo/elide/extension/deployment/ElideExtensionProcessor.java
+++ b/elide-quarkus/deployment/src/main/java/com/yahoo/elide/extension/deployment/ElideExtensionProcessor.java
@@ -7,10 +7,10 @@
 package com.yahoo.elide.extension.deployment;
 
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
+
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.annotation.SecurityCheck;
-//import com.yahoo.elide.core.exceptions.ErrorObjects;
 import com.yahoo.elide.core.security.checks.prefab.Collections;
 import com.yahoo.elide.core.utils.ClassScanner;
 import com.yahoo.elide.core.utils.coerce.converters.ElideTypeConverter;
@@ -27,7 +27,7 @@ import com.yahoo.elide.jsonapi.serialization.KeySerializer;
 import com.yahoo.elide.jsonapi.serialization.MetaDeserializer;
 import com.yahoo.elide.swagger.OpenApiDocument;
 import com.yahoo.elide.swagger.resources.ApiDocsEndpoint;
-//import com.yahoo.elide.swagger.resources.DocEndpoint;
+
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.impl.SimpleLog;
 import org.jboss.jandex.AnnotationInstance;
@@ -36,14 +36,11 @@ import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 
-//import graphql.execution.DataFetcherExceptionHandler;
-//import graphql.execution.SimpleDataFetcherExceptionHandler;
 import graphql.schema.GraphQLSchema;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
 import io.quarkus.arc.deployment.BeanDefiningAnnotationBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
-//import io.quarkus.arc.runtime.AdditionalBean;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Record;
@@ -56,7 +53,6 @@ import io.quarkus.resteasy.server.common.deployment.ResteasyDeploymentCustomizer
 import io.quarkus.undertow.deployment.ServletInitParamBuildItem;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Singleton;
-//import io.swagger.models.Swagger;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
+++ b/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
@@ -78,7 +78,7 @@ public class ElideExtensionTest {
                 .then()
                 .log().all()
                 .statusCode(HttpStatus.SC_CREATED);
-        RestAssured.when().get("/jsonapi/book").then().log().all().statusCode(200);
+        RestAssured.when().get("/test-jsonapi/book").then().log().all().statusCode(200);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class ElideExtensionTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .body(wrapped)
-                .post("/graphql")
+                .post("/test-graphql")
                 .then()
                 .log().all()
                 .statusCode(HttpStatus.SC_OK);
@@ -131,12 +131,12 @@ public class ElideExtensionTest {
 
     @Test
     public void testSwaggerCollectionEndpoint() {
-        RestAssured.when().get("/apiDocs").then().log().all().statusCode(200);
+        RestAssured.when().get("/test-apiDocs").then().log().all().statusCode(200);
     }
 
     @Test
     public void testSwaggerApiEndpoint() {
-        RestAssured.when().get("/apiDocs/api").then().log().all().statusCode(200);
+        RestAssured.when().get("/test-apiDocs/api").then().log().all().statusCode(200);
     }
 
     @Test

--- a/elide-quarkus/deployment/src/test/resources/application.properties
+++ b/elide-quarkus/deployment/src/test/resources/application.properties
@@ -1,9 +1,10 @@
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:mem:default
 quarkus.hibernate-orm.database.generation=drop-and-create
-quarkus.elide.default-page-size=200
-quarkus.elide.default-max-page-size=10000
-quarkus.elide.base-jsonapi=/api
-quarkus.elide.base-graphql=/fancy
+elide.default-page-size=200
+elide.default-max-page-size=10000
+elide.base-jsonapi=/test-jsonapi
+elide.base-graphql=/test-graphql
+elide.base-swagger=/test-apiDocs
 quarkus.log.level=INFO
 quarkus.log.category."com.yahoo.elide".level=DEBUG

--- a/elide-quarkus/integration-tests/src/main/resources/application.properties
+++ b/elide-quarkus/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+elide.base-jsonapi=/it-jsonapi
+elide.base-graphql=/it-graphql

--- a/elide-quarkus/pom.xml
+++ b/elide-quarkus/pom.xml
@@ -51,7 +51,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.7.0</quarkus.version> <!-- waiting for this to be released, for official H8 6.4 support -->
+    <quarkus.version>3.7.4</quarkus.version>
     <elide.version>7.0.3-SNAPSHOT</elide.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>

--- a/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
+++ b/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
@@ -102,7 +102,6 @@ public class ElideBeans {
     @ApplicationScoped
     public EntityDictionary produceDictionary(ClassScanner scanner, Injector injector) {
         LOG.debug("Creating EntityDictionary bean");
-        System.out.println("Creating EntityDictionary bean");
         return EntityDictionary.builder().scanner(scanner).injector(injector).build();
     }
 


### PR DESCRIPTION
## Description
- Bumped the Quarkus version from 3.7.0 to 3.7.4 (latest)
- Made the extension report its name as just "elide", rather than "elide-extension", in line with other extension names. 
- Tweaked existing tests so they're testing that the elide.base-xxx settings are working. 
- Removed commented-out imports and a println statement.

## Motivation and Context
Will be good to include the latest Quarkus version, and a consistent extension name, with the first Elide release containing the Quarkus extension.

## How Has This Been Tested?
Existing unit tests pass, and usage within my sample projects is unaffected by this change.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
