### PR TITLE
Optimize required dependencies for modules

### DIFF
--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -46,8 +46,15 @@
     <dependencies>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-core</artifactId>
+            <version>7.1.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-graphql</artifactId>
             <version>7.1.1-SNAPSHOT</version>
+            <scope>optional</scope>
         </dependency>
 
         <dependency>

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/User.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/User.java
@@ -5,25 +5,76 @@
  */
 package com.yahoo.elide.core.security;
 
-import lombok.Getter;
-
 import java.security.Principal;
+import java.util.Objects;
 
 /**
- * Wrapper for opaque user passed in every request.
+ * The user associated with the request.
  */
 public class User {
-    @Getter private final Principal principal;
+    private final Principal principal;
 
+    /**
+     * Constructor.
+     *
+     * @param principal the authenticated user
+     */
     public User(Principal principal) {
         this.principal = principal;
     }
 
-    public String getName() {
-        return principal != null ? principal.getName() : null;
+    /**
+     * Gets the user principal of the authenticated user.
+     *
+     * @param <T> the type of principal
+     * @return the principal
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends Principal> T getPrincipal() {
+        return (T) this.principal;
     }
 
+    /**
+     * Gets the name of the authenticated user.
+     *
+     * @return the name of the authenticated user
+     */
+    public String getName() {
+        return this.principal != null ? this.principal.getName() : null;
+    }
+
+    /**
+     * Returns whether the authenticated user has the specified role.
+     *
+     * @param role the role to check for
+     * @return true if the authenticated user has the role
+     */
     public boolean isInRole(String role) {
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return "User [principal=" + principal + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        User other = (User) obj;
+        return Objects.equals(principal, other.principal);
     }
 }

--- a/elide-datastore/elide-datastore-aggregation/pom.xml
+++ b/elide-datastore/elide-datastore-aggregation/pom.xml
@@ -56,12 +56,14 @@
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-graphql</artifactId>
+            <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-multiplex</artifactId>
             <version>7.1.1-SNAPSHOT</version>
+            <scope>test</scope>
         </dependency>
         
         <dependency>

--- a/elide-datastore/elide-datastore-jms/pom.xml
+++ b/elide-datastore/elide-datastore-jms/pom.xml
@@ -84,6 +84,10 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
         </dependency>

--- a/elide-graphql/pom.xml
+++ b/elide-graphql/pom.xml
@@ -69,18 +69,23 @@
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java-extended-scalars</artifactId>
         </dependency>
+        <!-- javadoc -->
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
+            <scope>provided</scope>
         </dependency>
+        <!-- com.yahoo.elide.graphql.subscriptions.websocket -->
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-client-api</artifactId>
+            <scope>provided</scope>
         </dependency>
-
+        <!-- com.yahoo.elide.graphql.subscriptions.hooks -->
         <dependency>
             <groupId>jakarta.jms</groupId>
             <artifactId>jakarta.jms-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>

--- a/elide-quarkus/pom.xml
+++ b/elide-quarkus/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <version>7.1.1-SNAPSHOT</version>
   <artifactId>elide-quarkus-extension-parent</artifactId>
   <packaging>pom</packaging>
   <name>Elide Quarkus Extension - Parent</name>
@@ -71,12 +70,22 @@
       </dependency>
       <dependency>
         <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-graphql</artifactId>
+        <version>${elide.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-aggregation</artifactId>
         <version>${elide.version}</version>
       </dependency>
       <dependency>
         <groupId>com.yahoo.elide</groupId>
         <artifactId>elide-datastore-jpa</artifactId>
+        <version>${elide.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.yahoo.elide</groupId>
+        <artifactId>elide-datastore-multiplex</artifactId>
         <version>${elide.version}</version>
       </dependency>
       <dependency>

--- a/elide-quarkus/runtime/pom.xml
+++ b/elide-quarkus/runtime/pom.xml
@@ -46,6 +46,10 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.elide</groupId>
+      <artifactId>elide-graphql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.elide</groupId>
       <artifactId>elide-datastore-aggregation</artifactId>
     </dependency>
     <dependency>

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -697,8 +697,8 @@ public class ElideAutoConfiguration {
             public ApiDocsController.ApiDocsRegistrations apiDocsRegistrations(RefreshableElide elide,
                     ElideConfigProperties settings, ServerProperties serverProperties,
                     OpenApiDocumentCustomizer customizer) {
-                return buildApiDocsRegistrations(elide, settings, serverProperties.getServlet().getContextPath(),
-                        customizer);
+                return ApiDocs.buildApiDocsRegistrations(elide, settings,
+                        serverProperties.getServlet().getContextPath(), customizer);
             }
 
             @Bean
@@ -804,8 +804,8 @@ public class ElideAutoConfiguration {
             public ApiDocsController.ApiDocsRegistrations apiDocsRegistrations(RefreshableElide elide,
                     ElideConfigProperties settings, ServerProperties serverProperties,
                     OpenApiDocumentCustomizer customizer) {
-                return buildApiDocsRegistrations(elide, settings, serverProperties.getServlet().getContextPath(),
-                        customizer);
+                return ApiDocs.buildApiDocsRegistrations(elide, settings,
+                        serverProperties.getServlet().getContextPath(), customizer);
             }
 
             @Bean
@@ -1162,58 +1162,65 @@ public class ElideAutoConfiguration {
         return new RefreshableElide(elide);
     }
 
-    public static ApiDocsController.ApiDocsRegistrations buildApiDocsRegistrations(RefreshableElide elide,
-            ElideConfigProperties settings, String contextPath, OpenApiDocumentCustomizer customizer) {
-        String jsonApiPath = settings.getJsonApi() != null ? settings.getJsonApi().getPath() : "";
+    /**
+     * ApiDocs holder class to make swagger optional.
+     */
+    public static class ApiDocs {
+        public static ApiDocsController.ApiDocsRegistrations buildApiDocsRegistrations(RefreshableElide elide,
+                ElideConfigProperties settings, String contextPath, OpenApiDocumentCustomizer customizer) {
+            String jsonApiPath = settings.getJsonApi() != null ? settings.getJsonApi().getPath() : "";
 
-        EntityDictionary dictionary = elide.getElide().getElideSettings().getEntityDictionary();
+            EntityDictionary dictionary = elide.getElide().getElideSettings().getEntityDictionary();
 
-        List<ApiDocsRegistration> registrations = new ArrayList<>();
-        dictionary.getApiVersions().stream().forEach(apiVersion -> {
-            Supplier<OpenAPI> document = () -> {
-                OpenApiBuilder builder = new OpenApiBuilder(dictionary, openApi -> {
-                    if (ApiDocsControllerProperties.Version.OPENAPI_3_1.equals(settings.getApiDocs().getVersion())) {
-                        openApi.specVersion(SpecVersion.V31).openapi("3.1.0");
+            List<ApiDocsRegistration> registrations = new ArrayList<>();
+            dictionary.getApiVersions().stream().forEach(apiVersion -> {
+                Supplier<OpenAPI> document = () -> {
+                    OpenApiBuilder builder = new OpenApiBuilder(dictionary, openApi -> {
+                        if (ApiDocsControllerProperties.Version.OPENAPI_3_1
+                                .equals(settings.getApiDocs().getVersion())) {
+                            openApi.specVersion(SpecVersion.V31).openapi("3.1.0");
+                        }
+                    }).apiVersion(apiVersion).supportLegacyFilterDialect(false);
+                    if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                        if (settings.getApiVersioningStrategy().getPath().isEnabled()) {
+                            // Path needs to be set
+                            builder.basePath("/" + settings.getApiVersioningStrategy().getPath().getVersionPrefix()
+                                    + apiVersion);
+                        } else if (settings.getApiVersioningStrategy().getHeader().isEnabled()) {
+                            // Header needs to be set
+                            builder.globalParameter(new Parameter().in("header")
+                                    .name(settings.getApiVersioningStrategy().getHeader().getHeaderName()[0])
+                                    .required(true)
+                                    .schema(new StringSchema().addEnumItem(apiVersion)));
+                        } else if (settings.getApiVersioningStrategy().getParameter().isEnabled()) {
+                            // Header needs to be set
+                            builder.globalParameter(new Parameter().in("query")
+                                    .name(settings.getApiVersioningStrategy().getParameter().getParameterName())
+                                    .required(true).schema(new StringSchema().addEnumItem(apiVersion)));
+                        }
                     }
-                }).apiVersion(apiVersion).supportLegacyFilterDialect(false);
-                if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
-                    if (settings.getApiVersioningStrategy().getPath().isEnabled()) {
-                        // Path needs to be set
-                        builder.basePath(
-                                "/" + settings.getApiVersioningStrategy().getPath().getVersionPrefix() + apiVersion);
-                    } else if (settings.getApiVersioningStrategy().getHeader().isEnabled()) {
-                        // Header needs to be set
-                        builder.globalParameter(new Parameter().in("header")
-                                .name(settings.getApiVersioningStrategy().getHeader().getHeaderName()[0]).required(true)
-                                .schema(new StringSchema().addEnumItem(apiVersion)));
-                    } else if (settings.getApiVersioningStrategy().getParameter().isEnabled()) {
-                        // Header needs to be set
-                        builder.globalParameter(new Parameter().in("query")
-                                .name(settings.getApiVersioningStrategy().getParameter().getParameterName())
-                                .required(true).schema(new StringSchema().addEnumItem(apiVersion)));
+                    String url = contextPath != null ? contextPath : "";
+                    url = url + jsonApiPath;
+                    if (url.isBlank()) {
+                        url = "/";
                     }
-                }
-                String url = contextPath != null ? contextPath : "";
-                url = url + jsonApiPath;
-                if (url.isBlank()) {
-                    url = "/";
-                }
-                OpenAPI openApi = builder.build();
-                openApi.addServersItem(new Server().url(url));
-                if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
-                    Info info = openApi.getInfo();
-                    if (info == null) {
-                        info = new Info();
-                        openApi.setInfo(info);
+                    OpenAPI openApi = builder.build();
+                    openApi.addServersItem(new Server().url(url));
+                    if (!EntityDictionary.NO_VERSION.equals(apiVersion)) {
+                        Info info = openApi.getInfo();
+                        if (info == null) {
+                            info = new Info();
+                            openApi.setInfo(info);
+                        }
+                        info.setVersion(apiVersion);
                     }
-                    info.setVersion(apiVersion);
-                }
-                customizer.customize(openApi);
-                return openApi;
-            };
-            registrations.add(new ApiDocsRegistration("", SingletonSupplier.of(document), apiVersion));
-        });
-        return new ApiDocsController.ApiDocsRegistrations(registrations);
+                    customizer.customize(openApi);
+                    return openApi;
+                };
+                registrations.add(new ApiDocsRegistration("", SingletonSupplier.of(document), apiVersion));
+            });
+            return new ApiDocsController.ApiDocsRegistrations(registrations);
+        }
     }
 
     /**

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionScanningConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideSubscriptionScanningConfiguration.java
@@ -26,7 +26,7 @@ import jakarta.jms.Message;
  * Scans for GraphQL subscriptions and registers lifecycle hooks.
  */
 @Configuration
-@ConditionalOnClass(GraphQLSettings.class)
+@ConditionalOnClass({ GraphQLSettings.class, ConnectionFactory.class })
 @ConditionalOnProperty(name = "elide.graphql.enabled", havingValue = "true")
 @ConditionalOnExpression(
     "${elide.graphql.subscription.enabled:false} && ${elide.graphql.subscription.publishing.enabled:true}")

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/GraphqlController.java
@@ -14,13 +14,12 @@ import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.graphql.QueryRunner;
 import com.yahoo.elide.graphql.QueryRunners;
 import com.yahoo.elide.spring.config.ElideConfigProperties;
-import com.yahoo.elide.spring.security.AuthenticationUser;
+import com.yahoo.elide.spring.security.HttpServletRequestUser;
 import com.yahoo.elide.utils.HeaderProcessor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -75,16 +74,16 @@ public class GraphqlController {
      * Single entry point for GraphQL requests.
      *
      * @param requestHeaders request headers
+     * @param allRequestParams request parameters
      * @param graphQLDocument post data as json document
-     * @param principal The user principal
+     * @param request http servlet request
      * @return response
      */
     @PostMapping(value = {"/**", ""}, consumes = JSON_CONTENT_TYPE, produces = JSON_CONTENT_TYPE)
     public Callable<ResponseEntity<String>> post(@RequestHeader HttpHeaders requestHeaders,
                                                  @RequestParam MultiValueMap<String, String> allRequestParams,
-                                                 @RequestBody String graphQLDocument, HttpServletRequest request,
-                                                 Authentication principal) {
-        final User user = new AuthenticationUser(principal);
+                                                 @RequestBody String graphQLDocument, HttpServletRequest request) {
+        final User user = new HttpServletRequestUser(request);
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String prefix = settings.getGraphql().getPath();
         final String baseUrl = getBaseUrl(prefix);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/controllers/JsonApiController.java
@@ -12,13 +12,12 @@ import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.spring.config.ElideConfigProperties;
-import com.yahoo.elide.spring.security.AuthenticationUser;
+import com.yahoo.elide.spring.security.HttpServletRequestUser;
 import com.yahoo.elide.utils.HeaderProcessor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -67,14 +66,14 @@ public class JsonApiController {
     @GetMapping(value = "/**", produces = JsonApi.MEDIA_TYPE)
     public Callable<ResponseEntity<String>> elideGet(@RequestHeader HttpHeaders requestHeaders,
                                                      @RequestParam MultiValueMap<String, String> allRequestParams,
-                                                     HttpServletRequest request, Authentication authentication) {
+                                                     HttpServletRequest request) {
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String prefix = settings.getJsonApi().getPath();
         final String baseUrl = getBaseUrl(prefix);
         final String pathname = getPath(request, prefix);
         Route route = routeResolver.resolve(JsonApi.MEDIA_TYPE, baseUrl, pathname, requestHeadersCleaned,
                 allRequestParams);
-        final User user = new AuthenticationUser(authentication);
+        final User user = new HttpServletRequestUser(request);
 
         return new Callable<ResponseEntity<String>>() {
             @Override
@@ -90,14 +89,14 @@ public class JsonApiController {
     public Callable<ResponseEntity<String>> elidePost(@RequestHeader HttpHeaders requestHeaders,
                                                       @RequestParam MultiValueMap<String, String> allRequestParams,
                                                       @RequestBody String body,
-                                                      HttpServletRequest request, Authentication authentication) {
+                                                      HttpServletRequest request) {
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         String prefix = settings.getJsonApi().getPath();
         final String baseUrl = getBaseUrl(prefix);
         final String pathname = getPath(request, prefix);
         Route route = routeResolver.resolve(JsonApi.MEDIA_TYPE, baseUrl, pathname, requestHeadersCleaned,
                 allRequestParams);
-        final User user = new AuthenticationUser(authentication);
+        final User user = new HttpServletRequestUser(request);
 
         return new Callable<ResponseEntity<String>>() {
             @Override
@@ -125,14 +124,14 @@ public class JsonApiController {
     public Callable<ResponseEntity<String>> elidePatch(@RequestHeader HttpHeaders requestHeaders,
                                                        @RequestParam MultiValueMap<String, String> allRequestParams,
                                                        @RequestBody String body,
-                                                       HttpServletRequest request, Authentication authentication) {
+                                                       HttpServletRequest request) {
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String prefix = settings.getJsonApi().getPath();
         final String baseUrl = getBaseUrl(prefix);
         final String pathname = getPath(request, prefix);
         Route route = routeResolver.resolve(JsonApi.MEDIA_TYPE, baseUrl, pathname, requestHeadersCleaned,
                 allRequestParams);
-        final User user = new AuthenticationUser(authentication);
+        final User user = new HttpServletRequestUser(request);
 
         return new Callable<ResponseEntity<String>>() {
             @Override
@@ -146,15 +145,14 @@ public class JsonApiController {
     @DeleteMapping(value = "/**", produces = JsonApi.MEDIA_TYPE)
     public Callable<ResponseEntity<String>> elideDelete(@RequestHeader HttpHeaders requestHeaders,
                                                         @RequestParam MultiValueMap<String, String> allRequestParams,
-                                                        HttpServletRequest request,
-                                                        Authentication authentication) {
+                                                        HttpServletRequest request) {
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String prefix = settings.getJsonApi().getPath();
         final String baseUrl = getBaseUrl(prefix);
         final String pathname = getPath(request, prefix);
         Route route = routeResolver.resolve(JsonApi.MEDIA_TYPE, baseUrl, pathname, requestHeadersCleaned,
                 allRequestParams);
-        final User user = new AuthenticationUser(authentication);
+        final User user = new HttpServletRequestUser(request);
 
         return new Callable<ResponseEntity<String>>() {
             @Override
@@ -170,15 +168,14 @@ public class JsonApiController {
             @RequestHeader HttpHeaders requestHeaders,
             @RequestParam MultiValueMap<String, String> allRequestParams,
             @RequestBody String body,
-            HttpServletRequest request,
-            Authentication authentication) {
+            HttpServletRequest request) {
         final Map<String, List<String>> requestHeadersCleaned = headerProcessor.process(requestHeaders);
         final String prefix = settings.getJsonApi().getPath();
         final String baseUrl = getBaseUrl(prefix);
         final String pathname = getPath(request, prefix);
         Route route = routeResolver.resolve(JsonApi.MEDIA_TYPE, baseUrl, pathname, requestHeadersCleaned,
                 allRequestParams);
-        final User user = new AuthenticationUser(authentication);
+        final User user = new HttpServletRequestUser(request);
 
         return new Callable<ResponseEntity<String>>() {
             @Override

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/datastore/config/DataStoreBuilder.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/datastore/config/DataStoreBuilder.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  */
 public class DataStoreBuilder {
     private final List<DataStore> dataStores = new ArrayList<>();
-    private Function<DataStore[], DataStore> multiplexer = MultiplexManager::new;
+    private Function<DataStore[], DataStore> multiplexer = null;
 
     public DataStoreBuilder dataStores(List<DataStore> dataStores) {
         this.dataStores.clear();
@@ -52,6 +52,11 @@ public class DataStoreBuilder {
         if (this.dataStores.size() == 1) {
             return this.dataStores.get(0);
         }
-        return multiplexer.apply(this.dataStores.toArray(DataStore[]::new));
+        if (multiplexer != null) {
+            return multiplexer.apply(this.dataStores.toArray(DataStore[]::new));
+        } else {
+            // Not set in ctor as multiplexer = MultiplexManager::new to make elide-datastore-multiplex optional
+            return new MultiplexManager(this.dataStores.toArray(DataStore[]::new));
+        }
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/security/AuthenticationUser.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/security/AuthenticationUser.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.GrantedAuthority;
  * Elide User object for Spring Boot.
  */
 public class AuthenticationUser extends User {
-    private Authentication authentication;
+    private final Authentication authentication;
 
     public AuthenticationUser(Authentication authentication) {
         super(authentication);

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/security/HttpServletRequestUser.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/security/HttpServletRequestUser.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.spring.security;
+
+import com.yahoo.elide.core.security.User;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * {@link User} of the {@link HttpServletRequest}.
+ * <p>
+ * Spring Security will wrap the request using the
+ * org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper.
+ */
+public class HttpServletRequestUser extends User {
+    private final HttpServletRequest httpRequest;
+
+    public HttpServletRequestUser(HttpServletRequest httpRequest) {
+        super(httpRequest.getUserPrincipal());
+        this.httpRequest = httpRequest;
+    }
+
+    @Override
+    public boolean isInRole(String role) {
+        return this.httpRequest.isUserInRole(role);
+    }
+
+    @Override
+    public String getName() {
+        String name = this.httpRequest.getRemoteUser();
+        if (name == null) {
+            name = super.getName();
+        }
+        return name;
+    }
+}

--- a/elide-standalone/pom.xml
+++ b/elide-standalone/pom.xml
@@ -76,6 +76,11 @@
         </dependency>
         <dependency>
             <groupId>com.yahoo.elide</groupId>
+            <artifactId>elide-datastore-multiplex</artifactId>
+            <version>7.1.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-datastore-jms</artifactId>
             <version>7.1.1-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
## Description
The following are the summary of the main changes. These changes don't affect users using `elide-spring-boot-starter` as that generally pulls all the modules.

**elide-async**
* Sets `elide-graphql` optional to allow users that just wish to use JSON-API. Users that use GraphQL would have included the `elide-graphql` dependency explicitly anyway.

**elide-datastore-aggregation**
* Sets `elide-graphql` and `elide-datastore-multiplex` to test scope as they are only used during testing.

**elide-graphql**
* Sets `jakarta.websocket-api`, `jakarta.websocket-client-api` and `jakarta.jms-api` to optional for users that wish to use GraphQL but not the subscription support.

**elide-spring-boot-autoconfigure**
* Adds a `HttpServletRequestUser` to be used in place of `AuthenticationUser` to remove a required dependency on Spring Security. When Spring Security is used it will by default wrap the `HttpServletRequest` using the `org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper` which will return Spring's `Authentication` via `getUserPrincipal()` and delegate accordingly when `isUserInRole()` is called. This is the equivalent of what `AuthenticationUser` is doing. Using the `HttpServletRequest` also allows integration with the security provided by the container or custom schemes where a filter is used to wrap the `HttpServletRequest`.

## Motivation and Context
The existing `elide-spring-boot-starter` is very good for pulling most of the dependencies needed to try out all of Elide's features but when it comes to picking and choosing modules to be deployed in production it is not ideal to exclude too many dependencies.

These changes makes it easier to import `elide-bom` and then include the individual modules that won't pull in optional dependencies unnecessarily.

## How Has This Been Tested?
This was tested by modifying the `elide-spring-boot-example` and testing that the modules that should work are working and that the autoconfiguration appropriately backs off and doesn't throw exceptions when modules are not included.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
