### PR TITLE
Add support for extension property of OpenAPI 3_0 (#3301)

### DIFF
--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/converter/JsonApiModelResolver.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/converter/JsonApiModelResolver.java
@@ -25,6 +25,7 @@ import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema.AccessMode;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import io.swagger.v3.oas.models.media.Schema;
@@ -35,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -223,6 +225,7 @@ public class JsonApiModelResolver extends ModelResolver {
         attribute.setReadOnly(getFieldReadOnly(clazzType, attributeName));
         attribute.setWriteOnly(getFieldWriteOnly(clazzType, attributeName));
         attribute.setRequired(getFieldRequiredProperties(clazzType, attributeName));
+        attribute.setExtensions(getExtensions(clazzType, attributeName));
 
         if (getFieldRequired(clazzType, attributeName)) {
             required.add(attributeName);
@@ -249,6 +252,7 @@ public class JsonApiModelResolver extends ModelResolver {
         relationship.setReadOnly(getFieldReadOnly(clazz, relationshipName));
         relationship.setWriteOnly(getFieldWriteOnly(clazz, relationshipName));
         relationship.setRequired(getFieldRequiredProperties(clazz, relationshipName));
+        relationship.setExtensions(getExtensions(clazz, relationshipName));
 
         if (getFieldRequired(clazz, relationshipName)) {
             required.add(relationshipName);
@@ -315,6 +319,14 @@ public class JsonApiModelResolver extends ModelResolver {
     private String getFieldDescription(Type<?> clazz, String fieldName) {
         io.swagger.v3.oas.annotations.media.Schema property = getSchema(clazz, fieldName);
         return property == null ? "" : property.description();
+    }
+
+    private Map<String, Object> getExtensions(Type<?> clazz, String fieldName) {
+        io.swagger.v3.oas.annotations.media.Schema property = getSchema(clazz, fieldName);
+        return property == null ? Map.of()
+                : Arrays.stream(property.extensions())
+                .flatMap(extension -> Arrays.stream(extension.properties()))
+                .collect(Collectors.toMap(ExtensionProperty::name, ExtensionProperty::value));
     }
 
     /**

--- a/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
+++ b/elide-swagger/src/test/java/com/yahoo/elide/swagger/OpenApiBuilderTest.java
@@ -821,6 +821,26 @@ class OpenApiBuilderTest {
     }
 
     @Test
+    void testExtendedAttribute() {
+        OpenAPI openAPI = new OpenApiBuilder(dictionary).build();
+        Schema<?> book = openAPI.getComponents().getSchemas().get("book");
+        Schema<?> attributes = book.getProperties().get("attributes");
+        Schema<?> titleAttribute = attributes.getProperties().get("title");
+        assertEquals("false", titleAttribute.getExtensions().get("isLocalized"));
+    }
+
+    @Test
+    void testExtendedAttributeRelationship() {
+        OpenAPI openAPI = new OpenApiBuilder(dictionary).build();
+        Schema<?> book = openAPI.getComponents().getSchemas().get("book");
+        Schema<?> relationships = book.getProperties().get("relationships");
+        Schema<?> publisherRelationship = relationships.getProperties().get("publisher");
+        Schema<?> publisherData = publisherRelationship.getProperties().get("data");
+        Schema<?> publisherItems = publisherData.getItems();
+        assertEquals("oneToOne", publisherItems.getExtensions().get("relationType"));
+    }
+
+    @Test
     void testEntityFilterCrud() {
         EntityDictionary entityDictionary = EntityDictionary.builder().build();
 

--- a/elide-swagger/src/test/java/example/models/Book.java
+++ b/elide-swagger/src/test/java/example/models/Book.java
@@ -10,6 +10,8 @@ import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.AccessMode;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
@@ -39,12 +41,21 @@ public class Book {
 
     @OneToOne
     @UpdatePermission(expression = "Principal is publisher")
+    @Schema(requiredMode = RequiredMode.REQUIRED, extensions = {
+            @Extension(properties = {
+                    @ExtensionProperty(name = "relationType", value = "oneToOne")
+            })
+    })
     public Publisher getPublisher() {
         return null;
     }
 
     @NotNull
-    @Schema(requiredMode = RequiredMode.REQUIRED)
+    @Schema(requiredMode = RequiredMode.REQUIRED, extensions = {
+            @Extension(properties = {
+                    @ExtensionProperty(name = "isLocalized", value = "false")
+            })
+    })
     public String title;
 
     @Schema(description = "Year published", example = "1999", accessMode = AccessMode.READ_ONLY)


### PR DESCRIPTION
Resolves #3301

## Description
<!--- Describe your changes in detail -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Currently, OpenAPI swagger documentation supports the definition of extension properties in the @Schema annotation, it is built like a Map<String, Object> and generally allows the OpenAPI user to define customs properties on the documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The reason I'm opening this feature is that I need to send more information to the FrontEnd point of my applications through OpenAPI to handle various situations, such as localized properties and others. By adding the extension property we are able to send all the necessary information and many more, leading to a more customizable experience for OpenAPI definition.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Aside from testing these changes by building some unit tests, I also applied the changes to my project and checked the openAPI documentation.
## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
