### PR TITLE
Add support for cursor pagination

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/annotation/Paginate.java
+++ b/elide-core/src/main/java/com/yahoo/elide/annotation/Paginate.java
@@ -37,4 +37,10 @@ public @interface Paginate {
      * @return the maximum limit
      */
     int maxPageSize() default 10000;
+
+    /**
+     * The pagination modes supported such as offset pagination or cursor pagination.
+     * @return the pagination modes supported
+     */
+    PaginationMode[] modes() default { PaginationMode.OFFSET };
 }

--- a/elide-core/src/main/java/com/yahoo/elide/annotation/PaginationMode.java
+++ b/elide-core/src/main/java/com/yahoo/elide/annotation/PaginationMode.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.annotation;
+
+/**
+ * Pagination Mode.
+ */
+public enum PaginationMode {
+    /**
+     * Offset Pagination.
+     */
+    OFFSET,
+    /**
+     * Cursor Pagination.
+     */
+    CURSOR
+}

--- a/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/pagination/PaginationImpl.java
@@ -21,6 +21,7 @@ import lombok.ToString;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 /**
@@ -32,7 +33,9 @@ public class PaginationImpl implements Pagination {
     /**
      * Denotes the internal field names for paging.
      */
-    public enum PaginationKey { offset, number, size, limit, totals }
+    public enum PaginationKey {
+        offset, number, size, limit, totals, first, after, last, before
+    }
 
     // For specifying which page of records is to be returned in the response
     public static final String PAGE_NUMBER_KEY = "page[number]";
@@ -49,16 +52,32 @@ public class PaginationImpl implements Pagination {
     // For requesting total pages/records be included in the response page meta data
     public static final String PAGE_TOTALS_KEY = "page[totals]";
 
+    // For cursor pagination with direction forward
+    public static final String PAGE_FIRST_KEY = "page[first]";
+
+    // For cursor pagination with direction forward
+    public static final String PAGE_AFTER_KEY = "page[after]";
+
+    // For cursor pagination with direction backward
+    public static final String PAGE_LAST_KEY = "page[last]";
+
+    // For cursor pagination with direction backward
+    public static final String PAGE_BEFORE_KEY = "page[before]";
+
     public static final Map<String, PaginationKey> PAGE_KEYS = ImmutableMap.of(
             PAGE_NUMBER_KEY, PaginationKey.number,
             PAGE_SIZE_KEY, PaginationKey.size,
             PAGE_OFFSET_KEY, PaginationKey.offset,
             PAGE_LIMIT_KEY, PaginationKey.limit,
-            PAGE_TOTALS_KEY, PaginationKey.totals);
+            PAGE_TOTALS_KEY, PaginationKey.totals,
+            PAGE_FIRST_KEY, PaginationKey.first,
+            PAGE_AFTER_KEY, PaginationKey.after,
+            PAGE_LAST_KEY, PaginationKey.last,
+            PAGE_BEFORE_KEY, PaginationKey.before);
 
     @Getter
     @Setter
-    private Long pageTotals = 0L;
+    private Long pageTotals = null; // By default this is null and must be explicitly set
 
     private static final String PAGE_KEYS_CSV = PAGE_KEYS.keySet().stream().collect(Collectors.joining(", "));
 
@@ -67,6 +86,31 @@ public class PaginationImpl implements Pagination {
 
     @Getter
     private final int limit;
+
+    @Getter
+    private final String before;
+
+    @Getter
+    private final String after;
+
+    @Getter
+    private final Direction direction;
+
+    @Getter
+    @Setter
+    private String startCursor;
+
+    @Getter
+    @Setter
+    private String endCursor;
+
+    @Getter
+    @Setter
+    private Boolean hasPreviousPage;
+
+    @Getter
+    @Setter
+    private Boolean hasNextPage;
 
     private final boolean generateTotals;
 
@@ -94,7 +138,7 @@ public class PaginationImpl implements Pagination {
                           Boolean generateTotals,
                           Boolean pageByPages) {
         this(ClassType.of(entityClass), clientOffset, clientLimit,
-                systemDefaultLimit, systemMaxLimit, generateTotals, pageByPages);
+                systemDefaultLimit, systemMaxLimit, generateTotals, pageByPages, null, null, null);
     }
 
     /**
@@ -114,9 +158,63 @@ public class PaginationImpl implements Pagination {
                            int systemMaxLimit,
                            Boolean generateTotals,
                            Boolean pageByPages) {
+        this(entityClass, clientOffset, clientLimit,
+                systemDefaultLimit, systemMaxLimit, generateTotals, pageByPages, null, null, null);
+    }
 
+    /**
+     * Constructor.
+     * @param entityClass The type of collection we are paginating.
+     * @param clientOffset The client requested offset or null if not provided.
+     * @param clientLimit The client requested limit or null if not provided.
+     * @param systemDefaultLimit The system default limit (in terms of records).
+     * @param systemMaxLimit The system max limit (in terms of records).
+     * @param generateTotals Whether to return the total number of records.
+     * @param pageByPages Whether to page by pages or records.
+     * @param before The cursor for cursor pagination.
+     * @param after The cursor for cursor pagination.
+     * @param direction The direction for cursor pagination.
+     */
+    public PaginationImpl(Class<?> entityClass,
+                          Integer clientOffset,
+                          Integer clientLimit,
+                          int systemDefaultLimit,
+                          int systemMaxLimit,
+                          Boolean generateTotals,
+                          Boolean pageByPages,
+                          String before,
+                          String after,
+                          Direction direction) {
+        this(ClassType.of(entityClass), clientOffset, clientLimit,
+                systemDefaultLimit, systemMaxLimit, generateTotals, pageByPages, before, after, direction);
+    }
+
+    /**
+     * Constructor.
+     * @param entityClass The type of collection we are paginating.
+     * @param clientOffset The client requested offset or null if not provided.
+     * @param clientLimit The client requested limit or null if not provided.
+     * @param systemDefaultLimit The system default limit (in terms of records).
+     * @param systemMaxLimit The system max limit (in terms of records).
+     * @param generateTotals Whether to return the total number of records.
+     * @param pageByPages Whether to page by pages or records.
+     * @param before The cursor for cursor pagination.
+     * @param after The cursor for cursor pagination.
+     * @param direction The direction for cursor pagination.
+     */
+    public PaginationImpl(Type<?> entityClass,
+                           Integer clientOffset,
+                           Integer clientLimit,
+                           int systemDefaultLimit,
+                           int systemMaxLimit,
+                           Boolean generateTotals,
+                           Boolean pageByPages,
+                           String before,
+                           String after,
+                           Direction direction) {
         this.entityClass = entityClass;
-        this.defaultInstance = (clientOffset == null && clientLimit == null && generateTotals == null);
+        this.defaultInstance = (clientOffset == null && clientLimit == null && generateTotals == null
+                && before == null && after == null);
 
         Paginate paginate = entityClass != null ? (Paginate) entityClass.getAnnotation(Paginate.class) : null;
 
@@ -138,6 +236,10 @@ public class PaginationImpl implements Pagination {
         }
 
         this.generateTotals = generateTotals != null && generateTotals && (paginate == null || paginate.countable());
+
+        this.direction = direction;
+        this.before = before;
+        this.after = after;
 
         if (pageByPages) {
             int pageNumber = clientOffset != null ? clientOffset : 1;
@@ -182,30 +284,44 @@ public class PaginationImpl implements Pagination {
         }
 
         final Map<PaginationKey, Integer> pageData = new HashMap<>();
-        queryParams.entrySet()
-                .forEach(paramEntry -> {
-                    final String queryParamKey = paramEntry.getKey();
-                    if (PAGE_KEYS.containsKey(queryParamKey)) {
-                        PaginationKey paginationKey = PAGE_KEYS.get(queryParamKey);
-                        if (paginationKey.equals(PaginationKey.totals)) {
-                            // page[totals] is a valueless parameter, use value of 0 just so that its presence can
-                            // be recorded in the map
-                            pageData.put(paginationKey, 0);
-                        } else {
-                            final String value = paramEntry.getValue().get(0);
-                            try {
-                                int intValue = Integer.parseInt(value, 10);
-                                pageData.put(paginationKey, intValue);
-                            } catch (NumberFormatException e) {
-                                throw new InvalidValueException("page values must be integers");
-                            }
-                        }
-                    } else if (queryParamKey.startsWith("page[")) {
-                        throw new InvalidValueException("Invalid Pagination Parameter. Accepted values are "
-                                + PAGE_KEYS_CSV);
+        String before = null;
+        String after = null;
+        Direction direction = null;
+
+        for (Entry<String, List<String>> paramEntry : queryParams.entrySet()) {
+            final String queryParamKey = paramEntry.getKey();
+            if (PAGE_KEYS.containsKey(queryParamKey)) {
+                PaginationKey paginationKey = PAGE_KEYS.get(queryParamKey);
+                if (paginationKey.equals(PaginationKey.totals)) {
+                    // page[totals] is a valueless parameter, use value of 0 just so that its presence can
+                    // be recorded in the map
+                    pageData.put(paginationKey, 0);
+                } else if (paginationKey.equals(PaginationKey.before)) {
+                    final String value = paramEntry.getValue().get(0);
+                    before = value;
+                    direction = Direction.BACKWARD;
+                } else if (paginationKey.equals(PaginationKey.after)) {
+                    final String value = paramEntry.getValue().get(0);
+                    after = value;
+                    direction = Direction.FORWARD;
+                } else {
+                    final String value = paramEntry.getValue().get(0);
+                    try {
+                        int intValue = Integer.parseInt(value, 10);
+                        pageData.put(paginationKey, intValue);
+                    } catch (NumberFormatException e) {
+                        throw new InvalidValueException("page values must be integers");
                     }
-                });
-        return getPagination(entityClass, pageData, elideSettings);
+                }
+            } else if (queryParamKey.startsWith("page[")) {
+                throw new InvalidValueException(
+                        "Invalid Pagination Parameter. Accepted values are " + PAGE_KEYS_CSV);
+            }
+        }
+        if (before != null && after != null) {
+            direction = Direction.BETWEEN;
+        }
+        return getPagination(entityClass, pageData, before, after, direction, elideSettings);
     }
 
 
@@ -214,13 +330,25 @@ public class PaginationImpl implements Pagination {
      *
      * @param entityClass The collection type.
      * @param pageData Map containing pagination information
+     * @param before the cursor
+     * @param after the cursor
+     * @param direction the cursor direction
      * @param elideSettings Settings containing pagination defaults
      * @return Pagination object
      */
     private static PaginationImpl getPagination(Type<?> entityClass, Map<PaginationKey, Integer> pageData,
-                                                ElideSettings elideSettings) {
+            String before, String after, Direction direction, ElideSettings elideSettings) {
         if (hasInvalidCombination(pageData)) {
             throw new InvalidValueException("Invalid usage of pagination parameters.");
+        }
+        if (pageData.containsKey(PaginationKey.first) && pageData.containsKey(PaginationKey.last)) {
+            throw new InvalidValueException("page[first] and page[last] cannot be used together.");
+        }
+        if (pageData.containsKey(PaginationKey.first) && direction != null) {
+            throw new InvalidValueException("page[first] cannot be used together with page[before] or page[after].");
+        }
+        if (pageData.containsKey(PaginationKey.last) && direction != null) {
+            throw new InvalidValueException("page[last] cannot be used together with page[before] or page[after].");
         }
 
         boolean pageByPages = false;
@@ -233,13 +361,25 @@ public class PaginationImpl implements Pagination {
             limit = pageData.getOrDefault(PaginationKey.size, null);
         }
 
+        // Cursor
+        if (pageData.containsKey(PaginationKey.first)) {
+            direction = Direction.FORWARD;
+            limit = pageData.getOrDefault(PaginationKey.first, null);
+        } else if (pageData.containsKey(PaginationKey.last)) {
+            direction = Direction.BACKWARD;
+            limit = pageData.getOrDefault(PaginationKey.last, null);
+        }
+
         return new PaginationImpl(entityClass,
                 offset,
                 limit,
                 elideSettings.getDefaultPageSize(),
                 elideSettings.getMaxPageSize(),
                 pageData.containsKey(PaginationKey.totals) ? true : null,
-                pageByPages);
+                pageByPages,
+                before,
+                after,
+                direction);
     }
 
     private static boolean hasInvalidCombination(Map<PaginationKey, Integer> pageData) {

--- a/elide-core/src/main/java/com/yahoo/elide/core/request/Pagination.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/request/Pagination.java
@@ -61,4 +61,91 @@ public interface Pagination {
      * @return true if pagination wasn't requested.  False otherwise.
      */
     boolean isDefaultInstance();
+
+    /**
+     * The direction for cursor pagination.
+     */
+    enum Direction {
+        FORWARD,
+        BACKWARD,
+        BETWEEN
+    }
+
+    /**
+     * Gets the cursor for cursor pagination.
+     *
+     * @return the cursor
+     */
+    default String getCursor() {
+        String before = getBefore();
+        String after = getAfter();
+        if (before != null && after != null) {
+            throw new IllegalArgumentException("Both before and after cursors exist.");
+        }
+        if (before != null) {
+            return before;
+        }
+        return after;
+    }
+
+    /**
+     * Gets the before cursor for cursor pagination.
+     *
+     * @return the before cursor
+     */
+    String getBefore();
+
+    /**
+     * Gets the after cursor for cursor pagination.
+     *
+     * @return the after cursor
+     */
+    String getAfter();
+
+    /**
+     * Gets the direction for cursor pagination.
+     *
+     * @return the direction for cursor pagination.
+     */
+    Direction getDirection();
+
+    /**
+     * Sets the cursor for the first item for cursor pagination.
+     */
+    void setStartCursor(String cursor);
+
+    /**
+     * Sets the cursor for the last item for cursor pagination.
+     */
+    void setEndCursor(String cursor);
+
+    /**
+     * Gets the cursor for the first item for cursor pagination.
+     */
+    String getStartCursor();
+
+    /**
+     * Gets the cursor for the last item for cursor pagination.
+     */
+    String getEndCursor();
+
+    /**
+     * Sets whether there is a previous page for cursor pagination.
+     */
+    void setHasPreviousPage(Boolean hasPreviousPage);
+
+    /**
+     * Gets whether there is a previous page for cursor pagination.
+     */
+    Boolean getHasPreviousPage();
+
+    /**
+     * Sets whether there is a next page for cursor pagination.
+     */
+    void setHasNextPage(Boolean hasNextPage);
+
+    /**
+     * Gets whether there is a next page for cursor pagination.
+     */
+    Boolean getHasNextPage();
 }

--- a/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/sort/SortingImpl.java
@@ -280,4 +280,13 @@ public class SortingImpl implements Sorting {
     public static Sorting getDefaultEmptyInstance() {
         return DEFAULT_EMPTY_INSTANCE;
     }
+
+    /**
+     * Gets the sort rules.
+     *
+     * @return the sort rules
+     */
+    public Map<String, SortOrder> getSortRules() {
+        return this.sortRules;
+    }
 }

--- a/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
+++ b/elide-core/src/main/java/com/yahoo/elide/jsonapi/parser/state/CollectionTerminalState.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 import reactor.core.publisher.Flux;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +91,7 @@ public class CollectionTerminalState extends BaseState {
         // Add pagination meta data
         if (!pagination.isDefaultInstance()) {
 
-            Map<String, Number> pageMetaData = new HashMap<>();
+            Map<String, Object> pageMetaData = new LinkedHashMap<>();
             pageMetaData.put("number", (pagination.getOffset() / pagination.getLimit()) + 1);
             pageMetaData.put("limit", pagination.getLimit());
 
@@ -102,8 +102,26 @@ public class CollectionTerminalState extends BaseState {
                         + ((totalRecords % pagination.getLimit()) > 0 ? 1 : 0));
                 pageMetaData.put("totalRecords", totalRecords);
             }
+            String startCursor = pagination.getStartCursor();
+            if (startCursor != null) {
+                pageMetaData.put("startCursor", startCursor);
+                pageMetaData.remove("number"); // remove page number
+            }
+            String endCursor = pagination.getEndCursor();
+            if (endCursor != null) {
+                pageMetaData.put("endCursor", endCursor);
+                pageMetaData.remove("number"); // remove page number
+            }
+            Boolean hasPreviousPage = pagination.getHasPreviousPage();
+            if (hasPreviousPage != null) {
+                pageMetaData.put("hasPreviousPage", hasPreviousPage);
+            }
+            Boolean hasNextPage = pagination.getHasNextPage();
+            if (hasNextPage != null) {
+                pageMetaData.put("hasNextPage", hasNextPage);
+            }
 
-            Map<String, Object> allMetaData = new HashMap<>();
+            Map<String, Object> allMetaData = new LinkedHashMap<>();
             allMetaData.put("page", pageMetaData);
 
             Meta meta = new Meta(allMetaData);

--- a/elide-core/src/test/java/com/yahoo/elide/core/pagination/PaginationImplTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/pagination/PaginationImplTest.java
@@ -7,6 +7,7 @@ package com.yahoo.elide.core.pagination;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,6 +15,7 @@ import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.annotation.Paginate;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
+import com.yahoo.elide.core.request.Pagination.Direction;
 import com.yahoo.elide.core.type.ClassType;
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +81,105 @@ public class PaginationImplTest {
         // offset is direct correlation to start field in query
         assertEquals(2, pageData.getOffset());
         assertEquals(10, pageData.getLimit());
+        assertNull(pageData.getDirection());
+    }
+
+    @Test
+    public void shouldParseQueryParamsFirst() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[first]", "10");
+
+        PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings);
+        assertEquals(10, pageData.getLimit());
+        assertEquals(Direction.FORWARD, pageData.getDirection());
+    }
+
+    @Test
+    public void shouldParseQueryParamsLast() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[last]", "10");
+
+        PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings);
+        assertEquals(10, pageData.getLimit());
+        assertEquals(Direction.BACKWARD, pageData.getDirection());
+    }
+
+    @Test
+    public void shouldParseQueryParamsAfterAndSize() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[after]", "cursor");
+        add(queryParams, "page[size]", "10");
+
+        PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings);
+        assertEquals(10, pageData.getLimit());
+        assertEquals(Direction.FORWARD, pageData.getDirection());
+        assertEquals("cursor", pageData.getCursor());
+    }
+
+    @Test
+    public void shouldParseQueryParamsBeforeAndSize() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[before]", "cursor");
+        add(queryParams, "page[size]", "10");
+
+        PaginationImpl pageData = PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings);
+        assertEquals(10, pageData.getLimit());
+        assertEquals(Direction.BACKWARD, pageData.getDirection());
+        assertEquals("cursor", pageData.getCursor());
+    }
+
+    @Test
+    public void shouldThrowExceptionForFirstAndLast() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[first]", "10");
+        add(queryParams, "page[last]", "10");
+
+        assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings));
+    }
+
+    @Test
+    public void shouldThrowExceptionForFirstAndAfter() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[first]", "10");
+        add(queryParams, "page[after]", "cursor");
+
+        assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings));
+    }
+
+    @Test
+    public void shouldThrowExceptionForFirstAndBefore() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[first]", "10");
+        add(queryParams, "page[before]", "cursor");
+
+        assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings));
+    }
+
+    @Test
+    public void shouldThrowExceptionForLastAndBefore() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[last]", "10");
+        add(queryParams, "page[before]", "cursor");
+
+        assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings));
+    }
+
+    @Test
+    public void shouldThrowExceptionForLastAndAfter() {
+        Map<String, List<String>> queryParams = new LinkedHashMap<>();
+        add(queryParams, "page[last]", "10");
+        add(queryParams, "page[after]", "cursor");
+
+        assertThrows(InvalidValueException.class, () -> PaginationImpl.parseQueryParams(ClassType.of(PaginationImplTest.class),
+                queryParams, elideSettings));
     }
 
     @Test

--- a/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
+++ b/elide-datastore/elide-datastore-aggregation/src/main/java/com/yahoo/elide/datastores/aggregation/query/ImmutablePagination.java
@@ -20,14 +20,34 @@ public class ImmutablePagination implements Pagination {
     private int limit;
     private boolean defaultInstance;
     private boolean returnPageTotals;
+    private String before;
+    private String after;
+    private Direction direction;
+
+    public ImmutablePagination(int offset, int limit, boolean defaultInstance, boolean returnPageTotals, String before,
+            String after,
+            Direction direction) {
+        super();
+        this.offset = offset;
+        this.limit = limit;
+        this.defaultInstance = defaultInstance;
+        this.returnPageTotals = returnPageTotals;
+        this.before = before;
+        this.after = after;
+        this.direction = direction;
+    }
+
+    public ImmutablePagination(int offset, int limit, boolean defaultInstance, boolean returnPageTotals) {
+        this(offset, limit, defaultInstance, returnPageTotals, null, null, null);
+    }
 
     public static ImmutablePagination from(Pagination src) {
         if (src instanceof ImmutablePagination) {
             return (ImmutablePagination) src;
         }
         if (src != null) {
-            return new ImmutablePagination(
-                    src.getOffset(), src.getLimit(), src.isDefaultInstance(), src.returnPageTotals());
+            return new ImmutablePagination(src.getOffset(), src.getLimit(), src.isDefaultInstance(),
+                    src.returnPageTotals(), src.getBefore(), src.getAfter(), src.getDirection());
         }
         return null;
     }
@@ -45,5 +65,45 @@ public class ImmutablePagination implements Pagination {
     @Override
     public void setPageTotals(Long pageTotals) {
         throw new UnsupportedOperationException("ImmutablePagination does not support setPageTotals");
+    }
+
+    @Override
+    public void setStartCursor(String cursor) {
+        throw new UnsupportedOperationException("ImmutablePagination does not support setStartCursor");
+    }
+
+    @Override
+    public void setEndCursor(String cursor) {
+        throw new UnsupportedOperationException("ImmutablePagination does not support setEndCursor");
+    }
+
+    @Override
+    public void setHasPreviousPage(Boolean hasPreviousPage) {
+        throw new UnsupportedOperationException("ImmutablePagination does not support setHasPreviousPage");
+    }
+
+    @Override
+    public void setHasNextPage(Boolean hasNextPage) {
+        throw new UnsupportedOperationException("ImmutablePagination does not support setHasNextPage");
+    }
+
+    @Override
+    public String getStartCursor() {
+        return null;
+    }
+
+    @Override
+    public String getEndCursor() {
+        return null;
+    }
+
+    @Override
+    public Boolean getHasPreviousPage() {
+        return null;
+    }
+
+    @Override
+    public Boolean getHasNextPage() {
+        return null;
     }
 }

--- a/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
+++ b/elide-datastore/elide-datastore-jpa/src/main/java/com/yahoo/elide/datastores/jpa/transaction/AbstractJpaTransaction.java
@@ -12,6 +12,9 @@ import com.yahoo.elide.datastores.jpa.porting.EntityManagerWrapper;
 import com.yahoo.elide.datastores.jpa.transaction.checker.PersistentCollectionChecker;
 import com.yahoo.elide.datastores.jpql.JPQLTransaction;
 import com.yahoo.elide.datastores.jpql.porting.QueryLogger;
+import com.yahoo.elide.datastores.jpql.query.CursorEncoder;
+import com.yahoo.elide.datastores.jpql.query.JacksonCursorEncoder;
+
 import org.apache.commons.collections4.CollectionUtils;
 
 import jakarta.persistence.EntityManager;
@@ -50,14 +53,31 @@ public abstract class AbstractJpaTransaction extends JPQLTransaction implements 
      * @param em The entity manager / session.
      * @param jpaTransactionCancel A function which can cancel a session.
      * @param logger Logs queries.
-     * @param isScrollEnabled Whether or not scrolling is enabled
      * @param delegateToInMemoryStore When fetching a subcollection from another multi-element collection,
      *                                whether or not to do sorting, filtering and pagination in memory - or
      *                                do N+1 queries.
+     * @param isScrollEnabled Whether or not scrolling is enabled
      */
     protected AbstractJpaTransaction(EntityManager em, Consumer<EntityManager> jpaTransactionCancel, QueryLogger logger,
             boolean delegateToInMemoryStore, boolean isScrollEnabled) {
-        super(new EntityManagerWrapper(em, logger), delegateToInMemoryStore, isScrollEnabled);
+        this(em, jpaTransactionCancel, logger, delegateToInMemoryStore, isScrollEnabled, new JacksonCursorEncoder());
+    }
+
+    /**
+     * Creates a new JPA transaction.
+     *
+     * @param em The entity manager / session.
+     * @param jpaTransactionCancel A function which can cancel a session.
+     * @param logger Logs queries.
+     * @param delegateToInMemoryStore When fetching a subcollection from another multi-element collection,
+     *                                whether or not to do sorting, filtering and pagination in memory - or
+     *                                do N+1 queries.
+     * @param isScrollEnabled Whether or not scrolling is enabled
+     * @param cursorEncoder the cursor encoder
+     */
+    protected AbstractJpaTransaction(EntityManager em, Consumer<EntityManager> jpaTransactionCancel, QueryLogger logger,
+            boolean delegateToInMemoryStore, boolean isScrollEnabled, CursorEncoder cursorEncoder) {
+        super(new EntityManagerWrapper(em, logger), delegateToInMemoryStore, isScrollEnabled, cursorEncoder);
         this.em = em;
         this.jpaTransactionCancel = jpaTransactionCancel;
     }

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/JPQLTransaction.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/JPQLTransaction.java
@@ -151,8 +151,12 @@ public abstract class JPQLTransaction implements DataStoreTransaction {
 
         if (pagination != null) {
             // Issue #1429
-            if (pagination.returnPageTotals() && (hasResults || pagination.getLimit() == 0)) {
-                pagination.setPageTotals(getTotalRecords(projection, scope.getDictionary()));
+            if (pagination.returnPageTotals()) {
+                if ((hasResults || pagination.getLimit() == 0)) {
+                    pagination.setPageTotals(getTotalRecords(projection, scope.getDictionary()));
+                } else {
+                    pagination.setPageTotals(0L);
+                }
             }
         }
 

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/CursorEncoder.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/CursorEncoder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jpql.query;
+
+import java.util.Map;
+
+/**
+ * Cursor encoder.
+ */
+public interface CursorEncoder {
+    /**
+     * Encode the cursor.
+     *
+     * @param keys the keys
+     * @return the encoded cursor
+     */
+    String encode(Map<String, String> keys);
+
+    /**
+     * Decode the cursor.
+     *
+     * @param cursor the encoded cursor
+     * @return the keys
+     */
+    Map<String, String> decode(String cursor);
+}

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/JacksonCursorEncoder.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/JacksonCursorEncoder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package com.yahoo.elide.datastores.jpql.query;
+
+import com.yahoo.elide.core.exceptions.InvalidValueException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * {@link CursorEncoder} using Jackson.
+ */
+public class JacksonCursorEncoder implements CursorEncoder {
+    private static class Holder {
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    }
+
+    private final ObjectMapper objectMapper;
+
+    public JacksonCursorEncoder() {
+        this(Holder.OBJECT_MAPPER);
+    }
+
+    public JacksonCursorEncoder(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String encode(Map<String, String> keys) {
+        try {
+            byte[] result = this.objectMapper.writeValueAsBytes(keys);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(result);
+        } catch (JsonProcessingException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public Map<String, String> decode(String cursor) {
+        if (cursor == null) {
+            return Collections.emptyMap();
+        }
+        try {
+            byte[] result = Base64.getUrlDecoder().decode(cursor);
+            TypeReference<LinkedHashMap<String, String>> typeRef = new TypeReference<LinkedHashMap<String, String>>() {
+            };
+            return this.objectMapper.readValue(result, typeRef);
+        } catch (IOException | IllegalArgumentException e) {
+            throw new InvalidValueException("cursor " + cursor);
+        }
+    }
+}

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/RootCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/RootCollectionPageTotalsQueryBuilder.java
@@ -27,8 +27,8 @@ public class RootCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilde
 
     public RootCollectionPageTotalsQueryBuilder(EntityProjection entityProjection,
                                                 EntityDictionary dictionary,
-                                                Session session) {
-        super(entityProjection, dictionary, session);
+                                                Session session, CursorEncoder cursorEncoder) {
+        super(entityProjection, dictionary, session, cursorEncoder);
     }
 
     /**

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/SubCollectionFetchQueryBuilder.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/SubCollectionFetchQueryBuilder.java
@@ -29,8 +29,8 @@ public class SubCollectionFetchQueryBuilder extends AbstractHQLQueryBuilder {
 
     public SubCollectionFetchQueryBuilder(Relationship relationship,
                                           EntityDictionary dictionary,
-                                          Session session) {
-        super(relationship.getRelationship().getProjection(), dictionary, session);
+                                          Session session, CursorEncoder cursorEncoder) {
+        super(relationship.getRelationship().getProjection(), dictionary, session, cursorEncoder);
         this.relationship = relationship;
     }
 

--- a/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/SubCollectionPageTotalsQueryBuilder.java
+++ b/elide-datastore/elide-datastore-jpql/src/main/java/com/yahoo/elide/datastores/jpql/query/SubCollectionPageTotalsQueryBuilder.java
@@ -34,8 +34,9 @@ public class SubCollectionPageTotalsQueryBuilder extends AbstractHQLQueryBuilder
 
     public SubCollectionPageTotalsQueryBuilder(Relationship relationship,
                                                EntityDictionary dictionary,
-                                               Session session) {
-        super(relationship.getRelationship().getProjection(), dictionary, session);
+                                               Session session,
+                                               CursorEncoder cursorEncoder) {
+        super(relationship.getRelationship().getProjection(), dictionary, session, cursorEncoder);
         this.relationship = relationship;
     }
 

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/AbstractHQLQueryBuilderTest.java
@@ -29,6 +29,8 @@ import com.yahoo.elide.core.sort.SortingImpl;
 import com.yahoo.elide.core.type.ClassType;
 import com.yahoo.elide.datastores.jpql.porting.Query;
 import com.yahoo.elide.datastores.jpql.query.AbstractHQLQueryBuilder;
+import com.yahoo.elide.datastores.jpql.query.JacksonCursorEncoder;
+
 import example.Author;
 import example.Book;
 import example.Chapter;
@@ -57,7 +59,7 @@ public class AbstractHQLQueryBuilderTest extends AbstractHQLQueryBuilder {
 
 
     public AbstractHQLQueryBuilderTest() {
-        super(getMockEntityProjection(), EntityDictionary.builder().build(), new TestSessionWrapper());
+        super(getMockEntityProjection(), EntityDictionary.builder().build(), new TestSessionWrapper(), new JacksonCursorEncoder());
         dictionary.bindEntity(Author.class);
         dictionary.bindEntity(Book.class);
         dictionary.bindEntity(Chapter.class);

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/RootCollectionPageTotalsQueryBuilderTest.java
@@ -16,6 +16,8 @@ import com.yahoo.elide.core.filter.predicates.InPredicate;
 import com.yahoo.elide.core.pagination.PaginationImpl;
 import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.Sorting;
+import com.yahoo.elide.datastores.jpql.query.CursorEncoder;
+import com.yahoo.elide.datastores.jpql.query.JacksonCursorEncoder;
 import com.yahoo.elide.datastores.jpql.query.RootCollectionPageTotalsQueryBuilder;
 import example.Author;
 import example.Book;
@@ -31,6 +33,7 @@ import java.util.List;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RootCollectionPageTotalsQueryBuilderTest {
     private EntityDictionary dictionary;
+    private CursorEncoder cursorEncoder = new JacksonCursorEncoder();
 
     private static final String TITLE = "title";
     private static final String BOOKS = "books";
@@ -49,7 +52,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
     public void testRootFetch() {
         EntityProjection entityProjection = EntityProjection.builder().type(Book.class).build();
         RootCollectionPageTotalsQueryBuilder builder = new RootCollectionPageTotalsQueryBuilder(
-                entityProjection, dictionary, new TestSessionWrapper()
+                entityProjection, dictionary, new TestSessionWrapper(), cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -72,7 +75,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
                 .sorting(sorting)
                 .build();
         TestQueryWrapper query = (TestQueryWrapper) new RootCollectionPageTotalsQueryBuilder(
-                entityProjection, dictionary, new TestSessionWrapper()
+                entityProjection, dictionary, new TestSessionWrapper(), cursorEncoder
         )
                 .build();
         String expected = "SELECT COUNT(example_Book) FROM example.Book AS example_Book";
@@ -89,7 +92,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
                 .pagination(pagination)
                 .build();
         TestQueryWrapper query = (TestQueryWrapper) new RootCollectionPageTotalsQueryBuilder(
-                entityProjection, dictionary, new TestSessionWrapper()
+                entityProjection, dictionary, new TestSessionWrapper(), cursorEncoder
         )
                 .build();
         String expected = "SELECT COUNT(example_Book) FROM example.Book AS example_Book";
@@ -126,7 +129,7 @@ public class RootCollectionPageTotalsQueryBuilderTest {
                 .build();
 
         RootCollectionPageTotalsQueryBuilder builder = new RootCollectionPageTotalsQueryBuilder(
-                entityProjection, dictionary, new TestSessionWrapper()
+                entityProjection, dictionary, new TestSessionWrapper(), cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionFetchQueryBuilderTest.java
@@ -21,6 +21,8 @@ import com.yahoo.elide.core.request.Relationship;
 import com.yahoo.elide.core.request.Sorting;
 import com.yahoo.elide.core.sort.SortingImpl;
 import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.datastores.jpql.query.CursorEncoder;
+import com.yahoo.elide.datastores.jpql.query.JacksonCursorEncoder;
 import com.yahoo.elide.datastores.jpql.query.RelationshipImpl;
 import com.yahoo.elide.datastores.jpql.query.SubCollectionFetchQueryBuilder;
 import example.Author;
@@ -41,6 +43,7 @@ import java.util.Map;
 public class SubCollectionFetchQueryBuilderTest {
 
     private EntityDictionary dictionary;
+    private CursorEncoder cursorEncoder = new JacksonCursorEncoder();
 
     private static final String AUTHORS = "authors";
     private static final String TITLE = "title";
@@ -83,7 +86,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -122,7 +126,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -167,7 +172,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -206,7 +212,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -254,7 +261,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -303,7 +311,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -356,7 +365,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         assertThrows(InvalidValueException.class, () -> {
@@ -401,7 +411,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -441,7 +452,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();
@@ -482,7 +494,8 @@ public class SubCollectionFetchQueryBuilderTest {
         SubCollectionFetchQueryBuilder builder = new SubCollectionFetchQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();

--- a/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionPageTotalsQueryBuilderTest.java
+++ b/elide-datastore/elide-datastore-jpql/src/test/java/com/yahoo/elide/datastores/hibernate/hql/SubCollectionPageTotalsQueryBuilderTest.java
@@ -17,6 +17,8 @@ import com.yahoo.elide.core.request.EntityProjection;
 import com.yahoo.elide.core.request.Relationship;
 import com.yahoo.elide.core.request.Sorting;
 import com.yahoo.elide.core.type.ClassType;
+import com.yahoo.elide.datastores.jpql.query.CursorEncoder;
+import com.yahoo.elide.datastores.jpql.query.JacksonCursorEncoder;
 import com.yahoo.elide.datastores.jpql.query.RelationshipImpl;
 import com.yahoo.elide.datastores.jpql.query.SubCollectionPageTotalsQueryBuilder;
 import example.Author;
@@ -34,6 +36,7 @@ import java.util.List;
 public class SubCollectionPageTotalsQueryBuilderTest {
 
     private EntityDictionary dictionary;
+    private CursorEncoder cursorEncoder = new JacksonCursorEncoder();
 
     private static final String BOOKS = "books";
     private static final String PUBLISHER = "publisher";
@@ -64,7 +67,7 @@ public class SubCollectionPageTotalsQueryBuilderTest {
         );
 
         SubCollectionPageTotalsQueryBuilder builder = new SubCollectionPageTotalsQueryBuilder(
-                relationship, dictionary, new TestSessionWrapper()
+                relationship, dictionary, new TestSessionWrapper(), cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder
@@ -108,7 +111,8 @@ public class SubCollectionPageTotalsQueryBuilderTest {
         TestQueryWrapper query = (TestQueryWrapper) new SubCollectionPageTotalsQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         ).build();
 
         String expected =
@@ -146,7 +150,8 @@ public class SubCollectionPageTotalsQueryBuilderTest {
         TestQueryWrapper query = (TestQueryWrapper) new SubCollectionPageTotalsQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         ).build();
 
         String expected =
@@ -194,7 +199,8 @@ public class SubCollectionPageTotalsQueryBuilderTest {
         SubCollectionPageTotalsQueryBuilder builder = new SubCollectionPageTotalsQueryBuilder(
                 relationship,
                 dictionary,
-                new TestSessionWrapper()
+                new TestSessionWrapper(),
+                cursorEncoder
         );
 
         TestQueryWrapper query = (TestQueryWrapper) builder.build();

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/Environment.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/Environment.java
@@ -29,8 +29,10 @@ public class Environment {
     public final Optional<String> sort;
     public final Optional<List<Map<String, Object>>> data;
     public final Optional<String> filters;
-    public final Optional<String> offset;
-    public final Optional<String> first;
+    public final Optional<Object> first;
+    public final Optional<Object> after;
+    public final Optional<Object> last;
+    public final Optional<Object> before;
     public final Object rawSource;
     public final GraphQLContainer container;
 
@@ -48,8 +50,10 @@ public class Environment {
         requestScope = environment.getLocalContext();
 
         filters = Optional.ofNullable((String) args.get(ModelBuilder.ARGUMENT_FILTER));
-        offset = Optional.ofNullable((String) args.get(ModelBuilder.ARGUMENT_AFTER));
-        first = Optional.ofNullable((String) args.get(ModelBuilder.ARGUMENT_FIRST));
+        first = Optional.ofNullable(args.get(ModelBuilder.ARGUMENT_FIRST));
+        after = Optional.ofNullable(args.get(ModelBuilder.ARGUMENT_AFTER));
+        last = Optional.ofNullable(args.get(ModelBuilder.ARGUMENT_FIRST));
+        before = Optional.ofNullable(args.get(ModelBuilder.ARGUMENT_AFTER));
         sort = Optional.ofNullable((String) args.get(ModelBuilder.ARGUMENT_SORT));
 
         parentType = environment.getParentType();

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/GraphQLScalars.java
@@ -88,4 +88,34 @@ public class GraphQLScalars {
                 }
             })
             .build();
+
+    public static GraphQLScalarType GRAPHQL_STRING_OR_INT_TYPE = GraphQLScalarType.newScalar()
+            .name("StringOrInt")
+            .description("The `StringOrInt` scalar type represents a type that can accept either a `String` "
+                    + "textual value or `Int` non-fractional signed whole numeric values.")
+            .coercing(new Coercing<Object, Object>() {
+                @Override
+                public Object serialize(Object o) {
+                    return o;
+                }
+
+                @Override
+                public Object parseValue(Object o) {
+                    return o;
+                }
+
+                @Override
+                public Object parseLiteral(Object o) {
+                    Object input;
+                    if (o instanceof IntValue) {
+                        input = ((IntValue) o).getValue().longValue();
+                    } else if (o instanceof StringValue) {
+                        input = ((StringValue) o).getValue();
+                    } else {
+                        throw new CoercingParseValueException(ERROR_BAD_EPOCH_TYPE);
+                    }
+                    return parseValue(input);
+                }
+            })
+            .build();
 }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/KeyWord.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/KeyWord.java
@@ -20,6 +20,7 @@ public enum KeyWord {
     NODE("node"),
     EDGES("edges"),
     PAGE_INFO("pageInfo"),
+    PAGE_INFO_HAS_PREVIOUS_PAGE("hasPreviousPage"),
     PAGE_INFO_HAS_NEXT_PAGE("hasNextPage"),
     PAGE_INFO_START_CURSOR("startCursor"),
     PAGE_INFO_END_CURSOR("endCursor"),

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/PersistentResourceFetcher.java
@@ -129,8 +129,8 @@ public class PersistentResourceFetcher implements DataFetcher<Object>, QueryLogg
      * @param environment Environment encapsulating graphQL's request environment
      */
     private void filterSortPaginateSanityCheck(Environment environment) {
-        if (environment.filters.isPresent() || environment.sort.isPresent() || environment.offset.isPresent()
-                || environment.first.isPresent()) {
+        if (environment.filters.isPresent() || environment.sort.isPresent() || environment.after.isPresent()
+                || environment.first.isPresent() || environment.before.isPresent() || environment.last.isPresent()) {
             throw new BadRequestException("Pagination/Filtering/Sorting is only supported with FETCH operation");
         }
     }

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/containers/PageInfoContainer.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/containers/PageInfoContainer.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 /**
  * Container for nodes.
  */
-public class PageInfoContainer implements GraphQLContainer {
+public class PageInfoContainer implements GraphQLContainer<Object> {
     @Getter private final ConnectionContainer connectionContainer;
 
     public PageInfoContainer(ConnectionContainer connectionContainer) {
@@ -38,25 +38,54 @@ public class PageInfoContainer implements GraphQLContainer {
                 .sorted()
                 .collect(Collectors.toList());
 
-        return pagination.map(pageValue -> {
-            switch (KeyWord.byName(fieldName)) {
-                case PAGE_INFO_HAS_NEXT_PAGE: {
-                    int numResults = ids.size();
-                    int nextOffset = numResults + pageValue.getOffset();
-                    return nextOffset < pageValue.getPageTotals();
-                }
-                case PAGE_INFO_START_CURSOR:
-                    return pageValue.getOffset();
-                case PAGE_INFO_END_CURSOR:
-                    return pageValue.getOffset() + ids.size();
-                case PAGE_INFO_TOTAL_RECORDS:
-                    return pageValue.getPageTotals();
-                default:
-                    break;
+        Pagination pageValue = pagination.orElseThrow(() -> new BadRequestException(
+                "Could not generate pagination information for type: " + connectionContainer.getTypeName()));
+
+        switch (KeyWord.byName(fieldName)) {
+        case PAGE_INFO_HAS_PREVIOUS_PAGE: {
+            if (pageValue.getHasPreviousPage() != null) {
+                return pageValue.getHasPreviousPage();
             }
-            throw new BadRequestException("Invalid request. Looking for field: "
-                    + fieldName + " in an pageInfo object.");
-        }).orElseThrow(() -> new BadRequestException("Could not generate pagination information for type: "
-                + connectionContainer.getTypeName()));
+            if (pageValue.getDirection() != null) { // cursor
+                return null; // if cannot efficiently determine return null
+            }
+            return pageValue.getOffset() > 0; // offset
+        }
+        case PAGE_INFO_HAS_NEXT_PAGE: {
+            if (pageValue.getHasNextPage() != null) {
+                return pageValue.getHasNextPage();
+            }
+            if (pageValue.getDirection() != null) { // cursor
+                return null; // if cannot efficiently determine return null
+            }
+            int numResults = ids.size();
+            int nextOffset = numResults + pageValue.getOffset();
+            if (pageValue.getPageTotals() == null) {
+                throw new BadRequestException("Cannot determine hasNextPage without totalRecords.");
+            }
+            return nextOffset < pageValue.getPageTotals(); // offset
+        }
+        case PAGE_INFO_START_CURSOR:
+            if (pageValue.getStartCursor() != null) {
+                return pageValue.getStartCursor();
+            }
+            if (pageValue.getDirection() != null) { // cursor
+                return null; // can be null if there are no results
+            }
+            return pageValue.getOffset(); // offset
+        case PAGE_INFO_END_CURSOR:
+            if (pageValue.getEndCursor() != null) {
+                return pageValue.getEndCursor();
+            }
+            if (pageValue.getDirection() != null) { // cursor
+                return null; // can be null if there are no results
+            }
+            return pageValue.getOffset() + ids.size(); // offset
+        case PAGE_INFO_TOTAL_RECORDS:
+            return pageValue.getPageTotals();
+        default:
+            break;
+        }
+        throw new BadRequestException("Invalid request. Looking for field: " + fieldName + " in an pageInfo object.");
     }
 }

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/GraphQLEndpointTest.java
@@ -1089,6 +1089,133 @@ public class GraphQLEndpointTest {
         }
     }
 
+    @Test
+    public void testCursorLast() throws JSONException {
+        String graphQLRequest = document(
+                selections(
+                        field(
+                                "book",
+                                arguments(argument("last", 1)),
+                                selections(
+                                        field("id"),
+                                        field("title"),
+                                        field(
+                                                "authors",
+                                                selection(
+                                                        field("name")
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        String graphQLResponse = document(
+                selection(
+                        field(
+                                "book",
+                                selections(
+                                        field("id", "1"),
+                                        field("title", "My first book"),
+                                        field(
+                                                "authors",
+                                                selection(
+                                                        field("name", "Ricky Carmichael")
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ).toResponse();
+
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        assert200EqualBody(response, graphQLResponse);
+    }
+
+    @Test
+    public void testCursorLastBefore() throws JSONException, IOException {
+        String graphQLRequest = document(
+                selections(
+                        field(
+                                "book",
+                                arguments(argument("last", 1), argument("before", "MQ", true)),
+                                selections(
+                                        field("id"),
+                                        field("title"),
+                                        field(
+                                                "authors",
+                                                selection(
+                                                        field("name")
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        JsonNode responseNode = extract200Response(response);
+        JsonNode resultNode = responseNode.at("/data/book/edges");
+        assertTrue(resultNode.isArray());
+        assertTrue(resultNode.isEmpty());
+    }
+
+    @Test
+    public void testCursorFirstAfter() throws JSONException, IOException {
+        String graphQLRequest = document(
+                selections(
+                        field(
+                                "book",
+                                arguments(argument("first", 1), argument("after", "MQ", true)),
+                                selections(
+                                        field("id"),
+                                        field("title"),
+                                        field(
+                                                "authors",
+                                                selection(
+                                                        field("name")
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        JsonNode responseNode = extract200Response(response);
+        JsonNode resultNode = responseNode.at("/data/book/edges");
+        assertTrue(resultNode.isArray());
+        assertTrue(resultNode.isEmpty());
+    }
+
+    @Test
+    public void testCursorAfterBefore() throws JSONException, IOException {
+        String graphQLRequest = document(
+                selections(
+                        field(
+                                "book",
+                                arguments(argument("after", "MQ", true), argument("before", "MQ", true)),
+                                selections(
+                                        field("id"),
+                                        field("title"),
+                                        field(
+                                                "authors",
+                                                selection(
+                                                        field("name")
+                                                )
+                                        )
+                                )
+                        )
+                )
+        ).toQuery();
+
+        Response response = endpoint.post("", uriInfo, requestHeaders, user1, graphQLRequestToJSON(graphQLRequest));
+        JsonNode responseNode = extract200Response(response);
+        JsonNode resultNode = responseNode.at("/data/book/edges");
+        assertTrue(resultNode.isArray());
+        assertTrue(resultNode.isEmpty());
+    }
+
     private static String graphQLRequestToJSON(String request) {
         return graphQLRequestToJSON(request, new HashMap<>());
     }

--- a/elide-graphql/src/test/java/graphqlEndpointTestModels/Book.java
+++ b/elide-graphql/src/test/java/graphqlEndpointTestModels/Book.java
@@ -16,6 +16,8 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.annotation.Paginate;
+import com.yahoo.elide.annotation.PaginationMode;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
@@ -52,6 +54,7 @@ import java.util.Set;
        operation = 10,
        logStatement = "{0}",
        logExpressions = {"${book.title}"})
+@Paginate(modes = { PaginationMode.OFFSET, PaginationMode.CURSOR })
 public class Book {
     long id;
     String title;

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/IdObfuscationIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/IdObfuscationIT.java
@@ -11,10 +11,22 @@ import static com.yahoo.elide.test.jsonapi.JsonApiDSL.attributes;
 import static com.yahoo.elide.test.jsonapi.JsonApiDSL.data;
 import static com.yahoo.elide.test.jsonapi.JsonApiDSL.datum;
 import static com.yahoo.elide.test.jsonapi.JsonApiDSL.id;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.linkage;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.patchOperation;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.patchSet;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.relation;
+import static com.yahoo.elide.test.jsonapi.JsonApiDSL.relationships;
 import static com.yahoo.elide.test.jsonapi.JsonApiDSL.resource;
 import static com.yahoo.elide.test.jsonapi.JsonApiDSL.type;
+import static com.yahoo.elide.test.jsonapi.elements.PatchOperationType.add;
+import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.eclipse.jetty.http.HttpStatus.OK_200;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.yahoo.elide.core.exceptions.HttpStatus;
@@ -24,6 +36,7 @@ import com.yahoo.elide.jsonapi.JsonApi;
 import com.yahoo.elide.jsonapi.resources.JsonApiEndpoint;
 import com.yahoo.elide.test.jsonapi.elements.Resource;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -35,6 +48,210 @@ public class IdObfuscationIT extends IntegrationTest {
 
     public IdObfuscationIT() {
         super(IdObfuscationTestApplicationResourceConfig.class, JsonApiEndpoint.class.getPackage().getName());
+    }
+
+    @BeforeEach
+    void setup() {
+        createBookEntities();
+    }
+
+    private void createBookEntities() {
+        String tempAuthorId1 = "12345678-1234-1234-1234-1234567890ab";
+        String tempAuthorId2 = "12345679-1234-1234-1234-1234567890ab";
+        String tempAuthorId3 = "12345681-1234-1234-1234-1234567890ab";
+
+        String tempBookId1 = "12345678-1234-1234-1234-1234567890ac";
+        String tempBookId2 = "12345678-1234-1234-1234-1234567890ad";
+        String tempBookId3 = "12345679-1234-1234-1234-1234567890ac";
+        String tempBookId4 = "23451234-1234-1234-1234-1234567890ac";
+        String tempBookId5 = "12345680-1234-1234-1234-1234567890ac";
+        String tempBookId6 = "12345680-1234-1234-1234-1234567890ad";
+        String tempBookId7 = "12345681-1234-1234-1234-1234567890ac";
+        String tempBookId8 = "12345681-1234-1234-1234-1234567890ad";
+
+        String tempPubId = "12345678-1234-1234-1234-1234567890ae";
+
+        given()
+            .contentType(JsonApi.JsonPatch.MEDIA_TYPE)
+            .accept(JsonApi.JsonPatch.MEDIA_TYPE)
+            .body(
+                patchSet(
+                    patchOperation(add, "/author", resource(
+                        type("author"),
+                        id(tempAuthorId1),
+                        attributes(
+                            attr("name", "Ernest Hemingway")
+                        ),
+                        relationships(
+                            relation("books",
+                                linkage(type("book"), id(tempBookId1)),
+                                linkage(type("book"), id(tempBookId2))
+                            )
+                        )
+                    )),
+                    patchOperation(add, "/book/", resource(
+                        type("book"),
+                        id(tempBookId1),
+                        attributes(
+                            attr("title", "The Old Man and the Sea"),
+                            attr("genre", "Literary Fiction"),
+                            attr("language", "English")
+                        ),
+                        relationships(
+                            relation("publisher",
+                                linkage(type("publisher"), id(tempPubId))
+
+                            )
+                        )
+                    )),
+                    patchOperation(add, "/book/", resource(
+                        type("book"),
+                        id(tempBookId2),
+                        attributes(
+                            attr("title", "For Whom the Bell Tolls"),
+                            attr("genre", "Literary Fiction"),
+                            attr("language", "English")
+                        )
+                    )),
+                    patchOperation(add, "/book/" + tempBookId1 + "/publisher", resource(
+                        type("publisher"),
+                        id(tempPubId),
+                        attributes(
+                            attr("name", "Default publisher")
+                        )
+                    ))
+                ).toJSON()
+            )
+            .patch("/")
+            .then()
+            .statusCode(OK_200);
+
+        given()
+            .contentType(JsonApi.JsonPatch.MEDIA_TYPE)
+            .accept(JsonApi.JsonPatch.MEDIA_TYPE)
+            .body(
+                patchSet(
+                    patchOperation(add, "/author", resource(
+                        type("author"),
+                        id(tempAuthorId2),
+                        attributes(
+                            attr("name", "Orson Scott Card")
+                        ),
+                        relationships(
+                            relation("books",
+                                linkage(type("book"), id(tempBookId3)),
+                                linkage(type("book"), id(tempBookId4))
+                            )
+                        )
+                    )),
+                    patchOperation(add, "/book", resource(
+                        type("book"),
+                        id(tempBookId3),
+                        attributes(
+                            attr("title", "Enders Game"),
+                            attr("genre", "Science Fiction"),
+                            attr("language", "English"),
+                            attr("publishDate", 1454638927412L)
+                        )
+                    )),
+                    patchOperation(add, "/book", resource(
+                        type("book"),
+                        id(tempBookId4),
+                        attributes(
+                            attr("title", "Enders Shadow"),
+                            attr("genre", "Science Fiction"),
+                            attr("language", "English"),
+                            attr("publishDate", 1464638927412L)
+                        )
+                    ))
+                )
+            )
+            .patch("/")
+            .then()
+            .statusCode(OK_200);
+
+        given()
+            .contentType(JsonApi.JsonPatch.MEDIA_TYPE)
+            .accept(JsonApi.JsonPatch.MEDIA_TYPE)
+            .body(
+                patchSet(
+                    patchOperation(add, "/author", resource(
+                        type("author"),
+                        id(tempAuthorId3),
+                        attributes(
+                            attr("name", "Isaac Asimov")
+                        ),
+                        relationships(
+                            relation("books",
+                                linkage(type("book"), id(tempBookId5)),
+                                linkage(type("book"), id(tempBookId6))
+                            )
+                        )
+                    )),
+                    patchOperation(add, "/book", resource(
+                        type("book"),
+                        id(tempBookId5),
+                        attributes(
+                            attr("title", "Foundation"),
+                            attr("genre", "Science Fiction"),
+                            attr("language", "English")
+                        )
+                    )),
+                    patchOperation(add, "/book", resource(
+                        type("book"),
+                        id(tempBookId6),
+                        attributes(
+                            attr("title", "The Roman Republic"),
+                            //genre null
+                            attr("language", "English")
+                        )
+                    ))
+                )
+            )
+            .patch("/")
+            .then()
+            .statusCode(OK_200);
+
+        given()
+            .contentType(JsonApi.JsonPatch.MEDIA_TYPE)
+            .accept(JsonApi.JsonPatch.MEDIA_TYPE)
+            .body(
+                patchSet(
+                    patchOperation(add, "/author", resource(
+                        type("author"),
+                        id(tempAuthorId3),
+                        attributes(
+                            attr("name", "Null Ned")
+                        ),
+                        relationships(
+                            relation("books",
+                                linkage(type("book"), id(tempBookId7)),
+                                linkage(type("book"), id(tempBookId8))
+                            )
+                        )
+                    )),
+                    patchOperation(add, "/book", resource(
+                        type("book"),
+                        id(tempBookId7),
+                        attributes(
+                            attr("title", "Life with Null Ned"),
+                            attr("language", "English")
+                        )
+                    )),
+                    patchOperation(add, "/book", resource(
+                        type("book"),
+                        id(tempBookId8),
+                        attributes(
+                            attr("title", "Life with Null Ned 2"),
+                            attr("genre", "Not Null"),
+                            attr("language", "English")
+                        )
+                    ))
+                ).toJSON()
+            )
+            .patch("/")
+            .then()
+            .statusCode(OK_200);
     }
 
     @Test
@@ -122,5 +339,72 @@ public class IdObfuscationIT extends IntegrationTest {
                 .delete("/customerInvoice/" + dataId)
                 .then()
                 .statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    void testPaginationCursorFirst() {
+        String url = "/book?page[first]=2";
+        when()
+            .get(url)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    void testPaginationCursorLast() {
+        String url = "/book?page[last]=2";
+        when()
+            .get(url)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    void testPaginationCursorAfter() {
+        String url = "/book?page[first]=2";
+        String endCursor = get(url).path("meta.page.endCursor");
+        String url2 = "/book?page[size]=2&page[after]=" + endCursor;
+        when()
+            .get(url2)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    void testPaginationCursorBefore() {
+        String url = "/book?page[last]=2";
+        String startCursor = get(url).path("meta.page.startCursor");
+        String url2 = "/book?page[size]=2&page[before]=" + startCursor;
+        when()
+            .get(url2)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    void testPaginationCursorAfterBefore() {
+        String url = "/book?page[last]=3";
+        String startCursor = get(url).path("meta.page.startCursor");
+        String endCursor = get(url).path("meta.page.endCursor");
+        String url2 = "/book?page[size]=2&page[after]=" + startCursor + "&page[before]=" + endCursor;
+        when()
+            .get(url2)
+            .then()
+            .body("data", hasSize(1),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
     }
 }

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
@@ -647,7 +647,6 @@ class PaginateIT extends IntegrationTest {
     }
 
     @Test
-    @Tag("excludeOnJPA")
     void testPaginationCursorFirst() {
         String url = "/book?page[first]=2";
         when()
@@ -660,7 +659,6 @@ class PaginateIT extends IntegrationTest {
     }
 
     @Test
-    @Tag("excludeOnJPA")
     void testPaginationCursorLast() {
         String url = "/book?page[last]=2";
         when()
@@ -673,7 +671,6 @@ class PaginateIT extends IntegrationTest {
     }
 
     @Test
-    @Tag("excludeOnJPA")
     void testPaginationCursorAfter() {
         String url = "/book?page[first]=2";
         String endCursor = get(url).path("meta.page.endCursor");
@@ -688,7 +685,6 @@ class PaginateIT extends IntegrationTest {
     }
 
     @Test
-    @Tag("excludeOnJPA")
     void testPaginationCursorBefore() {
         String url = "/book?page[last]=2";
         String startCursor = get(url).path("meta.page.startCursor");
@@ -703,7 +699,6 @@ class PaginateIT extends IntegrationTest {
     }
 
     @Test
-    @Tag("excludeOnJPA")
     void testPaginationCursorAfterBefore() {
         String url = "/book?page[last]=3";
         String startCursor = get(url).path("meta.page.startCursor");

--- a/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
+++ b/elide-integration-tests/src/test/java/com/yahoo/elide/tests/PaginateIT.java
@@ -25,8 +25,10 @@ import static org.eclipse.jetty.http.HttpStatus.CREATED_201;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -642,5 +644,77 @@ class PaginateIT extends IntegrationTest {
                 .body("data", hasSize(0),
                         "meta.page.totalRecords", equalTo(0)
                 );
+    }
+
+    @Test
+    @Tag("excludeOnJPA")
+    void testPaginationCursorFirst() {
+        String url = "/book?page[first]=2";
+        when()
+            .get(url)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    @Tag("excludeOnJPA")
+    void testPaginationCursorLast() {
+        String url = "/book?page[last]=2";
+        when()
+            .get(url)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    @Tag("excludeOnJPA")
+    void testPaginationCursorAfter() {
+        String url = "/book?page[first]=2";
+        String endCursor = get(url).path("meta.page.endCursor");
+        String url2 = "/book?page[size]=2&page[after]=" + endCursor;
+        when()
+            .get(url2)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    @Tag("excludeOnJPA")
+    void testPaginationCursorBefore() {
+        String url = "/book?page[last]=2";
+        String startCursor = get(url).path("meta.page.startCursor");
+        String url2 = "/book?page[size]=2&page[before]=" + startCursor;
+        when()
+            .get(url2)
+            .then()
+            .body("data", hasSize(2),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
+    }
+
+    @Test
+    @Tag("excludeOnJPA")
+    void testPaginationCursorAfterBefore() {
+        String url = "/book?page[last]=3";
+        String startCursor = get(url).path("meta.page.startCursor");
+        String endCursor = get(url).path("meta.page.endCursor");
+        String url2 = "/book?page[size]=2&page[after]=" + startCursor + "&page[before]=" + endCursor;
+        when()
+            .get(url2)
+            .then()
+            .body("data", hasSize(1),
+                  "meta.page.startCursor", not(emptyString()),
+                  "meta.page.endCursor", not(emptyString())
+            );
     }
 }


### PR DESCRIPTION
Resolves #1374

## Description
This adds support for cursor pagination by adding the appropriate input and return parameters for JSON API and GraphQL.

JSON API
* `page[first]`
* `page[after]`
* `page[last]`
* `page[before]`
* `startCursor`
* `endCursor`

GraphQL
* `last`
* `before`
* `endCursor`

This also modifies the `HashMapDataStore` to support cursors and the `JpaDataStore` to support keyset pagination. The keyset pagination assumes that appropriate indexes are created and that the sortable columns are non nullable.

Cursor pagination is not enabled for the models by default and needs to be enabled by using annotating the model with the `@Paginate` annotation.

```java
@Include
@Entity
@Paginate(modes = { PaginationMode.OFFSET, PaginationMode.CURSOR })
public class Book {
}
```

## Motivation and Context
Currently it is not possible to implement a custom datastore with a cursor pagination strategy as this is not supported by `Pagination`. It is also helpful if the `HashMapDataStore` and `JpaDataStore` supports cursor pagination.

## How Has This Been Tested?
Added the appropriate unit and integration tests. Also tested by modifying the `elide-spring-boot-example`.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.