### PR TITLE
Use quarkus-extension-maven-plugin

### DIFF
--- a/elide-quarkus/runtime/pom.xml
+++ b/elide-quarkus/runtime/pom.xml
@@ -84,7 +84,7 @@
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
         <version>3.0.0.Beta1</version>
         <executions>
           <execution>


### PR DESCRIPTION

## Description
Replaced quarkus-**bootstrap**-maven-plugin with quarkus-**extension**-maven-plugin, which appears to be a drop in replacement, as per the following build-time deprecation warning:

`[WARNING]  Goal 'extension-descriptor' is deprecated: in favor of {@code io.quarkus:quarkus-extension-maven-plugin}.
            <p>
            Generates Quarkus extension descriptor for the runtime artifact.
            <p>
            <p/>
            Also generates META-INF/quarkus-extension.json which includes properties of
            the extension such as name, labels, maven coordinates, etc that are used by
            the tools.
[WARNING] This Maven plugin was deprecated in favor of io.quarkus:quarkus-extension-maven-plugin:3.0.0.Beta1, please, update the artifactId of the plugin in your project configuration.`

## Motivation and Context
Removes a warning during build time.

## How Has This Been Tested?
- I've been using the version built with this change for a day locally and there appears to be no negative impacts. 
- All unit tests still pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
