### PR TITLE
Add support for obfuscated id or alternate entity id

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/annotation/EntityId.java
+++ b/elide-core/src/main/java/com/yahoo/elide/annotation/EntityId.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates the field or property that represents the identity of the entity.
+ * <p>
+ * This is intended to be used if the primary key undesirably leaks information
+ * about the record and to designate another field or property as the entity
+ * identifier.
+ * <p>
+ * Another option instead of using another field or column as the entity
+ * identifier is to obfuscate the id directly.
+ * <p>
+ * The following are some things to consider when choosing the entity id.
+ * <ul>
+ * <li>Opaque token</li>
+ * <li>Cryptographically secure</li>
+ * <li>Implementation only based on Randomness</li>
+ * <li>Predictability of the ID</li>
+ * <li>Leaks the count of items</li>
+ * <li>Leaks information about the machine/process</li>
+ * <li>Leaks the date of creation</li>
+ * </ul>
+ */
+@Target({ METHOD, FIELD })
+@Retention(RUNTIME)
+public @interface EntityId {
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/Path.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/Path.java
@@ -140,8 +140,8 @@ public class Path {
                                                String alias,
                                                Set<Argument> arguments,
                                                EntityDictionary dictionary) {
-        if (dictionary.isAttribute(entityClass, fieldName)
-                || fieldName.equals(dictionary.getIdFieldName(entityClass))) {
+        if (dictionary.isAttribute(entityClass, fieldName) || fieldName.equals(dictionary.getIdFieldName(entityClass))
+                || fieldName.equals(dictionary.getEntityIdFieldName(entityClass))) {
             Type<?> attributeClass = dictionary.getType(entityClass, fieldName);
             return new PathElement(entityClass, attributeClass, fieldName, alias, arguments);
         }

--- a/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/HashMapStoreTransaction.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/datastore/inmemory/HashMapStoreTransaction.java
@@ -130,6 +130,11 @@ public class HashMapStoreTransaction implements DataStoreTransaction {
             id = dictionary.getId(entity);
         }
 
+        String entityIdFieldName = dictionary.getEntityIdFieldName(entityClass);
+        if (entityIdFieldName != null) {
+            id = dictionary.getId(entity);
+        }
+
         replicateOperationToParent(entity, Operation.OpType.CREATE);
         operations.add(new Operation(id, entity, EntityDictionary.getType(entity), Operation.OpType.CREATE));
     }

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityDictionary.java
@@ -477,6 +477,16 @@ public class EntityDictionary {
     }
 
     /**
+     * Returns the name of the entity id field.
+     *
+     * @param entityClass Entity class
+     * @return entity id field name
+     */
+    public String getEntityIdFieldName(Type<?> entityClass) {
+        return getEntityBinding(entityClass).getEntityIdFieldName();
+    }
+
+    /**
      * Returns whether the entire entity uses Field or Property level access.
      * @param entityClass Entity Class
      * @return The JPA Access Type
@@ -1263,7 +1273,12 @@ public class EntityDictionary {
 
             for (; idField == null && valueClass != null; valueClass = valueClass.getSuperclass()) {
                 try {
-                    idField = getEntityBinding(valueClass).getIdField();
+                    EntityBinding entityBinding = getEntityBinding(valueClass);
+                    // Attempt to get the entity id field first
+                    idField = entityBinding.getEntityIdField();
+                    if (idField == null) {
+                        idField = entityBinding.getIdField();
+                    }
                 } catch (NullPointerException e) {
                     log.warn("Class: {} ID Field: {}", valueClass.getSimpleName(), idField);
                 }
@@ -1300,6 +1315,16 @@ public class EntityDictionary {
      */
     public Type<?> getIdType(Type<?> entityClass) {
         return getEntityBinding(entityClass).getIdType();
+    }
+
+    /**
+     * Returns type of entity id field.
+     *
+     * @param entityClass the entity class
+     * @return ID type
+     */
+    public Type<?> getEntityIdType(Type<?> entityClass) {
+        return getEntityBinding(entityClass).getEntityIdType();
     }
 
     /**
@@ -1737,6 +1762,18 @@ public class EntityDictionary {
      */
     public void setId(Object target, String id) {
         setValue(target, getIdFieldName(lookupBoundClass(getType(target))), id);
+    }
+
+    /**
+     * Sets the EntityId field of a target object.
+     * @param target the object which owns the entity ID to set.
+     * @param entity id the value to set
+     */
+    public void setEntityId(Object target, String entityId) {
+        String entityIdFieldName = getEntityIdFieldName(lookupBoundClass(getType(target)));
+        if (entityIdFieldName != null) {
+            setValue(target, entityIdFieldName, entityId);
+        }
     }
 
     /**

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/obfuscation/FunctionIdObfuscator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/obfuscation/FunctionIdObfuscator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.security.obfuscation;
+
+import com.yahoo.elide.core.exceptions.InvalidValueException;
+import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.core.type.Type;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.function.Function;
+
+/**
+ * {@link IdObfuscator} that accepts functions to perform obfuscation and
+ * deobfuscation.
+ */
+public class FunctionIdObfuscator implements IdObfuscator {
+    private final Function<byte[], byte[]> obfuscationFunction;
+    private final Function<byte[], byte[]> deobfuscationFunction;
+
+    public FunctionIdObfuscator(Function<byte[], byte[]> obfuscationFunction,
+            Function<byte[], byte[]> deobfuscationFunction) {
+        this.obfuscationFunction = obfuscationFunction;
+        this.deobfuscationFunction = deobfuscationFunction;
+    }
+
+    @Override
+    public String obfuscate(Object id) {
+        byte[] result;
+        if (id instanceof Long value) {
+            ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+            buffer.putLong(value);
+            result = obfuscationFunction.apply(buffer.array());
+        } else if (id instanceof Integer value) {
+            ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
+            buffer.putInt(value);
+            result = obfuscationFunction.apply(buffer.array());
+        } else if (id instanceof String value) {
+            result = obfuscationFunction.apply(value.getBytes(StandardCharsets.UTF_8));
+        } else {
+            throw new InvalidValueException("id");
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(result);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T deobfuscate(String obfuscatedId, Type<?> type) {
+        try {
+            byte[] value = Base64.getUrlDecoder().decode(obfuscatedId);
+            byte[] result = deobfuscationFunction.apply(value);
+            if (ClassType.LONG_TYPE.equals(type) || ClassType.PRIMITIVE_LONG_TYPE.equals(type)) {
+                ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+                buffer.put(result);
+                buffer.flip();
+                return (T) Long.valueOf(buffer.getLong());
+            } else if (ClassType.INTEGER_TYPE.equals(type) || ClassType.PRIMITIVE_INTEGER_TYPE.equals(type)) {
+                ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
+                buffer.put(result);
+                buffer.flip();
+                return (T) Integer.valueOf(buffer.getInt());
+            } else if (ClassType.STRING_TYPE.equals(type)) {
+                return (T) new String(result, StandardCharsets.UTF_8);
+            }
+            throw new InvalidValueException("id");
+        } catch (RuntimeException e) {
+            throw new InvalidValueException("id");
+        }
+    }
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/security/obfuscation/IdObfuscator.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/security/obfuscation/IdObfuscator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.security.obfuscation;
+
+import com.yahoo.elide.core.type.Type;
+
+/**
+ * Obfuscator that obfuscates the identifier of the entity which is the primary
+ * key.
+ * <p>
+ * This is intended to be used if the primary key undesirably leaks information
+ * about the record.
+ * <p>
+ * The following are things to consider when deciding to obfuscate the id.
+ * <ul>
+ * <li>Predictability of the ID</li>
+ * <li>Leaks the count of items</li>
+ * <li>Leaks information about the machine/process</li>
+ * <li>Leaks the date of creation</li>
+ * </ul>
+ * <p>
+ * Note that the sorting will be based on the original value prior to
+ * obfuscation.
+ * <p>
+ * Alternatively a separate field or property can be used to represent the
+ * entity identifier using {@link com.yahoo.elide.annotation.EntityId}.
+ */
+public interface IdObfuscator {
+    /**
+     * Obfuscates the id.
+     *
+     * @param id the id to obfuscate
+     * @return the obfuscated id
+     */
+    String obfuscate(Object id);
+
+    /**
+     * Deobfuscates the obfuscated id string.
+     * @param obfuscatedId the obfuscated id
+     * @param the id type
+     *
+     * @return the deobfuscated id
+     */
+    <T> T deobfuscate(String obfuscatedId, Type<?> type);
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
@@ -6,6 +6,7 @@
 package com.yahoo.elide.core.sort;
 
 import com.yahoo.elide.core.Path;
+import com.yahoo.elide.core.dictionary.EntityBinding;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.request.Attribute;
@@ -95,7 +96,15 @@ public class SortingImpl implements Sorting {
                                                           final EntityDictionary dictionary)
             throws InvalidValueException {
         Map<Path, SortOrder> returnMap = new LinkedHashMap<>();
-        for (Map.Entry<String, SortOrder> entry : replaceIdRule(dictionary.getIdFieldName(entityClass)).entrySet()) {
+
+        // Replace the id with either the EntityId field name or the Id field name
+        EntityBinding binding = dictionary.getEntityBinding(entityClass);
+        String idFieldName = binding.getEntityIdFieldName();
+        if (idFieldName == null) {
+            idFieldName = binding.getIdFieldName();
+        }
+
+        for (Map.Entry<String, SortOrder> entry : replaceIdRule(idFieldName).entrySet()) {
             String dotSeparatedPath = entry.getKey();
             SortOrder order = entry.getValue();
 

--- a/elide-core/src/main/java/com/yahoo/elide/core/type/ClassType.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/type/ClassType.java
@@ -35,12 +35,14 @@ public class ClassType<T> implements Type<T> {
     public static final ClassType<String> STRING_TYPE = ClassType.of(String.class);
     public static final ClassType<Boolean> BOOLEAN_TYPE = ClassType.of(Boolean.class);
     public static final ClassType<Long> LONG_TYPE = ClassType.of(Long.class);
+    public static final ClassType<Long> PRIMITIVE_LONG_TYPE = ClassType.of(long.class);
     public static final ClassType<BigDecimal> BIGDECIMAL_TYPE = ClassType.of(BigDecimal.class);
     public static final ClassType<Number> NUMBER_TYPE = ClassType.of(Number.class);
     public static final ClassType<Date> DATE_TYPE = ClassType.of(Date.class);
     public static final ClassType<Object> OBJECT_TYPE = ClassType.of(Object.class);
     public static final ClassType<Class> CLASS_TYPE = ClassType.of(Class.class);
     public static final ClassType<Integer> INTEGER_TYPE = ClassType.of(Integer.class);
+    public static final ClassType<Integer> PRIMITIVE_INTEGER_TYPE = ClassType.of(int.class);
 
     @Getter
     private Class<T> cls;

--- a/elide-core/src/test/java/com/yahoo/elide/core/dictionary/TestDictionary.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/dictionary/TestDictionary.java
@@ -34,7 +34,8 @@ public class TestDictionary extends EntityDictionary {
                 injector,
                 CoerceUtil::lookup,
                 Collections.emptySet(),
-                new DefaultClassScanner()
+                new DefaultClassScanner(),
+                null
         );
     }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/OperatorTest.java
@@ -49,7 +49,8 @@ public class OperatorTest {
                     EntityDictionary.DEFAULT_INJECTOR,
                     CoerceUtil::lookup,
                     Collections.emptySet(), //excluded entities
-                    new DefaultClassScanner()
+                    new DefaultClassScanner(),
+                    null
             );
         }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterExecutorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/filter/expression/InMemoryFilterExecutorTest.java
@@ -82,7 +82,8 @@ public class InMemoryFilterExecutorTest {
                     EntityDictionary.DEFAULT_INJECTOR,
                     CoerceUtil::lookup,
                     Collections.emptySet(), //excluded entities
-                    new DefaultClassScanner()
+                    new DefaultClassScanner(),
+                    null
             );
         }
 

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/obfuscation/AesBytesEncryptor.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/obfuscation/AesBytesEncryptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.security.obfuscation;
+
+import java.security.spec.KeySpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class AesBytesEncryptor {
+    private final SecretKey secretKey;
+
+    public AesBytesEncryptor(SecretKey secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public AesBytesEncryptor(String password, String salt) {
+        this(from(password, salt));
+    }
+
+    static SecretKey from(String password, String salt) {
+        try {
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            KeySpec spec = new PBEKeySpec(password.toCharArray(), salt.getBytes(), 65536, 256);
+            return new SecretKeySpec(factory.generateSecret(spec).getEncoded(), "AES");
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    byte[] encrypt(byte[] byteArray) {
+        try {
+            byte[] key = secretKey.getEncoded();
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
+            Cipher cipher = Cipher.getInstance("AES");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
+            return cipher.doFinal(byteArray);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    byte[] decrypt(byte[] encryptedByteArray) {
+        try {
+            byte[] key = secretKey.getEncoded();
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
+            Cipher cipher = Cipher.getInstance("AES");
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
+            return cipher.doFinal(encryptedByteArray);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/security/obfuscation/FunctionIdObfuscatorTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/security/obfuscation/FunctionIdObfuscatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.core.security.obfuscation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.yahoo.elide.core.type.ClassType;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * FunctionIdObfuscatorTest.
+ */
+class FunctionIdObfuscatorTest {
+    AesBytesEncryptor bytesEncryptor = new AesBytesEncryptor("yourPassword", "5c0744940b5c369b");
+
+    @Test
+    void testLong() {
+        IdObfuscator idObfuscator = new FunctionIdObfuscator(bytesEncryptor::encrypt, bytesEncryptor::decrypt);
+        String obfuscated = idObfuscator.obfuscate(Long.valueOf(12345L));
+        Long value = idObfuscator.deobfuscate(obfuscated, ClassType.LONG_TYPE);
+        assertEquals(12345L, value);
+    }
+
+    @Test
+    void testLongPrimitive() {
+        IdObfuscator idObfuscator = new FunctionIdObfuscator(bytesEncryptor::encrypt, bytesEncryptor::decrypt);
+        String obfuscated = idObfuscator.obfuscate(12345L);
+        Long value = idObfuscator.deobfuscate(obfuscated, ClassType.PRIMITIVE_LONG_TYPE);
+        assertEquals(12345L, value);
+    }
+
+    @Test
+    void testInteger() {
+        IdObfuscator idObfuscator = new FunctionIdObfuscator(bytesEncryptor::encrypt, bytesEncryptor::decrypt);
+        String obfuscated = idObfuscator.obfuscate(Integer.valueOf(12345));
+        Integer value = idObfuscator.deobfuscate(obfuscated, ClassType.INTEGER_TYPE);
+        assertEquals(12345, value);
+    }
+
+    @Test
+    void testIntegerPrimitive() {
+        IdObfuscator idObfuscator = new FunctionIdObfuscator(bytesEncryptor::encrypt, bytesEncryptor::decrypt);
+        String obfuscated = idObfuscator.obfuscate(12345);
+        Integer value = idObfuscator.deobfuscate(obfuscated, ClassType.PRIMITIVE_INTEGER_TYPE);
+        assertEquals(12345, value);
+    }
+
+    @Test
+    void testString() {
+        IdObfuscator idObfuscator = new FunctionIdObfuscator(bytesEncryptor::encrypt, bytesEncryptor::decrypt);
+        String obfuscated = idObfuscator.obfuscate("The quick brown fox jumped over the lazy dog");
+        String value = idObfuscator.deobfuscate(obfuscated, ClassType.STRING_TYPE);
+        assertEquals("The quick brown fox jumped over the lazy dog", value);
+    }
+}

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/ClassScannerTest.java
@@ -41,14 +41,14 @@ public class ClassScannerTest {
     @Test
     public void testGetAllAnnotatedClasses() {
         Set<Class<?>> classes = scanner.getAnnotatedClasses(Include.class);
-        assertEquals(48, classes.size(), "Actual: " + classes);
+        assertEquals(49, classes.size(), "Actual: " + classes);
         classes.forEach(cls -> assertTrue(cls.isAnnotationPresent(Include.class)));
     }
 
     @Test
     public void testGetAnyAnnotatedClasses() {
         Set<Class<?>> classes = scanner.getAnnotatedClasses(Include.class, Entity.class);
-        assertEquals(59, classes.size());
+        assertEquals(60, classes.size());
         for (Class<?> cls : classes) {
             assertTrue(cls.isAnnotationPresent(Include.class)
                     || cls.isAnnotationPresent(Entity.class));

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/JPQLTransaction.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/JPQLTransaction.java
@@ -83,8 +83,18 @@ public abstract class JPQLTransaction implements DataStoreTransaction {
         FilterExpression filterExpression = projection.getFilterExpression();
 
         EntityDictionary dictionary = scope.getDictionary();
-        Type<?> idType = dictionary.getIdType(entityClass);
-        String idField = dictionary.getIdFieldName(entityClass);
+        Type<?> entityIdType = dictionary.getEntityIdType(entityClass);
+        Type<?> idType;
+        String idField;
+
+        if (entityIdType == null) {
+            idType = dictionary.getIdType(entityClass);
+            idField = dictionary.getIdFieldName(entityClass);
+        } else {
+            // handling for entity id
+            idType = entityIdType;
+            idField = dictionary.getEntityIdFieldName(entityClass);
+        }
 
         // Construct a predicate that selects an individual element of the relationship's parent (Author.id = 3).
         FilterPredicate idExpression;

--- a/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
+++ b/elide-datastore/elide-datastore-multiplex/src/main/java/com/yahoo/elide/datastores/multiplex/MultiplexManager.java
@@ -103,7 +103,8 @@ public final class MultiplexManager implements DataStore {
                     dictionary.getInjector(),
                     dictionary.getSerdeLookup(),
                     dictionary.getEntitiesToExclude(),
-                    dictionary.getScanner());
+                    dictionary.getScanner(),
+                    dictionary.getIdObfuscator());
 
             dataStore.populateEntityDictionary(subordinateDictionary);
             for (EntityBinding binding : subordinateDictionary.getBindings(false)) {

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/NonEntityDictionary.java
@@ -33,7 +33,8 @@ public class NonEntityDictionary extends EntityDictionary {
                 DEFAULT_INJECTOR,
                 serdeLookup,
                 Collections.emptySet(), //Entity excludes
-                scanner);
+                scanner,
+                null);
     }
 
     /**

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/AesBytesEncryptor.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/AesBytesEncryptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.initialization;
+
+import java.security.spec.KeySpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class AesBytesEncryptor {
+    private final SecretKey secretKey;
+
+    public AesBytesEncryptor(SecretKey secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public AesBytesEncryptor(String password, String salt) {
+        this(from(password, salt));
+    }
+
+    static SecretKey from(String password, String salt) {
+        try {
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            KeySpec spec = new PBEKeySpec(password.toCharArray(), salt.getBytes(), 65536, 256);
+            return new SecretKeySpec(factory.generateSecret(spec).getEncoded(), "AES");
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    byte[] encrypt(byte[] byteArray) {
+        try {
+            byte[] key = secretKey.getEncoded();
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
+            Cipher cipher = Cipher.getInstance("AES");
+            cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
+            return cipher.doFinal(byteArray);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    byte[] decrypt(byte[] encryptedByteArray) {
+        try {
+            byte[] key = secretKey.getEncoded();
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key, "AES");
+            Cipher cipher = Cipher.getInstance("AES");
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
+            return cipher.doFinal(encryptedByteArray);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/IdObfuscationTestApplicationResourceConfig.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/initialization/IdObfuscationTestApplicationResourceConfig.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.initialization;
+
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.CREATE;
+
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.Operation.UPDATE;
+import static com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase.PRECOMMIT;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.core.audit.InMemoryLogger;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
+import com.yahoo.elide.core.filter.dialect.jsonapi.DefaultFilterDialect;
+import com.yahoo.elide.core.filter.dialect.jsonapi.MultipleFilterDialect;
+import com.yahoo.elide.core.security.obfuscation.FunctionIdObfuscator;
+import com.yahoo.elide.core.security.obfuscation.IdObfuscator;
+import com.yahoo.elide.jsonapi.JsonApiSettings;
+
+import example.TestCheckMappings;
+import example.models.triggers.Invoice;
+import example.models.triggers.InvoiceCompletionHook;
+import example.models.triggers.services.BillingService;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.server.ResourceConfig;
+
+import jakarta.inject.Inject;
+
+import java.util.Arrays;
+import java.util.Calendar;
+
+/**
+ * IdObfuscationTestApplicationResourceConfig.
+ */
+public class IdObfuscationTestApplicationResourceConfig extends ResourceConfig {
+    public static final InMemoryLogger LOGGER = new InMemoryLogger();
+
+    @Inject
+    public IdObfuscationTestApplicationResourceConfig(ServiceLocator injector) {
+        // Bind to injector
+        register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                AesBytesEncryptor bytesEncryptor = new AesBytesEncryptor("yourPassword", "5c0744940b5c369b");
+                IdObfuscator idObfuscator = new FunctionIdObfuscator(bytesEncryptor::encrypt, bytesEncryptor::decrypt);
+
+                EntityDictionary dictionary = EntityDictionary.builder()
+                        .injector(injector::inject)
+                        .checks(TestCheckMappings.MAPPINGS)
+                        .idObfuscator(idObfuscator)
+                        .build();
+
+                bind(dictionary).to(EntityDictionary.class);
+
+                DefaultFilterDialect defaultFilterStrategy = new DefaultFilterDialect(dictionary);
+                RSQLFilterDialect rsqlFilterStrategy = RSQLFilterDialect.builder().dictionary(dictionary).build();
+
+                MultipleFilterDialect multipleFilterStrategy = new MultipleFilterDialect(
+                        Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy),
+                        Arrays.asList(rsqlFilterStrategy, defaultFilterStrategy)
+                );
+                JsonApiSettings.JsonApiSettingsBuilder jsonApiSettings = JsonApiSettings.builder()
+                        .joinFilterDialect(multipleFilterStrategy)
+                        .subqueryFilterDialect(multipleFilterStrategy);
+
+                Elide elide = new Elide(ElideSettings.builder().dataStore(IntegrationTest.getDataStore())
+                        .auditLogger(LOGGER)
+                        .entityDictionary(dictionary)
+                        .serdes(serdes -> serdes.withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", Calendar.getInstance().getTimeZone()))
+                        .settings(jsonApiSettings)
+                        .build());
+                elide.doScans();
+                bind(elide).to(Elide.class).named("elide");
+
+                BillingService billingService = new BillingService() {
+                    @Override
+                    public long purchase(Invoice invoice) {
+                        return 100;
+                    }
+                };
+
+                bind(billingService).to(BillingService.class);
+
+                InvoiceCompletionHook invoiceCompletionHook = new InvoiceCompletionHook(billingService);
+                dictionary.bindTrigger(Invoice.class, "complete", CREATE, PRECOMMIT, invoiceCompletionHook);
+                dictionary.bindTrigger(Invoice.class, "complete", UPDATE, PRECOMMIT, invoiceCompletionHook);
+            }
+        });
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/IdObfuscationIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/IdObfuscationIT.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+
+package com.yahoo.elide.tests;
+
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attr;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attributes;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.data;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.datum;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.yahoo.elide.core.exceptions.HttpStatus;
+import com.yahoo.elide.initialization.IdObfuscationTestApplicationResourceConfig;
+import com.yahoo.elide.initialization.IntegrationTest;
+import com.yahoo.elide.jsonapi.JsonApi;
+import com.yahoo.elide.jsonapi.resources.JsonApiEndpoint;
+import com.yahoo.elide.test.jsonapi.elements.Resource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Tests for IdObfuscator.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class IdObfuscationIT extends IntegrationTest {
+
+    public IdObfuscationIT() {
+        super(IdObfuscationTestApplicationResourceConfig.class, JsonApiEndpoint.class.getPackage().getName());
+    }
+
+    @Test
+    void testIdObfuscation() {
+        // Create
+        String dataId = given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(
+                        datum(
+                                resource(
+                                        type("customerInvoice"),
+                                        attributes(
+                                                attr("complete", true),
+                                                attr("total", 1000)
+                                        )
+                                )
+                        )
+                )
+                .post("/customerInvoice")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body("data.attributes.total", equalTo(1100))
+                .body("data.attributes.complete", equalTo(true))
+                .extract()
+                .path("data.id");
+        assertTrue(dataId.length() > 10);
+        // Get
+        Resource resource = resource(
+                type("customerInvoice"),
+                id(dataId),
+                attributes(
+                        attr("complete", true),
+                        attr("total", 1100)
+                )
+        );
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .get("/customerInvoice/" + dataId)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(datum(resource).toJSON()));
+
+        // Patch
+        Resource modified = resource(
+                type("customerInvoice"),
+                id(dataId),
+                attributes(
+                        attr("complete", true),
+                        attr("total", 123456)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(modified))
+                .patch("/customerInvoice/" + dataId)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+
+        // Get again
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .get("/customerInvoice/" + dataId)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(datum(modified).toJSON()));
+
+        // Get list
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .get("/customerInvoice")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(data(modified).toJSON()));
+
+        // Delete
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .delete("/customerInvoice/" + dataId)
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+}

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/ResourceIT.java
@@ -2550,6 +2550,251 @@ public class ResourceIT extends IntegrationTest {
     }
 
     @Test
+    public void entityIdString() {
+
+        Resource resource = resource(
+                type("entityIdString"),
+                id("brelol876t98erdom98tc8rt"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(resource))
+                .post("/entityIdString")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(equalTo(datum(resource).toJSON()));
+
+        //Fetch newly created user
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .get("/entityIdString/brelol876t98erdom98tc8rt")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(datum(resource).toJSON()));
+
+        Resource modified = resource(
+                type("entityIdString"),
+                id("na0r0v9t197fku68r7fdku46"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(modified))
+                .patch("/entityIdString/brelol876t98erdom98tc8rt")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        //Delete
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .delete("/entityIdString/brelol876t98erdom98tc8rt")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void entityIdStringSort() {
+
+        Resource resource1 = resource(
+                type("entityIdString"),
+                id("na0r0v9t197fku68r7fdku46"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(resource1))
+                .post("/entityIdString")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(equalTo(datum(resource1).toJSON()));
+
+        Resource resource2 = resource(
+                type("entityIdString"),
+                id("brelol876t98erdom98tc8rt"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(resource2))
+                .post("/entityIdString")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(equalTo(datum(resource2).toJSON()));
+
+        given()
+                 .contentType(JsonApi.MEDIA_TYPE)
+                 .accept(JsonApi.MEDIA_TYPE)
+                 .get("/entityIdString?sort=id")
+                 .then()
+                 .statusCode(HttpStatus.SC_OK)
+                 .body(equalTo(data(resource2, resource1).toJSON()));
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .get("/entityIdString?sort=-id")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(data(resource1, resource2).toJSON()));
+
+        //Delete
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .delete("/entityIdString/na0r0v9t197fku68r7fdku46")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .delete("/entityIdString/brelol876t98erdom98tc8rt")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+
+    @Test
+    public void entityIdUuid() {
+
+        Resource resource = resource(
+                type("entityIdUuid"),
+                id("c25f34cb-d110-4373-87f4-604fe65c38ff"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(resource))
+                .post("/entityIdUuid")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(equalTo(datum(resource).toJSON()));
+
+        //Fetch newly created user
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .get("/entityIdUuid/c25f34cb-d110-4373-87f4-604fe65c38ff")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(equalTo(datum(resource).toJSON()));
+
+        Resource modified = resource(
+                type("entityIdUuid"),
+                id("14efb42c-e0c8-4aad-ab6a-ad081a96a7c9"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(modified))
+                .patch("/entityIdUuid/c25f34cb-d110-4373-87f4-604fe65c38ff")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+
+        //Delete
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .delete("/entityIdUuid/c25f34cb-d110-4373-87f4-604fe65c38ff")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void entityIdUuidSort() {
+
+        Resource resource1 = resource(
+                type("entityIdUuid"),
+                id("0190ec9b-799b-79ac-97c1-1075eb1ab9d7"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(resource1))
+                .post("/entityIdUuid")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(equalTo(datum(resource1).toJSON()));
+
+        Resource resource2 = resource(
+                type("entityIdUuid"),
+                id("0190ec9b-4a2c-7b41-9987-10b90b58391d"),
+                attributes(
+                        attr("value", 22)
+                )
+        );
+
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .body(datum(resource2))
+                .post("/entityIdUuid")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(equalTo(datum(resource2).toJSON()));
+
+        given()
+                 .contentType(JsonApi.MEDIA_TYPE)
+                 .accept(JsonApi.MEDIA_TYPE)
+                 .get("/entityIdUuid?sort=id")
+                 .then()
+                 .statusCode(HttpStatus.SC_OK)
+                 .body(equalTo(data(resource2, resource1).toJSON()));
+
+        given()
+                 .contentType(JsonApi.MEDIA_TYPE)
+                 .accept(JsonApi.MEDIA_TYPE)
+                 .get("/entityIdUuid?sort=-id")
+                 .then()
+                 .statusCode(HttpStatus.SC_OK)
+                 .body(equalTo(data(resource1, resource2).toJSON()));
+
+        //Delete
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .delete("/entityIdUuid/0190ec9b-799b-79ac-97c1-1075eb1ab9d7")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+        given()
+                .contentType(JsonApi.MEDIA_TYPE)
+                .accept(JsonApi.MEDIA_TYPE)
+                .delete("/entityIdUuid/0190ec9b-4a2c-7b41-9987-10b90b58391d")
+                .then()
+                .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
     public void assignedIdWithoutProvidedId() {
         Resource resource = resource(
                 type("assignedIdString"),

--- a/elide-integration-tests/src/test/java/example/EntityIdString.java
+++ b/elide-integration-tests/src/test/java/example/EntityIdString.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.EntityId;
+import com.yahoo.elide.annotation.Include;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entity ID test.
+ */
+@Entity
+@Table(name = "entity_id_string")
+@Include
+public class EntityIdString {
+    private long id;
+    private String entityId;
+    private int value;
+
+    @Id
+    @GeneratedValue
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @EntityId
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof EntityIdString && ((EntityIdString) obj).id == id;
+    }
+}

--- a/elide-integration-tests/src/test/java/example/EntityIdUuid.java
+++ b/elide-integration-tests/src/test/java/example/EntityIdUuid.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example;
+
+import com.yahoo.elide.annotation.EntityId;
+import com.yahoo.elide.annotation.Include;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.UUID;
+
+/**
+ * Entity ID test.
+ */
+@Entity
+@Table(name = "entity_id_uuid")
+@Include
+public class EntityIdUuid {
+    private long id;
+    private UUID entityId;
+    private int value;
+
+    @Id
+    @GeneratedValue
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    @EntityId
+    public UUID getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(UUID entityId) {
+        this.entityId = entityId;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof EntityIdUuid && ((EntityIdUuid) obj).id == id;
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAutoConfiguration.java
@@ -51,6 +51,7 @@ import com.yahoo.elide.core.request.route.PathRouteResolver;
 import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.prefab.Role;
+import com.yahoo.elide.core.security.obfuscation.IdObfuscator;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.ClassScanner;
@@ -262,6 +263,7 @@ public class ElideAutoConfiguration {
      * @param scanner the class scanner
      * @param settings Elide configuration settings.
      * @param entitiesToExclude set of Entities to exclude from binding.
+     * @param optionalIdObfuscator optional id obfuscator
      * @param customizerProvider the customizers
      * @return the EntityDictionaryBuilder
      */
@@ -271,6 +273,7 @@ public class ElideAutoConfiguration {
     public EntityDictionaryBuilder entityDictionaryBuilder(Injector injector, ClassScanner scanner,
             ElideConfigProperties settings,
             @Qualifier("entitiesToExclude") Set<Type<?>> entitiesToExclude,
+            Optional<IdObfuscator> optionalIdObfuscator,
             ObjectProvider<EntityDictionaryBuilderCustomizer> customizerProvider) {
         EntityDictionaryBuilder builder = EntityDictionary.builder();
 
@@ -284,6 +287,8 @@ public class ElideAutoConfiguration {
 
         builder.checks(checks).injector(injector).serdeLookup(CoerceUtil::lookup)
                 .entitiesToExclude(entitiesToExclude).scanner(scanner);
+
+        optionalIdObfuscator.ifPresent(builder::idObfuscator);
 
         customizerProvider.orderedStream().forEach(customizer -> customizer.customize(builder));
         return builder;

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/security/obfuscation/BytesEncryptorIdObfuscator.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/security/obfuscation/BytesEncryptorIdObfuscator.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.security.obfuscation;
+
+import com.yahoo.elide.core.security.obfuscation.FunctionIdObfuscator;
+
+import org.springframework.security.crypto.encrypt.BytesEncryptor;
+
+/**
+ * {@link com.yahoo.elide.core.security.obfuscation.IdObfuscator} that uses a
+ * {@link BytesEncryptor}.
+ */
+public class BytesEncryptorIdObfuscator extends FunctionIdObfuscator {
+    public BytesEncryptorIdObfuscator(BytesEncryptor bytesEncryptor) {
+        super(bytesEncryptor::encrypt, bytesEncryptor::decrypt);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/security/obfuscation/BytesEncryptorIdObfuscatorTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/security/obfuscation/BytesEncryptorIdObfuscatorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.spring.security.obfuscation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.yahoo.elide.core.security.obfuscation.IdObfuscator;
+import com.yahoo.elide.core.type.ClassType;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
+
+/**
+ * BytesEncryptorIdObfuscatorTest.
+ */
+class BytesEncryptorIdObfuscatorTest {
+
+    @Test
+    void deobfuscate() {
+        AesBytesEncryptor bytesEncryptor = new AesBytesEncryptor("yourPassword", "5c0744940b5c369b");
+        IdObfuscator idObfuscator = new BytesEncryptorIdObfuscator(bytesEncryptor);
+        Long value = 12345L;
+        String obfuscated = idObfuscator.obfuscate(value);
+        Long deobfuscated = idObfuscator.deobfuscate(obfuscated, ClassType.LONG_TYPE);
+        assertEquals(value, deobfuscated);
+    }
+
+    /**
+     * This tests that the identifier is stable. In this configuration the
+     * AesBytesEncryptor encrypts in CBC mode with an IV of all zeroes.
+     */
+    @Test
+    void stableIdentifier() {
+        AesBytesEncryptor bytesEncryptor = new AesBytesEncryptor("yourPassword", "5c0744940b5c369b");
+        IdObfuscator idObfuscator = new BytesEncryptorIdObfuscator(bytesEncryptor);
+        Long value = 12345L;
+        String obfuscated = idObfuscator.obfuscate(value);
+        String obfuscated2 = idObfuscator.obfuscate(value);
+        assertEquals(obfuscated2, obfuscated);
+    }
+}

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreIntegrationTestSetup.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/tests/ConfigStoreIntegrationTestSetup.java
@@ -59,7 +59,8 @@ public class ConfigStoreIntegrationTestSetup {
                 },
                 CoerceUtil::lookup, //Serde Lookup
                 entitiesToExclude,
-                scanner);
+                scanner,
+                null);
 
         return dictionary;
     }

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideResourceConfig.java
@@ -99,7 +99,7 @@ public class ElideResourceConfig extends ResourceConfig {
 
 
             EntityDictionary dictionary = settings.getEntityDictionary(injector, classScanner, dynamicConfiguration,
-                    settings.getEntitiesToExclude());
+                    settings.getEntitiesToExclude(), settings.getIdObfuscator());
 
             DataStore dataStore;
             Injector inject = new Injector() {

--- a/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
+++ b/elide-standalone/src/main/java/com/yahoo/elide/standalone/config/ElideStandaloneSettings.java
@@ -28,6 +28,7 @@ import com.yahoo.elide.core.request.Pagination;
 import com.yahoo.elide.core.request.route.RouteResolver;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.prefab.Role;
+import com.yahoo.elide.core.security.obfuscation.IdObfuscator;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.ClassScanner;
@@ -648,10 +649,12 @@ public interface ElideStandaloneSettings {
      * @param injector Service locator for web service for dependency injection.
      * @param dynamicConfiguration optional dynamic config object.
      * @param entitiesToExclude set of Entities to exclude from binding.
+     * @param idObfuscator the id obfuscator
      * @return EntityDictionary object initialized.
      */
     default EntityDictionary getEntityDictionary(ServiceLocator injector, ClassScanner scanner,
-            Optional<DynamicConfiguration> dynamicConfiguration, Set<Type<?>> entitiesToExclude) {
+            Optional<DynamicConfiguration> dynamicConfiguration, Set<Type<?>> entitiesToExclude,
+            IdObfuscator idObfuscator) {
 
         Map<String, Class<? extends Check>> checks = new HashMap<>();
 
@@ -678,7 +681,8 @@ public interface ElideStandaloneSettings {
                 },
                 CoerceUtil::lookup, //Serde Lookup
                 entitiesToExclude,
-                scanner);
+                scanner,
+                idObfuscator);
 
         dynamicConfiguration.map(DynamicConfiguration::getRoles).orElseGet(Collections::emptySet).forEach(role ->
             dictionary.addRoleCheck(role, new Role.RoleMemberCheck(role))
@@ -865,5 +869,14 @@ public interface ElideStandaloneSettings {
      */
     default int getDefaultPageSize() {
         return Pagination.DEFAULT_PAGE_SIZE;
+    }
+
+    /**
+     * The id obfuscator to use to obfuscate ids.
+     *
+     * @return the id obfuscator
+     */
+    default IdObfuscator getIdObfuscator() {
+        return null;
     }
 }

--- a/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
+++ b/elide-standalone/src/test/java/example/ElideStandaloneConfigStoreTest.java
@@ -29,6 +29,7 @@ import com.yahoo.elide.core.dictionary.Injector;
 import com.yahoo.elide.core.exceptions.HttpStatus;
 import com.yahoo.elide.core.security.checks.Check;
 import com.yahoo.elide.core.security.checks.prefab.Role;
+import com.yahoo.elide.core.security.obfuscation.IdObfuscator;
 import com.yahoo.elide.core.type.Type;
 import com.yahoo.elide.core.utils.ClassScanner;
 import com.yahoo.elide.core.utils.coerce.CoerceUtil;
@@ -76,7 +77,8 @@ public class ElideStandaloneConfigStoreTest {
 
             @Override
             public EntityDictionary getEntityDictionary(ServiceLocator injector, ClassScanner scanner,
-                                                        Optional<DynamicConfiguration> dynamicConfiguration, Set<Type<?>> entitiesToExclude) {
+                    Optional<DynamicConfiguration> dynamicConfiguration, Set<Type<?>> entitiesToExclude,
+                    IdObfuscator idObfuscator) {
 
                 Map<String, Class<? extends Check>> checks = new HashMap<>();
 
@@ -103,7 +105,8 @@ public class ElideStandaloneConfigStoreTest {
                         },
                         CoerceUtil::lookup, //Serde Lookup
                         entitiesToExclude,
-                        scanner);
+                        scanner,
+                        idObfuscator);
 
                 dynamicConfiguration.map(DynamicConfiguration::getRoles).orElseGet(Collections::emptySet).forEach(role ->
                         dictionary.addRoleCheck(role, new Role.RoleMemberCheck(role))


### PR DESCRIPTION
Resolves #522

## Description
This adds support for 2 different ways of not exposing the primary key of the entity if the primary key undesirably leaks information.
* Allows registering a `IdObfuscator` that can obfuscate the id. Typically an encryption algorithm is used.
* Allows designating another field or property as the `@EntityId` that will be used to look up the record instead of the `@Id`.

Two alternate means are provided to let users choose which best suits their needs. 

The `IdObfuscator` means that no additional column is required but some computation is required to always required to convert the ids. These ids will not be visible on the database level. Also sorting will typically take place on the underlying primary key and not the obfuscated value. If encryption is used for the obfuscation the user will need to safeguard those keys appropriately, also any changes to those keys or algorithm may mean that the ids will also correspondingly change.

Using the `@EntityId` allows the entity to have a totally separate column to identify the record that is not linked to the primary key in any way. A user could for instance choose Cuid2 as the entity id for its records. Sorting on id will sort on the entity id as this is a real column.

## Motivation and Context
The primary key may undesirably leak information, however at the same time using a random value as the primary key may affect performance.

## How Has This Been Tested?
Added the appropriate unit and integration tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.