### PR TITLE
Provide a default value for quarkus.http.root-path.

### DIFF
--- a/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
+++ b/elide-quarkus/runtime/src/main/java/com/yahoo/elide/extension/runtime/ElideBeans.java
@@ -44,7 +44,7 @@ import java.util.function.Consumer;
 @ApplicationScoped
 public class ElideBeans {
     private static final Logger LOG = Logger.getLogger(ElideBeans.class.getName());
-    @ConfigProperty(name = "quarkus.http.root-path")
+    @ConfigProperty(name = "quarkus.http.root-path", defaultValue = "/")
     String rootPath;
     private ElideConfig config;
 


### PR DESCRIPTION
## Description
Set the default value for "quarkus.http.root-path" to "/" at the configuration injection point.

## Motivation and Context
This improves developer experience for new projects in the early creation stages. Before this change, if the elide-quarks extension has been added, but the rest extension has not, Quarkus would fail with a complaint about this property being missing. It is arguably more intuitive to let the developer organically discover that nothing is listening on the HTTP port, rather than wondering what value they should be providing for this property and why it's not defaulting.

## How Has This Been Tested?
Tested on a local project both with and without the 'rest' extension present. Without the 'rest' extension present, Quarkus will now load without error, but will not be listening on any HTTP ports.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
