### PR TITLE
Improve mutation determination

### DIFF
--- a/elide-async/pom.xml
+++ b/elide-async/pom.xml
@@ -54,7 +54,7 @@
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-graphql</artifactId>
             <version>7.1.1-SNAPSHOT</version>
-            <scope>optional</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/parser/GraphQLEntityProjectionMaker.java
@@ -130,7 +130,16 @@ public class GraphQLEntityProjectionMaker {
         } catch (Exception e) {
             throw new InvalidEntityBodyException("Can't parse query: " + query);
         }
+        return make(parsedDocument);
+    }
 
+    /**
+     * Convert a GraphQL document into a collection of Elide {@link EntityProjection}s.
+     *
+     * @param parsedDocument GraphQL parsedDocument
+     * @return all projections in the query
+     */
+    public GraphQLProjectionInfo make(Document parsedDocument) {
         // resolve fragment definitions
         fragmentResolver.addFragments(parsedDocument);
 


### PR DESCRIPTION
## Description
Instead of attempting to guess if the query text is a `mutation` by checking the starting characters of the line parse the `Document` as the `GraphQLEntityProjectionMaker` is going to need it anyway to make the `GraphQLProjectionInfo`. It is then simple to check if the `mutation` operation is present in the `Document`.

## Motivation and Context
This for instance allows handling of cases where a `fragment` exists before the `mutation`.

```graphql
fragment postData on Post {
  id
  title
  text
  author {
    username
    displayName
  }
}
mutation addPost($post: AddPostInput!) {
  addPost(input: [$post]) {
    post {
      ...postData
    }
  }
}
```

## How Has This Been Tested?
Modified the appropriate unit tests.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
