### PR TITLE
Allow customization of GraphQLFieldDefinition

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/EntityHydrator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/queryengines/sql/EntityHydrator.java
@@ -205,7 +205,7 @@ public class EntityHydrator implements Iterable<Object> {
 
     @Override
     public Iterator<Object> iterator() {
-        return new Iterator<> () {
+        return new Iterator<>() {
 
             Object next = null;
             MutableInt counter = new MutableInt(0);

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/AnnotationGraphQLFieldDefinitionDescriptionCustomizer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/AnnotationGraphQLFieldDefinitionDescriptionCustomizer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.type.Type;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLFieldDefinition.Builder;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Function;
+
+/**
+ * {@link GraphQLFieldDefinitionCustomizer} that uses an annotation to determine
+ * the description.
+ *
+ * @param <A> annotation
+ */
+public class AnnotationGraphQLFieldDefinitionDescriptionCustomizer<A extends Annotation>
+        implements GraphQLFieldDefinitionCustomizer {
+    private final Class<A> annotationClass;
+    private final Function<A, String> descriptionFunction;
+
+    /**
+     * Constructor.
+     *
+     * @param annotationClass the annotation class to determine the description
+     * @param descriptionFunction function to get the description from the annotation
+     */
+    public AnnotationGraphQLFieldDefinitionDescriptionCustomizer(Class<A> annotationClass,
+            Function<A, String> descriptionFunction) {
+        this.annotationClass = annotationClass;
+        this.descriptionFunction = descriptionFunction;
+    }
+
+    @Override
+    public void customize(Builder fieldDefinition, Type<?> parentClass, Type<?> attributeClass, String attribute,
+            DataFetcher<?> fetcher, EntityDictionary entityDictionary) {
+        A annotation = entityDictionary.getAttributeOrRelationAnnotation(parentClass, this.annotationClass, attribute);
+        if (annotation != null) {
+            String description = descriptionFunction.apply(annotation);
+            if (description != null) {
+                fieldDefinition.description(description);
+            }
+        }
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/DefaultGraphQLFieldDefinitionCustomizer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/DefaultGraphQLFieldDefinitionCustomizer.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql;
+
+import com.yahoo.elide.graphql.annotation.GraphQLDescription;
+
+/**
+ * Default GraphQL Field Definition customizer.
+ */
+public class DefaultGraphQLFieldDefinitionCustomizer
+        extends AnnotationGraphQLFieldDefinitionDescriptionCustomizer<GraphQLDescription> {
+
+    public static final DefaultGraphQLFieldDefinitionCustomizer INSTANCE =
+            new DefaultGraphQLFieldDefinitionCustomizer();
+
+    public DefaultGraphQLFieldDefinitionCustomizer() {
+        super(GraphQLDescription.class, annotation -> annotation.value());
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLConversionUtils.java
@@ -59,9 +59,9 @@ public class GraphQLConversionUtils {
     protected NonEntityDictionary nonEntityDictionary;
     protected EntityDictionary entityDictionary;
 
-    private final Map<Type, GraphQLObjectType> outputConversions = new HashMap<>();
-    private final Map<Type, GraphQLInputObjectType> inputConversions = new HashMap<>();
-    private final Map<Type, GraphQLEnumType> enumConversions = new HashMap<>();
+    private final Map<Type<?>, GraphQLObjectType> outputConversions = new HashMap<>();
+    private final Map<Type<?>, GraphQLInputObjectType> inputConversions = new HashMap<>();
+    private final Map<Type<?>, GraphQLEnumType> enumConversions = new HashMap<>();
     private final Map<String, GraphQLEnumType> namedEnumConversions = new HashMap<>();
     private final Map<String, GraphQLList> mapConversions = new HashMap<>();
     private final GraphQLNameUtils nameUtils;
@@ -194,7 +194,7 @@ public class GraphQLConversionUtils {
      * @param fetcher The Datafetcher to assign to the created GraphQL object.
      * @return The created type.
      */
-    public GraphQLList classToQueryMap(Type<?> keyClazz, Type<?> valueClazz, DataFetcher fetcher) {
+    public GraphQLList classToQueryMap(Type<?> keyClazz, Type<?> valueClazz, DataFetcher<?> fetcher) {
         String mapName = nameUtils.toMapEntryOutputName(keyClazz, valueClazz);
 
         if (mapConversions.containsKey(mapName)) {
@@ -203,7 +203,6 @@ public class GraphQLConversionUtils {
 
         GraphQLOutputType keyType = fetchScalarOrObjectOutput(keyClazz, fetcher);
         GraphQLOutputType valueType = fetchScalarOrObjectOutput(valueClazz, fetcher);
-
         GraphQLObjectType mapType = newObject()
                 .name(mapName)
                 .field(newFieldDefinition()
@@ -267,7 +266,7 @@ public class GraphQLConversionUtils {
     public GraphQLOutputType attributeToQueryObject(Type<?> parentClass,
                                                     Type<?> attributeClass,
                                                     String attribute,
-                                                    DataFetcher fetcher) {
+                                                    DataFetcher<?> fetcher) {
         return attributeToQueryObject(
                 parentClass,
                 attributeClass,
@@ -289,7 +288,7 @@ public class GraphQLConversionUtils {
     protected GraphQLOutputType attributeToQueryObject(Type<?> parentClass,
                                                        Type<?> attributeClass,
                                                        String attribute,
-                                                       DataFetcher fetcher,
+                                                       DataFetcher<?> fetcher,
                                                        EntityDictionary dictionary) {
 
         /* Determine if we've already processed this item. */
@@ -399,7 +398,7 @@ public class GraphQLConversionUtils {
      */
     public GraphQLObjectType classToQueryObject(
             Type<?> clazz,
-            DataFetcher fetcher) {
+            DataFetcher<?> fetcher) {
         log.info("Building query object for type: {}", clazz.getName());
 
         if (!nonEntityDictionary.hasBinding(clazz)) {
@@ -491,7 +490,7 @@ public class GraphQLConversionUtils {
      */
     public List<GraphQLArgument> attributeArgumentToQueryObject(Type<?> entityClass,
                                                                 String attribute,
-                                                                DataFetcher fetcher) {
+                                                                DataFetcher<?> fetcher) {
         return attributeArgumentToQueryObject(entityClass, attribute, fetcher, entityDictionary);
     }
 
@@ -505,7 +504,7 @@ public class GraphQLConversionUtils {
      */
     public List<GraphQLArgument> attributeArgumentToQueryObject(Type<?> entityClass,
                                                                 String attribute,
-                                                                DataFetcher fetcher,
+                                                                DataFetcher<?> fetcher,
                                                                 EntityDictionary dictionary) {
         return dictionary.getAttributeArguments(entityClass, attribute)
                 .stream()

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLFieldDefinitionCustomizer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLFieldDefinitionCustomizer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql;
+
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.type.Type;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLFieldDefinition;
+
+/**
+ * Customizer for GraphQLFieldDefinition.
+ */
+@FunctionalInterface
+public interface GraphQLFieldDefinitionCustomizer {
+    /**
+     * Customize the field definition.
+     *
+     * @param fieldDefinition the field definition to customize
+     * @param parentClass the entity class
+     * @param attributeClass the attribute class
+     * @param attribute the attribute name
+     * @param fetcher the fetcher
+     * @param entityDictionary the entity dictionary
+     */
+    void customize(GraphQLFieldDefinition.Builder fieldDefinition, Type<?> parentClass, Type<?> attributeClass,
+            String attribute, DataFetcher<?> fetcher, EntityDictionary entityDictionary);
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLSettings.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLSettings.java
@@ -151,7 +151,8 @@ public class GraphQLSettings implements Settings {
         protected FilterDialect filterDialect;
         protected GraphQLExceptionHandler graphqlExceptionHandler = new DefaultGraphQLExceptionHandler(
                 new Slf4jExceptionLogger(), BasicExceptionMappers.builder().build(), new DefaultGraphQLErrorMapper());
-        protected GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer = null;
+        protected GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer =
+                DefaultGraphQLFieldDefinitionCustomizer.INSTANCE;
 
         protected abstract S self();
 

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLSettings.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLSettings.java
@@ -67,14 +67,17 @@ public class GraphQLSettings implements Settings {
     private final Federation federation;
     private final FilterDialect filterDialect;
     private final GraphQLExceptionHandler graphqlExceptionHandler;
+    private final GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer;
 
     public GraphQLSettings(boolean enabled, String path, Federation federation, FilterDialect filterDialect,
-            GraphQLExceptionHandler graphqlExceptionHandler) {
+            GraphQLExceptionHandler graphqlExceptionHandler,
+            GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer) {
         this.enabled = enabled;
         this.path = path;
         this.federation = federation;
         this.filterDialect = filterDialect;
         this.graphqlExceptionHandler = graphqlExceptionHandler;
+        this.graphqlFieldDefinitionCustomizer = graphqlFieldDefinitionCustomizer;
     }
 
     /**
@@ -118,7 +121,7 @@ public class GraphQLSettings implements Settings {
                 this.processor.accept(this);
             }
             return new GraphQLSettings(this.enabled, this.path, this.federation.build(), this.filterDialect,
-                    this.graphqlExceptionHandler);
+                    this.graphqlExceptionHandler, this.graphqlFieldDefinitionCustomizer);
         }
 
         @Override
@@ -148,6 +151,7 @@ public class GraphQLSettings implements Settings {
         protected FilterDialect filterDialect;
         protected GraphQLExceptionHandler graphqlExceptionHandler = new DefaultGraphQLExceptionHandler(
                 new Slf4jExceptionLogger(), BasicExceptionMappers.builder().build(), new DefaultGraphQLErrorMapper());
+        protected GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer = null;
 
         protected abstract S self();
 
@@ -199,10 +203,21 @@ public class GraphQLSettings implements Settings {
          * Sets the {@link GraphQLExceptionHandler}.
          *
          * @param graphqlExceptionHandler the exception handler
-         * @return
+         * @return the builder
          */
         public S graphqlExceptionHandler(GraphQLExceptionHandler graphqlExceptionHandler) {
             this.graphqlExceptionHandler = graphqlExceptionHandler;
+            return self();
+        }
+
+        /**
+         * Sets the {@link GraphQLFieldDefinitionCustomizer}.
+         *
+         * @param graphqlFieldDefinitionCustomizer the customizer
+         * @return the builder
+         */
+        public S graphqlFieldDefinitionCustomizer(GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer) {
+            this.graphqlFieldDefinitionCustomizer = graphqlFieldDefinitionCustomizer;
             return self();
         }
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/annotation/GraphQLDescription.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/annotation/GraphQLDescription.java
@@ -3,15 +3,23 @@
  * Licensed under the Apache License, Version 2.0
  * See LICENSE file in project root for terms.
  */
-package com.yahoo.elide.graphql;
+package com.yahoo.elide.graphql.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Description for a GraphQL field.
+ */
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLDescription {
+    /**
+     * Description for a GraphQL field.
+     *
+     * @return the description
+     */
     String value() default "";
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/SubscriptionWebSocket.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/websocket/SubscriptionWebSocket.java
@@ -146,7 +146,7 @@ public class SubscriptionWebSocket extends Endpoint {
                     new NonEntityDictionary(new DefaultClassScanner(), CoerceUtil::lookup);
 
             SubscriptionModelBuilder builder = new SubscriptionModelBuilder(dictionary, nonEntityDictionary,
-                    new SubscriptionDataFetcher(nonEntityDictionary), apiVersion);
+                    elide.getElideSettings(), new SubscriptionDataFetcher(nonEntityDictionary), apiVersion);
 
             try {
                 GraphQL api = GraphQL.newGraphQL(builder.build())

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLDescription.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLDescription.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.graphql;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLDescription {
+    String value() default "";
+}

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -416,8 +416,7 @@ public class ModelBuilderTest {
 
     @Test
     public void testGraphQLFieldDefinitionCustomizer() {
-        GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer = new AnnotationGraphQLFieldDefinitionDescriptionCustomizer<>(
-                GraphQLDescription.class, annotation -> annotation.value());
+        GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer = DefaultGraphQLFieldDefinitionCustomizer.INSTANCE;
         DataFetcher<?> fetcher = mock(DataFetcher.class);
         ElideSettings settings = ElideSettings.builder().entityDictionary(dictionary).settings(GraphQLSettingsBuilder
                 .withDefaults(dictionary).graphqlFieldDefinitionCustomizer(graphqlFieldDefinitionCustomizer)).build();

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/ModelBuilderTest.java
@@ -33,6 +33,7 @@ import com.apollographql.federation.graphqljava.FederationDirectives;
 import example.Address;
 import example.Author;
 import example.Book;
+import example.Preview;
 import example.Publisher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -116,6 +117,7 @@ public class ModelBuilderTest {
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Publisher.class);
         dictionary.bindEntity(Address.class);
+        dictionary.bindEntity(Preview.class);
     }
 
     @Test
@@ -224,7 +226,6 @@ public class ModelBuilderTest {
         GraphQLType internalBookInput = schema.getType("ElideInternalBookInput");
         assertNotNull(internalBookInput);
     }
-
 
     @Test
     public void testPageInfoObject() {
@@ -411,6 +412,25 @@ public class ModelBuilderTest {
         /* book.authors is a 'to many' relationship and has the argument "filterAuthor" defined */
         GraphQLFieldDefinition authorField = bookType.getFieldDefinition(FIELD_AUTHORS);
         assertNotNull(authorField.getArgument("filterAuthor"));
+    }
+
+    @Test
+    public void testGraphQLFieldDefinitionCustomizer() {
+        GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer = new AnnotationGraphQLFieldDefinitionDescriptionCustomizer<>(
+                GraphQLDescription.class, annotation -> annotation.value());
+        DataFetcher<?> fetcher = mock(DataFetcher.class);
+        ElideSettings settings = ElideSettings.builder().entityDictionary(dictionary).settings(GraphQLSettingsBuilder
+                .withDefaults(dictionary).graphqlFieldDefinitionCustomizer(graphqlFieldDefinitionCustomizer)).build();
+        ModelBuilder builder = new ModelBuilder(dictionary,
+                new NonEntityDictionary(new DefaultClassScanner(), CoerceUtil::lookup),
+                settings, fetcher, NO_VERSION);
+
+        GraphQLSchema schema = builder.build();
+        GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
+        assertEquals("The title of the book", bookType.getFieldDefinition("title").getDescription());
+        assertEquals("The genre of the book", bookType.getFieldDefinition("genre").getDescription());
+        assertEquals("The previews of the book", bookType.getFieldDefinition("previews").getDescription());
+        assertEquals("The authors of the book", bookType.getFieldDefinition("authors").getDescription());
     }
 
     @Include

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcherTest.java
@@ -109,7 +109,7 @@ public class SubscriptionDataFetcherTest extends GraphQLTest {
         NonEntityDictionary nonEntityDictionary =
                 new NonEntityDictionary(new DefaultClassScanner(), CoerceUtil::lookup);
 
-        SubscriptionModelBuilder builder = new SubscriptionModelBuilder(dictionary, nonEntityDictionary,
+        SubscriptionModelBuilder builder = new SubscriptionModelBuilder(dictionary, nonEntityDictionary, settings,
                 new SubscriptionDataFetcher(nonEntityDictionary), NO_VERSION);
 
         api = GraphQL.newGraphQL(builder.build())

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
@@ -14,10 +14,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.DefaultClassScanner;
 import com.yahoo.elide.core.utils.coerce.CoerceUtil;
+import com.yahoo.elide.graphql.GraphQLDescription;
+import com.yahoo.elide.graphql.GraphQLFieldDefinitionCustomizer;
 import com.yahoo.elide.graphql.GraphQLScalars;
+import com.yahoo.elide.graphql.GraphQLSettings;
 import com.yahoo.elide.graphql.NonEntityDictionary;
 import example.Address;
 import example.Author;
@@ -30,6 +35,7 @@ import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLFieldDefinition.Builder;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
@@ -69,15 +75,29 @@ public class SubscriptionModelBuilderTest {
 
     @Test
     public void testRootType() {
-        DataFetcher fetcher = mock(DataFetcher.class);
+        DataFetcher<?> fetcher = mock(DataFetcher.class);
+        GraphQLFieldDefinitionCustomizer graphqlFieldDefinitionCustomizer = (Builder fieldDefinition,
+                Type<?> parentClass, Type<?> attributeClass, String attribute, DataFetcher<?> dataFetcher,
+                EntityDictionary entityDictionary) -> {
+            GraphQLDescription description = entityDictionary.getAttributeOrRelationAnnotation(parentClass,
+                    GraphQLDescription.class, attribute);
+            if (description != null) {
+                fieldDefinition.description(description.value());
+            }
+        };
         SubscriptionModelBuilder builder = new SubscriptionModelBuilder(dictionary,
-                new NonEntityDictionary(new DefaultClassScanner(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(new DefaultClassScanner(), CoerceUtil::lookup),
+                ElideSettings.builder().settings(GraphQLSettings.builder().graphqlFieldDefinitionCustomizer(graphqlFieldDefinitionCustomizer)).build(), fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
         GraphQLObjectType subscriptionType = (GraphQLObjectType) schema.getType("Subscription");
 
         //Book Type
         GraphQLObjectType bookType = (GraphQLObjectType) schema.getType(TYPE_BOOK);
+        assertEquals("The title of the book", bookType.getFieldDefinition("title").getDescription());
+        assertEquals("The genre of the book", bookType.getFieldDefinition("genre").getDescription());
+        assertEquals("The previews of the book", bookType.getFieldDefinition("previews").getDescription());
+        assertEquals("The authors of the book", bookType.getFieldDefinition("authors").getDescription());
 
         GraphQLFieldDefinition bookField = subscriptionType.getFieldDefinition(BOOK);
         GraphQLEnumType bookTopicType = (GraphQLEnumType) bookField.getArgument(TOPIC).getType();
@@ -113,9 +133,10 @@ public class SubscriptionModelBuilderTest {
 
     @Test
     public void testModelTypes() {
-        DataFetcher fetcher = mock(DataFetcher.class);
+        DataFetcher<?> fetcher = mock(DataFetcher.class);
         SubscriptionModelBuilder builder = new SubscriptionModelBuilder(dictionary,
-                new NonEntityDictionary(new DefaultClassScanner(), CoerceUtil::lookup), fetcher, NO_VERSION);
+                new NonEntityDictionary(new DefaultClassScanner(), CoerceUtil::lookup), ElideSettings.builder().build(),
+                fetcher, NO_VERSION);
 
         GraphQLSchema schema = builder.build();
 

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/subscriptions/SubscriptionModelBuilderTest.java
@@ -19,11 +19,12 @@ import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.DefaultClassScanner;
 import com.yahoo.elide.core.utils.coerce.CoerceUtil;
-import com.yahoo.elide.graphql.GraphQLDescription;
 import com.yahoo.elide.graphql.GraphQLFieldDefinitionCustomizer;
 import com.yahoo.elide.graphql.GraphQLScalars;
 import com.yahoo.elide.graphql.GraphQLSettings;
 import com.yahoo.elide.graphql.NonEntityDictionary;
+import com.yahoo.elide.graphql.annotation.GraphQLDescription;
+
 import example.Address;
 import example.Author;
 import example.Book;

--- a/elide-graphql/src/test/java/example/Book.java
+++ b/elide-graphql/src/test/java/example/Book.java
@@ -7,6 +7,7 @@ package example;
 
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.graphql.GraphQLDescription;
 import com.yahoo.elide.graphql.subscriptions.annotations.Subscription;
 import com.yahoo.elide.graphql.subscriptions.annotations.SubscriptionField;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -76,6 +77,7 @@ public class Book {
     }
 
     @SubscriptionField
+    @GraphQLDescription("The title of the book")
     public String getTitle() {
         return title;
     }
@@ -85,6 +87,7 @@ public class Book {
     }
 
     @SubscriptionField
+    @GraphQLDescription("The genre of the book")
     public String getGenre() {
         return genre;
     }
@@ -144,6 +147,7 @@ public class Book {
 
     @SubscriptionField
     @ManyToMany
+    @GraphQLDescription("The authors of the book")
     public Collection<Author> getAuthors() {
         return authors;
     }
@@ -154,6 +158,7 @@ public class Book {
 
     @SubscriptionField
     @OneToMany(mappedBy = "book")
+    @GraphQLDescription("The previews of the book")
     public Collection<Preview> getPreviews() {
         return previews;
     }

--- a/elide-graphql/src/test/java/example/Book.java
+++ b/elide-graphql/src/test/java/example/Book.java
@@ -7,7 +7,7 @@ package example;
 
 import com.yahoo.elide.annotation.Audit;
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.graphql.GraphQLDescription;
+import com.yahoo.elide.graphql.annotation.GraphQLDescription;
 import com.yahoo.elide.graphql.subscriptions.annotations.Subscription;
 import com.yahoo.elide.graphql.subscriptions.annotations.SubscriptionField;
 import com.fasterxml.jackson.annotation.JsonIgnore;


### PR DESCRIPTION
Resolves #3214

## Description
* Adds a `GraphQLFieldDefinitionCustomizer` to allow customization of the `GraphQLFieldDefinition`
* Adds a setting on the `GraphQLSettings` for the customization

As there is no standard annotation for this there is no default implementation.

```java
@Configuration
public class ElideConfiguration {
  @Bean
  GraphQLSettingsBuilderCustomizer graphqlSettingsBuilderCustomizer() {
    return graphqlSettings -> graphqlSettings.graphqlFieldDefinitionCustomizer(
       ((fieldDefinition, parentClass, attributeClass, attribute, fetcher, entityDictionary) -> {
          Description description = entityDictionary.getAttributeOrRelationAnnotation(parentClass,
              Description.class, attribute);
          if (description != null) {
            fieldDefinition.description(description.value());
          }
        }));
  }
}
```

## Motivation and Context
Allows the customization of the `GraphQLFieldDefinition` to set the description.

## How Has This Been Tested?
Added the relevant tests in `ModelBuilderTest` and `SubscriptionModelBuilderTest`.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
