### PR TITLE
Quarkus: do all scans (not limited to security checks)

### DIFF
--- a/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
+++ b/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
@@ -82,6 +82,11 @@ public class ElideExtensionTest {
     }
 
     @Test
+    public void testTypeConvertersAreRegistered() {
+        RestAssured.when().get("/test-jsonapi/book?filter=releaseDate<2025-02-19T19:17:53Z").then().log().all().statusCode(200);
+    }
+
+    @Test
     public void testBookGraphqlEndpoint() {
         String query = document(
                 selection(

--- a/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/models/Book.java
+++ b/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/models/Book.java
@@ -11,6 +11,8 @@ import com.yahoo.elide.annotation.Include;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
+import java.time.OffsetDateTime;
+
 @Include
 @Entity
 public class Book {
@@ -18,4 +20,6 @@ public class Book {
     private long id;
 
     private String title;
+
+    private OffsetDateTime releaseDate;
 }

--- a/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
+++ b/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
@@ -72,10 +72,9 @@ public class ElideBeans {
             builder = builder.verboseErrors(true);
         }
 
-        LOG.debug("Scanning for security checks...");
-        dictionary.scanForSecurityChecks();
-
-        return new Elide(builder.build());
+        Elide elide = new Elide(builder.build());
+        elide.doScans();
+        return elide;
     }
 
     @Produces


### PR DESCRIPTION
## Description
Rather than just calling `dictionary.scanForSecurityChecks()` we now call `elide.doScans()` instead. This causes the built-in type converters to be registered, whereas they weren't before. Security checks are still also registered, as before.

## Motivation and Context
This solves the issue whereby the built in type converters were not being registered by the quarkus extension. For example, attempting to use OffsetDateTime as a field type resulted in a failure at runtime due to the type being unknown.

## How Has This Been Tested?
A simple new, passing test is added that filters on a OffsetDateTime field. I have confirmed the test failed before the change was implemented.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
