### PR TITLE
Migrate RxJava2 to reactor

### DIFF
--- a/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/service/storageengine/RedisResultStorageEngineTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.plugins.RxJavaPlugins;
 import redis.clients.jedis.JedisPooled;
 import redis.embedded.RedisServer;
 
@@ -136,21 +135,11 @@ public class RedisResultStorageEngineTest {
     // Redis server does not exist.
     @Test
     public void testStoreResultsFail() throws IOException {
-        io.reactivex.functions.Consumer<? super Throwable> old = RxJavaPlugins.getErrorHandler();
-
-        try {
-            RxJavaPlugins.setErrorHandler(e -> {
-                // Ignore all errors
-            });
-
-            destroy();
-            assertThrows(UncheckedIOException.class, () ->
-                    storeResults("store_results_fail",
-                            outputStream -> write(outputStream, new String[]{"hi", "hello"}))
-            );
-        } finally {
-            RxJavaPlugins.setErrorHandler(old);
-        }
+        destroy();
+        assertThrows(UncheckedIOException.class, () ->
+                storeResults("store_results_fail",
+                        outputStream -> write(outputStream, new String[]{"hi", "hello"}))
+        );
     }
 
     @Test

--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -94,8 +94,8 @@
             <artifactId>rsql-parser</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
-            <artifactId>rxjava</artifactId>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
         </dependency>
 
         <!-- JSR 303 Validation -->

--- a/elide-core/src/main/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/filter/visitors/VerifyFieldAccessFilterExpressionVisitor.java
@@ -23,7 +23,7 @@ import com.yahoo.elide.core.request.Relationship;
 import com.yahoo.elide.core.security.PermissionExecutor;
 import com.yahoo.elide.core.security.permissions.ExpressionResult;
 
-import io.reactivex.Observable;
+import reactor.core.publisher.Flux;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -77,8 +77,8 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
                         .filter(Objects::nonNull)
                         .flatMap(x ->
                                 getValueChecked(x, fieldName, requestScope)
-                                        .toList(LinkedHashSet::new)
-                                        .blockingGet()
+                                        .collect(Collectors.toCollection(LinkedHashSet::new))
+                                        .block()
                                         .stream())
                         .filter(Objects::nonNull)
                         .collect(Collectors.toSet());
@@ -94,7 +94,7 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
         return true;
     }
 
-    private Observable<PersistentResource> getValueChecked(PersistentResource<?> resource, String fieldName,
+    private Flux<PersistentResource> getValueChecked(PersistentResource<?> resource, String fieldName,
                                                            RequestScope requestScope) {
 
         EntityDictionary dictionary = resource.getDictionary();
@@ -105,7 +105,7 @@ public class VerifyFieldAccessFilterExpressionVisitor implements FilterExpressio
         Object entity = resource.getObject();
         if (entity == null || resource.getDictionary()
                 .getRelationshipType(resource.getResourceType(), fieldName) == RelationshipType.NONE) {
-            return Observable.empty();
+            return Flux.empty();
         }
 
         Relationship relationship = Relationship.builder()

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/document/processors/IncludedProcessor.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A Document Processor that add requested relations to the include block of the JsonApiDocument.
@@ -93,8 +94,8 @@ public class IncludedProcessor implements DocumentProcessor {
         Set<PersistentResource> collection;
         Relationship relationship = projection.getRelationship(relation).orElseThrow(IllegalStateException::new);
         try {
-            collection = rec.getRelationCheckedFiltered(relationship).toList(LinkedHashSet::new).blockingGet();
-
+            collection = rec.getRelationCheckedFiltered(relationship)
+                    .collect(Collectors.toCollection(LinkedHashSet::new)).block();
         } catch (ForbiddenAccessException e) {
             return;
         }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RecordState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/RecordState.java
@@ -17,7 +17,7 @@ import com.yahoo.elide.generated.parsers.CoreParser.SubCollectionRelationshipCon
 import com.yahoo.elide.generated.parsers.CoreParser.SubCollectionSubCollectionContext;
 import com.google.common.base.Preconditions;
 
-import io.reactivex.Observable;
+import reactor.core.publisher.Flux;
 
 import java.util.Optional;
 
@@ -58,7 +58,7 @@ public class RecordState extends BaseState {
         final CollectionTerminalState collectionTerminalState =
                 new CollectionTerminalState(entityClass, Optional.of(resource),
                         Optional.of(subCollection), projection);
-        Observable<PersistentResource> collection = null;
+        Flux<PersistentResource> collection = null;
         if (type.isToOne()) {
             collection = resource.getRelationCheckedFiltered(projection.getRelationship(subCollection)
                     .orElseThrow(IllegalStateException::new));

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistenceResourceTestSetup.java
@@ -57,7 +57,6 @@ import example.nontransferable.ShareableWithPackageShare;
 import example.nontransferable.StrictNoTransfer;
 import example.nontransferable.Untransferable;
 
-import io.reactivex.Observable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
@@ -65,6 +64,7 @@ import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import nocreate.NoCreateEntity;
+import reactor.core.publisher.Flux;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -76,6 +76,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class PersistenceResourceTestSetup extends PersistentResource {
     private static final AuditLogger MOCK_AUDIT_LOGGER = mock(AuditLogger.class);
@@ -288,10 +289,10 @@ public class PersistenceResourceTestSetup extends PersistentResource {
     }
 
     public Set<PersistentResource> getRelation(PersistentResource resource, String relation) {
-        Observable<PersistentResource> resources =
+        Flux<PersistentResource> resources =
                 resource.getRelationCheckedFiltered(getRelationship(resource.getResourceType(), relation));
 
-        return resources.toList(LinkedHashSet::new).blockingGet();
+        return resources.collect(Collectors.toCollection(LinkedHashSet::new)).block();
     }
 
     public com.yahoo.elide.core.request.Relationship getRelationship(Type<?> type, String name) {

--- a/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/PersistentResourceTest.java
@@ -89,8 +89,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
 
-import io.reactivex.Observable;
 import nocreate.NoCreateEntity;
+import reactor.core.publisher.Flux;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -407,13 +407,12 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
             PersistentResource<Child> child3Resource = new PersistentResource<>(child3, "3", scope);
             PersistentResource<Child> child4Resource = new PersistentResource<>(child4, "-4", scope);
 
-            Observable<PersistentResource> resources =
-                    Observable.fromArray(child1Resource, child2Resource, child3Resource, child4Resource);
+            Flux<PersistentResource> resources = Flux.just(child1Resource, child2Resource, child3Resource,
+                    child4Resource);
 
-            Set<PersistentResource> results =
-                    PersistentResource.filter(
-                            ReadPermission.class,
-                            Optional.empty(), ALL_FIELDS, resources).toList(LinkedHashSet::new).blockingGet();
+            Set<PersistentResource> results = PersistentResource
+                    .filter(ReadPermission.class, Optional.empty(), ALL_FIELDS, resources)
+                    .collect(Collectors.toCollection(LinkedHashSet::new)).block();
 
             assertEquals(2, results.size(), "Only a subset of the children are readable");
             assertTrue(results.contains(child1Resource), "Readable children includes children with positive IDs");
@@ -427,11 +426,12 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
             PersistentResource<Child> child3Resource = new PersistentResource<>(child3, "3", scope);
             PersistentResource<Child> child4Resource = new PersistentResource<>(child4, "-4", scope);
 
-            Observable<PersistentResource> resources =
-                    Observable.fromArray(child1Resource, child2Resource, child3Resource, child4Resource);
+            Flux<PersistentResource> resources = Flux.just(child1Resource, child2Resource, child3Resource,
+                    child4Resource);
 
-            Set<PersistentResource> results = PersistentResource.filter(ReadPermission.class,
-                    Optional.empty(), ALL_FIELDS, resources).toList(LinkedHashSet::new).blockingGet();
+            Set<PersistentResource> results = PersistentResource
+                    .filter(ReadPermission.class, Optional.empty(), ALL_FIELDS, resources)
+                    .collect(Collectors.toCollection(LinkedHashSet::new)).block();
 
             assertEquals(0, results.size(), "No children are readable by an invalid user");
         }
@@ -2136,7 +2136,7 @@ public class PersistentResourceTest extends PersistenceResourceTestSetup {
 
         Set<PersistentResource> loaded = PersistentResource.loadRecords(EntityProjection.builder()
                 .type(Child.class)
-                .build(), new ArrayList<>(), goodScope).toList(LinkedHashSet::new).blockingGet();
+                .build(), Collections.emptyList(), goodScope).collect(Collectors.toCollection(LinkedHashSet::new)).block();
 
         Set<Child> expected = Sets.newHashSet(child1, child4, child5);
 

--- a/elide-core/src/test/java/com/yahoo/elide/jsonapi/models/DataTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/jsonapi/models/DataTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.jsonapi.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.yahoo.elide.core.dictionary.RelationshipType;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+/**
+ * Test for Data.
+ */
+class DataTest {
+    @Test
+    void getSingleValueNullShouldNotThrow() {
+        Data<Resource> data = new Data<Resource>((Resource) null);
+        assertNull(data.getSingleValue());
+    }
+
+    @Test
+    void getSingleValueShouldNotThrow() {
+        Resource resource = new Resource("book", "1");
+        Data<Resource> data = new Data<Resource>(resource);
+        assertEquals(resource, data.getSingleValue());
+    }
+
+    @Test
+    void getSingleValueCollectionShouldThrow() {
+        Data<Resource> data = new Data<>(List.of(new Resource("book", "1"), new Resource("book", "2")));
+        assertThrows(IllegalAccessError.class, () -> data.getSingleValue());
+    }
+
+    @Test
+    void getNullShouldNotThrow() {
+        Data<Resource> data = new Data<Resource>((Resource) null);
+        assertTrue(data.get().isEmpty());
+    }
+
+    @Test
+    void getSingleValueCollectionAsToOneShouldThrow() {
+        Data<Resource> data = new Data<>(List.of(new Resource("book", "1"), new Resource("book", "2")),
+                RelationshipType.MANY_TO_ONE);
+        assertThrows(IndexOutOfBoundsException.class, () -> data.getSingleValue());
+    }
+
+    @Test
+    void sort() {
+        Data<Resource> data = new Data<>(List.of(new Resource("book", "1"), new Resource("book", "2")));
+        data.sort((left, right) -> {
+            return right.getId().compareTo(left.getId());
+        });
+        assertEquals("2", data.get().iterator().next().getId());
+    }
+
+    @Test
+    void flux() {
+        Data<Resource> data = new Data<>(Flux.just(new Resource("book", "1"), new Resource("book", "2")));
+        List<Resource> resource = data.get().stream().toList();
+        assertEquals(2, resource.size());
+        assertEquals("1", resource.get(0).getId());
+        assertEquals("2", resource.get(1).getId());
+    }
+
+    @Test
+    void toResourceIdentifiers() {
+        Data<Resource> data = new Data<>(Flux.just(new Resource("book", "1"), new Resource("book", "2")));
+        List<ResourceIdentifier> identifiers = data.toResourceIdentifiers().stream().toList();
+        assertEquals(2, identifiers.size());
+        assertEquals("1", identifiers.get(0).getId());
+        assertEquals("2", identifiers.get(1).getId());
+
+        identifiers = data.toResourceIdentifiers().stream().toList();
+        assertEquals(2, identifiers.size());
+        assertEquals("1", identifiers.get(0).getId());
+        assertEquals("2", identifiers.get(1).getId());
+    }
+}

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/SubscriptionDataFetcher.java
@@ -18,11 +18,10 @@ import com.yahoo.elide.graphql.subscriptions.containers.SubscriptionNodeContaine
 import graphql.language.OperationDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.Flowable;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
 
-import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Data Fetcher which fetches Elide subscription models.
@@ -31,7 +30,7 @@ import java.util.ArrayList;
 public class SubscriptionDataFetcher implements DataFetcher<Object>, QueryLogger {
 
     private final NonEntityDictionary nonEntityDictionary;
-    private final Integer bufferSize;
+    private final int bufferSize;
 
     /**
      * Constructor.
@@ -74,10 +73,9 @@ public class SubscriptionDataFetcher implements DataFetcher<Object>, QueryLogger
                     .getProjectionInfo()
                     .getProjection(aliasName, entityName);
 
-            Flowable<PersistentResource> recordPublisher =
-                    PersistentResource.loadRecords(projection, new ArrayList<>(), context.requestScope)
-                            .toFlowable(BackpressureStrategy.BUFFER)
-                            .onBackpressureBuffer(bufferSize, true, false);
+            Flux<PersistentResource> recordPublisher = PersistentResource
+                    .loadRecords(projection, Collections.emptyList(), context.requestScope)
+                    .onBackpressureBuffer(bufferSize);
 
             return recordPublisher.map(SubscriptionNodeContainer::new);
         }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/containers/SubscriptionNodeContainer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/subscriptions/containers/SubscriptionNodeContainer.java
@@ -31,7 +31,7 @@ public class SubscriptionNodeContainer extends NodeContainer {
         if (type.isToOne()) {
             Set<PersistentResource> resources = (Set<PersistentResource>) context.parentResource
                     .getRelationCheckedFiltered(relationship)
-                    .toList(LinkedHashSet::new).blockingGet();
+                    .collect(Collectors.toCollection(LinkedHashSet::new)).block();
             if (resources.size() > 0) {
                 return new SubscriptionNodeContainer(resources.iterator().next());
             } else {
@@ -40,7 +40,7 @@ public class SubscriptionNodeContainer extends NodeContainer {
         } else {
             Set<PersistentResource> resources = (Set<PersistentResource>) context.parentResource
                     .getRelationCheckedFiltered(relationship)
-                    .toList(LinkedHashSet::new).blockingGet();
+                    .collect(Collectors.toCollection(LinkedHashSet::new)).block();
 
             return resources.stream()
                     .map(SubscriptionNodeContainer::new)

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <lombok.version>1.18.32</lombok.version>
         <poi.version>5.2.5</poi.version>
         <rest-assured.version>5.4.0</rest-assured.version>
-        <rxjava.version>2.2.21</rxjava.version>
+        <reactor-bom.version>2023.0.6</reactor-bom.version>
         <rsql-parser.version>2.1.0</rsql-parser.version>
         <slf4j.version>2.0.13</slf4j.version>
         <spring-boot.version>3.2.5</spring-boot.version>
@@ -412,11 +412,6 @@
                 <version>${rsql-parser.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.reactivex.rxjava2</groupId>
-                <artifactId>rxjava</artifactId>
-                <version>${rxjava.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.owasp.encoder</groupId>
                 <artifactId>encoder</artifactId>
                 <version>${encoder.version}</version>
@@ -444,6 +439,14 @@
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-bom</artifactId>
                 <version>${jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-bom</artifactId>
+                <version>${reactor-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Description
Migrate from RxJava2 to Reactor.

## Motivation and Context
As RxJava2 has been EOL it would be good to migrate to something else.

The following options were considered
* RxJava3
* Reactor
* Mutiny

Micronaut had also migrated from RxJava2 to Reactor instead of migrating to RxJava3. This would also align with Spring and reduce having an additional library if the Spring Reactive stack is used. The R2DBC drivers are implemented using Reactor.

## How Has This Been Tested?
Added tests and existing tests passed. Also tested with the elide-spring-boot-example.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
