### PR TITLE
Bump org.springdoc:springdoc-openapi-starter-common from 2.6.0 to 2.8.5

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/DefaultElideGroupedOpenApiCustomizer.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/api/DefaultElideGroupedOpenApiCustomizer.java
@@ -40,7 +40,7 @@ public class DefaultElideGroupedOpenApiCustomizer implements ElideGroupedOpenApi
 
     @Override
     public void customize(GroupedOpenApi groupedOpenApi) {
-        groupedOpenApi.getOpenApiCustomizers().add(0, new ElideOpenApiCustomizer() {
+        groupedOpenApi.getOpenApiCustomizers().add(new ElideOpenApiCustomizer() {
             @Override
             public void customise(OpenAPI openApi) {
                 OpenApis.removePathsByTags(openApi, "graphql-controller", "api-docs-controller", "json-api-controller");
@@ -65,7 +65,7 @@ public class DefaultElideGroupedOpenApiCustomizer implements ElideGroupedOpenApi
 
             if (match(groupedOpenApi, path)) {
                 String basePath = path;
-                groupedOpenApi.getOpenApiCustomizers().add(0, new ElideOpenApiCustomizer() {
+                groupedOpenApi.getOpenApiCustomizers().add(new ElideOpenApiCustomizer() {
                     @Override
                     public void customise(OpenAPI openApi) {
                         OpenApiBuilder builder = new OpenApiBuilder(

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <spring-boot.version>3.4.0</spring-boot.version>
         <spring-framework.version>6.1.10</spring-framework.version>
         <spring-cloud-commons.version>4.1.4</spring-cloud-commons.version>
-        <springdoc.version>2.6.0</springdoc.version>
+        <springdoc.version>2.8.5</springdoc.version>
         <swagger-api.version>2.2.26</swagger-api.version>
         <system-lambda.version>1.2.1</system-lambda.version>
         <tomcat.version>10.1.31</tomcat.version>


### PR DESCRIPTION
Resolves #3306 

## Description
Upgrades `org.springdoc:springdoc-openapi-starter-common` from 2.6.0 to 2.8.5.

There was a change in the library from a `List` to a `Set` which will cause an error when used.

## Motivation and Context
To allow upgrading to the latest library.

## How Has This Been Tested?
Existing tests continue to pass.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
