### PR TITLE
Include number, temporal, date and enum in OpenAPI sortable fields

### DIFF
--- a/elide-core/src/main/java/com/yahoo/elide/core/type/ClassType.java
+++ b/elide-core/src/main/java/com/yahoo/elide/core/type/ClassType.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.math.BigDecimal;
+import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -43,6 +44,8 @@ public class ClassType<T> implements Type<T> {
     public static final ClassType<Class> CLASS_TYPE = ClassType.of(Class.class);
     public static final ClassType<Integer> INTEGER_TYPE = ClassType.of(Integer.class);
     public static final ClassType<Integer> PRIMITIVE_INTEGER_TYPE = ClassType.of(int.class);
+    public static final ClassType<Enum> ENUM_TYPE = ClassType.of(Enum.class);
+    public static final ClassType<Temporal> TEMPORAL_TYPE = ClassType.of(Temporal.class);
 
     @Getter
     private Class<T> cls;

--- a/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
+++ b/elide-swagger/src/main/java/com/yahoo/elide/swagger/OpenApiBuilder.java
@@ -620,7 +620,11 @@ public class OpenApiBuilder {
         private Parameter getSortParameter() {
             List<String> filterAttributes = dictionary.getAttributes(type).stream().filter(name -> {
                 Type<?> attributeClass = dictionary.getType(type, name);
-                return (attributeClass.isPrimitive() || ClassType.STRING_TYPE.isAssignableFrom(attributeClass));
+                return (attributeClass.isPrimitive() || ClassType.STRING_TYPE.isAssignableFrom(attributeClass)
+                        || ClassType.DATE_TYPE.isAssignableFrom(attributeClass)
+                        || ClassType.NUMBER_TYPE.isAssignableFrom(attributeClass)
+                        || ClassType.ENUM_TYPE.isAssignableFrom(attributeClass)
+                        || ClassType.TEMPORAL_TYPE.isAssignableFrom(attributeClass));
             }).map(name -> Arrays.asList(name, "-" + name)).flatMap(Collection::stream).collect(Collectors.toList());
 
             filterAttributes.add("id");

--- a/elide-swagger/src/test/java/example/models/Sort.java
+++ b/elide-swagger/src/test/java/example/models/Sort.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025, the original author or authors.
+ * Licensed under the Apache License, Version 2.0
+ * See LICENSE file in project root for terms.
+ */
+package example.models;
+
+
+import com.yahoo.elide.annotation.Include;
+
+import jakarta.persistence.Entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Entity
+@Include(friendlyName = "Sort")
+public class Sort {
+    public static enum Enumeration {
+        UP,
+        DOWN
+    }
+
+    public Enumeration enumeration;
+    public Date date;
+    public LocalDateTime localDateTime;
+    public BigDecimal bigDecimal;
+}


### PR DESCRIPTION
Resolves #3396 

## Description
Updated `OpenApiBuilder.getSortParameter()` to consider attributes that are assignable from `Number`, `Temporal`, `Enum`, and `Date` as sortable.

## Motivation and Context
Fixes the issue where sortable parameters are not in the OpenAPI document.

## How Has This Been Tested?
Added test case to ensure that the OpenAPI document generated now list such parameters as sortable.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
