### PR TITLE
Remove attributes and relationships from swagger components (#3229)

### DIFF
--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Resource.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Resource.java
@@ -5,6 +5,7 @@
  */
 package com.yahoo.elide.swagger.models.media;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -46,10 +47,12 @@ public class Resource extends ObjectSchema {
         relationships.addProperty(relationshipName, new Data(relationship));
     }
 
+    @JsonIgnore
     public ObjectSchema getAttributes() {
         return this.attributes;
     }
 
+    @JsonIgnore
     public ObjectSchema getRelationships() {
         return this.relationships;
     }

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiIT.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiIT.java
@@ -48,8 +48,21 @@ class OpenApiIT extends AbstractApiResourceInitializer {
         assertTrue(node.get("paths").size() > 1);
         assertNotNull(node.get("paths").get("/book"));
         assertNotNull(node.get("paths").get("/publisher"));
+
         assertNotNull(node.get("components").get("schemas").get("book"));
+        assertEquals(4, node.get("components").get("schemas").get("book").size());
+        assertNotNull(node.get("components").get("schemas").get("book").get("title"));
+        assertNotNull(node.get("components").get("schemas").get("book").get("type"));
+        assertNotNull(node.get("components").get("schemas").get("book").get("properties"));
+        assertNotNull(node.get("components").get("schemas").get("book").get("description"));
+
         assertNotNull(node.get("components").get("schemas").get("publisher"));
+        assertEquals(4, node.get("components").get("schemas").get("publisher").size());
+        assertNotNull(node.get("components").get("schemas").get("publisher").get("title"));
+        assertNotNull(node.get("components").get("schemas").get("publisher").get("type"));
+        assertNotNull(node.get("components").get("schemas").get("publisher").get("properties"));
+        assertNotNull(node.get("components").get("schemas").get("publisher").get("description"));
+
     }
 
     @Test


### PR DESCRIPTION
Resolves #3229

## Description
The additional attributes and relationships in Resource.java were being serialized into the generated swagger.

## Motivation and Context
A lot of the tooling will just ignore these additional invalid fields. However tools like swagger codegen fail with errors like:

![image](https://github.com/yahoo/elide/assets/842288/008b9149-1ef1-45ba-b1d6-d44f218d28d6)

## How Has This Been Tested?
Updated the existing test assertions to check the structure of the generated schema.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
