### PR TITLE
Upgrade hibernate from 6.5.2.Final to 6.6.3.Final

### DIFF
--- a/elide-integration-tests/src/test/java/example/Parent.java
+++ b/elide-integration-tests/src/test/java/example/Parent.java
@@ -15,6 +15,7 @@ import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
@@ -53,7 +54,8 @@ public class Parent extends BaseId {
     @UpdatePermission(expression = "Prefab.Role.All OR Prefab.Role.None")
     // Hibernate
     @ManyToMany(
-            targetEntity = Child.class
+            targetEntity = Child.class,
+            cascade = CascadeType.ALL
     )
     @JoinTable(
             name = "Parent_Child",

--- a/elide-quarkus/deployment/pom.xml
+++ b/elide-quarkus/deployment/pom.xml
@@ -100,6 +100,9 @@
               <version>${quarkus.version}</version>
             </path>
           </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-AlegacyConfigRoot=true</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/elide-quarkus/deployment/src/test/resources/application.properties
+++ b/elide-quarkus/deployment/src/test/resources/application.properties
@@ -8,3 +8,5 @@ elide.base-graphql=/test-graphql
 elide.base-swagger=/test-apiDocs
 quarkus.log.level=INFO
 quarkus.log.category."com.yahoo.elide".level=DEBUG
+quarkus.index-dependency.jooq.group-id=com.yahoo.elide
+quarkus.index-dependency.jooq.artifact-id=elide-swagger

--- a/elide-quarkus/pom.xml
+++ b/elide-quarkus/pom.xml
@@ -49,7 +49,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.13.1</quarkus.version>
+    <quarkus.version>3.17.3</quarkus.version>
     <elide.version>7.1.5-SNAPSHOT</elide.version>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
     <parent.pom.dir>${project.basedir}/../..</parent.pom.dir>

--- a/elide-quarkus/runtime/pom.xml
+++ b/elide-quarkus/runtime/pom.xml
@@ -108,6 +108,9 @@
               <version>${quarkus.version}</version>
             </path>
           </annotationProcessorPaths>
+          <compilerArgs>
+            <arg>-AlegacyConfigRoot=true</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <graal-sdk.version>24.0.1</graal-sdk.version>
         <guava.version>33.2.0-jre</guava.version>
         <handlebars.version>4.4.0</handlebars.version>
-        <hibernate.version>6.5.2.Final</hibernate.version>
+        <hibernate.version>6.6.3.Final</hibernate.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <hibernate-search.version>6.2.4.Final</hibernate-search.version>
         <hjson.version>3.1.0</hjson.version>


### PR DESCRIPTION
Resolves #3310

## Description
Upgrades 6.5.2.Final to 6.6.3.Final.

This also upgrades Quarkus to the latest to support 6.6.x.

## Motivation and Context
Spring Boot's managed dependencies are also now at 6.6.x.

## How Has This Been Tested?
Existing integration tests pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
