### PR TITLE
Fix async when graphql not enabled

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/hooks/AsyncQueryHook.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/hooks/AsyncQueryHook.java
@@ -18,6 +18,7 @@ import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.graphql.QueryRunner;
+import com.yahoo.elide.graphql.QueryRunners;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -44,7 +45,8 @@ public class AsyncQueryHook extends AsyncApiHook<AsyncQuery> {
         super.validateOptions(query, requestScope);
 
         if (query.getQueryType().equals(QueryType.GRAPHQL_V1_0)) {
-            QueryRunner runner = getAsyncExecutorService().getRunners().get(requestScope.getRoute().getApiVersion());
+            QueryRunner runner = getAsyncExecutorService().getProviders().getProvider(QueryRunners.class)
+                    .getRunner(requestScope.getRoute().getApiVersion());
             if (runner == null) {
                 throw new InvalidOperationException("Invalid API Version");
             }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperation.java
@@ -13,6 +13,7 @@ import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.graphql.QueryRunner;
+import com.yahoo.elide.graphql.QueryRunners;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +34,7 @@ public class GraphQLAsyncQueryOperation extends AsyncQueryOperation {
     public ElideResponse<String> execute(AsyncApi queryObj, RequestScope scope) throws URISyntaxException {
         User user = scope.getUser();
         String apiVersion = scope.getRoute().getApiVersion();
-        QueryRunner runner = getService().getRunners().get(apiVersion);
+        QueryRunner runner = getService().getProviders().getProvider(QueryRunners.class).getRunner(apiVersion);
         if (runner == null) {
             throw new InvalidOperationException("Invalid API Version");
         }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLTableExportOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/GraphQLTableExportOperation.java
@@ -19,6 +19,7 @@ import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.route.Route;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.graphql.GraphQLRequestScope;
+import com.yahoo.elide.graphql.GraphQLSettings;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.graphql.parser.GraphQLEntityProjectionMaker;
 import com.yahoo.elide.graphql.parser.GraphQLProjectionInfo;
@@ -78,5 +79,18 @@ public class GraphQLTableExportOperation extends TableExportOperation {
         }
 
         return projectionInfo.getProjections().values();
+    }
+
+    @Override
+    public String getBaseUrl(RequestScope requestScope) {
+        String baseUrl = requestScope.getRoute().getBaseUrl();
+        GraphQLSettings graphqlSettings = requestScope.getElideSettings().getSettings(GraphQLSettings.class);
+        if (graphqlSettings != null) {
+            String graphqlApiPath = graphqlSettings.getPath();
+            if (graphqlApiPath != null && baseUrl.endsWith(graphqlApiPath)) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - graphqlApiPath.length());
+            }
+        }
+        return baseUrl;
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperation.java
@@ -38,7 +38,7 @@ public class JsonApiAsyncQueryOperation extends AsyncQueryOperation {
     @Override
     public ElideResponse<String> execute(AsyncApi queryObj, RequestScope scope)
             throws URISyntaxException {
-        JsonApi jsonApi = getService().getJsonApi();
+        JsonApi jsonApi = getService().getProviders().getProvider(JsonApi.class);
         User user = scope.getUser();
         String apiVersion = scope.getRoute().getApiVersion();
         UUID requestUUID = UUID.fromString(queryObj.getRequestId());

--- a/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiTableExportOperation.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/operation/JsonApiTableExportOperation.java
@@ -21,6 +21,7 @@ import com.yahoo.elide.core.request.route.Route;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.EntityProjectionMaker;
 import com.yahoo.elide.jsonapi.JsonApiRequestScope;
+import com.yahoo.elide.jsonapi.JsonApiSettings;
 
 import org.apache.hc.core5.net.URIBuilder;
 
@@ -98,5 +99,18 @@ public class JsonApiTableExportOperation extends TableExportOperation {
             throw new BadRequestException(e.getMessage());
         }
         return Collections.singletonList(projection);
+    }
+
+    @Override
+    public String getBaseUrl(RequestScope requestScope) {
+        String baseUrl = requestScope.getRoute().getBaseUrl();
+        JsonApiSettings jsonApiSettings = requestScope.getElideSettings().getSettings(JsonApiSettings.class);
+        if (jsonApiSettings != null) {
+            String jsonApiPath = jsonApiSettings.getPath();
+            if (jsonApiPath != null && baseUrl.endsWith(jsonApiPath)) {
+                baseUrl = baseUrl.substring(0, baseUrl.length() - jsonApiPath.length());
+            }
+        }
+        return baseUrl;
     }
 }

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncProviderService.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncProviderService.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Service that returns the providers needed.
+ */
+public class AsyncProviderService {
+    private final Map<String, Object> providers;
+
+    /**
+     * Constructor.
+     *
+     * @param providers the providers
+     */
+    public AsyncProviderService(Map<String, Object> providers) {
+        this.providers = providers;
+    }
+
+    /**
+     * Gets the provider.
+     *
+     * @param <T> the provider type
+     * @param clazz the provider type
+     * @return the provider
+     */
+    public <T> T getProvider(Class<T> clazz) {
+        return clazz.cast(providers.get(clazz.getName()));
+    }
+
+    /**
+     * Gets the builder for {@link AsyncProviderService}.
+     *
+     * @return the builder.
+     */
+    public static AsyncProviderServiceBuilder builder() {
+        return new AsyncProviderServiceBuilder();
+    }
+
+    /**
+     * Builder for {@link AsyncProviderService}.
+     */
+    public static class AsyncProviderServiceBuilder
+            extends AsyncProviderServiceBuilderSupport<AsyncProviderServiceBuilder> {
+        public AsyncProviderService build() {
+            return new AsyncProviderService(this.providers);
+        }
+
+        @Override
+        public AsyncProviderServiceBuilder self() {
+            return this;
+        }
+    }
+
+    /**
+     * Builder Support for {@link AsyncProviderService}.
+     *
+     * @param <S> the builder class
+     */
+    public static abstract class AsyncProviderServiceBuilderSupport<S> {
+        public abstract S self();
+        protected Map<String, Object> providers = new HashMap<>();
+
+        /**
+         * Sets the providers.
+         *
+         * @param providers the providers
+         * @return the builder
+         */
+        public S providers(Map<String, Object> providers) {
+            this.providers = providers;
+            return self();
+        }
+
+        /**
+         * Customize the providers.
+         *
+         * @param customizer the customizer
+         * @return the builder
+         */
+        public S providers(Consumer<Map<String, Object>> customizer) {
+            customizer.accept(this.providers);
+            return self();
+        }
+
+        /**
+         * Sets the provider.
+         *
+         * @param <T> the provider type
+         * @param clazz the provider class
+         * @param provider the provider instance
+         * @return the builder
+         */
+        public <T> S provider(Class<T> clazz, T provider) {
+            // The clazz is not obtained from the provider object as it may be a derived class or proxy
+            this.providers.put(clazz.getName(), provider);
+            return self();
+        }
+    }
+}

--- a/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncProviderServiceBuilderCustomizer.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/service/AsyncProviderServiceBuilderCustomizer.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.async.service;
+
+import com.yahoo.elide.async.service.AsyncProviderService.AsyncProviderServiceBuilder;
+
+/**
+ * Customizer for {@link AsyncProviderServiceBuilder}.
+ */
+public interface AsyncProviderServiceBuilderCustomizer {
+    void customize(AsyncProviderServiceBuilder builder);
+}

--- a/elide-async/src/test/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperationTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/operation/GraphQLAsyncQueryOperationTest.java
@@ -17,10 +17,13 @@ import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryType;
 import com.yahoo.elide.async.service.AsyncExecutorService;
+import com.yahoo.elide.async.service.AsyncProviderService;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.exceptions.InvalidOperationException;
 import com.yahoo.elide.core.request.route.Route;
 import com.yahoo.elide.graphql.QueryRunner;
+import com.yahoo.elide.graphql.QueryRunners;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +38,7 @@ public class GraphQLAsyncQueryOperationTest {
     private Map<String, QueryRunner> runners = new HashMap<>();
     private QueryRunner runner;
     private AsyncExecutorService asyncExecutorService;
+    private AsyncProviderService asyncProviderService;
 
     @BeforeEach
     public void setupMocks() {
@@ -44,8 +48,11 @@ public class GraphQLAsyncQueryOperationTest {
         runner = mock(QueryRunner.class);
         runners.put("v1", runner);
         asyncExecutorService = mock(AsyncExecutorService.class);
+        asyncProviderService = mock(AsyncProviderService.class);
+        QueryRunners queryRunners = new QueryRunners(runners);
+        when(asyncProviderService.getProvider(QueryRunners.class)).thenReturn(queryRunners);
         when(asyncExecutorService.getElide()).thenReturn(elide);
-        when(asyncExecutorService.getRunners()).thenReturn(runners);
+        when(asyncExecutorService.getProviders()).thenReturn(asyncProviderService);
     }
 
     @Test

--- a/elide-async/src/test/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperationTest.java
+++ b/elide-async/src/test/java/com/yahoo/elide/async/operation/JsonApiAsyncQueryOperationTest.java
@@ -17,6 +17,7 @@ import com.yahoo.elide.async.models.AsyncQuery;
 import com.yahoo.elide.async.models.AsyncQueryResult;
 import com.yahoo.elide.async.models.QueryType;
 import com.yahoo.elide.async.service.AsyncExecutorService;
+import com.yahoo.elide.async.service.AsyncProviderService;
 import com.yahoo.elide.core.RequestScope;
 import com.yahoo.elide.core.request.route.Route;
 import com.yahoo.elide.jsonapi.JsonApi;
@@ -32,6 +33,7 @@ public class JsonApiAsyncQueryOperationTest {
     private JsonApi jsonApi;
     private RequestScope requestScope;
     private AsyncExecutorService asyncExecutorService;
+    private AsyncProviderService asyncProviderService;
 
     @BeforeEach
     public void setupMocks() {
@@ -39,9 +41,11 @@ public class JsonApiAsyncQueryOperationTest {
         jsonApi = mock(JsonApi.class);
         requestScope = mock(RequestScope.class);
         asyncExecutorService = mock(AsyncExecutorService.class);
+        asyncProviderService = mock(AsyncProviderService.class);
+        when(asyncProviderService.getProvider(JsonApi.class)).thenReturn(jsonApi);
         when(requestScope.getRoute()).thenReturn(Route.builder().build());
         when(asyncExecutorService.getElide()).thenReturn(elide);
-        when(asyncExecutorService.getJsonApi()).thenReturn(jsonApi);
+        when(asyncExecutorService.getProviders()).thenReturn(asyncProviderService);
     }
 
     @Test

--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/DefaultClassScanner.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/DefaultClassScanner.java
@@ -64,13 +64,9 @@ public class DefaultClassScanner implements ClassScanner {
     public Set<Class<?>> getAnnotatedClasses(List<Class<? extends Annotation>> annotations,
             FilterExpression filter) {
         Set<Class<?>> result = new LinkedHashSet<>();
-
         for (Class<? extends Annotation> annotation : annotations) {
-            result.addAll(startupCache.get(annotation.getCanonicalName()).stream()
-                    .filter(filter::include)
-                    .collect(Collectors.toCollection(LinkedHashSet::new)));
+            startupCache.get(annotation.getCanonicalName()).stream().filter(filter::include).forEach(result::add);
         }
-
         return result;
     }
 

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TemplateConfigValidator.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/validator/TemplateConfigValidator.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.datastores.aggregation.validator;
 
+import com.yahoo.elide.core.dictionary.Injector;
 import com.yahoo.elide.core.utils.ClassScanner;
 import com.yahoo.elide.datastores.aggregation.DefaultQueryValidator;
 import com.yahoo.elide.datastores.aggregation.metadata.FormulaValidator;
@@ -28,23 +29,26 @@ public class TemplateConfigValidator implements Validator {
 
     private final ClassScanner scanner;
     private final String configRoot;
+    private final Injector injector;
 
     public TemplateConfigValidator(
             ClassScanner scanner,
+            Injector injector,
             String configRoot
     ) {
         this.scanner = scanner;
+        this.injector = injector;
         this.configRoot = configRoot;
     }
 
     //Rebuilds the MetaDataStore for each validation so that we can validate templates.
     MetaDataStore rebuildMetaDataStore(Map<String, ConfigFile> resourceMap) {
-        DynamicConfigValidator validator = new DynamicConfigValidator(scanner,
-                configRoot);
+        DynamicConfigValidator validator = new DynamicConfigValidator(
+                entityDictionaryBuilder -> entityDictionaryBuilder.scanner(scanner).injector(injector), configRoot);
 
         validator.validate(resourceMap);
 
-        MetaDataStore metaDataStore = new MetaDataStore(scanner, validator.getTables(),
+        MetaDataStore metaDataStore = new MetaDataStore(scanner, injector, validator.getTables(),
                 validator.getNamespaceConfigurations(), false);
 
         //Populates the metadata store with SQL tables.

--- a/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
+++ b/elide-datastore/elide-datastore-aggregation/src/test/java/com/yahoo/elide/datastores/aggregation/validator/ColumnArgumentValidatorTest.java
@@ -118,7 +118,7 @@ class ColumnArgumentValidatorTest {
         Set<Table> tables = new HashSet<>();
         tables.add(mainTable);
         tables.add(joinTableBuilder.build());
-        MetaDataStore metaDataStore = new MetaDataStore(new DefaultClassScanner(), tables, this.namespaceConfigs, true);
+        MetaDataStore metaDataStore = new MetaDataStore(new DefaultClassScanner(), EntityDictionary.DEFAULT_INJECTOR, tables, this.namespaceConfigs, true);
         QueryPlanMerger merger = new DefaultQueryPlanMerger(metaDataStore);
         Exception e = assertThrows(IllegalStateException.class, () -> new SQLQueryEngine(metaDataStore, connectionLookup, optimizers, merger, queryValidator));
 

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/async/integration/tests/framework/AsyncIntegrationTestApplicationResourceConfig.java
@@ -30,6 +30,7 @@ import com.yahoo.elide.async.models.security.AsyncApiInlineChecks;
 import com.yahoo.elide.async.resources.ExportApiEndpoint.ExportApiProperties;
 import com.yahoo.elide.async.service.AsyncCleanerService;
 import com.yahoo.elide.async.service.AsyncExecutorService;
+import com.yahoo.elide.async.service.AsyncProviderService;
 import com.yahoo.elide.async.service.dao.AsyncApiDao;
 import com.yahoo.elide.async.service.dao.DefaultAsyncApiDao;
 import com.yahoo.elide.async.service.storageengine.FileResultStorageEngine;
@@ -41,6 +42,8 @@ import com.yahoo.elide.core.filter.dialect.jsonapi.DefaultFilterDialect;
 import com.yahoo.elide.core.filter.dialect.jsonapi.MultipleFilterDialect;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.graphql.GraphQLSettings.GraphQLSettingsBuilder;
+import com.yahoo.elide.graphql.QueryRunners;
+import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.jsonapi.JsonApiSettings.JsonApiSettingsBuilder;
 
 import example.TestCheckMappings;
@@ -130,8 +133,13 @@ public class AsyncIntegrationTestApplicationResourceConfig extends ResourceConfi
                 bind(asyncAPIDao).to(AsyncApiDao.class);
 
                 ExecutorService executorService = (ExecutorService) servletContext.getAttribute(ASYNC_EXECUTOR_ATTR);
+                AsyncProviderService asyncProviderService = AsyncProviderService.builder()
+                        .provider(JsonApi.class, new JsonApi(elide)).provider(QueryRunners.class,
+                                new QueryRunners(elide, Optional.of(new SimpleDataFetcherExceptionHandler())))
+                        .build();
+
                 AsyncExecutorService asyncExecutorService = new AsyncExecutorService(elide,
-                        executorService, executorService, asyncAPIDao, Optional.of(new SimpleDataFetcherExceptionHandler()));
+                        executorService, executorService, asyncAPIDao, asyncProviderService);
 
                 // Create ResultStorageEngine
                 Path storageDestination = (Path) servletContext.getAttribute(STORAGE_DESTINATION_ATTR);

--- a/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
+++ b/elide-model-config/src/main/java/com/yahoo/elide/modelconfig/validator/DynamicConfigValidator.java
@@ -12,6 +12,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.SecurityCheck;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.dictionary.EntityDictionaryBuilderCustomizer;
 import com.yahoo.elide.core.dictionary.EntityPermissions;
 import com.yahoo.elide.core.exceptions.BadRequestException;
 import com.yahoo.elide.core.security.checks.Check;
@@ -93,10 +94,27 @@ public class DynamicConfigValidator implements DynamicConfiguration, Validator {
     private static final Pattern FILTER_VARIABLE_PATTERN = Pattern.compile(".*?\\{\\{(\\w+)\\}\\}");
 
     public DynamicConfigValidator(ClassScanner scanner, String configDir) {
-        dictionary = EntityDictionary.builder().scanner(scanner).build();
-        fileLoader = new FileLoader(configDir);
+        this(builder -> builder.scanner(scanner), configDir);
+    }
 
+    public DynamicConfigValidator(EntityDictionaryBuilderCustomizer entityDictionaryBuilderCustomizer,
+            String configDir) {
+        this(buildEntityDictionary(entityDictionaryBuilderCustomizer), configDir);
+    }
+
+    public DynamicConfigValidator(EntityDictionary dictionary, String configDir) {
+        this.dictionary = dictionary;
+        this.fileLoader = new FileLoader(configDir);
         initialize();
+    }
+
+    protected static EntityDictionary buildEntityDictionary(
+            EntityDictionaryBuilderCustomizer entityDictionaryBuilderCustomizer) {
+        EntityDictionary.EntityDictionaryBuilder  builder = EntityDictionary.builder();
+        if (entityDictionaryBuilderCustomizer != null) {
+            entityDictionaryBuilderCustomizer.customize(builder);
+        }
+        return builder.build();
     }
 
     private void initialize() {

--- a/elide-spring/elide-spring-boot-autoconfigure/pom.xml
+++ b/elide-spring/elide-spring-boot-autoconfigure/pom.xml
@@ -82,6 +82,13 @@
 
         <dependency>
             <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-datastore-multiplex</artifactId>
+            <version>7.1.1-SNAPSHOT</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-swagger</artifactId>
             <version>7.1.1-SNAPSHOT</version>
             <optional>true</optional>

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/AsyncProperties.java
@@ -67,5 +67,5 @@ public class AsyncProperties {
      * Settings for the export controller.
      */
     @NestedConfigurationProperty
-    private ExportControllerProperties export;
+    private ExportControllerProperties export = new ExportControllerProperties();
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionConfiguration.java
@@ -19,9 +19,11 @@ import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfigurator;
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfigurator.SubscriptionWebSocketConfiguratorBuilder;
 import com.yahoo.elide.datastores.jms.websocket.SubscriptionWebSocketConfiguratorBuilderCustomizer;
+import com.yahoo.elide.graphql.GraphQLSettings;
 import com.yahoo.elide.graphql.subscriptions.websocket.SubscriptionWebSocket;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -40,6 +42,7 @@ import jakarta.websocket.server.ServerEndpointConfig;
  */
 @Configuration
 @ConditionalOnProperty(name = "elide.graphql.enabled", havingValue = "true")
+@ConditionalOnClass(GraphQLSettings.class)
 @EnableConfigurationProperties(ElideConfigProperties.class)
 public class ElideSubscriptionConfiguration {
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionScanningConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionScanningConfiguration.java
@@ -7,8 +7,10 @@ package com.yahoo.elide.spring.config;
 
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.RefreshableElide;
+import com.yahoo.elide.graphql.GraphQLSettings;
 import com.yahoo.elide.graphql.subscriptions.hooks.SubscriptionScanner;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
@@ -24,6 +26,7 @@ import jakarta.jms.Message;
  * Scans for GraphQL subscriptions and registers lifecycle hooks.
  */
 @Configuration
+@ConditionalOnClass(GraphQLSettings.class)
 @ConditionalOnProperty(name = "elide.graphql.enabled", havingValue = "true")
 @ConditionalOnExpression(
     "${elide.graphql.subscription.enabled:false} && ${elide.graphql.subscription.publishing.enabled:true}")

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTransactionTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideAutoConfigurationTransactionTest.java
@@ -23,6 +23,7 @@ import com.yahoo.elide.spring.orm.jpa.config.JpaDataStoreRegistrations;
 import com.atomikos.spring.AtomikosAutoConfiguration;
 import com.atomikos.spring.AtomikosDataSourceBean;
 
+import example.AppConfiguration;
 import example.models.jpa.ArtifactGroup;
 import example.models.jpa.v2.ArtifactGroupV2;
 import example.models.jpa.v3.ArtifactGroupV3;
@@ -38,6 +39,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.EntityManagerFactoryBuilderCustomizer;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
 import org.springframework.boot.orm.jpa.hibernate.SpringJtaPlatform;
@@ -71,6 +73,7 @@ import javax.sql.XADataSource;
  */
 class ElideAutoConfigurationTransactionTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(UserConfigurations.of(AppConfiguration.class))
             .withConfiguration(AutoConfigurations.of(ElideAutoConfiguration.class, DataSourceAutoConfiguration.class,
                     HibernateJpaAutoConfiguration.class, TransactionAutoConfiguration.class, RefreshAutoConfiguration.class));
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideSubscriptionScanningConfigurationTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/config/ElideSubscriptionScanningConfigurationTest.java
@@ -8,6 +8,8 @@ package com.yahoo.elide.spring.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import example.AppConfiguration;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -15,6 +17,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.autoconfigure.transaction.TransactionAutoConfiguration;
+import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.autoconfigure.RefreshAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +30,7 @@ import jakarta.jms.ConnectionFactory;
  */
 class ElideSubscriptionScanningConfigurationTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(UserConfigurations.of(AppConfiguration.class))
             .withConfiguration(AutoConfigurations.of(ElideAutoConfiguration.class, DataSourceAutoConfiguration.class,
                     HibernateJpaAutoConfiguration.class, TransactionAutoConfiguration.class,
                     RefreshAutoConfiguration.class, ElideSubscriptionScanningConfiguration.class));
@@ -34,7 +38,7 @@ class ElideSubscriptionScanningConfigurationTest {
     @Configuration
     public static class JmsConfiguration {
         @Bean
-        public ConnectionFactory connectionFactory() {
+        ConnectionFactory connectionFactory() {
             return Mockito.mock(ConnectionFactory.class);
         }
     }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/AppConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/AppConfiguration.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import example.models.services.HookService;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfiguration {
+    @Bean
+    HookService hookService() {
+        return new HookService();
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/SecurityConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/SecurityConfiguration.java
@@ -18,10 +18,10 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfiguration {
-
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.authorizeHttpRequests().anyRequest().permitAll().and().csrf().disable();
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable());
         return http.build();
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/hooks/ArtifactGroupHook.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/hooks/ArtifactGroupHook.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.hooks;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+
+import example.models.jpa.ArtifactGroup;
+import example.models.services.HookService;
+
+import java.util.Optional;
+
+/**
+ * Test hook.
+ */
+public class ArtifactGroupHook implements LifeCycleHook<ArtifactGroup> {
+    private final HookService hookService;
+
+    /**
+     * This requires a dependency injected service to test the injector.
+     *
+     * @param hookService the hook service
+     */
+    public ArtifactGroupHook(HookService hookService) {
+        this.hookService = hookService;
+    }
+
+    @Override
+    public void execute(Operation operation, TransactionPhase phase, ArtifactGroup elideEntity,
+            RequestScope requestScope, Optional<ChangeSpec> changes) {
+    }
+
+    public HookService getService() {
+        return this.hookService;
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactGroup.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/jpa/ArtifactGroup.java
@@ -7,11 +7,13 @@ package example.models.jpa;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.annotation.UpdatePermission;
 import com.yahoo.elide.graphql.subscriptions.annotations.Subscription;
 import com.yahoo.elide.graphql.subscriptions.annotations.SubscriptionField;
-import example.checks.AdminCheck;
 
+import example.checks.AdminCheck;
+import example.hooks.ArtifactGroupHook;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
@@ -24,6 +26,7 @@ import java.util.List;
 @Entity
 @Data
 @Subscription
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.PREFLUSH, hook = ArtifactGroupHook.class)
 public class ArtifactGroup {
     @Id
     private String name = "";

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/services/HookService.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/models/services/HookService.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.models.services;
+
+/**
+ * Service to be injected into a hook.
+ */
+public class HookService {
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/configs/models/security.hjson
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/resources/configs/models/security.hjson
@@ -1,0 +1,7 @@
+{
+  roles:
+  [
+    admin.user
+    guest.user
+  ]
+}

--- a/elide-spring/elide-spring-boot-starter/README.md
+++ b/elide-spring/elide-spring-boot-starter/README.md
@@ -11,16 +11,16 @@ Opinionated jar which packages dependencies to get started with Elide and Spring
 ## Maven Dependency
 
 ```xml
-   <dependency>
-       <groupId>com.yahoo.elide</groupId>
-       <artifactId>elide-spring-boot-starter</artifactId>
-       <version>${elide.version}</version>
-   </dependency>
+<dependency>
+    <groupId>com.yahoo.elide</groupId>
+    <artifactId>elide-spring-boot-starter</artifactId>
+    <version>${elide.version}</version>
+</dependency>
 ```
 
 ## Example Usage.
 
-An example project can be viewed [here](https://github.com/aklish/elide-spring).
+An example project can be viewed [here](https://github.com/yahoo/elide-spring-boot-example).
 
 ## Configuration
 
@@ -28,22 +28,56 @@ Elide can be configured in `application.yaml` with settings like this:
 
 ```yaml
 elide:
-  pageSize: 1000
-  maxPageSize: 10000
+  default-page-size: 1000
+  max-page-size: 10000
   json-api:
     path: /json
     enabled: true
   graphql:
     path: /graphql
     enabled: true
-  swagger:
+  api-docs:
     path: /doc
     enabled: true
-    name: 'My Awesome Service'
-    version: "1.0"
 ```
 
-For more information on custom configuration, see the [elide-spring-boot-autoconfigure documentation](https://github.com/yahoo/elide/blob/master/elide-spring/elide-spring-boot-autoconfigure/README.md).
+For more information on custom configuration, see the [configuration documentation](https://elide.io/pages/guide/v7/17-configuration.html).
+
+
+## Dependencies
+
+### Excludable Dependencies
+
+The following dependencies are automatically included, but can be explicitly excluded if they are not required.
+
+```xml
+<dependency>
+    <groupId>com.yahoo.elide</groupId>
+    <artifactId>elide-spring-boot-starter</artifactId>
+    <exclusions>
+        <exclusion>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-async</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-datastore-aggregation</artifactId>
+        </exclusion>				
+        <exclusion>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-datastore-jms</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-graphql</artifactId>
+        </exclusion>
+        <exclusion>
+            <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-swagger</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+```
 
 ## License
 This project is licensed under the terms of the [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) open source license.

--- a/elide-spring/elide-spring-boot-starter/pom.xml
+++ b/elide-spring/elide-spring-boot-starter/pom.xml
@@ -73,6 +73,12 @@
 
         <dependency>
             <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-datastore-multiplex</artifactId>
+            <version>7.1.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-swagger</artifactId>
             <version>7.1.1-SNAPSHOT</version>
         </dependency>

--- a/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneMetadataStoreMissingTest.java
@@ -7,6 +7,7 @@ package example;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.yahoo.elide.core.dictionary.Injector;
 import com.yahoo.elide.core.utils.ClassScanner;
 import com.yahoo.elide.datastores.aggregation.metadata.MetaDataStore;
 import com.yahoo.elide.datastores.aggregation.queryengines.sql.dialects.SQLDialectFactory;
@@ -61,7 +62,8 @@ public class ElideStandaloneMetadataStoreMissingTest {
             }
 
             @Override
-            public MetaDataStore getMetaDataStore(ClassScanner scanner, Optional<DynamicConfiguration> validator) {
+            public MetaDataStore getMetaDataStore(ClassScanner scanner, Injector injector,
+                    Optional<DynamicConfiguration> validator) {
                 return null;
             }
         });


### PR DESCRIPTION
Resolves #3245 

## Description
This adds a `AsyncProviderService` that is injected into the `AsyncExecutorService` to decouple the `AsyncExecutorService` implementation from the `JsonApi` and `QueryRunners` implementations. These are now registered into the `AsyncProviderService`.

The `AsyncQueryOperation` implementations then get the providers that they need in the following manner.

```java
JsonApi jsonApi = getService().getProviders().getProvider(JsonApi.class);
```

```java
QueryRunners queryRunners = getService().getProviders().getProvider(QueryRunners.class);
```

## Motivation and Context
This fixes the bug where an exception is thrown when `elide.async.enabled` is `true` and `elide.graphql.enabled` is false.

This also allows the `elide-graphql` dependency to be excluded without errors if GraphQL is not required.

## How Has This Been Tested?
A `asyncEnabledJsonApiEnabledGraphqlNotEnabled` test was added to `ElideAutoConfigurationTest`.

This was also tested manually with the `elide-spring-boot-example` by manually excluding the `elide-graphql` dependency and exercising the `asyncQuery` and `tableExport` functionality.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
