### PR TITLE
Replace `@EntityScan` with `@AutoConfigurationPackage` for async

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/README.md
+++ b/elide-spring/elide-spring-boot-autoconfigure/README.md
@@ -192,7 +192,6 @@ The API information such as the title can be set by the application by annotatin
 
 ```java
 @SpringBootApplication
-@EntityScan
 @OpenAPIDefinition(info = @Info(title = "My Title", description = "My Description"))
 public class App {
     public static void main(String[] args) throws Exception {

--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/config/ElideAsyncConfiguration.java
@@ -41,10 +41,10 @@ import com.yahoo.elide.graphql.QueryRunners;
 import com.yahoo.elide.jsonapi.JsonApi;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -62,7 +62,7 @@ import java.util.concurrent.Executors;
 @Configuration
 @ConditionalOnClass(AsyncSettingsBuilder.class)
 @ConditionalOnProperty(prefix = "elide.async", name = "enabled", matchIfMissing = false)
-@EntityScan(basePackageClasses = AsyncQuery.class)
+@AutoConfigurationPackage(basePackageClasses = AsyncQuery.class)
 @EnableConfigurationProperties(ElideConfigProperties.class)
 public class ElideAsyncConfiguration {
 

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/App.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/example/App.java
@@ -7,7 +7,6 @@ package example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +19,6 @@ import java.util.TimeZone;
  */
 @Slf4j
 @SpringBootApplication
-@EntityScan
 public class App {
     public static void main(String[] args) throws Exception {
         SpringApplication.run(App.class, args);


### PR DESCRIPTION
Resolves #3283 

## Description
This replaces the use of `@EntityScan` with `@AutoConfigurationPackage`

## Motivation and Context
Using `@EntityScan` in a library breaks users that are relying on auto configuration.

Note that this fix will be a breaking change for existing users who specified `@EntityScan` as they now need to explicitly specify `AsyncQuery.class`. The `elide-spring-boot-example` has `@EntityScan` on the `App` which will cause `@AutoConfigurationPackage` to back off. This means they need to ensure that they also explicitly add `AsyncQuery.class` if they are using `@EntityScan` ie `@EntityScan(basePackageClasses = { App.class, AsyncQuery.class })`. I will separately make a PR to remove the `@EntityScan` annotation on `App` in `elide-spring-boot-example` when this gets merged.

The following is some context on why `@EntityScan` shouldn't be used
* https://github.com/spring-projects/spring-boot/issues/19024#issuecomment-808290317

## How Has This Been Tested?
Tested manually using the `elide-spring-boot-example`.

Note that either `@EntityScan` needs to be removed from `App` or `@EntityScan(basePackageClasses = { App.class, AsyncQuery.class })` needs to be specified for it to work.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
