### PR TITLE
Fix coercing to String for Serdes

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/utils/coerce/CoerceUtil.java
@@ -83,8 +83,11 @@ public class CoerceUtil {
         ConvertUtils.register(new Converter() {
 
             @Override
-            public <T> T convert(Class<T> aClass, Object o) {
-                return (T) serde.deserialize(aClass, (S) o);
+            public <V> V convert(Class<V> aClass, Object o) {
+                if (String.class.equals(aClass)) {
+                    return (V) serde.serialize((T) o);
+                }
+                return (V) serde.deserialize(aClass, (S) o);
             }
 
         }, targetType);

--- a/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
+++ b/elide-core/src/test/java/com/yahoo/elide/core/utils/coerce/CoerceUtilTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.verify;
 import com.yahoo.elide.core.exceptions.InvalidValueException;
 import com.yahoo.elide.core.utils.coerce.converters.EpochToDateConverter;
 import com.yahoo.elide.core.utils.coerce.converters.ISO8601DateSerde;
+import com.yahoo.elide.core.utils.coerce.converters.InstantSerde;
+import com.yahoo.elide.core.utils.coerce.converters.OffsetDateTimeSerde;
 import com.yahoo.elide.core.utils.coerce.converters.Serde;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,6 +29,8 @@ import lombok.NoArgsConstructor;
 
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -222,6 +226,24 @@ public class CoerceUtilTest {
         assertEquals(date.getTime(), timestamp.getTime());
         CoerceUtil.register(Date.class, oldDateSerde);
         CoerceUtil.register(java.sql.Timestamp.class, oldTimestampSerde);
+    }
+
+    @Test
+    public void testOffsetDateTimeToString() {
+        CoerceUtil.register(OffsetDateTime.class, new OffsetDateTimeSerde());
+        OffsetDateTime time = OffsetDateTime.now();
+        String value = CoerceUtil.coerce(time, String.class);
+        OffsetDateTime converted = CoerceUtil.coerce(value, OffsetDateTime.class);
+        assertEquals(time, converted);
+    }
+
+    @Test
+    public void testInstantToString() {
+        CoerceUtil.register(Instant.class, new InstantSerde());
+        Instant time = Instant.now();
+        String value = CoerceUtil.coerce(time, String.class);
+        Instant converted = CoerceUtil.coerce(value, Instant.class);
+        assertEquals(time, converted);
     }
 
     /**


### PR DESCRIPTION
Resolves #3363

## Description
When coercing to String the serialize method on the Serde is called.

## Motivation and Context
Required when coercing to String.

## How Has This Been Tested?
Added tests in `CoerceUtilTest` and manually to verify no errors when using sorts for cursor based pagination.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
