### PR TITLE
Fix pagination set page totals to zero after non-zero query

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/InMemoryStoreTransaction.java
@@ -316,6 +316,10 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
     private List<Object> paginateInMemory(List<Object> records, Pagination pagination) {
         int offset = pagination.getOffset();
         int limit = pagination.getLimit();
+        if (pagination.returnPageTotals()) {
+            pagination.setPageTotals((long) records.size());
+        }
+
         if (offset < 0 || offset >= records.size()) {
             return Collections.emptyList();
         }
@@ -323,10 +327,6 @@ public class InMemoryStoreTransaction implements DataStoreTransaction {
         int endIdx = offset + limit;
         if (endIdx > records.size()) {
             endIdx = records.size();
-        }
-
-        if (pagination.returnPageTotals()) {
-            pagination.setPageTotals((long) records.size());
         }
         return records.subList(offset, endIdx);
     }


### PR DESCRIPTION
Resolves #3257 

## Description
Fixes a bug where page totals were not being set for empty collections

## Motivation and Context
This was usually correct, but if the page totals had been previously set - the pagination object seemed to be reused when querying graphql relationships with pageInfo - they would not be correctly reset for the next entity

## How Has This Been Tested?
Added unit test to verify

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
