### PR TITLE
Apply DISTINCT for RootCollectionPageTotalsQueryBuilder only on JOINS

### DIFF
--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/RootCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/RootCollectionPageTotalsQueryBuilder.java
@@ -69,7 +69,9 @@ public class RootCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilde
             joinClause = "";
         }
 
-        Query query = session.createQuery("SELECT COUNT(DISTINCT "
+        boolean requiresDistinct = joinClause != null && !joinClause.isEmpty();
+
+        Query query = session.createQuery("SELECT COUNT(" + (requiresDistinct ? DISTINCT  + " " : "")
                 + entityAlias
                 + ") "
                 + FROM

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
@@ -55,7 +55,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
 
         String expected =
-            "SELECT COUNT(DISTINCT example_Book) "
+            "SELECT COUNT(example_Book) "
             + "FROM example.Book AS example_Book";
 
         String actual = query.getQueryText();
@@ -75,7 +75,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
                 entityProjection, dictionary, new TestSessionWrapper()
         )
                 .build();
-        String expected = "SELECT COUNT(DISTINCT example_Book) FROM example.Book AS example_Book";
+        String expected = "SELECT COUNT(example_Book) FROM example.Book AS example_Book";
         String actual = query.getQueryText();
         actual = actual.trim().replaceAll(" +", " ");
         assertEquals(expected, actual);
@@ -92,7 +92,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
                 entityProjection, dictionary, new TestSessionWrapper()
         )
                 .build();
-        String expected = "SELECT COUNT(DISTINCT example_Book) FROM example.Book AS example_Book";
+        String expected = "SELECT COUNT(example_Book) FROM example.Book AS example_Book";
         String actual = query.getQueryText();
         actual = actual.trim().replaceAll(" +", " ");
         assertEquals(expected, actual);


### PR DESCRIPTION
Speed up regular count queries without joins

## Description
For large datasets, removing DISTINCT can significantly enhance performance.

## Motivation and Context
Removing DISTINCT from count queries that do not involve joins.

## How Has This Been Tested?
Tests have been updated according to the changes made in the logic.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
