### PR TITLE
Fix spring transactional resource leak

### DIFF
--- a/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransaction.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/main/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransaction.java
@@ -35,7 +35,7 @@ public class PlatformJpaTransaction extends AbstractJpaTransaction {
 
     private final EntityManagerFactory entityManagerFactory;
 
-    private TransactionStatus status;
+    private TransactionStatus status = null;
 
     public PlatformJpaTransaction(PlatformTransactionManager transactionManager, TransactionDefinition definition,
             EntityManagerFactory entityManagerFactory, EntityManager em, Consumer<EntityManager> jpaTransactionCancel,
@@ -48,8 +48,8 @@ public class PlatformJpaTransaction extends AbstractJpaTransaction {
 
     @Override
     public void begin() {
-        this.status = this.transactionManager.getTransaction(this.definition);
         if (this.em instanceof SupplierEntityManager supplierEntityManager) {
+            this.status = this.transactionManager.getTransaction(this.definition);
             EntityManagerHolder entityManagerHolder = (EntityManagerHolder) TransactionSynchronizationManager
                     .getResource(this.entityManagerFactory);
             if (entityManagerHolder != null) {
@@ -85,6 +85,6 @@ public class PlatformJpaTransaction extends AbstractJpaTransaction {
 
     @Override
     public boolean isOpen() {
-        return this.em.isOpen() && this.status != null && !this.status.isCompleted();
+        return this.status != null && !this.status.isCompleted();
     }
 }

--- a/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransactionTest.java
+++ b/elide-spring/elide-spring-boot-autoconfigure/src/test/java/com/yahoo/elide/spring/orm/jpa/PlatformJpaTransactionTest.java
@@ -10,10 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -28,6 +30,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests for PlatformJpaTransaction.
@@ -40,15 +44,30 @@ class PlatformJpaTransactionTest {
     @Mock
     EntityManagerFactory entityManagerFactory;
 
-    @Mock
+    // strictness set to lenient as entityManager.isOpen is no longer checked in the implementation
+    // but it is useful to document the state of the entityManager
+    @Mock(strictness = Mock.Strictness.LENIENT)
     EntityManager entityManager;
+
+    @AfterEach
+    void cleanup() {
+        // Ensure the thread locals are cleaned up
+        TransactionSynchronizationManager.clear();
+        List<Object> keys = new ArrayList<>(TransactionSynchronizationManager.getResourceMap().keySet());
+        for (Object key : keys) {
+            TransactionSynchronizationManager.unbindResourceIfPossible(key);
+        }
+    }
 
     @Test
     void entityManagerShouldBeSupplierEntityManager() throws IOException {
+        DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
         try (PlatformJpaTransaction jpaTransaction = new PlatformJpaTransaction(transactionManager,
-                new DefaultTransactionDefinition(), entityManagerFactory, entityManager, entityManager -> {
+                definition, entityManagerFactory, entityManager, entityManager -> {
                 }, DEFAULT_LOGGER, true, true)) {
             assertThatThrownBy(() -> jpaTransaction.begin()).isInstanceOf(IllegalStateException.class);
+            // getTransaction should not be called or it will leak transactional resources as commit/rollback not called
+            verify(transactionManager, never()).getTransaction(definition);
         }
     }
 
@@ -61,7 +80,7 @@ class PlatformJpaTransactionTest {
     @Test
     void closeShouldNotCloseEntityManager() throws IOException {
         SimpleTransactionStatus status = new SimpleTransactionStatus();
-        when(entityManager.isOpen()).thenReturn(true);
+        when(entityManager.isOpen()).thenReturn(true); // stub not used
         when(transactionManager.getTransaction(any())).thenReturn(status);
         doAnswer(invocation -> {
             TransactionSynchronizationManager.unbindResource(this.entityManagerFactory);
@@ -79,5 +98,42 @@ class PlatformJpaTransactionTest {
         assertThat(proxy.getTargetEntityManager()).isEqualTo(entityManager);
         verify(entityManager, times(0)).close();
         assertThat(TransactionSynchronizationManager.getResource(this.entityManagerFactory)).isNull();
+        assertThat(TransactionSynchronizationManager.getResourceMap()).isEmpty();
+    }
+
+    /**
+     * Ensure that the transactionManager.rollback is called even if the
+     * entityManager is closed. This can happen when spring.jpa.open-in-view=true
+     * (default setting) and the async request times out (default 30 seconds) which
+     * causes the entity manager to be closed. Subsequent requests using the thread
+     * will all fail when JpaTransactionManager attempts to start a transaction as
+     * the ConnectionHolder is still bound to the thread local in
+     * TransactionSynchronizationManager.
+     *
+     * @see org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor#afterCompletion(org.springframework.web.context.request.WebRequest,
+     *      Exception)
+     * @see org.springframework.orm.jpa.JpaTransactionManager
+     * @throws IOException when close
+     */
+    @Test
+    void closeShouldRollbackTransactionEvenIfEntityManagerIsClosed() throws IOException {
+        SimpleTransactionStatus status = new SimpleTransactionStatus();
+        when(entityManager.isOpen()).thenReturn(false); // stub not used
+        when(transactionManager.getTransaction(any())).thenReturn(status);
+        doAnswer(invocation -> {
+            TransactionSynchronizationManager.unbindResource(this.entityManagerFactory);
+            status.setCompleted();
+            return null;
+        }).when(transactionManager).rollback(any());
+        EntityManagerHolder holder = new EntityManagerHolder(entityManager);
+        TransactionSynchronizationManager.bindResource(this.entityManagerFactory, holder);
+        BasicEntityManagerProxy proxy = new BasicEntityManagerProxy();
+        try (PlatformJpaTransaction jpaTransaction = new PlatformJpaTransaction(transactionManager,
+                new DefaultTransactionDefinition(), entityManagerFactory, proxy, entityManager -> {
+                }, DEFAULT_LOGGER, true, true)) {
+            jpaTransaction.begin();
+        }
+        assertThat(TransactionSynchronizationManager.getResourceMap()).isEmpty();
+        verify(transactionManager, times(1)).rollback(status);
     }
 }


### PR DESCRIPTION
Resolves #3394 

## Description
Removes `em.isOpen()` as a condition for determining if the transaction is open and only rely on the transaction status.

## Motivation and Context
This resolves a transactional resource leak which causes all subsequent async requests that are dispatched to the same thread to fail when the `JpaTransactionManager` attempts to acquire a connection as there is already a `ConnectionHolder` still bound to the thread local in `TransactionalSynchronizationManager`.

## How Has This Been Tested?
Added the unit and integration tests to verify that the `IllegalTransactionStateException` with the message `Pre-bound JDBC Connection found! JpaTransactionManager does not support running within DataSourceTransactionManager if told to manage the DataSource itself. It is recommended to use a single JpaTransactionManager for all transactions on a single DataSource, no matter whether JPA or JDBC access.` is no longer thrown when attempting to start a new transaction if the entity manager was closed during the previous transaction.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
