### PR TITLE
Remove empty link

### DIFF
--- a/translations/zh/README.md
+++ b/translations/zh/README.md
@@ -224,7 +224,7 @@ public static class IsAdminUser extends UserCheck {
 
 ## 开源许可
 
-该项目根据 [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html) 开源许可证条款获得许可。请参阅[许可证](https://github.com/paion-data/elide/blob/master/LICENSE.txt)了解完整条款。
+该项目根据 [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html) 开源许可证条款获得许可。请参阅[许可证](https://github.com/yahoo/elide/blob/master/LICENSE.txt)了解完整条款。
 
 ## 参考文献
 


### PR DESCRIPTION
Addresses PSECBUGS-98299 where a link pointed to an unregistered fork.

Resolves #<issue number> (if appropriate)

## Description
Update the translated README.md to fix a link

## Motivation and Context
The link is to a now removed fork of this repo, which would potentially allow something or other bad to happen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
