### PR TITLE
Support @IdGeneratorType

### DIFF
--- a/elide-core/pom.xml
+++ b/elide-core/pom.xml
@@ -202,6 +202,11 @@
             <artifactId>hibernate-validator</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityBinding.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/dictionary/EntityBinding.java
@@ -360,6 +360,16 @@ public class EntityBinding {
         }
         if (fieldOrMethod.isAnnotationPresent(GeneratedValue.class)) {
             idGenerated = true;
+        } else {
+            for (Annotation annotation : fieldOrMethod.getAnnotations()) {
+                for (Annotation nestedAnnotation : annotation.annotationType().getAnnotations()) {
+                    //Annotation checked by name so as not to require hibernate dependency
+                    if ("org.hibernate.annotations.IdGeneratorType"
+                            .equals(nestedAnnotation.annotationType().getName())) {
+                        idGenerated = true;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #3340 

## Description
Adds support for using an annotation with the `@IdGeneratorType` meta-annotation.

## Motivation and Context
Required to support custom id generation with Hibernate.

## How Has This Been Tested?
* `EntityBindingTest` was updated to ensure that `isIdGenerated` is true
* Manually tested that the id was generated using example project


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
