### PR TITLE
Upgrade dependencies

### DIFF
--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/NoCacheAggregationDataStoreIntegrationTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/integration/NoCacheAggregationDataStoreIntegrationTest.java
@@ -35,12 +35,15 @@ import com.yahoo.elide.datastores.aggregation.metadata.enums.TimeGrain;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.ConnectionDetails;
 import com.yahoo.elide.test.graphql.elements.Arguments;
 import example.PlayerStats;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import graphql.introspection.GoodFaithIntrospection;
 
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.ws.rs.core.MediaType;
@@ -61,6 +64,7 @@ public class NoCacheAggregationDataStoreIntegrationTest extends AggregationDataS
 
     public NoCacheAggregationDataStoreIntegrationTest() {
         super();
+        GoodFaithIntrospection.enabledJvmWide(false); // due to testGraphQLSchema
     }
 
     @Override
@@ -77,6 +81,20 @@ public class NoCacheAggregationDataStoreIntegrationTest extends AggregationDataS
 
     @Test
     public void testGraphQLSchema() throws IOException {
+        /*
+         * Note that the following query triggers the following from the GoodFaithIntrospection.
+         *
+         * {
+         *   "errors": [
+         *     {
+         *       "message": "This request is not asking for introspection in good faith - __Type.fields is present too often!",
+         *       "extensions": {
+         *         "classification": "BadFaithIntrospection"
+         *       }
+         *     }
+         *   ]
+         * }
+         */
         String graphQLRequest = "{"
                 + "__type(name: \"PlayerStatsWithViewEdge\") {"
                 + "   name "

--- a/elide-quarkus/pom.xml
+++ b/elide-quarkus/pom.xml
@@ -43,14 +43,14 @@
     <module>runtime</module>
   </modules>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>3.13.0</compiler-plugin.version>
     <failsafe-plugin.version>3.2.5</failsafe-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.9.4</quarkus.version>
+    <quarkus.version>3.11.0</quarkus.version>
     <elide.version>7.0.6-SNAPSHOT</elide.version>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
     <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -44,7 +44,7 @@
     </scm>
 
     <properties>
-        <metrics.version>4.2.22</metrics.version>
+        <metrics.version>4.2.25</metrics.version>
 
         <!-- Settings -->
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -83,32 +83,32 @@
 
         <!-- dependency versions -->
         <antlr4.version>4.13.1</antlr4.version>
-        <artemis.version>2.31.2</artemis.version>
+        <artemis.version>2.33.0</artemis.version>
         <atomikos.version>6.0.0</atomikos.version>
-        <calcite.version>1.36.0</calcite.version>
+        <calcite.version>1.37.0</calcite.version>
         <caffeine.version>3.1.8</caffeine.version>
         <classgraph.version>4.8.172</classgraph.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
-        <commons-cli.version>1.6.0</commons-cli.version>
+        <commons-cli.version>1.8.0</commons-cli.version>
         <commons-collections4.version>4.4</commons-collections4.version>
-        <commons-compress.version>1.26.1</commons-compress.version>
+        <commons-compress.version>1.26.2</commons-compress.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <embedded-redis.version>0.11.0</embedded-redis.version>
         <encoder.version>1.2.3</encoder.version>
-        <federation-graphql-java-support-api.version>4.2.0</federation-graphql-java-support-api.version>
-        <graphql-java.version>21.0</graphql-java.version>
-        <graal-sdk.version>23.1.1</graal-sdk.version>
-        <guava.version>33.1.0-jre</guava.version>
+        <federation-graphql-java-support-api.version>5.0.0</federation-graphql-java-support-api.version>
+        <graphql-java.version>22.0</graphql-java.version>
+        <graal-sdk.version>24.0.1</graal-sdk.version>
+        <guava.version>33.2.0-jre</guava.version>
         <handlebars.version>4.4.0</handlebars.version>
-        <hibernate.version>6.4.4.Final</hibernate.version>
+        <hibernate.version>6.5.2.Final</hibernate.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
-        <hibernate-search.version>6.2.3.Final</hibernate-search.version>
+        <hibernate-search.version>6.2.4.Final</hibernate-search.version>
         <hjson.version>3.1.0</hjson.version>
         <httpclient5.version>5.3.1</httpclient5.version>
-        <gson.version>2.10.1</gson.version>
+        <gson.version>2.11.0</gson.version>
         <h2.version>2.2.224</h2.version>
         <hikaricp.version>5.1.0</hikaricp.version>
-        <jackson-bom.version>2.16.1</jackson-bom.version>
+        <jackson-bom.version>2.17.1</jackson-bom.version>
         <jakarta-inject.version>2.0.1</jakarta-inject.version>
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
         <jakarta-persistence.version>3.1.0</jakarta-persistence.version>
@@ -117,13 +117,13 @@
         <jakarta-ws-rs.version>3.1.0</jakarta-ws-rs.version>
         <jakarta-validation.version>3.0.2</jakarta-validation.version>
         <jansi.version>2.4.1</jansi.version>
-        <jersey.version>3.1.5</jersey.version>
-        <jetty.version>12.0.5</jetty.version>
-        <jedis.version>5.1.0</jedis.version>
+        <jersey.version>3.1.7</jersey.version>
+        <jetty.version>12.0.9</jetty.version>
+        <jedis.version>5.1.3</jedis.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <json-path.version>2.9.0</json-path.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>
-        <junit.version>5.10.1</junit.version>
+        <junit.version>5.10.2</junit.version>
         <logback.version>1.5.6</logback.version>
         <lombok.version>1.18.32</lombok.version>
         <poi.version>5.2.5</poi.version>
@@ -131,33 +131,33 @@
         <rxjava.version>2.2.21</rxjava.version>
         <rsql-parser.version>2.1.0</rsql-parser.version>
         <slf4j.version>2.0.13</slf4j.version>
-        <spring-boot.version>3.2.5</spring-boot.version>
-        <spring-framework.version>6.1.3</spring-framework.version>
+        <spring-boot.version>3.3.0</spring-boot.version>
+        <spring-framework.version>6.1.8</spring-framework.version>
         <spring-cloud-commons.version>4.1.2</spring-cloud-commons.version>
         <springdoc.version>2.5.0</springdoc.version>
-        <swagger-api.version>2.2.19</swagger-api.version>
+        <swagger-api.version>2.2.22</swagger-api.version>
         <system-lambda.version>1.2.1</system-lambda.version>
-        <tomcat.version>10.1.19</tomcat.version>
-        <mockito.version>5.11.0</mockito.version>
-        <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+        <tomcat.version>10.1.24</tomcat.version>
+        <mockito.version>5.12.0</mockito.version>
+        <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
-        <checkstyle.version>10.16.0</checkstyle.version>
-        <dependency-check-maven.version>9.1.0</dependency-check-maven.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <checkstyle.version>10.17.0</checkstyle.version>
+        <dependency-check-maven.version>9.2.0</dependency-check-maven.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
-        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
-        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
         <maven-gpg-plugin.version>3.2.1</maven-gpg-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-scm-provider-gitexe.version>2.0.1</maven-scm-provider-gitexe.version>
+        <maven-scm-provider-gitexe.version>2.1.0</maven-scm-provider-gitexe.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
         <maven-scm-api.version>2.1.0</maven-scm-api.version>
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>


### PR DESCRIPTION
## Description
Upgrades dependencies for compatibility with Spring Boot 3.3.0.

## Motivation and Context
Spring Boot 3.3.0 targets Jetty 12.0.9. 

Spring Boot 3.3.0 `org.springframework.boot.web.embedded.jetty.JettyEmbeddedWebAppContext` is using Jetty 12.0.9 `org.eclipse.jetty.util.ClassMatcher`.

Older versions of Jetty with Spring Boot 3.3.0 results in `Caused by: java.lang.NoClassDefFoundError: org/eclipse/jetty/util/ClassMatcher`.

## How Has This Been Tested?
Existing tests continue to pass. Also tested by modifying `elide-spring-boot-example`.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
