### PR TITLE
Add atomic operations to OpenAPI document

### DIFF
--- a/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/AsyncQuery.java
@@ -21,7 +21,7 @@ import lombok.EqualsAndHashCode;
  * after asyncexecutorservice is initialized.
  */
 @Entity
-@Include(name = "asyncQuery")
+@Include(name = "asyncQuery", description = "Async query.", friendlyName = "AsyncQuery")
 @ReadPermission(expression = "Principal is Owner OR Principal is Admin")
 @UpdatePermission(expression = "Prefab.Role.None")
 @DeletePermission(expression = "Prefab.Role.None")

--- a/elide-async/src/main/java/com/yahoo/elide/async/models/TableExport.java
+++ b/elide-async/src/main/java/com/yahoo/elide/async/models/TableExport.java
@@ -22,7 +22,7 @@ import lombok.EqualsAndHashCode;
  * after asyncexecutorservice is initialized.
  */
 @Entity
-@Include(name = "tableExport")
+@Include(name = "tableExport", description = "Table export.", friendlyName = "TableExport")
 @ReadPermission(expression = "Principal is Owner OR Principal is Admin")
 @UpdatePermission(expression = "Prefab.Role.None")
 @DeletePermission(expression = "Prefab.Role.None")

--- a/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
+++ b/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
@@ -19,7 +19,6 @@ import com.yahoo.elide.datastores.jpa.transaction.NonJtaTransaction;
 import com.yahoo.elide.graphql.GraphQLSettings;
 import com.yahoo.elide.jsonapi.JsonApiSettings;
 import com.yahoo.elide.swagger.OpenApiBuilder;
-import com.yahoo.elide.swagger.OpenApiDocument;
 import com.yahoo.elide.swagger.resources.ApiDocsEndpoint;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hibernate.Session;
@@ -131,8 +130,7 @@ public class ElideBeans {
             OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(apiVersion);
             String moduleBasePath = "/apiDocs/";
             OpenAPI openApi = builder.build().info(info).addServersItem(new Server().url(moduleBasePath));
-            docs.add(new ApiDocsEndpoint.ApiDocsRegistration("api", () -> openApi,
-                    OpenApiDocument.Version.OPENAPI_3_0.getValue(), apiVersion));
+            docs.add(new ApiDocsEndpoint.ApiDocsRegistration("api", () -> openApi, apiVersion));
         });
 
         return docs;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ApiDocsController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/ApiDocsController.java
@@ -67,9 +67,8 @@ public class ApiDocsController {
     @Data
     @AllArgsConstructor
     public static class ApiDocsRegistrations {
-
-        public ApiDocsRegistrations(Supplier<OpenAPI> doc, String version, String apiVersion) {
-            registrations = List.of(new ApiDocsRegistration("", doc, version, apiVersion));
+        public ApiDocsRegistrations(Supplier<OpenAPI> doc, String apiVersion) {
+            registrations = List.of(new ApiDocsRegistration("", doc, apiVersion));
         }
 
         List<ApiDocsRegistration> registrations;
@@ -80,11 +79,6 @@ public class ApiDocsController {
     public static class ApiDocsRegistration {
         private String path;
         private Supplier<OpenAPI> document;
-
-        /**
-         * The OpenAPI Specification Version.
-         */
-        private String version;
 
         /**
          * The API version.
@@ -109,8 +103,7 @@ public class ApiDocsController {
             apiVersion = apiVersion == null ? NO_VERSION : apiVersion;
             String apiPath = doc.path;
 
-            this.documents.put(Pair.of(apiVersion, apiPath),
-                    new OpenApiDocument(doc.document, OpenApiDocument.Version.from(doc.version)));
+            this.documents.put(Pair.of(apiVersion, apiPath), new OpenApiDocument(doc.document));
         });
     }
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/api/BasicOpenApiDocumentCustomizerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/api/BasicOpenApiDocumentCustomizerTest.java
@@ -34,7 +34,7 @@ class BasicOpenApiDocumentCustomizerTest {
     @OpenAPIDefinition(info = @Info(title = "My Title"))
     public static class UserDefinitionOpenApiConfiguration {
         @Bean
-        public OpenApiDocumentCustomizer openApiDocumentCustomizer() {
+        OpenApiDocumentCustomizer openApiDocumentCustomizer() {
             return new BasicOpenApiDocumentCustomizer();
         }
     }
@@ -43,7 +43,7 @@ class BasicOpenApiDocumentCustomizerTest {
     @OpenAPIDefinition(info = @Info(description = "My Description"))
     public static class UserDefinitionNoTitleOpenApiConfiguration {
         @Bean
-        public OpenApiDocumentCustomizer openApiDocumentCustomizer() {
+        OpenApiDocumentCustomizer openApiDocumentCustomizer() {
             return new BasicOpenApiDocumentCustomizer();
         }
     }
@@ -51,7 +51,7 @@ class BasicOpenApiDocumentCustomizerTest {
     @Configuration
     public static class UserNoDefinitionOpenApiConfiguration {
         @Bean
-        public OpenApiDocumentCustomizer openApiDocumentCustomizer() {
+        OpenApiDocumentCustomizer openApiDocumentCustomizer() {
             return new BasicOpenApiDocumentCustomizer();
         }
     }
@@ -66,7 +66,7 @@ class BasicOpenApiDocumentCustomizerTest {
         )
     public static class UserSecurityOpenApiConfiguration {
         @Bean
-        public OpenApiDocumentCustomizer openApiDocumentCustomizer() {
+        OpenApiDocumentCustomizer openApiDocumentCustomizer() {
             return new BasicOpenApiDocumentCustomizer();
         }
     }
@@ -121,6 +121,30 @@ class BasicOpenApiDocumentCustomizerTest {
             openApi.addTagsItem(new Tag().name("1-test"));
             context.getBean(OpenApiDocumentCustomizer.class).customize(openApi);
             assertThat(openApi.getTags()).extracting("name").containsExactly("1-test", "a-test", "b-test", "z-test");
+        });
+    }
+
+    @Test
+    void shouldUseOpenApiDefinitionExceptNonNullExisting() {
+        contextRunner.withUserConfiguration(UserDefinitionOpenApiConfiguration.class).run(context -> {
+            OpenAPI openApi = new OpenAPI();
+            openApi.setInfo(new io.swagger.v3.oas.models.info.Info().title("Should Be Overridden").version("v2"));
+            context.getBean(OpenApiDocumentCustomizer.class).customize(openApi);
+            assertThat(openApi.getInfo().getTitle()).isEqualTo("My Title");
+            assertThat(openApi.getInfo().getVersion()).isEqualTo("v2");
+        });
+    }
+
+    /**
+     * The OpenAPI document /info/version is a required property.
+     */
+    @Test
+    void shouldNotHaveNullVersion() {
+        contextRunner.withUserConfiguration(UserDefinitionOpenApiConfiguration.class).run(context -> {
+            OpenAPI openApi = new OpenAPI();
+            context.getBean(OpenApiDocumentCustomizer.class).customize(openApi);
+            assertThat(openApi.getInfo().getVersion()).isNotNull();
+            assertThat(openApi.getInfo().getVersion()).isEqualTo("");
         });
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/api/DefaultElideGroupedOpenApiCustomizerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/api/DefaultElideGroupedOpenApiCustomizerTest.java
@@ -28,6 +28,7 @@ import io.swagger.v3.oas.models.PathItem;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 /**
  * Test for DefaultElideGroupedOpenApiCustomizer.
@@ -71,6 +72,14 @@ class DefaultElideGroupedOpenApiCustomizerTest {
         openApi.path("/json-api", new PathItem().get(new Operation().addTagsItem("json-api-controller")));
         openApi.path("/api-docs", new PathItem().get(new Operation().addTagsItem("api-docs-controller")));
         groupedOpenApi.getOpenApiCustomizers().forEach(customizer -> customizer.customise(openApi));
-        assertThat(openApi.getPaths()).isEmpty();
+        List<PathItem> paths = openApi.getPaths().values().stream().filter(path -> {
+            Operation post = path.getPost();
+            if (post != null && !post.getTags().isEmpty()) {
+                // filter out the atomic operations paths
+                return !post.getTags().get(0).contains("atomic");
+            }
+            return true;
+        }).toList();
+        assertThat(paths).isEmpty();
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/api/DefaultElideOpenApiCustomizerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/api/DefaultElideOpenApiCustomizerTest.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.PathItem;
 
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 /**
  * Test for DefaultElideOpenApiCustomizer.
@@ -63,6 +64,14 @@ class DefaultElideOpenApiCustomizerTest {
         openApi.path("/json-api", new PathItem().get(new Operation().addTagsItem("json-api-controller")));
         openApi.path("/api-docs", new PathItem().get(new Operation().addTagsItem("api-docs-controller")));
         customizer.customise(openApi);
-        assertThat(openApi.getPaths()).isEmpty();
+        List<PathItem> paths = openApi.getPaths().values().stream().filter(path -> {
+            Operation post = path.getPost();
+            if (post != null && !post.getTags().isEmpty()) {
+                // filter out the atomic operations paths
+                return !post.getTags().get(0).contains("atomic");
+            }
+            return true;
+        }).toList();
+        assertThat(paths).isEmpty();
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/AsyncTest.java
@@ -1119,11 +1119,11 @@ public class AsyncTest extends IntegrationTest {
                 .get("/doc")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("tags.name", containsInAnyOrder("group", "argument", "metric",
-                        "dimension", "column", "table", "asyncQuery",
-                        "timeDimensionGrain", "timeDimension", "product", "playerCountry", "version", "playerStats",
-                        "stats", "tableExport", "namespace", "tableSource", "maintainer", "book", "publisher", "person",
-                        "export"));
+                .body("tags.name",
+                        containsInAnyOrder("atomic", "group", "argument", "metric", "dimension", "column", "table",
+                                "asyncQuery", "timeDimensionGrain", "timeDimension", "product", "playerCountry",
+                                "version", "playerStats", "stats", "tableExport", "namespace", "tableSource",
+                                "maintainer", "book", "publisher", "person", "export"));
     }
 
     protected Object[] readRow(XSSFSheet sheet, int rowNumber) {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -1107,11 +1107,11 @@ public class ControllerTest extends IntegrationTest {
                 .get("/doc")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("tags.name", containsInAnyOrder("group", "argument", "metric",
-                        "dimension", "column", "table", "asyncQuery",
-                        "timeDimensionGrain", "timeDimension", "product", "playerCountry", "version", "playerStats",
-                        "stats", "namespace", "tableSource", "maintainer", "book", "publisher", "person",
-                        "export"));
+                .body("tags.name",
+                        containsInAnyOrder("atomic", "group", "argument", "metric", "dimension", "column", "table",
+                                "asyncQuery", "timeDimensionGrain", "timeDimension", "product", "playerCountry",
+                                "version", "playerStats", "stats", "namespace", "tableSource", "maintainer", "book",
+                                "publisher", "person", "export"));
     }
 
     @Test

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ControllerTest.java
@@ -41,7 +41,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.yahoo.elide.core.exceptions.HttpStatus;
@@ -1129,7 +1128,6 @@ public class ControllerTest extends IntegrationTest {
         assertTrue(tags.isArray());
     }
 
-
     @Test
     public void versionedApiDocsDocumentTest() {
         ExtractableResponse<Response> v0 = given()
@@ -1138,6 +1136,7 @@ public class ControllerTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .extract();
+        assertEquals("", v0.path("info.version"));
 
         ExtractableResponse<Response> v1 = given()
                 .header("ApiVersion", "1.0")
@@ -1147,7 +1146,6 @@ public class ControllerTest extends IntegrationTest {
                 .statusCode(HttpStatus.SC_OK)
                 .extract();
         assertNotEquals(v0.asString(), v1.asString());
-        assertNull(v0.path("info.version"));
         assertEquals("1.0", v1.path("info.version"));
 
         given()

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableAggStoreControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableAggStoreControllerTest.java
@@ -29,7 +29,7 @@ public class DisableAggStoreControllerTest extends ControllerTest {
                 .get("/doc")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("tags.name", containsInAnyOrder("group", "asyncQuery", "product", "version", "maintainer", "book",
-                        "publisher", "person", "export"));
+                .body("tags.name", containsInAnyOrder("atomic", "group", "asyncQuery", "product", "version",
+                        "maintainer", "book", "publisher", "person", "export"));
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableMetaDataStoreControllerTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/DisableMetaDataStoreControllerTest.java
@@ -30,8 +30,7 @@ public class DisableMetaDataStoreControllerTest extends ControllerTest {
                 .get("/doc")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
-                .body("tags.name", containsInAnyOrder("playerCountry", "version",
-                        "asyncQuery", "playerStats", "stats", "product", "group", "maintainer", "book", "publisher", "person",
-                        "export"));
+                .body("tags.name", containsInAnyOrder("atomic", "playerCountry", "version", "asyncQuery", "playerStats",
+                        "stats", "product", "group", "maintainer", "book", "publisher", "person", "export"));
     }
 }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -82,6 +82,7 @@ import graphql.execution.DataFetcherExceptionHandler;
 import graphql.execution.SimpleDataFetcherExceptionHandler;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.persistence.EntityManager;
@@ -471,15 +472,19 @@ public interface ElideStandaloneSettings {
             Info info = new Info()
                     .title(getApiTitle())
                     .version(apiVersion);
-            OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(apiVersion);
+            OpenApiBuilder builder = new OpenApiBuilder(dictionary, openApi -> {
+                OpenApiVersion openApiVersion = getOpenApiVersion();
+                if (OpenApiVersion.OPENAPI_3_1.equals(openApiVersion)) {
+                    openApi.specVersion(SpecVersion.V31).openapi("3.1.0");
+                }
+            }).apiVersion(apiVersion);
             if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
                 // Path needs to be set
                 builder.basePath("/" + "v" + apiVersion);
             }
             String moduleBasePath = getJsonApiPathSpec().replace("/*", "");
             OpenAPI openApi = builder.build().info(info).addServersItem(new Server().url(moduleBasePath));
-            docs.add(new ApiDocsEndpoint.ApiDocsRegistration("", () -> openApi, getOpenApiVersion().getValue(),
-                    apiVersion));
+            docs.add(new ApiDocsEndpoint.ApiDocsRegistration("", () -> openApi, apiVersion));
         });
 
         return docs;

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableAggStoreTest.java
@@ -69,7 +69,7 @@ public class ElideStandaloneDisableAggStoreTest extends ElideStandaloneTest {
                 .get("/api-docs")
                 .then()
                 .statusCode(200)
-                .body("tags.name", containsInAnyOrder("post", "asyncQuery"));
+                .body("tags.name", containsInAnyOrder("atomic", "post", "asyncQuery"));
     }
 
     @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneDisableMetaDataStoreTest.java
@@ -66,7 +66,7 @@ public class ElideStandaloneDisableMetaDataStoreTest extends ElideStandaloneTest
                 .get("/api-docs")
                 .then()
                 .statusCode(200)
-                .body("tags.name", containsInAnyOrder("post", "asyncQuery", "postView"));
+                .body("tags.name", containsInAnyOrder("atomic", "post", "asyncQuery", "postView"));
     }
 
     @Override

--- a/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneExportTest.java
@@ -232,8 +232,9 @@ public class ElideStandaloneExportTest {
                .get("/api-docs")
                 .then()
                 .statusCode(200)
-                .body("tags.name", containsInAnyOrder("post", "argument", "metric",
-                        "dimension", "column", "table", "asyncQuery",
-                        "timeDimensionGrain", "timeDimension", "postView", "tableExport", "namespace", "tableSource"));
+                .body("tags.name",
+                        containsInAnyOrder("atomic", "post", "argument", "metric", "dimension", "column", "table",
+                                "asyncQuery", "timeDimensionGrain", "timeDimension", "postView", "tableExport",
+                                "namespace", "tableSource"));
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneTest.java
@@ -256,9 +256,10 @@ public class ElideStandaloneTest {
                 .get("/api-docs")
                 .then()
                 .statusCode(200)
-                .body("tags.name", containsInAnyOrder("post", "argument", "metric",
-                        "dimension", "column", "table", "asyncQuery",
-                        "timeDimensionGrain", "timeDimension", "postView", "namespace", "tableSource"));
+                .body("tags.name",
+                        containsInAnyOrder("atomic", "post", "argument", "metric", "dimension", "column", "table",
+                                "asyncQuery", "timeDimensionGrain", "timeDimension", "postView", "namespace",
+                                "tableSource"));
     }
 
     @Test

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
@@ -21,8 +21,11 @@ import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.swagger.converter.JsonApiModelResolver;
+import com.yahoo.elide.swagger.models.media.AtomicOperations;
+import com.yahoo.elide.swagger.models.media.AtomicResults;
 import com.yahoo.elide.swagger.models.media.Data;
 import com.yahoo.elide.swagger.models.media.Datum;
+import com.yahoo.elide.swagger.models.media.Errors;
 import com.yahoo.elide.swagger.models.media.Relationship;
 import com.google.common.collect.Sets;
 
@@ -36,6 +39,7 @@ import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.IntegerSchema;
@@ -60,6 +64,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -748,7 +754,7 @@ public class OpenApiBuilder {
      * @return the builder
      */
     public OpenApiBuilder managedClasses(Set<Type<?>> classes) {
-        this.managedClasses = new HashSet<>(classes);
+        this.managedClasses = new LinkedHashSet<>(classes);
         return this;
     }
 
@@ -760,7 +766,7 @@ public class OpenApiBuilder {
      * @return the builder
      */
     public OpenApiBuilder filterOperators(Set<Operator> ops) {
-        this.filterOperators = new HashSet<>(ops);
+        this.filterOperators = new LinkedHashSet<>(ops);
         return this;
     }
 
@@ -804,6 +810,9 @@ public class OpenApiBuilder {
                 throw new IllegalArgumentException("None of the provided classes are exported by Elide");
             }
         }
+        managedClasses = managedClasses.stream()
+                .sorted((left, right) -> left.getSimpleName().compareTo(right.getSimpleName()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         /*
          * Create a Model for each Elide entity.
@@ -827,13 +836,13 @@ public class OpenApiBuilder {
 
         rootClasses = managedClasses.stream()
                 .filter(dictionary::isRoot)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         /* Find all the paths starting from the root entities. */
         Set<PathMetaData> pathData =  rootClasses.stream()
                 .map(this::find)
                 .flatMap(Collection::stream)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         /* Prune the discovered paths to remove redundant elements */
         Set<PathMetaData> toRemove = new HashSet<>();
@@ -883,11 +892,136 @@ public class OpenApiBuilder {
                 .map(type -> new Tag().name(tagNameOf(type))
                         .description(EntityDictionary.getEntityDescription(type)))
                 .forEach(openApi::addTagsItem);
+
+        /* Atomic operations */
+        atomicOperations(openApi);
         return this;
+    }
+
+    /**
+     * Adds the operations path for JSON API atomic operations.
+     *
+     * @param openApi the open api
+     */
+    protected void atomicOperations(OpenAPI openApi) {
+        String tagName = tagNameOf("atomic");
+        openApi.addTagsItem(new Tag().name(tagName).description("Atomic operations."));
+        Map<String, Example> examples = atomicOperationsExamples();
+        Map<String, Object> example = null;
+        AtomicOperations atomicOperations = new AtomicOperations();
+        // Try to determine more specific examples for atomic operations
+        Optional<Type<?>> optionalCanCreateType = this.rootClasses.stream().filter(this::canCreate).findFirst();
+        if (optionalCanCreateType.isPresent()) {
+            Type<?> type = optionalCanCreateType.get();
+            String typeName = dictionary.getJsonAliasFor(type);
+
+            Map<String, Object> attributes = dataAttributes(type);
+            Map<String, Object> creatingResourcesData = new LinkedHashMap<>();
+            creatingResourcesData.put("type", typeName);
+            creatingResourcesData.put("lid", "string");
+            creatingResourcesData.put("attributes", attributes);
+            Map<String, Object> creatingResourcesOp = new LinkedHashMap<>();
+            creatingResourcesOp.put("op", "add");
+            creatingResourcesOp.put("href", "/" + typeName);
+            creatingResourcesOp.put("data", creatingResourcesData);
+            creatingResourcesOp.put("meta", new LinkedHashMap<>());
+            Map<String, Object> creatingResources = Map.of("atomic:operations", List.of(creatingResourcesOp));
+            example = creatingResources;
+            // Replace generic example
+            examples.put("Creating Resources",
+                    new Example().value(creatingResources).description(CREATING_RESOURCES_DESCRIPTION));
+        }
+        Optional<Type<?>> optionalCanUpdateType = this.rootClasses.stream().filter(this::canUpdate).findFirst();
+        if (optionalCanUpdateType.isPresent()) {
+            Type<?> type = optionalCanUpdateType.get();
+            String typeName = dictionary.getJsonAliasFor(type);
+
+            Map<String, Object> attributes = dataAttributes(type);
+            Map<String, Object> updatingResourcesData = new LinkedHashMap<>();
+            updatingResourcesData.put("type", typeName);
+            updatingResourcesData.put("id", "string");
+            updatingResourcesData.put("attributes", attributes);
+            Map<String, Object> updatingResourcesOp = new LinkedHashMap<>();
+            updatingResourcesOp.put("op", "update");
+            updatingResourcesOp.put("data", updatingResourcesData);
+            updatingResourcesOp.put("meta", new LinkedHashMap<>());
+            Map<String, Object> updatingResources = Map.of("atomic:operations", List.of(updatingResourcesOp));
+            if (example == null) {
+                example = updatingResources;
+            }
+            // Replace generic example
+            examples.put("Updating Resources",
+                    new Example().value(updatingResources).description(UPDATING_RESOURCES_DESCRIPTION));
+        }
+        Optional<Type<?>> optionalCanDeleteType = this.rootClasses.stream().filter(this::canDelete).findFirst();
+        if (optionalCanDeleteType.isPresent()) {
+            Type<?> type = optionalCanDeleteType.get();
+            String typeName = dictionary.getJsonAliasFor(type);
+
+            Map<String, Object> deletingResourcesRef = new LinkedHashMap<>();
+            deletingResourcesRef.put("type", typeName);
+            deletingResourcesRef.put("id", "string");
+            Map<String, Object> deletingResourcesOp = new LinkedHashMap<>();
+            deletingResourcesOp.put("op", "remove");
+            deletingResourcesOp.put("ref", deletingResourcesRef);
+            Map<String, Object> deletingResources = Map.of("atomic:operations", List.of(deletingResourcesOp));
+            if (example == null) {
+                example = deletingResources;
+            }
+            // Replace generic example
+            examples.put("Deleting Resources",
+                    new Example().value(deletingResources).description(DELETING_RESOURCES_DESCRIPTION));
+        }
+        // Must call setExample() and cannot call example() as it calls toString on the
+        // example
+        if (example != null) {
+            atomicOperations.setExample(example);
+        }
+
+        // Create that path for /operations
+        PathItem operations = new PathItem();
+        operations.post(new Operation().tags(List.of(tagName))
+                .description("Perform atomic operations")
+                .requestBody(new RequestBody().content(new Content().addMediaType(JsonApi.AtomicOperations.MEDIA_TYPE,
+                        new MediaType().schema(atomicOperations).examples(examples))))
+                .responses(new ApiResponses()
+                        .addApiResponse("200",
+                                new ApiResponse().description("Successful response")
+                                        .content(new Content().addMediaType(JsonApi.AtomicOperations.MEDIA_TYPE,
+                                                new MediaType().schema(new AtomicResults()))))
+                        .addApiResponse("400",
+                                new ApiResponse().description("Bad request")
+                                        .content(new Content().addMediaType(JsonApi.AtomicOperations.MEDIA_TYPE,
+                                                new MediaType().schema(new Errors()))))
+                        .addApiResponse("423",
+                                new ApiResponse().description("Locked")
+                                        .content(new Content().addMediaType(JsonApi.AtomicOperations.MEDIA_TYPE,
+                                                new MediaType().schema(new Errors()))))));
+        openApi.path(pathOf("/operations"), operations);
+    }
+
+    protected Map<String, Object> dataAttributes(Type<?> type) {
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        List<String> attributeNames = dictionary.getAttributes(type);
+        for (String attributeName : attributeNames) {
+            Type<?> attributeClass = dictionary.getType(type, attributeName);
+            if (ClassType.STRING_TYPE.isAssignableFrom(attributeClass)) {
+                attributes.put(attributeName, "string");
+            } else if (ClassType.NUMBER_TYPE.isAssignableFrom(attributeClass)) {
+                attributes.put(attributeName, 0);
+            } else if (ClassType.BOOLEAN_TYPE.isAssignableFrom(attributeClass)) {
+                attributes.put(attributeName, true);
+            }
+        }
+        return attributes;
     }
 
     protected String tagNameOf(Type<?> type) {
         String tagName = dictionary.getJsonAliasFor(type);
+        return tagNameOf(tagName);
+    }
+
+    protected String tagNameOf(String tagName) {
         if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
             tagName = "v" + apiVersion + "/" + tagName;
         }
@@ -924,7 +1058,7 @@ public class OpenApiBuilder {
      */
     protected Set<PathMetaData> find(Type<?> rootClass) {
         Queue<PathMetaData> toVisit = new ArrayDeque<>();
-        Set<PathMetaData> paths = new HashSet<>();
+        Set<PathMetaData> paths = new LinkedHashSet<>();
 
         toVisit.add(new PathMetaData(rootClass));
 
@@ -1117,4 +1251,219 @@ public class OpenApiBuilder {
         }
         return null;
     }
+
+    protected Map<String, Example> atomicOperationsExamples() {
+        Map<String, Example> examples = new LinkedHashMap<>();
+
+        // Creating Resources
+        Map<String, Object> creatingResources = exampleCreatingResources();
+        examples.put("Creating Resources",
+                new Example().value(creatingResources).description(CREATING_RESOURCES_DESCRIPTION));
+
+        // Updating Resources
+        Map<String, Object> updatingResources = exampleUpdatingResources();
+        examples.put("Updating Resources",
+                new Example().value(updatingResources).description(UPDATING_RESOURCES_DESCRIPTION));
+
+        // Deleting Resources
+        Map<String, Object> deletingResources = exampleDeletingResources();
+        examples.put("Deleting Resources",
+                new Example().value(deletingResources).description(DELETING_RESOURCES_DESCRIPTION));
+
+        // Updating To-One Relationships
+        Map<String, Object> updatingToOneRelationships = exampleUpdatingToOneRelationships();
+        examples.put("Updating To-One Relationships",
+                new Example().value(updatingToOneRelationships).description(UPDATING_TO_ONE_RELATIONSHIPS_DESCRIPTION));
+
+        // Deleting To-One Relationships
+        Map<String, Object> deletingToOneRelationships = exampleDeletingToOneRelationships();
+        examples.put("Deleting To-One Relationships",
+                new Example().value(deletingToOneRelationships).description(DELETING_TO_ONE_RELATIONSHIPS_DESCRIPTION));
+
+        // Creating To-Many Relationships
+        Map<String, Object> creatingToManyRelationships = exampleCreatingToManyRelationships();
+        examples.put("Creating To-Many Relationships", new Example().value(creatingToManyRelationships)
+                .description(CREATING_TO_MANY_RELATIONSHIPS_DESCRIPTION));
+
+        // Updating To-Many Relationships
+        Map<String, Object> updatingToManyRelationships = exampleUpdatingToManyRelationships();
+        examples.put("Updating To-Many Relationships", new Example().value(updatingToManyRelationships)
+                .description(UPDATING_TO_MANY_RELATIONSHIPS_DESCRIPTION));
+
+        // Deleting To-Many Relationships
+        Map<String, Object> deletingToManyRelationships = exampleDeletingToManyRelationships();
+        examples.put("Deleting To-Many Relationships", new Example().value(deletingToManyRelationships)
+                .description(DELETING_TO_MANY_RELATIONSHIPS_DESCRIPTION));
+
+        return examples;
+    }
+
+    protected Map<String, Object> exampleDeletingToManyRelationships() {
+        Map<String, Object> deletingToManyRelationshipsOp = new LinkedHashMap<>();
+        Map<String, Object> deletingToManyRelationshipsRef = new LinkedHashMap<>();
+        deletingToManyRelationshipsRef.put("type", "articles");
+        deletingToManyRelationshipsRef.put("id", "1");
+        deletingToManyRelationshipsRef.put("relationship", "comments");
+        Map<String, Object> deletingToManyRelationshipsData1 = new LinkedHashMap<>();
+        deletingToManyRelationshipsData1.put("type", "comments");
+        deletingToManyRelationshipsData1.put("id", "12");
+        Map<String, Object> deletingToManyRelationshipsData2 = new LinkedHashMap<>();
+        deletingToManyRelationshipsData2.put("type", "comments");
+        deletingToManyRelationshipsData2.put("id", "13");
+        deletingToManyRelationshipsOp.put("op", "remove");
+        deletingToManyRelationshipsOp.put("ref", deletingToManyRelationshipsRef);
+        deletingToManyRelationshipsOp.put("data",
+                List.of(deletingToManyRelationshipsData1, deletingToManyRelationshipsData2));
+        Map<String, Object> deletingToManyRelationships = Map.of("atomic:operations",
+                List.of(deletingToManyRelationshipsOp));
+        return deletingToManyRelationships;
+    }
+
+    protected Map<String, Object> exampleUpdatingToManyRelationships() {
+        Map<String, Object> updatingToManyRelationshipsOp = new LinkedHashMap<>();
+        Map<String, Object> updatingToManyRelationshipsRef = new LinkedHashMap<>();
+        updatingToManyRelationshipsRef.put("type", "articles");
+        updatingToManyRelationshipsRef.put("id", "1");
+        updatingToManyRelationshipsRef.put("relationship", "tags");
+        Map<String, Object> updatingToManyRelationshipsData1 = new LinkedHashMap<>();
+        updatingToManyRelationshipsData1.put("type", "tags");
+        updatingToManyRelationshipsData1.put("id", "2");
+        Map<String, Object> updatingToManyRelationshipsData2 = new LinkedHashMap<>();
+        updatingToManyRelationshipsData2.put("type", "tags");
+        updatingToManyRelationshipsData2.put("id", "3");
+        updatingToManyRelationshipsOp.put("op", "update");
+        updatingToManyRelationshipsOp.put("ref", updatingToManyRelationshipsRef);
+        updatingToManyRelationshipsOp.put("data",
+                List.of(updatingToManyRelationshipsData1, updatingToManyRelationshipsData2));
+        Map<String, Object> updatingToManyRelationships = Map.of("atomic:operations",
+                List.of(updatingToManyRelationshipsOp));
+        return updatingToManyRelationships;
+    }
+
+    protected Map<String, Object> exampleCreatingToManyRelationships() {
+        Map<String, Object> creatingToManyRelationshipsOp = new LinkedHashMap<>();
+        Map<String, Object> creatingToManyRelationshipsRef = new LinkedHashMap<>();
+        creatingToManyRelationshipsRef.put("type", "articles");
+        creatingToManyRelationshipsRef.put("id", "1");
+        creatingToManyRelationshipsRef.put("relationship", "comments");
+        Map<String, Object> creatingToManyRelationshipsData = new LinkedHashMap<>();
+        creatingToManyRelationshipsData.put("type", "comments");
+        creatingToManyRelationshipsData.put("id", "1");
+        creatingToManyRelationshipsOp.put("op", "add");
+        creatingToManyRelationshipsOp.put("ref", creatingToManyRelationshipsRef);
+        creatingToManyRelationshipsOp.put("data", List.of(creatingToManyRelationshipsData));
+        Map<String, Object> creatingToManyRelationships = Map.of("atomic:operations",
+                List.of(creatingToManyRelationshipsOp));
+        return creatingToManyRelationships;
+    }
+
+    protected Map<String, Object> exampleDeletingToOneRelationships() {
+        Map<String, Object> deletingToOneRelationshipsOp = new LinkedHashMap<>();
+        Map<String, Object> deletingToOneRelationshipsRef = new LinkedHashMap<>();
+        deletingToOneRelationshipsRef.put("type", "articles");
+        deletingToOneRelationshipsRef.put("id", "13");
+        deletingToOneRelationshipsRef.put("relationship", "author");
+        deletingToOneRelationshipsOp.put("op", "update");
+        deletingToOneRelationshipsOp.put("ref", deletingToOneRelationshipsRef);
+        deletingToOneRelationshipsOp.put("data", null);
+        Map<String, Object> deletingToOneRelationships = Map.of("atomic:operations",
+                List.of(deletingToOneRelationshipsOp));
+        return deletingToOneRelationships;
+    }
+
+    protected Map<String, Object> exampleUpdatingToOneRelationships() {
+        Map<String, Object> updatingToOneRelationshipsOp = new LinkedHashMap<>();
+        Map<String, Object> updatingToOneRelationshipsRef = new LinkedHashMap<>();
+        updatingToOneRelationshipsRef.put("type", "articles");
+        updatingToOneRelationshipsRef.put("id", "13");
+        updatingToOneRelationshipsRef.put("relationship", "author");
+        Map<String, Object> updatingToOneRelationshipsData = new LinkedHashMap<>();
+        updatingToOneRelationshipsData.put("type", "people");
+        updatingToOneRelationshipsData.put("id", "9");
+        updatingToOneRelationshipsOp.put("op", "update");
+        updatingToOneRelationshipsOp.put("ref", updatingToOneRelationshipsRef);
+        updatingToOneRelationshipsOp.put("data", updatingToOneRelationshipsData);
+        Map<String, Object> updatingToOneRelationships = Map.of("atomic:operations",
+                List.of(updatingToOneRelationshipsOp));
+        return updatingToOneRelationships;
+    }
+
+    protected Map<String, Object> exampleDeletingResources() {
+        Map<String, Object> deletingResourcesOp = new LinkedHashMap<>();
+        Map<String, Object> deletingResourcesRef = new LinkedHashMap<>();
+        deletingResourcesRef.put("type", "articles");
+        deletingResourcesRef.put("id", "13");
+        deletingResourcesOp.put("op", "remove");
+        deletingResourcesOp.put("ref", deletingResourcesRef);
+        Map<String, Object> deletingResources = Map.of("atomic:operations",
+                List.of(deletingResourcesOp));
+        return deletingResources;
+    }
+
+    protected Map<String, Object> exampleUpdatingResources() {
+        Map<String, Object> updatingResourcesOp = new LinkedHashMap<>();
+        Map<String, Object> updatingResourcesData = new LinkedHashMap<>();
+        updatingResourcesData.put("type", "articles");
+        updatingResourcesData.put("id", "13");
+        updatingResourcesData.put("attributes", Map.of("title", "Title"));
+        updatingResourcesOp.put("op", "update");
+        updatingResourcesOp.put("data", updatingResourcesData);
+        Map<String, Object> updatingResources = Map.of("atomic:operations",
+                List.of(updatingResourcesOp));
+        return updatingResources;
+    }
+
+    protected Map<String, Object> exampleCreatingResources() {
+        Map<String, Object> creatingResourcesOp = new LinkedHashMap<>();
+        Map<String, Object> creatingResourcesData = new LinkedHashMap<>();
+        creatingResourcesData.put("type", "articles");
+        creatingResourcesData.put("attributes", Map.of("title", "Title"));
+        creatingResourcesOp.put("op", "add");
+        creatingResourcesOp.put("href", "/blogPosts");
+        creatingResourcesOp.put("data", creatingResourcesData);
+        Map<String, Object> creatingResources = Map.of("atomic:operations",
+                List.of(creatingResourcesOp));
+        return creatingResources;
+    }
+
+    private static final String CREATING_RESOURCES_DESCRIPTION = ""
+            + "To create a resource, the operation MUST include an op code of \"add\" "
+            + "as well as a resource object as data. "
+            + "The resource object MUST contain at least a type member. An operation that creates a "
+            + "resource MAY target a resource collection through the operation's href member.";
+    private static final String UPDATING_RESOURCES_DESCRIPTION = ""
+            + "To update a resource, the operation MUST include an op code of \"update\" "
+            + "as well as a resource object as data. "
+            + "An operation that updates a resource MAY target that resource through the "
+            + "operation's ref or href members, but not both.";
+    private static final String DELETING_RESOURCES_DESCRIPTION = ""
+            + "To delete a resource, the operation MUST include an op code of \"remove\". "
+            + "An operation that deletes a resource MUST target that resource through the "
+            + "operation's ref or href members, but not both.";
+    private static final String UPDATING_TO_ONE_RELATIONSHIPS_DESCRIPTION = ""
+            + "To assign a to-one relationship, the operation MUST include an op code of \"update\" "
+            + "as well as a resource identifier object as data. "
+            + "An operation that updates a resource's to-one relationship "
+            + "MUST target that relationship through the operation's ref or href members, but not both.";
+    private static final String DELETING_TO_ONE_RELATIONSHIPS_DESCRIPTION = ""
+            + "To clear a to-one relationship, the operation MUST include an op code of \"update\" "
+            + "as well as setting the data to \"null\". "
+            + "An operation that updates a resource's to-one relationship "
+            + "MUST target that relationship through the operation's ref or href members, but not both.";
+    private static final String CREATING_TO_MANY_RELATIONSHIPS_DESCRIPTION = ""
+            + "To add members to a to-many relationship, the operation MUST include an op code of \"add\" "
+            + "as well as an array of resource identifier objects as data." + " "
+            + "An operation that updates a resource's to-many relationship MUST target that "
+            + "relationship through the operation's ref or href members, but not both.";
+    private static final String UPDATING_TO_MANY_RELATIONSHIPS_DESCRIPTION = ""
+            + "To replace all the members of a to-many relationship, "
+            + "the operation MUST include an op code of \"update\" "
+            + "as well as an array of resource identifier objects as data. "
+            + "An operation that updates a resource's to-many relationship MUST target that "
+            + "relationship through the operation's ref or href members, but not both.";
+    private static final String DELETING_TO_MANY_RELATIONSHIPS_DESCRIPTION = ""
+            + "To remove members from a to-many relationship, the operation MUST include an op code of \"remove\" "
+            + "as well as an array of resource identifier objects as data. "
+            + "An operation that updates a resource's to-many relationship MUST target that "
+            + "relationship through the operation's ref or href members, but not both.";
 }

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
@@ -684,10 +684,13 @@ public class OpenApiBuilder {
 
     /**
      * Constructor.
+     * <p>
+     * The customizer can be used to set the OpenAPI SpecVersion.
      *
-     * @param dictionary The entity dictionary.
+     * @param dictionary        The entity dictionary.
+     * @param openApiCustomizer The OpenAPI customizer.
      */
-    public OpenApiBuilder(EntityDictionary dictionary) {
+    public OpenApiBuilder(EntityDictionary dictionary, Consumer<OpenAPI> openApiCustomizer) {
         this.dictionary = dictionary;
         this.supportLegacyFilterDialect = true;
         this.supportRSQLFilterDialect = true;
@@ -698,6 +701,18 @@ public class OpenApiBuilder {
                 Operator.POSTFIX, Operator.GE, Operator.GT, Operator.LE, Operator.LT, Operator.ISNULL,
                 Operator.NOTNULL);
         this.openApi = new OpenAPI();
+        if (openApiCustomizer != null) {
+            openApiCustomizer.accept(this.openApi);
+        }
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param dictionary The entity dictionary.
+     */
+    public OpenApiBuilder(EntityDictionary dictionary) {
+        this(dictionary, null);
     }
 
     /**
@@ -1095,8 +1110,10 @@ public class OpenApiBuilder {
     }
 
     protected String getSchemaName(Type<?> type) {
+        // Should be the same as JsonApiModelResolver#getSchemaName
         String schemaName = dictionary.getJsonAliasFor(type);
-        if (!EntityDictionary.NO_VERSION.equals(this.apiVersion)) {
+        String apiVersion = EntityDictionary.getModelVersion(type);
+        if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
             schemaName = "v" + this.apiVersion + "_" + schemaName;
         }
         return schemaName;

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiDocument.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiDocument.java
@@ -10,6 +10,7 @@ import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,44 +33,15 @@ public class OpenApiDocument {
         public static final String APPLICATION_YAML = "application/yaml";
     }
 
-    /**
-     * The OpenAPI Specification Version.
-     */
-    public enum Version {
-        OPENAPI_3_0("3.0"),
-        OPENAPI_3_1("3.1");
-
-        private final String value;
-
-        Version(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return this.value;
-        }
-
-        public static Version from(String version) {
-            if (version.startsWith(OPENAPI_3_1.getValue())) {
-                return OPENAPI_3_1;
-            } else if (version.startsWith(OPENAPI_3_0.getValue())) {
-                return OPENAPI_3_0;
-            }
-            throw new IllegalArgumentException("Invalid OpenAPI version. Only versions 3.0 and 3.1 are supported.");
-        }
-    }
-
     private final Map<String, String> documents = new ConcurrentHashMap<>(2);
     private final Supplier<OpenAPI> openApi;
-    private final Version version;
 
-    public OpenApiDocument(OpenAPI openApi, Version version) {
-        this(() -> openApi, version);
+    public OpenApiDocument(OpenAPI openApi) {
+        this(() -> openApi);
     }
 
-    public OpenApiDocument(Supplier<OpenAPI> openApi, Version version) {
+    public OpenApiDocument(Supplier<OpenAPI> openApi) {
         this.openApi = openApi;
-        this.version = version;
     }
 
     public String ofMediaType(String mediaType) {
@@ -79,24 +51,23 @@ public class OpenApiDocument {
         } else {
             key = MediaType.APPLICATION_JSON;
         }
-        return this.documents.computeIfAbsent(key, type -> of(this.openApi.get(), this.version, type));
+        return this.documents.computeIfAbsent(key, type -> of(this.openApi.get(), type));
     }
 
     /**
      * Converts a OpenAPI document to human-formatted JSON/YAML.
      *
      * @param openApi   OpenAPI document
-     * @param version   OpenAPI version
      * @param mediaType Either application/json or application/yaml
      * @return Pretty printed 'OpenAPI' document in JSON.
      */
-    public static String of(OpenAPI openApi, Version version, String mediaType) {
+    public static String of(OpenAPI openApi, String mediaType) {
         if (MediaType.APPLICATION_YAML.equalsIgnoreCase(mediaType)) {
-            if (Version.OPENAPI_3_1.equals(version)) {
+            if (SpecVersion.V31.equals(openApi.getSpecVersion())) {
                 return Yaml31.pretty(openApi);
             }
             return Yaml.pretty(openApi);
-        } else if (Version.OPENAPI_3_1.equals(version)) {
+        } else if (SpecVersion.V31.equals(openApi.getSpecVersion())) {
             return Json31.pretty(openApi);
         }
         return Json.pretty(openApi);

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicOperation.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicOperation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Atomic operation.
+ */
+public class AtomicOperation extends ObjectSchema {
+    public AtomicOperation() {
+        this.addProperty("op", new StringSchema()._enum(List.of("add", "update", "remove")));
+        this.addProperty("ref",
+                new ObjectSchema().addProperty("type", new StringSchema()).addProperty("id", new StringSchema())
+                        .addProperty("lid", new StringSchema()).addProperty("relationship", new StringSchema()));
+        this.addProperty("href", new StringSchema());
+        Schema<?> data = new ObjectSchema().addProperty("type", new StringSchema())
+                .addProperty("id", new StringSchema()).addProperty("lid", new StringSchema())
+                .addProperty("attributes", new ObjectSchema());
+        data = data.nullable(true); // For OpenAPI 3.0
+        data.getTypes().add("null"); // For OpenAPI 3.1
+        @SuppressWarnings("rawtypes")
+        List<Schema> anyOfData = new ArrayList<>();
+        anyOfData.add(new ArraySchema().items(data));
+        anyOfData.add(data);
+        this.addProperty("data", new Schema<>().anyOf(anyOfData));
+        this.addProperty("meta", new ObjectSchema());
+        this.required(List.of("op"));
+
+        Schema<?> refOrHref = new Schema<>().not(new ObjectSchema().required(List.of("ref", "href")));
+        this.allOf(List.of(refOrHref));
+    }
+}

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicOperations.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicOperations.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+
+/**
+ * Atomic operations.
+ */
+public class AtomicOperations extends ObjectSchema {
+    public AtomicOperations() {
+        ArraySchema atomicOperations = new ArraySchema();
+        atomicOperations.items(new AtomicOperation());
+        this.addProperty("atomic:operations", atomicOperations);
+    }
+}

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicResult.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicResult.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+/**
+ * Atomic result.
+ */
+public class AtomicResult extends ObjectSchema {
+    public AtomicResult() {
+        ObjectSchema data = new ObjectSchema();
+        data.addProperty("link", new ObjectSchema());
+        data.addProperty("type", new StringSchema());
+        data.addProperty("id", new StringSchema());
+        data.addProperty("attributes", new ObjectSchema());
+
+        this.addProperty("data", data);
+    }
+}

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicResults.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/AtomicResults.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+
+/**
+ * Atomic results.
+ */
+public class AtomicResults extends ObjectSchema {
+    public AtomicResults() {
+        ArraySchema atomicResults = new ArraySchema();
+        atomicResults.items(new AtomicResult());
+        this.addProperty("atomic:results", atomicResults);
+    }
+}

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Error.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Error.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+/**
+ * Error.
+ */
+public class Error extends ObjectSchema {
+    /**
+     * Links.
+     */
+    public static class Links extends ObjectSchema {
+        /**
+         * Used to construct links.
+         */
+        public Links() {
+            this.addProperty("about", new StringSchema());
+            this.addProperty("type", new StringSchema());
+        }
+    }
+
+    /**
+     * Source.
+     */
+    public static class Source extends ObjectSchema {
+        /**
+         * Used to construct a source.
+         */
+        public Source() {
+            this.addProperty("pointer", new StringSchema());
+            this.addProperty("parameter", new StringSchema());
+            this.addProperty("header", new StringSchema());
+        }
+    }
+
+    /**
+     * Used to construct an error.
+     */
+    public Error() {
+        this.addProperty("id", new StringSchema());
+        this.addProperty("links", new Links());
+        this.addProperty("status", new StringSchema());
+        this.addProperty("code", new StringSchema());
+        this.addProperty("title", new StringSchema());
+        this.addProperty("detail", new StringSchema());
+        this.addProperty("source", new Source());
+    }
+}

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Errors.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Errors.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import io.swagger.v3.oas.models.media.ArraySchema;
+
+/**
+ * Errors.
+ */
+public class Errors extends ArraySchema {
+    /**
+     * Used to construct errors.
+     */
+    public Errors() {
+        this.items(new Error());
+    }
+}

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Meta.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/models/media/Meta.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import io.swagger.v3.oas.models.media.ObjectSchema;
+
+/**
+ * Meta.
+ */
+public class Meta extends ObjectSchema {
+}

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/resources/ApiDocsEndpoint.java
@@ -59,11 +59,6 @@ public class ApiDocsEndpoint {
         private Supplier<OpenAPI> document;
 
         /**
-         * The OpenAPI Specification Version.
-         */
-        private String version;
-
-        /**
          * The API version.
          */
         private String apiVersion;
@@ -84,8 +79,7 @@ public class ApiDocsEndpoint {
             String apiVersion = doc.getApiVersion();
             apiVersion = apiVersion == null ? NO_VERSION : apiVersion;
             String apiPath = doc.path;
-            documents.put(Pair.of(apiVersion, apiPath),
-                    new OpenApiDocument(doc.document, OpenApiDocument.Version.from(doc.version)));
+            documents.put(Pair.of(apiVersion, apiPath), new OpenApiDocument(doc.document));
         });
 
         this.routeResolver = optionalRouteResolver.orElseGet(() -> {

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/ApiDocsResourceConfig.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/ApiDocsResourceConfig.java
@@ -67,8 +67,8 @@ public class ApiDocsResourceConfig extends ResourceConfig {
                         OpenAPI openApi2 = builder2.build().info(info2);
 
                         List<ApiDocsEndpoint.ApiDocsRegistration> docs = new ArrayList<>();
-                        docs.add(new ApiDocsEndpoint.ApiDocsRegistration("test", () -> openApi1, "3.0", info1.getVersion()));
-                        docs.add(new ApiDocsEndpoint.ApiDocsRegistration("test", () -> openApi2, "3.0", info2.getVersion()));
+                        docs.add(new ApiDocsEndpoint.ApiDocsRegistration("test", () -> openApi1, info1.getVersion()));
+                        docs.add(new ApiDocsEndpoint.ApiDocsRegistration("test", () -> openApi2, info2.getVersion()));
                         return docs;
                     }
 

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
@@ -48,6 +48,7 @@ import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Content;
@@ -1020,7 +1021,8 @@ class OpenApiBuilderTest {
         Info info = new Info().title("Test Service").version(NO_VERSION);
         EntityDictionary dictionary = EntityDictionary.builder().build();
         dictionary.bindEntity(Book.class);
-        OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(info.getVersion());
+        OpenApiBuilder builder = new OpenApiBuilder(dictionary,
+                openApi -> openApi.specVersion(SpecVersion.V31).openapi("3.1.0")).apiVersion(info.getVersion());
         OpenAPI openApi = builder.build();
         JsonNode jsonNode = Json31.mapper().readTree(Json31.pretty(openApi));
         JsonNode operations = jsonNode.at("/paths/~1operations");

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
@@ -30,6 +30,7 @@ import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.swagger.models.media.Data;
 import com.yahoo.elide.swagger.models.media.Datum;
 import com.yahoo.elide.swagger.models.media.Relationship;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import example.models.Agent;
 import example.models.Author;
@@ -42,6 +43,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
@@ -108,6 +111,10 @@ class OpenApiBuilderTest {
         Schema<?> schema = openApi.getComponents().getSchemas().get("v2_book");
         assertNotNull(schema);
         openApi.getPaths().forEach((path, pathItem) -> {
+          if ("/operations".equals(path)) {
+              return; // skip atomic:operations
+          }
+
           Operation get = pathItem.getGet();
           if (get != null) {
               get.getTags().contains(tag);
@@ -140,7 +147,7 @@ class OpenApiBuilderTest {
 
         OpenApiBuilder builder = new OpenApiBuilder(dynamicDictionary).apiVersion(info.getVersion());
         OpenAPI dynamicOpenApi = builder.build();
-        assertEquals(2, dynamicOpenApi.getPaths().size());
+        assertEquals(3, dynamicOpenApi.getPaths().size());
     }
 
     @Test
@@ -196,13 +203,18 @@ class OpenApiBuilderTest {
         assertTrue(openApi.getPaths().containsKey("/product"));
         assertTrue(openApi.getPaths().containsKey("/product/{productId}"));
 
-        assertEquals(24, openApi.getPaths().size());
+        assertTrue(openApi.getPaths().containsKey("/operations")); // atomic:operations
+
+        assertEquals(25, openApi.getPaths().size());
     }
 
     @Test
     void testOperationGeneration() throws Exception {
         /* For each path, ensure the correct operations exist */
         openApi.getPaths().forEach((url, path) -> {
+            if ("/operations".equals(url)) {
+                return; // skip atomic:operations
+            }
 
             /* All paths should have a GET */
             assertNotNull(path.getGet());
@@ -365,7 +377,9 @@ class OpenApiBuilderTest {
     void testOperationSuccessResponseCodes() throws Exception {
         /* For each path, ensure the correct operations exist */
         openApi.getPaths().forEach((url, path) -> {
-
+            if ("/operations".equals(url)) {
+                return; // skip atomic:operations
+            }
             Operation getOperation = path.getGet();
             assertTrue(getOperation.getResponses().containsKey("200"));
 
@@ -569,7 +583,7 @@ class OpenApiBuilderTest {
     void testTagGeneration() throws Exception {
 
         /* Check for the global tag definitions */
-        assertEquals(5, openApi.getTags().size());
+        assertEquals(6, openApi.getTags().size());
 
         String bookTag = openApi.getTags().stream()
                 .filter((tag) -> tag.getName().equals("book"))
@@ -980,6 +994,43 @@ class OpenApiBuilderTest {
                 assertNull(path.getPost());
             }
         });
+    }
+
+    @Test
+    void testAtomicOperationsOpenApi30() throws Exception {
+        Info info = new Info().title("Test Service").version(NO_VERSION);
+        EntityDictionary dictionary = EntityDictionary.builder().build();
+        dictionary.bindEntity(Book.class);
+        OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(info.getVersion());
+        OpenAPI openApi = builder.build();
+        JsonNode jsonNode = Json.mapper().readTree(Json.pretty(openApi));
+        JsonNode operations = jsonNode.at("/paths/~1operations");
+        JsonNode schema = operations.at("/post/requestBody/content/application~1vnd.api+json; ext=\"https:~1~1jsonapi.org~1ext~1atomic\"/schema");
+        JsonNode dataSchema = schema.at("/properties/atomic:operations/items/properties/data");
+        JsonNode typeSchema = dataSchema.at("/anyOf/1/type");
+        assertTrue(typeSchema.isTextual()); // OpenAPI 3.0 doesn't support type: null
+        assertEquals("object", typeSchema.asText());
+        JsonNode nullableSchema = dataSchema.at("/anyOf/1/nullable");
+        assertTrue(nullableSchema.isBoolean()); // OpenaAPI 3.0 supports nullable
+        assertTrue(nullableSchema.booleanValue());
+    }
+
+    @Test
+    void testAtomicOperationsOpenApi31() throws Exception {
+        Info info = new Info().title("Test Service").version(NO_VERSION);
+        EntityDictionary dictionary = EntityDictionary.builder().build();
+        dictionary.bindEntity(Book.class);
+        OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(info.getVersion());
+        OpenAPI openApi = builder.build();
+        JsonNode jsonNode = Json31.mapper().readTree(Json31.pretty(openApi));
+        JsonNode operations = jsonNode.at("/paths/~1operations");
+        JsonNode schema = operations.at("/post/requestBody/content/application~1vnd.api+json; ext=\"https:~1~1jsonapi.org~1ext~1atomic\"/schema");
+        JsonNode dataSchema = schema.at("/properties/atomic:operations/items/properties/data");
+        JsonNode typeSchema = dataSchema.at("/anyOf/1/type");
+        assertTrue(typeSchema.isArray());
+        assertEquals("null", typeSchema.get(1).asText()); // OpenAPI 3.1 supports type: null
+        JsonNode nullableSchema = dataSchema.at("/anyOf/1/nullable");
+        assertTrue(nullableSchema.isMissingNode()); // OpenAPI 3.1 does not support nullable
     }
 
     /**

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiIT.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiIT.java
@@ -66,11 +66,24 @@ class OpenApiIT extends AbstractApiResourceInitializer {
     }
 
     @Test
+    void testDocumentAtomicOperations() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(given().accept(MediaType.APPLICATION_JSON).get("/test").asString());
+        assertTrue(node.get("paths").size() > 1);
+        JsonNode operations = node.get("paths").get("/operations");
+        assertNotNull(operations);
+        JsonNode atomicOperations = operations.at("/post/requestBody/content/application~1vnd.api+json; ext=\"https:~1~1jsonapi.org~1ext~1atomic\"/schema");
+        JsonNode atomicResults = operations.at("/post/responses/200/content/application~1vnd.api+json; ext=\"https:~1~1jsonapi.org~1ext~1atomic\"/schema");
+        assertNotNull(atomicOperations);
+        assertNotNull(atomicResults);
+    }
+
+    @Test
     void testVersion2DocumentFetchJson() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(
                 given().accept(MediaType.APPLICATION_JSON).header("ApiVersion", "1.0").get("/test").asString());
-        assertEquals(2, node.get("paths").size());
+        assertEquals(3, node.get("paths").size());
         assertNotNull(node.get("paths").get("/book"));
         assertNotNull(node.get("paths").get("/book/{bookId}"));
     }
@@ -80,7 +93,7 @@ class OpenApiIT extends AbstractApiResourceInitializer {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(
                 given().accept(MediaType.APPLICATION_JSON).get("/v1.0/test").asString());
-        assertEquals(2, node.get("paths").size());
+        assertEquals(3, node.get("paths").size());
         assertNotNull(node.get("paths").get("/book"));
         assertNotNull(node.get("paths").get("/book/{bookId}"));
     }
@@ -101,7 +114,7 @@ class OpenApiIT extends AbstractApiResourceInitializer {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         JsonNode node = mapper.readTree(
                 given().accept(MediaType.APPLICATION_YAML).header("ApiVersion", "1.0").get("/test").asString());
-        assertEquals(2, node.get("paths").size());
+        assertEquals(3, node.get("paths").size());
         assertNotNull(node.get("paths").get("/book"));
         assertNotNull(node.get("paths").get("/book/{bookId}"));
     }

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/models/media/AtomicOperationTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/models/media/AtomicOperationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.swagger.models.media;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
+
+/**
+ * Test for AtomicOperation.
+ */
+class AtomicOperationTest {
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * For OpenAPI 3.1 the nullable keyword is not allowed.
+     *
+     * @throws JsonMappingException exception
+     * @throws JsonProcessingException exception
+     */
+    @Test
+    void openApi31() throws JsonMappingException, JsonProcessingException {
+        AtomicOperation atomicOperation = new AtomicOperation();
+        String result = Json31.pretty(atomicOperation);
+        JsonNode jsonNode = objectMapper.readTree(result);
+        JsonNode data = jsonNode.at("/properties/data/anyOf/1");
+        JsonNode type = data.at("/type");
+        JsonNode nullable = data.at("/nullable");
+        assertTrue(type.isArray());
+        assertTrue(nullable.isMissingNode());
+    }
+
+    /**
+     * For OpenAPI 3.0 the null type is not allowed.
+     *
+     * @throws JsonMappingException exception
+     * @throws JsonProcessingException exception
+     */
+    @Test
+    void openApi30() throws JsonMappingException, JsonProcessingException {
+        AtomicOperation atomicOperation = new AtomicOperation();
+        String result = Json.pretty(atomicOperation);
+        JsonNode jsonNode = objectMapper.readTree(result);
+        JsonNode data = jsonNode.at("/properties/data/anyOf/1");
+        JsonNode type = data.at("/type");
+        JsonNode nullable = data.at("/nullable");
+        assertTrue(type.isTextual());
+        assertTrue(nullable.isBoolean());
+    }
+}


### PR DESCRIPTION
## Description
This adds the JSON API atomic operations to the OpenAPI document.

This also fixes issues with the generation of OpenAPI 3.1 documents and other issues.
* The `specVersion` and `openapi` values on `OpenAPI` are now appropriately set when configured to use OpenAPI 3.1
* The `/info/version` is a required property and is now set to an empty string if null.
* The `/info/version` is now not overridden if the annotation does not set the version.
* OpenAPI documents with a version other than the default will now generate a correct reference to its schema if the model is not versioned.

## Motivation and Context
This makes the atomic operations feature more visible and easier to use.

There are 8 different operations that can be performed in atomic operations
* Creating Resources
* Updating Resources
* Deleting Resources
* Updating To-One Relationships
* Deleting To-One Relationships
* Creating To-Many Relationships
* Updating To-Many Relationships
* Deleting To-Many Relationships

The specific request bodies needed for each of the operations can be difficult to remember without examples so the examples and descriptions were added to make it easier.

## How Has This Been Tested?
Added / changed the appropriate unit / integration tests.

Also tested that the generate OpenAPI document can be successfully processed by the `openapi-generator-cli`.

## Screenshots (if appropriate):

![atomic](https://github.com/yahoo/elide/assets/49700559/385715f0-08a0-4392-9fb6-828a5c90c803)


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
