### PR TITLE
Inverse relationship type calculation (#3172)

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -738,7 +738,7 @@ public class EntityDictionary {
             String inverseMappedBy = inverseMapping.getValue();
 
             if (relation.equals(inverseMappedBy)
-                    && getParameterizedType(inverseType, inverseRelationName).equals(clsBinding.entityClass)) {
+                    && getParameterizedType(inverseType, inverseRelationName).isAssignableFrom(clsBinding.entityClass)) {
                 return inverseRelationName;
             }
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -737,8 +737,8 @@ public class EntityDictionary {
             String inverseRelationName = inverseMapping.getKey();
             String inverseMappedBy = inverseMapping.getValue();
 
-            if (relation.equals(inverseMappedBy)
-                    && getParameterizedType(inverseType, inverseRelationName).isAssignableFrom(clsBinding.entityClass)) {
+            if (relation.equals(inverseMappedBy) && getParameterizedType(inverseType, inverseRelationName)
+                    .isAssignableFrom(clsBinding.entityClass)) {
                 return inverseRelationName;
             }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransactionTest.java
@@ -604,6 +604,7 @@ public class InMemoryStoreTransactionTest {
             "example.PrimitiveId",
             "example.Publisher",
             "example.Right",
+            "example.Righter",
             "example.StringId",
             "example.UpdateAndCreate",
             "example.User",

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/EntityDictionaryTest.java
@@ -55,6 +55,7 @@ import example.Parent;
 import example.Price;
 import example.Publisher;
 import example.Right;
+import example.Righter;
 import example.StringId;
 import example.User;
 import example.models.generics.Employee;
@@ -116,6 +117,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         bindEntity(User.class);
         bindEntity(Left.class);
         bindEntity(Right.class);
+        bindEntity(Righter.class);
         bindEntity(StringId.class);
         bindEntity(Friend.class);
         bindEntity(FieldAnnotations.class);
@@ -487,6 +489,22 @@ public class EntityDictionaryTest extends EntityDictionary {
                 "children",
                 getRelationInverse(ClassType.of(Child.class), "parents"),
                 "The inverse relationship of children should be parents");
+    }
+
+    @Test
+    public void testGetInverseRelationshipOnPolymorphicBaseType() {
+        assertEquals(
+                "one2many",
+                getRelationInverse(ClassType.of(Right.class), "many2one"),
+                "The inverse relationship of one2many should be many2one");
+    }
+
+    @Test
+    public void testGetInverseRelationshipOnPolymorphicDerivedType() {
+        assertEquals(
+                "one2many",
+                getRelationInverse(ClassType.of(Righter.class), "many2one"),
+                "The inverse relationship of one2many should be many2one");
     }
 
     @Test
@@ -1097,7 +1115,7 @@ public class EntityDictionaryTest extends EntityDictionary {
         assertTrue(models.contains(ClassType.of(BookV2.class)));
 
         models = getBoundClassesByVersion(NO_VERSION);
-        assertEquals(21, models.size());
+        assertEquals(22, models.size());
     }
 
     @Test

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
@@ -33,21 +33,21 @@ public class ClassScannerTest {
     @Test
     public void testGetAnnotatedClasses() {
         Set<Class<?>> classes = scanner.getAnnotatedClasses("example", Include.class);
-        assertEquals(32, classes.size(), "Actual: " + classes);
+        assertEquals(33, classes.size(), "Actual: " + classes);
         classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(Include.class)));
     }
 
     @Test
     public void testGetAllAnnotatedClasses() {
         Set<Class<?>> classes = scanner.getAnnotatedClasses(Include.class);
-        assertEquals(44, classes.size(), "Actual: " + classes);
+        assertEquals(45, classes.size(), "Actual: " + classes);
         classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(Include.class)));
     }
 
     @Test
     public void testGetAnyAnnotatedClasses() {
         Set<Class<?>> classes = scanner.getAnnotatedClasses(Include.class, Entity.class);
-        assertEquals(55, classes.size());
+        assertEquals(56, classes.size());
         for (Class<?> cls : classes) {
             assertTrue(cls.isAnnotationPresent(Include.class)
                     || cls.isAnnotationPresent(Entity.class));

--- a/elide-core/src/test/java/example/Right.java
+++ b/elide-core/src/test/java/example/Right.java
@@ -31,7 +31,7 @@ import java.util.Set;
 @Entity
 @Table(name = "xright")     // right is SQL keyword
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name="type", discriminatorType = DiscriminatorType.STRING)
+@DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
 public class Right {
     @JsonIgnore
     private long id;

--- a/elide-core/src/test/java/example/Right.java
+++ b/elide-core/src/test/java/example/Right.java
@@ -10,10 +10,14 @@ import com.yahoo.elide.annotation.UpdatePermission;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
@@ -26,6 +30,8 @@ import java.util.Set;
 @UpdatePermission(expression = "Prefab.Role.None")
 @Entity
 @Table(name = "xright")     // right is SQL keyword
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name="type", discriminatorType = DiscriminatorType.STRING)
 public class Right {
     @JsonIgnore
     private long id;

--- a/elide-core/src/test/java/example/Righter.java
+++ b/elide-core/src/test/java/example/Righter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.UpdatePermission;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import java.util.Set;
+
+
+@Include(name = "righter")
+@UpdatePermission(expression = "Prefab.Role.None")
+@Entity
+@DiscriminatorValue("righter")
+public class Righter extends Right {
+    private String moreRight;
+
+    public String getMoreRight() {
+        return moreRight;
+    }
+
+    public void setMoreRight(String moreRight) {
+        this.moreRight = moreRight;
+    }
+}

--- a/elide-core/src/test/java/example/Righter.java
+++ b/elide-core/src/test/java/example/Righter.java
@@ -7,20 +7,8 @@ package example;
 
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
-
-import java.util.Set;
 
 
 @Include(name = "righter")


### PR DESCRIPTION
Resolves #3172 (if appropriate)

## Description
Calculate the inverse relationship for inherited entities.

## Motivation and Context
The delete lifecycle hooks do not trigger if you delete the many side of a oneToMany where the many side is a polymorphic type.

## How Has This Been Tested?
Added unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
