### PR TITLE
Fixing switch from oss.sonatype to central.sonatype.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,14 +52,14 @@
     </developers>
 
     <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
+       <snapshotRepository>
+         <id>central</id>
+         <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+       </snapshotRepository>
+       <repository>
+         <id>central</id>
+         <url>https://central.sonatype.com/repository/maven-releases/</url>
+       </repository>
     </distributionManagement>
 
     <scm>
@@ -585,7 +585,7 @@
     
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <properties>
                 <gpg.executable>gpg</gpg.executable>
                 <gpg.keyname>${env.GPG_KEYNAME_2}</gpg.keyname>
@@ -625,10 +625,10 @@
                         <version>${nexus-staging-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <serverId>central</serverId>
+                            <nexusUrl>https://central.sonatype.com/service/local/</nexusUrl>
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                            </configuration>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -60,8 +60,8 @@ jobs:
         - GPG_KEYNAME_2  
         - GPG_PASSPHRASE_2
         - GPG_ENCPHRASE_2
-        - OSSRH_USER  
-        - OSSRH_TOKEN
+        - SONATYPE_USER
+        - SONATYPE_TOKEN
     requires: [~tag:/^7/, ~release:/^7/]
     steps:
       - prebuild: microdnf install --nodocs openssl gnupg 
@@ -74,8 +74,8 @@ jobs:
         - GPG_KEYNAME_2  
         - GPG_PASSPHRASE_2
         - GPG_ENCPHRASE_2
-        - OSSRH_USER
-        - OSSRH_TOKEN
+        - SONATYPE_USER
+        - SONATYPE_TOKEN
     requires: [~tag:/^6/, ~release:/^6/]
     steps:
       - build: "screwdriver/scripts/build.sh"

--- a/screwdriver/scripts/publish.sh
+++ b/screwdriver/scripts/publish.sh
@@ -18,7 +18,7 @@ gpg --batch --yes --import screwdriver/deploy/secring-private.asc
 gpg --list-secret-keys --keyid-format LONG
 
 # Maven deploy
-mvn -B deploy -P ossrh -Dmaven.test.skip=true \
+mvn -B deploy -P central -Dmaven.test.skip=true \
     --settings screwdriver/settings/settings-publish.xml \
     -Dgpg.executable=gpg \
     -Dgpg.args="--batch --yes --pinentry-mode loopback"

--- a/screwdriver/settings/settings-publish.xml
+++ b/screwdriver/settings/settings-publish.xml
@@ -1,9 +1,9 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>ossrh</id>
-      <username>${env.OSSRH_USER}</username>
-      <password>${env.OSSRH_TOKEN}</password>
+      <id>central</id>
+      <username>${env.SONATYPE_USER}</username>
+      <password>${env.SONATYPE_TOKEN}</password>
     </server>
   </servers>
 </settings>


### PR DESCRIPTION
## Description
oss.sonatype.org switch to a new portal: central.sonatype.com

As part of this switch, all old upload tokens have to be regenerated in the new system.

## Motivation and Context
Builds are broken

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
