### PR TITLE
New Quarkus property for API docs title

### DIFF
--- a/elide-quarkus/deployment/src/main/java/com/yahoo/elide/extension/deployment/ElideExtensionProcessor.java
+++ b/elide-quarkus/deployment/src/main/java/com/yahoo/elide/extension/deployment/ElideExtensionProcessor.java
@@ -103,14 +103,12 @@ public class ElideExtensionProcessor {
     }
 
     /**
-     * When Quarkus warns during build-time about Elide-specific classes that "are not in the Jandex  index"
+     * When Quarkus warns during build-time about Elide-specific classes that "are not in the Jandex index"
      * we add those classes here. Unlike using the IndexDependencyBuildItem, this more specific approach
      * prevents the Elide JAX-RS endpoints from being deployed at their default "/" paths.
-     * @param additionalIndexedClassesBuildItemBuildProducer
      */
     @BuildStep
-    public void indexElideClasses(BuildProducer<AdditionalIndexedClassesBuildItem>
-                                                 indexedClassesProducer) {
+    public void indexElideClasses(BuildProducer<AdditionalIndexedClassesBuildItem> indexedClassesProducer) {
         indexedClassesProducer.produce(
                 new io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem(
                         OperationCheck.class.getCanonicalName(),

--- a/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
+++ b/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
@@ -153,7 +153,7 @@ public class ElideExtensionTest {
 
     @Test
     public void testSwaggerApiEndpoint() {
-        RestAssured.when().get("/test-apiDocs/api").then().log().all().statusCode(200);
+        RestAssured.when().get("/test-apiDocs/api").then().log().all().body(containsString("Test Documentation")).statusCode(200);
     }
 
     @Test

--- a/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
+++ b/elide-quarkus/deployment/src/test/java/com/yahoo/elide/extension/test/ElideExtensionTest.java
@@ -6,7 +6,6 @@
 
 package com.yahoo.elide.extension.test;
 
-//import static com.yahoo.elide.Elide.JSONAPI_CONTENT_TYPE;
 import static com.yahoo.elide.test.graphql.GraphQLDSL.document;
 import static com.yahoo.elide.test.graphql.GraphQLDSL.field;
 import static com.yahoo.elide.test.graphql.GraphQLDSL.selection;
@@ -87,7 +86,7 @@ public class ElideExtensionTest {
     }
 
     /**
-     * Previously, when we had a IndexDependencyBuildItem for "com.yahoo.elide:elide-core", it would cause each Elide JAX-RS endpoint to be
+     * Previously, when we had an IndexDependencyBuildItem for "com.yahoo.elide:elide-core", it would cause each Elide JAX-RS endpoint to be
      * deployed at its default, root path, as well as at the configured path. This test is a reminder that the current build-time advice of
      * "Consider adding them to the index" for certain Elide classes is not without consequence.
      */

--- a/elide-quarkus/deployment/src/test/resources/application.properties
+++ b/elide-quarkus/deployment/src/test/resources/application.properties
@@ -6,5 +6,6 @@ elide.default-max-page-size=10000
 elide.json-api.path=/test-jsonapi
 elide.graphql.path=/test-graphql
 elide.api-docs.path=/test-apiDocs
+elide.api-docs.title=Test Documentation
 quarkus.log.level=INFO
 quarkus.log.category."com.yahoo.elide".level=DEBUG

--- a/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
+++ b/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
@@ -129,7 +129,7 @@ public class ElideBeans {
         List<ApiDocsEndpoint.ApiDocsRegistration> docs = new ArrayList<>();
 
         dictionary.getApiVersions().stream().forEach(apiVersion -> {
-            Info info = new Info().title("Elide Service").version(apiVersion);
+            Info info = new Info().title(config.apiDocs().title()).version(apiVersion);
             OpenApiBuilder builder = new OpenApiBuilder(dictionary).apiVersion(apiVersion);
             String moduleBasePath = "/apiDocs/";
             OpenAPI openApi = builder.build().info(info).addServersItem(new Server().url(moduleBasePath));

--- a/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideConfig.java
+++ b/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideConfig.java
@@ -6,6 +6,7 @@
 
 package com.yahoo.elide.extension.runtime;
 
+import com.yahoo.elide.swagger.OpenApiDocument;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -17,6 +18,7 @@ public interface ElideConfig {
     public static final String JSONAPI_PATH = "/jsonapi";
     public static final String GRAPHQL_PATH = "/graphql";
     public static final String APIDOCS_PATH = "/apiDocs";
+    public static final String APIDOCS_TITLE = OpenApiDocument.DEFAULT_TITLE;
 
     interface JsonApiConfig {
         /**
@@ -43,6 +45,12 @@ public interface ElideConfig {
          */
         @WithDefault(APIDOCS_PATH)
         String path();
+
+        /**
+         * The title of the Elide Swagger document.
+         */
+        @WithDefault(APIDOCS_TITLE)
+        String title();
     }
 
     /**


### PR DESCRIPTION
There is currently no way to customise the title of the Swagger API documentation. This change adds that property.

## Description
Add a new property "elide.api-docs.title" that is injected into ElideConfig.java, using OpenApiDocument.DEFAULT_TITLE as the default value. 

## Motivation and Context
This limitation was mentioned in the example application by Chirdeep Tomar at https://github.com/chirdeeptomar/notes-api

## How Has This Been Tested?
Updated the existing test that fetches the swagger API to now also assert that the configured title is present.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
