### PR TITLE
Fix graphql fetcher to allow REMOVE and DELETE for toOne relationship

### DIFF
--- a/elide-graphql/src/main/java/com/yahoo/elide/graphql/Entity.java
+++ b/elide-graphql/src/main/java/com/yahoo/elide/graphql/Entity.java
@@ -164,6 +164,9 @@ public class Entity {
     public Optional<String> getId() {
         EntityDictionary dictionary = this.requestScope.getDictionary();
         String idFieldName = dictionary.getIdFieldName(this.entityClass);
+        if (this.attributes == null) {
+            return Optional.empty();
+        }
         return this.attributes.stream()
                 .filter(entry -> idFieldName.equalsIgnoreCase(entry.name))
                 .map(e -> (String) e.value)

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherDeleteTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherDeleteTest.java
@@ -112,6 +112,19 @@ public class FetcherDeleteTest extends PersistentResourceFetcherTest {
     }
 
     @Test
+    public void testNestedToOne() throws Exception {
+        String graphQLRequest = "mutation { "
+                + "author(ids: [\"1\"]) { "
+                + "edges { node {"
+                + "penName(op:DELETE) { "
+                + "edges { node { id } } "
+                + "} } }"
+                + "}"
+                + "}";
+        assertQueryEquals(graphQLRequest, "{\"author\":{\"edges\":[{\"node\":{\"penName\":{\"edges\":[]}}}]}}");
+    }
+
+    @Test
     public void testNestedCollection() throws Exception {
         // Part 1: Delete the objects
         runComparisonTest("nestedCollectionPt1");

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherRemoveTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherRemoveTest.java
@@ -110,6 +110,19 @@ public class FetcherRemoveTest extends PersistentResourceFetcherTest {
         assertQueryFails(graphQLRequest);
     }
 
+    @Test
+    public void testNestedToOne() throws Exception {
+        String graphQLRequest = "mutation { "
+                + "author(ids: [\"1\"]) { "
+                + "edges { node {"
+                + "penName(op:REMOVE) { "
+                + "edges { node { id } } "
+                + "} } }"
+                + "}"
+                + "}";
+        assertQueryEquals(graphQLRequest, "{\"author\":{\"edges\":[{\"node\":{\"penName\":{\"edges\":[]}}}]}}");
+    }
+
     @Override
     public void runComparisonTest(String testName) throws Exception {
         super.runComparisonTest("remove/" + testName);

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherReplaceTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherReplaceTest.java
@@ -30,6 +30,58 @@ public class FetcherReplaceTest extends PersistentResourceFetcherTest {
         runErrorComparisonTest("replaceWithIdsFails", expectedMessage);
     }
 
+    @Test
+    public void testReplaceNestedToOneWithId() throws Exception {
+        String graphQLRequest = "mutation { "
+                + "author(ids: [\"3\"]) { "
+                + "edges { node {"
+                + "penName(op:REPLACE, data: { id: \"1\"}) { "
+                + "edges { node { id name } } "
+                + "} } }"
+                + "}"
+                + "}";
+        assertQueryEquals(graphQLRequest, "{\"author\":{\"edges\":[{\"node\":{\"penName\":{\"edges\":[{\"node\":{\"id\":\"1\",\"name\":\"The People's Author\"}}]}}}]}}");
+    }
+
+    @Test
+    public void testReplaceNestedToOneWithData() throws Exception {
+        String graphQLRequest = "mutation { "
+                + "author(ids: [\"3\"]) { "
+                + "edges { node {"
+                + "penName(op:REPLACE, data: { name: \"Hello World\"}) { "
+                + "edges { node { id name } } "
+                + "} } }"
+                + "}"
+                + "}";
+        assertQueryEquals(graphQLRequest, "{\"author\":{\"edges\":[{\"node\":{\"penName\":{\"edges\":[{\"node\":{\"id\":\"3\",\"name\":\"Hello World\"}}]}}}]}}");
+    }
+
+    @Test
+    public void testReplaceNestedToOneWithNullData() throws Exception {
+        String graphQLRequest = "mutation { "
+                + "author(ids: [\"3\"]) { "
+                + "edges { node {"
+                + "penName(op:REPLACE, data: null) { "
+                + "edges { node { id name } } "
+                + "} } }"
+                + "}"
+                + "}";
+        assertQueryFailsWith(graphQLRequest, "Exception while fetching data (/author/edges[0]/node/penName) : REPLACE must include data argument");
+    }
+
+    @Test
+    public void testReplaceNestedToOneWithEmptyData() throws Exception {
+        String graphQLRequest = "mutation { "
+                + "author(ids: [\"3\"]) { "
+                + "edges { node {"
+                + "penName(op:REPLACE, data: {}) { "
+                + "edges { node { id name } } "
+                + "} } }"
+                + "}"
+                + "}";
+        assertQueryEquals(graphQLRequest, "{\"author\":{\"edges\":[{\"node\":{\"penName\":{\"edges\":[{\"node\":{\"id\":\"3\",\"name\":null}}]}}}]}}");
+    }
+
     @Override
     public void runComparisonTest(String testName) throws Exception {
         super.runComparisonTest("replace/" + testName);

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherUpdateTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/FetcherUpdateTest.java
@@ -93,6 +93,22 @@ public class FetcherUpdateTest extends PersistentResourceFetcherTest {
         runComparisonTest("updateComplexGraph");
     }
 
+    @Test
+    public void testNestedToOne() throws Exception {
+        // While it might be logical to update the toOne relationship in this manner
+        // the PersistentResourceFetcher#updateObject doesn't have the context on
+        // which parent resource relationship is being cleared
+        String graphQLRequest = "mutation { "
+                + "author(op:UPDATE, data:{id:\"1\", penName: null}) { "
+                + "edges { node {"
+                + "penName { "
+                + "edges { node { id } } "
+                + "} } }"
+                + "}"
+                + "}";
+        assertQueryFailsWith(graphQLRequest, "Exception while fetching data (/author) : UPDATE data objects must include ids");
+    }
+
     // TODO: Reeanble when supporting arguments into computed attributes.
     @Disabled
     public void testSetComputedAttribute() throws Exception {

--- a/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
+++ b/elide-graphql/src/test/java/com/yahoo/elide/graphql/PersistentResourceFetcherTest.java
@@ -185,9 +185,22 @@ public abstract class PersistentResourceFetcherTest extends GraphQLTest {
         publisher1.setBooks(new HashSet<>(Arrays.asList(book1, book2)));
         publisher2.setBooks(new HashSet<>(Arrays.asList(book3)));
 
+        Author author3 = new Author();
+        author3.setId(3L);
+        author3.setName("Mary Ann Evans");
+        author3.setType(Author.AuthorType.EXCLUSIVE);
+
+        Pseudonym authorThree = new Pseudonym();
+        authorThree.setId(2L);
+        authorThree.setName("George Eliot");
+
+        author3.setPenName(authorThree);
+
         tx.save(author1, null);
         tx.save(authorOne, null);
         tx.save(author2, null);
+        tx.save(author3, null);
+        tx.save(authorThree, null);
         tx.save(book1, null);
         tx.save(book2, null);
         tx.save(book3, null);

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/computedAttributes.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/computedAttributes.json
@@ -15,6 +15,12 @@
             "default_Doctor Zhivago"
           ]
         }
+      },
+      {
+        "node": {
+          "bookTitlesWithPrefix": [
+          ]
+        }
       }
     ]
   }

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentOnConnection.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentOnConnection.json
@@ -42,6 +42,18 @@
           "__typename": "Author"
         },
         "__typename": "AuthorEdge"
+      },
+      {
+        "node": {
+          "id": "3",
+          "books": {
+            "edges": [
+            ],
+            "__typename": "BookConnection"
+          },
+          "__typename": "Author"
+        },
+        "__typename": "AuthorEdge"
       }
     ]
   }

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentOnEdges.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentOnEdges.json
@@ -42,6 +42,18 @@
           "__typename": "Author"
         },
         "__typename": "AuthorEdge"
+      },
+      {
+        "node": {
+          "id": "3",
+          "books": {
+            "edges": [
+            ],
+            "__typename": "BookConnection"
+          },
+          "__typename": "Author"
+        },
+        "__typename": "AuthorEdge"
       }
     ]
   }

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentOnNode.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/fragmentOnNode.json
@@ -42,6 +42,18 @@
           "__typename": "Author"
         },
         "__typename": "AuthorEdge"
+      },
+      {
+        "node": {
+          "id": "3",
+          "books": {
+            "edges": [
+            ],
+            "__typename": "BookConnection"
+          },
+          "__typename": "Author"
+        },
+        "__typename": "AuthorEdge"
       }
     ]
   }

--- a/elide-graphql/src/test/resources/graphql/responses/fetch/pageTotalsRelationship.json
+++ b/elide-graphql/src/test/resources/graphql/responses/fetch/pageTotalsRelationship.json
@@ -42,10 +42,22 @@
             }
           }
         }
+      },
+      {
+        "node": {
+          "id": "3",
+          "books": {
+            "edges": [
+            ],
+            "pageInfo": {
+              "totalRecords": 0
+            }
+          }
+        }
       }
     ],
     "pageInfo": {
-      "totalRecords": 2
+      "totalRecords": 3
     }
   }
 }

--- a/elide-graphql/src/test/resources/graphql/responses/replace/replaceNestedCollection.json
+++ b/elide-graphql/src/test/resources/graphql/responses/replace/replaceNestedCollection.json
@@ -9,7 +9,7 @@
             "edges": [
               {
                 "node": {
-                  "id": "3",
+                  "id": "4",
                   "name": "My New Author"
                 }
               },
@@ -31,7 +31,7 @@
             "edges": [
               {
                 "node": {
-                  "id": "4",
+                  "id": "5",
                   "name": "My New Author"
                 }
               },
@@ -53,7 +53,7 @@
             "edges": [
               {
                 "node": {
-                  "id": "5",
+                  "id": "6",
                   "name": "My New Author"
                 }
               },


### PR DESCRIPTION
Resolves #3373 

## Description

* Allows the use of the `REMOVE` op on a to-one relationship without `ids` specified to remove the relationship.
* Allows the use of the `DELETE` op on a to-one relationship without `ids` specified to remove the relationship and delete the object.
* Returns `Optional.empty()` for `Entity.getId()` when attributes is `null` to prevent a NPE and allow the error message `UPDATE data objects must include ids` to be correctly generated.

## Motivation and Context
It's currently not possible to remove a to-one relationship.

## How Has This Been Tested?
* `FetcherRemoveTest` was updated to test `REMOVE` on a to-one relationship
* `FetcherDeleteTest` was updated to test `DELETE` on a to-one relationship
* `FetcherUpdateTest` was updated to test the error message when `UPDATE` is used with a `null` object
* `FetcherReplaceTest` was updated to test the existing behavior when `REPLACE` is called on a to-one relationship

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.