### PR TITLE
Remove spring-boot-properties-migrator

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -226,12 +226,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-properties-migrator</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jakarta-server</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Description
Removes the `spring-boot-properties-migrator` from `elide-spring-boot-autoconfigure`.

## Motivation and Context
The `spring-boot-properties-migrator` is used to detect deprecated Spring Boot properties and is largely a dev tool to be added when necessary. Having this dependency in `elide-spring-boot-autoconfigure` means unnecessary libraries are included for production.

## How Has This Been Tested?
Existing tests were run after the modifications.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
